### PR TITLE
feat(web): M5 SPA lobby, room, WebSocket + WebRTC (#17)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -8,5 +8,15 @@
 # Example: https://abcd1234.execute-api.us-east-1.amazonaws.com
 # VITE_PUBLIC_API_BASE_URL=
 
+# WebSocket API (`wss://…` CDK output `WebSocketUrl`). Required for `/room` realtime (chat / signaling).
+# VITE_PUBLIC_WS_URL=
+
+# Fan Hosted UI PKCE (`/auth/callback` must be allowed in the Cognito app client redirect URLs).
+# VITE_COGNITO_HOSTED_UI_DOMAIN=
+# VITE_COGNITO_CLIENT_ID=
+
+# Optional. JSON **`iceServers`** for WebRTC (`RTCPeerConnection`). Add TURN when mesh needs relay.
+# VITE_WEBRTC_ICE_SERVERS_JSON=[{"urls":"stun:stun.l.google.com:19302"}]
+
 # Local development: copy to `.env.development` and point at a deployed staging API or mock.
 # Without `VITE_PUBLIC_API_BASE_URL`, `vite dev` loads `data/catalog/episodes.json` as a fallback only.

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -6,10 +6,12 @@ import { LobbyPage } from './pages/LobbyPage'
 import { RoomPage } from './pages/RoomPage'
 import { AdminShellPage } from './pages/AdminShellPage'
 import { SoloWatchPage } from './pages/SoloWatchPage'
+import { AuthCallbackPage } from './pages/AuthCallbackPage'
 
 export function AppRoutes() {
   return (
     <Routes>
+      <Route path="/auth/callback" element={<AuthCallbackPage />} />
       <Route element={<SiteLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/catalog" element={<CatalogPage />} />

--- a/apps/web/src/api/roomsApi.ts
+++ b/apps/web/src/api/roomsApi.ts
@@ -1,0 +1,138 @@
+import type { PlaybackExpectation } from '../catalog/catalogTypes'
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+
+export type RoomPlaybackExpectation = 'free' | 'premium'
+
+export function catalogToRoomPlayback(ep: { playbackExpectation?: PlaybackExpectation }): RoomPlaybackExpectation {
+  return ep.playbackExpectation === 'premium' ? 'premium' : 'free'
+}
+
+export function roomPlaybackForBadge(p: RoomPlaybackExpectation | undefined): PlaybackExpectation {
+  if (p === 'premium') return 'premium'
+  return 'ad_supported'
+}
+
+export interface LobbyRoomRow {
+  roomId: string
+  catalogEpisodeId: string
+  youtubeVideoId?: string
+  playbackExpectation?: RoomPlaybackExpectation
+  lastActivityAt?: number
+  catalog?: {
+    id: string
+    title: string
+    experimentNumber?: number
+    posterImageUrl?: string | null
+  }
+}
+
+export interface LobbyResponse {
+  rooms: LobbyRoomRow[]
+  staleRoomMsHint?: number
+}
+
+export async function fetchLobby(sessionId: string): Promise<LobbyResponse> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    throw new Error('Configure VITE_PUBLIC_API_BASE_URL for lobby requests.')
+  }
+  const res = await fetch(`${base}/v1/lobby`, {
+    headers: {
+      Accept: 'application/json',
+      'X-Session-Id': sessionId,
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`Lobby failed (${res.status})`)
+  }
+  return (await res.json()) as LobbyResponse
+}
+
+export interface RoomSnapshot {
+  roomId: string
+  hostSub: string
+  catalogEpisodeId: string
+  youtubeVideoId: string
+  playbackExpectation: RoomPlaybackExpectation
+  visibility: 'public' | 'private'
+  lastActivityAt: number
+  version: number
+}
+
+export async function fetchRoom(roomId: string): Promise<RoomSnapshot | null> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const res = await fetch(`${base}/v1/rooms/${encodeURIComponent(roomId)}`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Room read failed (${res.status})`)
+  const body = (await res.json()) as { room?: RoomSnapshot }
+  return body.room ?? null
+}
+
+export async function createRoom(
+  accessToken: string,
+  body: {
+    catalogEpisodeId: string
+    playbackExpectation: RoomPlaybackExpectation
+    visibility: 'public' | 'private'
+  },
+): Promise<RoomSnapshot & { roomId: string }> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const res = await fetch(`${base}/v1/rooms`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  if (res.status === 401) throw new Error('Sign in again — host token rejected')
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(`Create room failed (${res.status}): ${t}`)
+  }
+  return (await res.json()) as RoomSnapshot & { roomId: string }
+}
+
+export interface RoomPatchResult {
+  ok: true
+  roomId: string
+  version: number
+  catalogEpisodeId: string
+  youtubeVideoId: string
+  visibility: 'public' | 'private'
+  lastActivityAt: number
+}
+
+export async function patchRoom(
+  accessToken: string,
+  roomId: string,
+  patch: {
+    catalogEpisodeId?: string
+    visibility?: 'public' | 'private'
+    playbackExpectation?: RoomPlaybackExpectation
+  },
+): Promise<RoomPatchResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const res = await fetch(`${base}/v1/rooms/${encodeURIComponent(roomId)}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(patch),
+  })
+  if (res.status === 403) throw new Error('Only the room host can change the episode.')
+  if (res.status === 401) throw new Error('Sign in again — host token rejected')
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(`Update room failed (${res.status}): ${t}`)
+  }
+  return (await res.json()) as RoomPatchResult
+}

--- a/apps/web/src/auth/fanHostedUiPkce.ts
+++ b/apps/web/src/auth/fanHostedUiPkce.ts
@@ -1,0 +1,117 @@
+import { setFanTokenBundle } from './fanTokens'
+
+const PKCE_VERIFIER = 'riffsync.pkceVerifier'
+const OAUTH_STATE = 'riffsync.oauthState'
+const RETURN = 'riffsync.returnTo'
+
+function randomString(len: number): string {
+  const bytes = new Uint8Array(len)
+  crypto.getRandomValues(bytes)
+  const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  let s = ''
+  for (let i = 0; i < len; i++) {
+    s += chars[bytes[i]! % chars.length]!
+  }
+  return s
+}
+
+async function base64urlSha256(plain: string): Promise<string> {
+  const data = new TextEncoder().encode(plain)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  const bytes = new Uint8Array(hash)
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function hostedDomain(): string {
+  const d = import.meta.env.VITE_COGNITO_HOSTED_UI_DOMAIN?.trim()
+  if (!d) throw new Error('Missing VITE_COGNITO_HOSTED_UI_DOMAIN')
+  return d.replace(/^https?:\/\//, '')
+}
+
+function clientId(): string {
+  const c = import.meta.env.VITE_COGNITO_CLIENT_ID?.trim()
+  if (!c) throw new Error('Missing VITE_COGNITO_CLIENT_ID')
+  return c
+}
+
+function redirectUri(): string {
+  return `${window.location.origin}/auth/callback`
+}
+
+/**
+ * PKCE + Cognito Hosted UI (Facebook IdP). Redirects the browser.
+ */
+export async function startFanHostedUiSignIn(returnPath: string): Promise<void> {
+  const verifier = randomString(64)
+  const challenge = await base64urlSha256(verifier)
+  const state = randomString(32)
+  sessionStorage.setItem(PKCE_VERIFIER, verifier)
+  sessionStorage.setItem(OAUTH_STATE, state)
+  sessionStorage.setItem(RETURN, returnPath)
+
+  const params = new URLSearchParams({
+    client_id: clientId(),
+    response_type: 'code',
+    scope: 'openid email profile',
+    redirect_uri: redirectUri(),
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    identity_provider: 'Facebook',
+  })
+
+  const url = `https://${hostedDomain()}/oauth2/authorize?${params.toString()}`
+  window.location.assign(url)
+}
+
+export function popReturnPath(): string {
+  const p = sessionStorage.getItem(RETURN) ?? '/catalog'
+  sessionStorage.removeItem(RETURN)
+  return p
+}
+
+export async function exchangeFanAuthorizationCode(
+  code: string,
+  state: string,
+): Promise<void> {
+  const expectedState = sessionStorage.getItem(OAUTH_STATE)
+  const verifier = sessionStorage.getItem(PKCE_VERIFIER)
+  if (!expectedState || state !== expectedState) {
+    throw new Error('OAuth state mismatch — try signing in again.')
+  }
+  if (!verifier) {
+    throw new Error('Missing PKCE verifier — try signing in again.')
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: clientId(),
+    code,
+    redirect_uri: redirectUri(),
+    code_verifier: verifier,
+  })
+
+  const res = await fetch(`https://${hostedDomain()}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  sessionStorage.removeItem(OAUTH_STATE)
+  sessionStorage.removeItem(PKCE_VERIFIER)
+
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(`Token exchange failed (${res.status}): ${t}`)
+  }
+
+  const json = (await res.json()) as { access_token?: string; expires_in?: number }
+  if (!json.access_token || typeof json.expires_in !== 'number') {
+    throw new Error('Token response missing access_token / expires_in')
+  }
+  setFanTokenBundle(json.access_token, json.expires_in)
+}

--- a/apps/web/src/auth/fanTokens.ts
+++ b/apps/web/src/auth/fanTokens.ts
@@ -1,0 +1,38 @@
+const LS_ACCESS = 'riffsync.fanAccessToken'
+const LS_EXPIRES = 'riffsync.fanAccessTokenExp'
+
+export interface FanTokenBundle {
+  accessToken: string
+  /** Epoch seconds (Cognito `exp` claim rounded / server `expires_in`). */
+  expiresAtSec: number
+}
+
+export function getFanTokenBundle(): FanTokenBundle | null {
+  const accessToken = localStorage.getItem(LS_ACCESS)
+  const expRaw = localStorage.getItem(LS_EXPIRES)
+  if (!accessToken) return null
+  const expiresAtSec = expRaw ? Number.parseInt(expRaw, 10) : 0
+  if (!Number.isFinite(expiresAtSec) || expiresAtSec <= 0) return { accessToken, expiresAtSec: 0 }
+  return { accessToken, expiresAtSec }
+}
+
+export function getFanAccessToken(): string | null {
+  const b = getFanTokenBundle()
+  if (!b) return null
+  const now = Math.floor(Date.now() / 1000)
+  if (b.expiresAtSec && now >= b.expiresAtSec - 30) {
+    return null
+  }
+  return b.accessToken
+}
+
+export function setFanTokenBundle(accessToken: string, expiresInSec: number): void {
+  const now = Math.floor(Date.now() / 1000)
+  localStorage.setItem(LS_ACCESS, accessToken)
+  localStorage.setItem(LS_EXPIRES, String(now + expiresInSec))
+}
+
+export function clearFanTokens(): void {
+  localStorage.removeItem(LS_ACCESS)
+  localStorage.removeItem(LS_EXPIRES)
+}

--- a/apps/web/src/auth/jwtDecode.ts
+++ b/apps/web/src/auth/jwtDecode.ts
@@ -1,0 +1,19 @@
+/** Decode JWT payload (no signature verify — UI + client-side checks only). */
+
+export function jwtPayload<T extends Record<string, unknown>>(accessToken: string): T | null {
+  const parts = accessToken.split('.')
+  if (parts.length < 2) return null
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4))
+    const json = atob(b64 + pad)
+    return JSON.parse(json) as T
+  } catch {
+    return null
+  }
+}
+
+export function cognitoSub(accessToken: string): string | undefined {
+  const p = jwtPayload<{ sub?: unknown }>(accessToken)
+  return typeof p?.sub === 'string' ? p.sub : undefined
+}

--- a/apps/web/src/components/site/SiteHeader.tsx
+++ b/apps/web/src/components/site/SiteHeader.tsx
@@ -46,7 +46,6 @@ export function SiteHeader() {
                       </PrimaryNavItem>
                       <PrimaryNavItem to="/catalog">Catalog</PrimaryNavItem>
                       <PrimaryNavItem to="/lobby">Lobby</PrimaryNavItem>
-                      <PrimaryNavItem to="/room/demo-room">Room (demo)</PrimaryNavItem>
                       <PrimaryNavItem to="/admin" end={false}>
                         Admin
                       </PrimaryNavItem>

--- a/apps/web/src/config/iceServers.ts
+++ b/apps/web/src/config/iceServers.ts
@@ -1,0 +1,16 @@
+/** RTCPeerConnection ICE config from env or public STUN fallback. */
+export function getRtcIceServers(): RTCIceServer[] {
+  const raw = import.meta.env.VITE_WEBRTC_ICE_SERVERS_JSON?.trim()
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (!Array.isArray(parsed)) {
+        throw new Error('iceServers must be a JSON array')
+      }
+      return parsed as RTCIceServer[]
+    } catch {
+      console.warn('[riffsync] VITE_WEBRTC_ICE_SERVERS_JSON invalid; using default STUN')
+    }
+  }
+  return [{ urls: 'stun:stun.l.google.com:19302' }]
+}

--- a/apps/web/src/config/wsUrl.ts
+++ b/apps/web/src/config/wsUrl.ts
@@ -1,0 +1,17 @@
+/**
+ * WebSocket API URL (`wss://…/staging` or `/prod`) from **`RiffSyncApi-*`** **`WebSocketUrl`** output.
+ */
+export function getPublicWsUrl(): string | undefined {
+  const raw = import.meta.env.VITE_PUBLIC_WS_URL?.trim()
+  return raw && raw.length > 0 ? raw.replace(/\/$/, '') : undefined
+}
+
+export function getWsUrlOrThrow(): string {
+  const u = getPublicWsUrl()
+  if (!u) {
+    throw new Error(
+      'Set VITE_PUBLIC_WS_URL to the deployed WebSocket URL (see infra/cdk/README — WebSocketUrl output).',
+    )
+  }
+  return u
+}

--- a/apps/web/src/pages/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { exchangeFanAuthorizationCode, popReturnPath } from '../auth/fanHostedUiPkce'
+
+export function AuthCallbackPage() {
+  const [params] = useSearchParams()
+  const navigate = useNavigate()
+  const code = params.get('code')
+  const state = params.get('state')
+  const missing = !code || !state
+
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!code || !state) return undefined
+    let cancelled = false
+    void exchangeFanAuthorizationCode(code, state)
+      .then(() => {
+        if (cancelled) return
+        const next = popReturnPath()
+        navigate(next, { replace: true })
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setErr(e instanceof Error ? e.message : 'Sign-in failed')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [navigate, code, state])
+
+  if (missing) {
+    return (
+      <div className="container" role="alert">
+        <h1>Sign-in</h1>
+        <p>Missing OAuth code or state.</p>
+        <p>
+          <a href="/catalog">← Catalog</a>
+        </p>
+      </div>
+    )
+  }
+
+  if (err) {
+    return (
+      <div className="container" role="alert">
+        <h1>Sign-in</h1>
+        <p>{err}</p>
+        <p>
+          <a href="/catalog">← Catalog</a>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container">
+      <p>Completing sign-in…</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,10 +1,54 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
+import { useEffect } from 'react'
 import { useCatalogEntriesQuery } from '../catalog/useCatalogQuery'
 import { catalogCardImageUrl } from '../catalog/mockCatalog'
 import { PlaybackExpectationBadge } from '../components/watch/PlaybackExpectationBadge'
 import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { catalogToRoomPlayback, createRoom } from '../api/roomsApi'
+import { getFanAccessToken } from '../auth/fanTokens'
+import { startFanHostedUiSignIn } from '../auth/fanHostedUiPkce'
+
+const PENDING_PARTY = 'riffsync.pendingPartyEpisodeId'
 
 const eraLabel = (era: string) => era.replace(/^./, (c) => c.toUpperCase())
+
+function CatalogPartyActions({ episode }: { episode: CatalogEpisode }) {
+  const navigate = useNavigate()
+  const token = getFanAccessToken()
+
+  const start = async () => {
+    if (!token) return
+    try {
+      const room = await createRoom(token, {
+        catalogEpisodeId: episode.id,
+        playbackExpectation: catalogToRoomPlayback(episode),
+        visibility: 'public',
+      })
+      navigate(`/room/${encodeURIComponent(room.roomId)}`)
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : 'Could not create room')
+    }
+  }
+
+  const signInFirst = () => {
+    sessionStorage.setItem(PENDING_PARTY, episode.id)
+    void startFanHostedUiSignIn('/catalog')
+  }
+
+  return (
+    <div className="riffsync-catalog-card__party">
+      {token ? (
+        <button type="button" className="gen-button" onClick={() => void start()}>
+          Start party
+        </button>
+      ) : (
+        <button type="button" className="gen-button" onClick={signInFirst}>
+          Sign in to host — start party
+        </button>
+      )}
+    </div>
+  )
+}
 
 function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
   const img = catalogCardImageUrl(episode)
@@ -40,6 +84,7 @@ function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
               <div className="riffsync-catalog-card__advisory">
                 <PlaybackExpectationBadge expectation={episode.playbackExpectation} />
               </div>
+              <CatalogPartyActions episode={episode} />
               {episode.embedAllows === false && (
                 <p className="riffsync-catalog-card__embed" role="status">
                   Not embeddable in-app — use YouTube directly if available.
@@ -54,7 +99,29 @@ function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
 }
 
 export function CatalogPage() {
+  const navigate = useNavigate()
   const { data, isPending, isError, error } = useCatalogEntriesQuery()
+
+  useEffect(() => {
+    const pending = sessionStorage.getItem(PENDING_PARTY)
+    const token = getFanAccessToken()
+    if (!pending || !data?.length || !token) return
+    const ep = data.find((e) => e.id === pending)
+    sessionStorage.removeItem(PENDING_PARTY)
+    if (!ep) return
+    void (async () => {
+      try {
+        const room = await createRoom(token, {
+          catalogEpisodeId: ep.id,
+          playbackExpectation: catalogToRoomPlayback(ep),
+          visibility: 'public',
+        })
+        navigate(`/room/${encodeURIComponent(room.roomId)}`, { replace: true })
+      } catch (e) {
+        window.alert(e instanceof Error ? e.message : 'Could not create room')
+      }
+    })()
+  }, [data, navigate])
 
   if (isPending) {
     return (

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -1,8 +1,101 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { LobbyResponse } from '../api/roomsApi'
+import { fetchLobby, roomPlaybackForBadge } from '../api/roomsApi'
+import { ensureGuestSession } from '../session/guestSession'
+import { PlaybackExpectationBadge } from '../components/watch/PlaybackExpectationBadge'
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+
 export function LobbyPage() {
+  const apiUrl = getPublicApiBaseUrl()
+  const [data, setData] = useState<LobbyResponse | null>(null)
+  const [fetchErr, setFetchErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!apiUrl) return
+    const { sessionId } = ensureGuestSession('lobby')
+    void fetchLobby(sessionId)
+      .then(setData)
+      .catch((e: unknown) =>
+        setFetchErr(e instanceof Error ? e.message : 'Lobby request failed'),
+      )
+  }, [apiUrl])
+
+  if (!apiUrl) {
+    return (
+      <div className="container" role="alert">
+        <h1>Lobby</h1>
+        <p>Configure VITE_PUBLIC_API_BASE_URL to load the lobby.</p>
+        <p>
+          <Link to="/">← Home</Link>
+        </p>
+      </div>
+    )
+  }
+
+  if (fetchErr) {
+    return (
+      <div className="container" role="alert">
+        <h1>Lobby</h1>
+        <p>{fetchErr}</p>
+        <p>
+          <Link to="/">← Home</Link>
+        </p>
+      </div>
+    )
+  }
+
+  const rooms = data?.rooms ?? []
+  const staleMs = data?.staleRoomMsHint
+
   return (
-    <div className="container">
+    <div className="container riffsync-lobby-page">
       <h1>Lobby</h1>
-      <p>M2 scaffold — live room listing will call the lobby HTTP API when backend work lands.</p>
+      <p className="riffsync-lobby-page__lede">
+        Public parties from the deployed API. Guests join anonymously; hosts sign in before creating a room from the{' '}
+        <Link to="/catalog">catalog</Link>.
+      </p>
+      {typeof staleMs === 'number' && (
+        <p className="riffsync-muted" role="note">
+          Inactive listings may expire after roughly {Math.round(staleMs / 60_000)} minutes server-side — refresh to see updates.
+        </p>
+      )}
+      {!data ? (
+        <p>Loading lobby…</p>
+      ) : rooms.length === 0 ? (
+        <p>No public parties right now. Start one from the catalog when signed in as a host.</p>
+      ) : (
+        <ul className="riffsync-lobby-list">
+          {rooms.map((row) => {
+            const title = row.catalog?.title ?? row.catalogEpisodeId
+            const poster = row.catalog?.posterImageUrl
+            const badge = roomPlaybackForBadge(row.playbackExpectation)
+            return (
+              <li key={row.roomId} className="riffsync-lobby-list__item">
+                {poster ? (
+                  <img className="riffsync-lobby-list__poster" src={poster} alt="" loading="lazy" />
+                ) : null}
+                <div>
+                  <h2>
+                    <Link to={`/room/${encodeURIComponent(row.roomId)}`}>{title}</Link>
+                  </h2>
+                  <p className="riffsync-lobby-list__meta">
+                    Room <code>{row.roomId.slice(0, 8)}…</code>
+                    {' · '}Experiment{' '}
+                    {row.catalog?.experimentNumber ?? <span title={row.catalogEpisodeId}>—</span>}
+                  </p>
+                  <PlaybackExpectationBadge expectation={badge} />
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      <p>
+        <Link to="/catalog">Browse catalog</Link>
+        {' · '}
+        <Link to="/">Home</Link>
+      </p>
     </div>
   )
 }

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -1,15 +1,634 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
+import type { MutableRefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { RoomPatchResult, RoomSnapshot } from '../api/roomsApi'
+import {
+  catalogToRoomPlayback,
+  fetchRoom,
+  patchRoom,
+  roomPlaybackForBadge,
+} from '../api/roomsApi'
+import { fetchCatalogEpisodeById, fetchCatalogEntries } from '../catalog/catalogApi'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { cognitoSub } from '../auth/jwtDecode'
+import { getFanAccessToken } from '../auth/fanTokens'
+import { startFanHostedUiSignIn } from '../auth/fanHostedUiPkce'
+import { ensureGuestSession } from '../session/guestSession'
+import { getPublicWsUrl } from '../config/wsUrl'
+import { getPublicOrigin } from '../config/publicOrigin'
+import { getRtcIceServers } from '../config/iceServers'
+import { useRoomWebSocket } from '../room/useRoomWebSocket'
+import { PlaybackExpectationBadge } from '../components/watch/PlaybackExpectationBadge'
+import { SoloYouTubePlayer } from '../components/watch/SoloYouTubePlayer'
+
+type ChatMsg = { sessionId: string; text: string; ts: number }
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+type HostNegotiateCtx = {
+  iceServers: RTCIceServer[]
+  sendJson: (payload: Record<string, unknown>) => void
+  peerByGuestRef: MutableRefObject<Map<string, RTCPeerConnection>>
+  pendingReadyGuestsRef: MutableRefObject<Set<string>>
+}
+
+async function ensureHostPeerNegotiated(
+  ctx: HostNegotiateCtx & { captureStream: MediaStream },
+  guestSessionId: string,
+): Promise<void> {
+  const stream = ctx.captureStream
+  let pc = ctx.peerByGuestRef.current.get(guestSessionId)
+  if (pc && pc.signalingState !== 'closed') {
+    pc.close()
+  }
+  pc = new RTCPeerConnection({ iceServers: ctx.iceServers })
+  ctx.peerByGuestRef.current.set(guestSessionId, pc)
+  for (const t of stream.getTracks()) {
+    pc.addTrack(t, stream)
+  }
+  pc.onicecandidate = (e) => {
+    if (e.candidate) {
+      ctx.sendJson({
+        action: 'signaling',
+        envelope: {
+          kind: 'ice',
+          candidate: e.candidate.toJSON(),
+          targetSessionId: guestSessionId,
+        },
+      })
+    }
+  }
+  const offer = await pc.createOffer()
+  await pc.setLocalDescription(offer)
+  ctx.sendJson({
+    action: 'signaling',
+    envelope: {
+      kind: 'offer',
+      sdp: { type: offer.type, sdp: offer.sdp ?? '' },
+      targetSessionId: guestSessionId,
+    },
+  })
+}
+
+async function flushHostPending(
+  opts: HostNegotiateCtx & { captureStream: MediaStream },
+): Promise<void> {
+  const ids = [...opts.pendingReadyGuestsRef.current]
+  opts.pendingReadyGuestsRef.current.clear()
+  for (const sid of ids) {
+    await ensureHostPeerNegotiated(opts, sid).catch(() => undefined)
+  }
+}
+
+async function handleHostSignal(
+  ctx: HostNegotiateCtx & { captureStream: MediaStream | null; fromSessionId: string; envelope: Record<string, unknown> },
+): Promise<void> {
+  const guestSignaling = ctx.envelope.guestSignaling === true
+  const kind = ctx.envelope.kind
+
+  if (guestSignaling && kind === 'ready') {
+    if (!ctx.captureStream) {
+      ctx.pendingReadyGuestsRef.current.add(ctx.fromSessionId)
+      return
+    }
+    await ensureHostPeerNegotiated(
+      {
+        captureStream: ctx.captureStream,
+        iceServers: ctx.iceServers,
+        sendJson: ctx.sendJson,
+        peerByGuestRef: ctx.peerByGuestRef,
+        pendingReadyGuestsRef: ctx.pendingReadyGuestsRef,
+      },
+      ctx.fromSessionId,
+    ).catch(() => undefined)
+    return
+  }
+
+  const pc = ctx.peerByGuestRef.current.get(ctx.fromSessionId)
+  if (!pc) return
+
+  if (guestSignaling && kind === 'answer') {
+    const sdp = ctx.envelope.sdp
+    if (isRecord(sdp) && typeof sdp.sdp === 'string' && typeof sdp.type === 'string') {
+      try {
+        await pc.setRemoteDescription(
+          new RTCSessionDescription(sdp as unknown as RTCSessionDescriptionInit),
+        )
+      } catch {
+        /* ignore malformed SDP */
+      }
+    }
+    return
+  }
+
+  if (guestSignaling && kind === 'ice') {
+    const cand = ctx.envelope.candidate
+    if (isRecord(cand)) {
+      try {
+        await pc.addIceCandidate(new RTCIceCandidate(cand as RTCIceCandidateInit))
+      } catch {
+        /* ignore stale / invalid candidate */
+      }
+    }
+  }
+}
+
+async function handleGuestSignal(ctx: {
+  mySessionId: string
+  iceServers: RTCIceServer[]
+  sendJson: (payload: Record<string, unknown>) => void
+  guestPcRef: MutableRefObject<RTCPeerConnection | null>
+  setGuestRemote: (s: MediaStream | null) => void
+  envelope: Record<string, unknown>
+}): Promise<void> {
+  const kind = ctx.envelope.kind
+
+  if (kind === 'offer') {
+    if (ctx.envelope.targetSessionId !== ctx.mySessionId) return
+    const sdp = ctx.envelope.sdp
+    if (!isRecord(sdp) || typeof sdp.sdp !== 'string' || typeof sdp.type !== 'string') return
+
+    const prev = ctx.guestPcRef.current
+    prev?.close()
+    const pc = new RTCPeerConnection({ iceServers: ctx.iceServers })
+    ctx.guestPcRef.current = pc
+
+    pc.ontrack = (ev) => {
+      const [stream] = ev.streams
+      if (stream) ctx.setGuestRemote(stream)
+    }
+    pc.onicecandidate = (e) => {
+      if (e.candidate) {
+        ctx.sendJson({
+          action: 'signaling',
+          envelope: {
+            guestSignaling: true,
+            kind: 'ice',
+            candidate: e.candidate.toJSON(),
+          },
+        })
+      }
+    }
+
+    try {
+      await pc.setRemoteDescription(
+        new RTCSessionDescription(sdp as unknown as RTCSessionDescriptionInit),
+      )
+      const answer = await pc.createAnswer()
+      await pc.setLocalDescription(answer)
+      ctx.sendJson({
+        action: 'signaling',
+        envelope: {
+          guestSignaling: true,
+          kind: 'answer',
+          sdp: { type: answer.type, sdp: answer.sdp ?? '' },
+        },
+      })
+    } catch {
+      /* ignore handshake failure */
+    }
+    return
+  }
+
+  if (kind === 'ice' && ctx.envelope.targetSessionId === ctx.mySessionId) {
+    const cand = ctx.envelope.candidate
+    const pc = ctx.guestPcRef.current
+    if (!pc || !isRecord(cand)) return
+    try {
+      await pc.addIceCandidate(new RTCIceCandidate(cand as RTCIceCandidateInit))
+    } catch {
+      /* ignore */
+    }
+  }
+}
 
 export function RoomPage() {
-  const { roomId } = useParams<{ roomId: string }>()
+  const { roomId: roomIdParam } = useParams<{ roomId: string }>()
+  const roomId = roomIdParam ? decodeURIComponent(roomIdParam) : ''
+
+  const [{ sessionId, displayName }] = useState(() => ensureGuestSession('room'))
+
+  const [room, setRoom] = useState<RoomSnapshot | null | undefined>(undefined)
+  const [roomErr, setRoomErr] = useState<string | null>(null)
+  const [catalogEp, setCatalogEp] = useState<CatalogEpisode | null>(null)
+  const [catalogList, setCatalogList] = useState<CatalogEpisode[]>([])
+  const [chat, setChat] = useState<ChatMsg[]>([])
+  const [chatDraft, setChatDraft] = useState('')
+  const [patchErr, setPatchErr] = useState<string | null>(null)
+  const [shareHint, setShareHint] = useState<string | null>(null)
+  const [captureErr, setCaptureErr] = useState<string | null>(null)
+  const [captureStream, setCaptureStream] = useState<MediaStream | null>(null)
+  const [guestRemote, setGuestRemote] = useState<MediaStream | null>(null)
+  const [guestPlayHint, setGuestPlayHint] = useState(false)
+
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const peerByGuestRef = useRef(new Map<string, RTCPeerConnection>())
+  const pendingReadyGuestsRef = useRef(new Set<string>())
+  const guestPcRef = useRef<RTCPeerConnection | null>(null)
+  const readySentRef = useRef(false)
+
+  const wsBase = getPublicWsUrl()
+  const fanToken = getFanAccessToken()
+  const isPublisher = Boolean(room && fanToken && cognitoSub(fanToken) === room.hostSub)
+
+  const iceServers = useMemo(() => getRtcIceServers(), [])
+
+  const loadRoom = useCallback(async () => {
+    if (!roomId) return
+    try {
+      const snap = await fetchRoom(roomId)
+      setRoom(snap)
+      setRoomErr(snap ? null : 'Room not found.')
+    } catch (e) {
+      setRoom(null)
+      setRoomErr(e instanceof Error ? e.message : 'Could not load room')
+    }
+  }, [roomId])
+
+  useEffect(() => {
+    queueMicrotask(() => void loadRoom())
+  }, [loadRoom])
+
+  useEffect(() => {
+    if (!roomId || !room) return
+    const t = window.setInterval(() => {
+      void loadRoom()
+    }, 5000)
+    return () => window.clearInterval(t)
+  }, [roomId, room, loadRoom])
+
+  useEffect(() => {
+    if (!room?.catalogEpisodeId) return
+    void fetchCatalogEpisodeById(room.catalogEpisodeId)
+      .then(setCatalogEp)
+      .catch(() => setCatalogEp(null))
+  }, [room?.catalogEpisodeId])
+
+  useEffect(() => {
+    if (!isPublisher) return
+    void fetchCatalogEntries()
+      .then(setCatalogList)
+      .catch(() => setCatalogList([]))
+  }, [isPublisher])
+
+  const sendJsonRef = useRef<(o: Record<string, unknown>) => void>(() => {})
+
+  const onWsMessage = useCallback(
+    (data: Record<string, unknown>) => {
+      const t = data.type
+      if (t === 'chat' && typeof data.sessionId === 'string' && typeof data.text === 'string') {
+        const ts = typeof data.ts === 'number' ? data.ts : Date.now()
+        setChat((prev) => [
+          ...prev,
+          {
+            sessionId: data.sessionId as string,
+            text: String(data.text),
+            ts,
+          },
+        ])
+        return
+      }
+      if (t !== 'signaling') return
+
+      const fromSessionId = typeof data.fromSessionId === 'string' ? data.fromSessionId : ''
+      const role = data.role
+      const envelope = data.envelope
+      if (!fromSessionId || !isRecord(envelope)) return
+
+      if (!isPublisher) {
+        if (role !== 'host') return
+        void handleGuestSignal({
+          mySessionId: sessionId,
+          iceServers,
+          sendJson: (payload) => sendJsonRef.current(payload),
+          guestPcRef,
+          setGuestRemote,
+          envelope,
+        })
+        return
+      }
+
+      if (role !== 'guest') return
+      void handleHostSignal({
+        fromSessionId,
+        envelope,
+        captureStream,
+        iceServers,
+        sendJson: (payload) => sendJsonRef.current(payload),
+        peerByGuestRef,
+        pendingReadyGuestsRef,
+      }).catch(() => undefined)
+    },
+    [captureStream, iceServers, isPublisher, sessionId],
+  )
+
+  const { status: wsStatus, sendJson } = useRoomWebSocket({
+    url: wsBase,
+    roomId,
+    sessionId,
+    accessToken: isPublisher ? fanToken : null,
+    enabled: Boolean(wsBase && roomId && room),
+    onMessage: onWsMessage,
+  })
+
+  useEffect(() => {
+    sendJsonRef.current = sendJson
+  }, [sendJson])
+
+  useEffect(() => {
+    if (!isPublisher) return
+    const peerMap = peerByGuestRef.current
+    const pend = pendingReadyGuestsRef.current
+    return () => {
+      for (const pc of peerMap.values()) {
+        pc.close()
+      }
+      peerMap.clear()
+      pend.clear()
+    }
+  }, [isPublisher])
+
+  useEffect(() => {
+    if (isPublisher || wsStatus !== 'open') return
+    if (readySentRef.current) return
+    readySentRef.current = true
+    sendJson({
+      action: 'signaling',
+      envelope: { guestSignaling: true, kind: 'ready' },
+    })
+  }, [isPublisher, sendJson, wsStatus])
+
+  useEffect(() => {
+    if (wsStatus !== 'open') {
+      readySentRef.current = false
+    }
+  }, [wsStatus])
+
+  useEffect(() => {
+    if (!captureStream || !isPublisher) return
+    void flushHostPending({
+      captureStream,
+      iceServers,
+      sendJson: (payload) => sendJsonRef.current(payload),
+      peerByGuestRef,
+      pendingReadyGuestsRef,
+    }).catch(() => undefined)
+  }, [captureStream, iceServers, isPublisher])
+
+  useEffect(() => {
+    if (isPublisher) return
+    queueMicrotask(() => {
+      guestPcRef.current?.close()
+      guestPcRef.current = null
+      setGuestRemote(null)
+    })
+  }, [isPublisher])
+
+  useEffect(() => {
+    const v = videoRef.current
+    if (!v || !guestRemote || isPublisher) return
+    setGuestPlayHint(false)
+    v.srcObject = guestRemote
+    void v.play().catch(() => setGuestPlayHint(true))
+  }, [guestRemote, isPublisher])
+
+  const startCapture = async () => {
+    setCaptureErr(null)
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { preferCurrentTab: true } as MediaTrackConstraints & { preferCurrentTab?: boolean },
+        audio: true,
+      })
+      stream.getTracks().forEach((tr) => {
+        tr.addEventListener('ended', () => {
+          stream.getTracks().forEach((x) => x.stop())
+          setCaptureStream(null)
+        })
+      })
+      setCaptureStream(stream)
+    } catch (e) {
+      setCaptureErr(e instanceof Error ? e.message : 'Could not start tab capture')
+    }
+  }
+
+  const sendChat = () => {
+    const txt = chatDraft.trim()
+    if (!txt) return
+    sendJson({ action: 'chat', text: txt })
+    setChatDraft('')
+  }
+
+  const copyShare = async () => {
+    const url = `${getPublicOrigin()}/room/${encodeURIComponent(roomId)}`
+    try {
+      await navigator.clipboard.writeText(url)
+      setShareHint('Link copied')
+    } catch {
+      setShareHint(`Copy manually: ${url}`)
+    }
+    window.setTimeout(() => setShareHint(null), 4000)
+  }
+
+  const onEpisodeChange = async (nextId: string) => {
+    if (!room || !fanToken || !isPublisher) return
+    setPatchErr(null)
+    const ep = catalogList.find((e) => e.id === nextId)
+    try {
+      const body: Parameters<typeof patchRoom>[2] = { catalogEpisodeId: nextId }
+      if (ep) {
+        body.playbackExpectation = catalogToRoomPlayback(ep)
+      }
+      const res: RoomPatchResult = await patchRoom(fanToken, roomId, body)
+      setRoom({
+        ...room,
+        catalogEpisodeId: res.catalogEpisodeId,
+        youtubeVideoId: res.youtubeVideoId,
+        version: res.version,
+        lastActivityAt: res.lastActivityAt,
+        visibility: res.visibility,
+      })
+      void fetchCatalogEpisodeById(res.catalogEpisodeId).then(setCatalogEp)
+    } catch (e) {
+      setPatchErr(e instanceof Error ? e.message : 'Patch failed')
+    }
+  }
+
+  const playGuestVideo = async () => {
+    const v = videoRef.current
+    if (!v) return
+    try {
+      await v.play()
+      setGuestPlayHint(false)
+    } catch {
+      setGuestPlayHint(true)
+    }
+  }
+
+  if (!roomId) {
+    return (
+      <div className="container">
+        <p>Missing room id.</p>
+      </div>
+    )
+  }
+
+  if (room === undefined && !roomErr) {
+    return (
+      <div className="container">
+        <p>Loading room…</p>
+      </div>
+    )
+  }
+
+  if (roomErr || !room) {
+    return (
+      <div className="container" role="alert">
+        <h1>Room</h1>
+        <p>{roomErr ?? 'Room unavailable.'}</p>
+        <p>
+          <Link to="/lobby">← Lobby</Link>
+        </p>
+      </div>
+    )
+  }
+
+  const title = catalogEp?.title ?? room.catalogEpisodeId
 
   return (
-    <div className="container">
-      <h1>Room</h1>
-      <p>
-        M2 scaffold — room id: <code>{roomId ?? '—'}</code>
+    <div className="container riffsync-room-page">
+      <h1>{title}</h1>
+      <p className="riffsync-room-page__meta">
+        You are <strong>{displayName}</strong> (<code>{sessionId.slice(0, 8)}…</code>){' '}
+        {isPublisher ? <span>— hosting</span> : <span>— guest</span>}
       </p>
-      <p>WebSocket, WebRTC, and YouTube embed land in later milestones.</p>
+      <p>
+        <PlaybackExpectationBadge expectation={roomPlaybackForBadge(room.playbackExpectation)} />
+      </p>
+
+      {!wsBase && (
+        <p role="status" className="riffsync-muted">
+          Set <code>VITE_PUBLIC_WS_URL</code> for chat and synchronized watch parties.
+        </p>
+      )}
+      {wsBase ? (
+        <p className="riffsync-muted" role="status">
+          Realtime: <code>{wsStatus}</code>
+        </p>
+      ) : null}
+
+      <p>
+        <button type="button" className="gen-button" onClick={() => void copyShare()}>
+          Copy room link
+        </button>
+        {shareHint ? <span className="riffsync-room-page__hint"> {shareHint}</span> : null}
+      </p>
+
+      {isPublisher ? (
+        <section className="riffsync-room-page__host" aria-label="Host controls">
+          <h2>Host</h2>
+          {patchErr ? <p role="alert">{patchErr}</p> : null}
+          <div className="riffsync-room-page__picker">
+            <label htmlFor="episode-picker">Episode</label>
+            <select
+              id="episode-picker"
+              value={room.catalogEpisodeId}
+              onChange={(e) => void onEpisodeChange(e.target.value)}
+              disabled={catalogList.length === 0}
+            >
+              {catalogList.map((e) => (
+                <option key={e.id} value={e.id}>
+                  #{e.experimentNumber} — {e.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <p>
+            <button type="button" className="gen-button" onClick={() => void startCapture()}>
+              Share this tab (video + audio)
+            </button>
+          </p>
+          {captureErr ? <p role="alert">{captureErr}</p> : null}
+          <p className="riffsync-muted">
+            Capture the browser tab showing the embedded player so guests receive one consistent picture—including any on-screen honor-system cues.
+          </p>
+          <div className="riffsync-room-page__embed">
+            <SoloYouTubePlayer key={room.youtubeVideoId} videoId={room.youtubeVideoId} titleHint={title} />
+          </div>
+        </section>
+      ) : (
+        <>
+          <p>
+            You are viewing the host&apos;s shared tab. If playback does not start automatically, tap Play (
+            autoplay/browser policies).
+          </p>
+          {guestPlayHint ? (
+            <p>
+              <button type="button" className="gen-button" onClick={() => void playGuestVideo()}>
+                Play video
+              </button>
+            </p>
+          ) : null}
+          <video
+            ref={videoRef}
+            className="riffsync-room-page__guest-video"
+            playsInline
+            controls
+            muted={false}
+          />
+          <p className="riffsync-muted">
+            {fanToken ? (
+              <>You are signed in, but only the party creator can administer this room.</>
+            ) : (
+              <>
+                Hosts sign in with Facebook via Cognito to create rooms.{' '}
+                <button
+                  type="button"
+                  className="gen-button"
+                  onClick={() =>
+                    void startFanHostedUiSignIn(`/room/${encodeURIComponent(roomId)}`).catch(console.error)
+                  }
+                >
+                  Sign in (optional)
+                </button>
+              </>
+            )}
+          </p>
+        </>
+      )}
+
+      <section className="riffsync-room-page__chat" aria-label="Chat">
+        <h2>Chat</h2>
+        <ul className="riffsync-room-chat-log">
+          {chat.map((m) => (
+            <li key={`${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`}>
+              <span className="riffsync-room-chat-log__who">{m.sessionId.slice(0, 6)}…</span>
+              {': '}
+              {m.text}
+            </li>
+          ))}
+        </ul>
+        <div className="riffsync-room-chat-compose">
+          <input
+            type="text"
+            maxLength={2000}
+            value={chatDraft}
+            placeholder="Say something…"
+            onChange={(e) => setChatDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') sendChat()
+            }}
+          />
+          <button type="button" className="gen-button" onClick={sendChat}>
+            Send
+          </button>
+        </div>
+      </section>
+
+      <p>
+        <Link to="/lobby">← Lobby</Link>
+      </p>
     </div>
   )
 }

--- a/apps/web/src/room/useRoomWebSocket.ts
+++ b/apps/web/src/room/useRoomWebSocket.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const PING_MS = 25_000
+
+export type WsStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
+
+export function useRoomWebSocket(options: {
+  url: string | undefined
+  roomId: string
+  sessionId: string
+  accessToken: string | null
+  enabled: boolean
+  onMessage: (data: Record<string, unknown>) => void
+}): {
+  status: WsStatus
+  sendJson: (payload: Record<string, unknown>) => void
+} {
+  const { url, roomId, sessionId, accessToken, enabled, onMessage } = options
+  const enabledRef = useRef(enabled)
+  const wsRef = useRef<WebSocket | null>(null)
+  const pingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const backoffRef = useRef(1000)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [status, setStatus] = useState<WsStatus>('idle')
+  const onMessageRef = useRef(onMessage)
+
+  useEffect(() => {
+    onMessageRef.current = onMessage
+  }, [onMessage])
+
+  useEffect(() => {
+    enabledRef.current = enabled
+  }, [enabled])
+
+  const clearPing = () => {
+    if (pingRef.current) {
+      clearInterval(pingRef.current)
+      pingRef.current = null
+    }
+  }
+
+  const clearReconnectTimer = () => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    if (!enabled || !url) {
+      clearPing()
+      clearReconnectTimer()
+      wsRef.current?.close()
+      wsRef.current = null
+      queueMicrotask(() => setStatus('idle'))
+      return
+    }
+
+    let cancelled = false
+
+    const openWs = (): void => {
+      if (cancelled || !enabledRef.current) return
+
+      clearPing()
+      clearReconnectTimer()
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+
+      queueMicrotask(() => setStatus('connecting'))
+
+      const qp = new URLSearchParams({ roomId, sessionId })
+      if (accessToken) {
+        qp.set('accessToken', accessToken)
+      }
+      const wsUrlBase = `${url}?${qp.toString()}`
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(wsUrlBase)
+      } catch {
+        queueMicrotask(() => setStatus('error'))
+        return
+      }
+      wsRef.current = ws
+
+      ws.addEventListener('open', () => {
+        if (cancelled) return
+        backoffRef.current = 1000
+        setStatus('open')
+        pingRef.current = setInterval(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ action: 'ping' }))
+          }
+        }, PING_MS)
+      })
+
+      ws.addEventListener('message', (ev) => {
+        try {
+          const data = JSON.parse(String(ev.data)) as Record<string, unknown>
+          onMessageRef.current(data)
+        } catch {
+          /* ignore malformed */
+        }
+      })
+
+      ws.addEventListener('close', () => {
+        clearPing()
+        wsRef.current = null
+        if (cancelled) return
+        queueMicrotask(() => setStatus('closed'))
+        if (!enabledRef.current) return
+        const delay = Math.min(backoffRef.current, 60_000)
+        backoffRef.current = Math.min(backoffRef.current * 2, 60_000)
+        reconnectTimerRef.current = window.setTimeout(() => {
+          reconnectTimerRef.current = null
+          openWs()
+        }, delay)
+      })
+
+      ws.addEventListener('error', () => {
+        if (!cancelled) queueMicrotask(() => setStatus('error'))
+      })
+    }
+
+    backoffRef.current = 1000
+    openWs()
+
+    return () => {
+      cancelled = true
+      clearPing()
+      clearReconnectTimer()
+      wsRef.current?.close()
+      wsRef.current = null
+    }
+  }, [accessToken, enabled, roomId, sessionId, url])
+
+  const sendJson = useCallback((payload: Record<string, unknown>) => {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload))
+    }
+  }, [])
+
+  return { status, sendJson }
+}

--- a/apps/web/src/session/guestSession.ts
+++ b/apps/web/src/session/guestSession.ts
@@ -1,0 +1,40 @@
+const STORAGE_SESSION = 'riffsync.sessionId'
+const STORAGE_DISPLAY = 'riffsync.displayName'
+
+const adjectives = ['Quick', 'Quiet', 'Brave', 'Bright', 'Calm', 'Cosmic', 'Clever', 'Daring']
+const nouns = ['MSTie', 'Crow', 'Tom', 'Joel', 'Gizmo', 'Riff', 'Party', 'Phantom']
+
+function randomName(): string {
+  const a = adjectives[Math.floor(Math.random() * adjectives.length)]
+  const n = nouns[Math.floor(Math.random() * nouns.length)]
+  const x = Math.floor(Math.random() * 900 + 100)
+  return `${a}${n}${x}`
+}
+
+function newSessionId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+/** Mint session + display name only when entering lobby or room — not catalog browse. */
+export function ensureGuestSession(reason: 'lobby' | 'room'): { sessionId: string; displayName: string } {
+  void reason
+  let sessionId = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_SESSION) : null
+  let displayName = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_DISPLAY) : null
+  if (!sessionId) {
+    sessionId = newSessionId()
+    localStorage.setItem(STORAGE_SESSION, sessionId)
+  }
+  if (!displayName?.trim()) {
+    displayName = randomName()
+    localStorage.setItem(STORAGE_DISPLAY, displayName)
+  }
+  return { sessionId, displayName: displayName.trim() }
+}
+
+export function headersWithSession(reason: 'lobby' | 'room' = 'lobby'): Record<string, string> {
+  const { sessionId } = ensureGuestSession(reason)
+  return { 'X-Session-Id': sessionId }
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -4,6 +4,17 @@ interface ImportMetaEnv {
   readonly VITE_PUBLIC_ORIGIN?: string
   /** HTTPS origin of the public HTTP API (e.g. `https://abc.execute-api.us-east-1.amazonaws.com`). */
   readonly VITE_PUBLIC_API_BASE_URL?: string
+  /** API Gateway WebSocket **`wss://…`** (`WebSocketUrl` CDK output; include stage path if present). */
+  readonly VITE_PUBLIC_WS_URL?: string
+  /** Cognito Hosted UI domain only (no `https://`; e.g. `your-domain.auth.region.amazoncognito.com`). */
+  readonly VITE_COGNITO_HOSTED_UI_DOMAIN?: string
+  /** Fan app client id (SPA / public client) for Hosted UI PKCE + token exchange. */
+  readonly VITE_COGNITO_CLIENT_ID?: string
+  /**
+   * Optional JSON array passed to **`RTCPeerConnection`** **`iceServers`** (STUN/TURN).
+   * Default: `[{ urls: 'stun:stun.l.google.com:19302' }]`.
+   */
+  readonly VITE_WEBRTC_ICE_SERVERS_JSON?: string
 }
 
 interface ImportMeta {

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -8,7 +8,7 @@ Fan clients connect to **`RiffSyncApi-{env}`** **`WebSocketUrl`** (**`wss://…`
 | --- | --- |
 | **Query** `roomId` | Target room (**must exist**). |
 | **Query** `sessionId` | Opaque anonymous session (**`authorization.md`**). |
-| **Header** `Authorization` | **`Bearer <Cognito access token>`** only when claiming **publisher** (**`JWT.sub`** must equal **`room.hostSub`**). |
+| **Header** `Authorization` OR **Query** `accessToken` | **`Bearer <Cognito access token>`** (**header**) or bare/minimal raw token (**query**) only when claiming **publisher** (**`JWT.sub`** must equal **`room.hostSub`**). Browsers normally **cannot** set WebSocket **`Authorization`**; the SPA MUST pass **`accessToken`** (**URL-encoded JWT**) — avoid logging query strings containing tokens. |
 
 Malformed or mismatched JWT → **`403`**; missing room/session → **`400`**.
 
@@ -20,7 +20,7 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 | --- | --- | --- |
 | **`ping`** | Heartbeat — bumps **`lastActivityAt`** (and **`lobbySk`** when room is **`public`**). | **Guest OK** once connected. |
 | **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars). |
-| **`signaling`** | WebRTC relay to peers. Body: **`envelope`** (opaque JSON). | **Publisher only** (**`$connect`** proved **`JWT.sub === room.hostSub`**). |
+| **`signaling`** | WebRTC relay to peers (`**envelope`** JSON). | **Host:** publisher **`JWT`** on **`$connect`**. **Guest:** only **`guestSignaling`** with **`kind`** **`ready`**, **`answer`**, or **`ice`** (see below). |
 
 ## Server → client fan-out (`PostToConnection`)
 
@@ -32,8 +32,32 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 
 ### Signaling
 
+Outbound fan-out payloads share a common envelope (**`Publishers`** and **`guest`** relay):
+
 ```json
-{ "type": "signaling", "roomId": "<id>", "envelope": {} }
+{
+  "type": "signaling",
+  "roomId": "<id>",
+  "fromSessionId": "<sender session opaque id>",
+  "role": "host" | "guest",
+  "envelope": {}
+}
 ```
 
-**`ts`** is server **`Date.now()`** (**epoch ms**). **`envelope`** is forwarded without validation (SDP / ICE blobs per SPA agreement).
+### Guest → relay (**`guestSignaling`**)
+
+Guests may **`POST`** messages on the **`signaling`** route only when **`envelope`** is **`{ guestSignaling: true, kind: … }`**:
+
+| **`kind`** | Purpose |
+| --- | --- |
+| **`ready`** | Guest announces WebRTC handshake readiness (prompts host to **`createOffer`** for that **`fromSessionId`**). |
+| **`answer`** | WebRTC SDP answer (`**sdp`** object: **`type`** + **`sdp`** string). |
+| **`ice`** | ICE candidate (**`candidate`** ICE payload). |
+
+**`offer`** and arbitrary publisher envelopes **must not** arrive on the guest path (**`403`** otherwise).
+
+Hosts send **`signaling`** without **`guestSignaling`** (publisher path). Typical host **`envelope`** fields: **`kind`**: **`offer`** | **`ice`**, **`sdp`** / **`candidate`**, **`targetSessionId`** (which guest applies the payload).
+
+SDP and ICE blobs are forwarded without semantic validation (**SPA-owned** contract).
+
+**`chat`** payloads are unchanged (**`Date.now()`** server timestamp).

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -1,0 +1,39 @@
+# WebSocket message contracts (M5)
+
+Fan clients connect to **`RiffSyncApi-{env}`** **`WebSocketUrl`** (**`wss://…`**).
+
+## `$connect`
+
+| Input | Requirement |
+| --- | --- |
+| **Query** `roomId` | Target room (**must exist**). |
+| **Query** `sessionId` | Opaque anonymous session (**`authorization.md`**). |
+| **Header** `Authorization` | **`Bearer <Cognito access token>`** only when claiming **publisher** (**`JWT.sub`** must equal **`room.hostSub`**). |
+
+Malformed or mismatched JWT → **`403`**; missing room/session → **`400`**.
+
+## Route selection (`$request.body.action`)
+
+Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `chat`, `signaling`). **`$default`** maps **`body.action`** when the route selector misses.
+
+| **`action`** | Purpose | Auth |
+| --- | --- | --- |
+| **`ping`** | Heartbeat — bumps **`lastActivityAt`** (and **`lobbySk`** when room is **`public`**). | **Guest OK** once connected. |
+| **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars). |
+| **`signaling`** | WebRTC relay to peers. Body: **`envelope`** (opaque JSON). | **Publisher only** (**`$connect`** proved **`JWT.sub === room.hostSub`**). |
+
+## Server → client fan-out (`PostToConnection`)
+
+### Chat
+
+```json
+{ "type": "chat", "roomId": "<id>", "sessionId": "<sender>", "text": "…", "ts": 0 }
+```
+
+### Signaling
+
+```json
+{ "type": "signaling", "roomId": "<id>", "envelope": {} }
+```
+
+**`ts`** is server **`Date.now()`** (**epoch ms**). **`envelope`** is forwarded without validation (SDP / ICE blobs per SPA agreement).

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -9,6 +9,7 @@ AWS CDK **v2** (TypeScript) for **hosted** environments only: **`staging`** and 
 | `bin/riffsync.ts` | App entry; validates `environment` context |
 | `lib/static-site-stack.ts` | Private **S3** origin + **CloudFront** with **origin access control (OAC)** |
 | `lib/api-catalog-stack.ts` | **DynamoDB Catalog** + **HTTP API** + read Lambdas + **TMDB reconcile** Lambda + **Secrets Manager** + **EventBridge** schedule |
+| `lib/fan-auth-stack.ts` | **Fan** Cognito **User Pool** + **Hosted UI** domain + **Facebook** IdP + SPA app client (**no** native password auth) |
 | `lambda/catalog-*.ts` | Catalog read handlers (**`Scan`** / **`GetItem`**) |
 | `lambda/tmdb-reconcile-*.ts` | Scheduled **`GET /configuration`**, **`/search/movie`**, **`/movie/{id}`** enrichment (**`docs/contracts.tmdb.md`**) |
 | `scripts/seed-catalog-from-json.ts` | Validates **`data/catalog/episodes.json`** against **`catalog.schema.json`**, **`BatchWriteItem`** into the deployed table |
@@ -52,6 +53,30 @@ JSON response shapes: **`docs/api.catalog.md`**.
 
 **Tests:** `npm test` (Vitest — catalog projections + TMDB reconcile core with mocked **`fetch`**).
 
+### Fan Cognito + Facebook Hosted UI (M5+)
+
+Hosted stacks **`RiffSyncFanAuth-staging`** / **`RiffSyncFanAuth-prod`** provision a **fan-only** pool suitable for **`POST /v1/rooms`** and room-admin JWTs per **`.forge/integration/authorization.md`** (stable **`sub`** for **`hostSub`**). **Staff** `/v1/admin/*` pool remains a **separate** future stack.
+
+| Decision | Choice |
+| --- | --- |
+| **Native email/password** | **Off** for MVP — **Hosted UI + Facebook** only (`authFlows.userPassword` / `userSrp` disabled). |
+| **Meta app secret** | **Secrets Manager** secret **`riffsync/<env>/facebook-app-secret`** (template **`REPLACE_WITH_META_APP_SECRET`**). **Never** put the app secret in the SPA. |
+| **Meta app ID** | **CDK context** **`facebookAppId`** (public). CI **`cdk synth`** omits it and uses a numeric **placeholder**; real deploys should pass **`--context facebookAppId=<meta-app-id>`** (or set in **`cdk.json`** / deploy env). |
+| **Callback / sign-out URLs** | **Prod:** **`https://riffsync.tv/`** and **`https://riffsync.tv/callback`**. **Staging:** those plus **`https://staging.riffsync.tv/*`**, **localhost** Vite ports, and optional extras via **`--context fanAuthOAuthExtras=https://d111111abcdef8.cloudfront.net/,https://d111111abcdef8.cloudfront.net/callback`**. |
+| **Hosted domain prefix** | Default **`riffsync-fan-staging`** / **`riffsync-fan-prod`** (must be **unique** in the Region). Override collision: **`--context fanAuthCognitoDomainPrefix=your-prefix`**. |
+
+**CloudFormation outputs:** **`FanUserPoolId`**, **`FanUserPoolClientId`**, **`FanHostedUiDomainPrefix`**, **`FanHostedUiBaseUrl`**, **`FanFacebookAppSecretSecretArn`**.
+
+**Meta developer app (manual):**
+
+1. Create a **Meta** app with **Facebook Login** and add **Cognito’s** redirect URI exactly: **`https://<FanHostedUiDomainPrefix>.auth.<region>.amazoncognito.com/oauth2/idpresponse`** (use **`FanHostedUiBaseUrl`** output + **`/oauth2/idpresponse`**).
+2. Set **Privacy Policy** and **Data deletion** URLs on the Meta app to your public policy pages (align with **`docs/architecture.frontend.md`** / product legal). Complete Meta **Data Use Checkup** when required.
+3. Put the live **app secret** in Secrets Manager at **`FanFacebookAppSecretSecretArn`** **before** expecting federated sign-in to succeed (replace the template placeholder).
+
+**Smoke (staging):** open **`FanHostedUiBaseUrl`** in the console flow or build the **`/oauth2/authorize`** link (response_type **`code`**, client_id **`FanUserPoolClientId`**, redirect_uri **must** match an allowlisted SPA URL, scope **`openid email profile`**, identity_provider **`Facebook`**). After sign-in, inspect **`id_token`** / **`access_token`** (`sub` is the host id). **Do not** commit tokens.
+
+**Deploy IAM:** the OIDC deploy role needs **Cognito** create/update permissions for this stack (extend the role if **`cdk deploy`** fails on **`cognito-idp:*`**).
+
 ## Prerequisites
 
 - **Node.js** LTS (**≥ 20**) on your machine for **`npm`/`cdk`**; synthesized **Lambda** runtimes are **Node.js 24** (matches **`cfn-lint`** / AWS deprecation policy).
@@ -88,6 +113,7 @@ Full server IAM (Lambda, API Gateway, EventBridge, DynamoDB, Cognito, Secrets Ma
 - **`RiffSyncStatic-*` —** **S3 bucket policy** statements: deny insecure transport; allow **`s3:GetObject`** for **CloudFront** via OAC (**resource-based**, not a standalone IAM role).
 - **`RiffSyncStatic-*` —** **CloudFront** service-managed roles for the distribution (implicit in **`AWS::CloudFront::Distribution`**).
 - **`RiffSyncApi-*` —** **HTTP API** + **DynamoDB** read (**catalog list/get**); **DynamoDB** read/write + **Secrets Manager** + **EventBridge** for **TMDB reconcile**; **`cloudwatch:PutMetricData`** not required when using **EMF** in **`stdout`** ( **`infra/cdk/README.md`** TMDB §).
+- **`RiffSyncFanAuth-*` —** **Cognito User Pool** + **UserPoolDomain** + **Facebook** `UserPoolIdentityProvider` + **UserPoolClient** (OAuth) + **Secrets Manager** secret for Meta app secret.
 
 Older milestone copy: **M1** alone only created the static stack.
 

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -8,9 +8,12 @@ AWS CDK **v2** (TypeScript) for **hosted** environments only: **`staging`** and 
 | --- | --- |
 | `bin/riffsync.ts` | App entry; validates `environment` context |
 | `lib/static-site-stack.ts` | Private **S3** origin + **CloudFront** with **origin access control (OAC)** |
-| `lib/api-catalog-stack.ts` | **DynamoDB Catalog** + **HTTP API** + read Lambdas + **TMDB reconcile** Lambda + **Secrets Manager** + **EventBridge** schedule |
+| `lib/api-catalog-stack.ts` | **Catalog** + **Rooms** + **Connections** Dynamo tables, **HTTP API** (catalog, rooms, lobby), **JWT** (**fan pool**), **WebSocket API** (ping/chat/signaling), **TMDB reconcile** + schedules |
 | `lib/fan-auth-stack.ts` | **Fan** Cognito **User Pool** + **Hosted UI** domain + **Facebook** IdP + SPA app client (**no** native password auth) |
 | `lambda/catalog-*.ts` | Catalog read handlers (**`Scan`** / **`GetItem`**) |
+| `lambda/room-*.ts` | **`POST/PATCH`** room + **`GET`** lobby/read (**`authorization.md`**) |
+| `lambda/ws-*.ts` | WebSocket **`$connect`** / **`$disconnect`** / message routes |
+| `lambda/room-shared.ts` | Shared parsing + **`STALE_ROOM_MS`** (**lobby staleness**) |
 | `lambda/tmdb-reconcile-*.ts` | Scheduled **`GET /configuration`**, **`/search/movie`**, **`/movie/{id}`** enrichment (**`docs/contracts.tmdb.md`**) |
 | `scripts/seed-catalog-from-json.ts` | Validates **`data/catalog/episodes.json`** against **`catalog.schema.json`**, **`BatchWriteItem`** into the deployed table |
 
@@ -51,7 +54,31 @@ npm run seed:catalog -- "$TABLE_NAME"
 
 JSON response shapes: **`docs/api.catalog.md`**.
 
-**Tests:** `npm test` (Vitest — catalog projections + TMDB reconcile core with mocked **`fetch`**).
+**Tests:** `npm test` (Vitest — catalog + **room parsers** + TMDB reconcile core with mocked **`fetch`**).
+
+### Rooms, lobby & WebSocket (M5+)
+
+Deployed with **`RiffSyncApi-{staging|prod}`** (same CloudFormation stack as catalog). Depends on **`RiffSyncFanAuth-*`** (**`bin/riffsync.ts`** synthesizes Fan stack **before** API so JWT issuer + client IDs exist).
+
+**DynamoDB**
+
+| Logical | PK | GSI |
+| --- | --- | --- |
+| **Rooms** | **`roomId`** | **`PublicLobbyIndex`**: **`lobbyPk=PUBLIC`**, **`lobbySk`** (sortable activity key) |
+| **Connections** | **`connectionId`** (**API Gateway**) | **`RoomConnectionsIndex`**: **`roomId`**, **`connectionId`** (fan-out queries) |
+
+**HTTP** (JWT = **fan pool access token**, audience = **`FanUserPoolClientId`**)
+
+| Route | Auth | Behavior |
+| --- | --- | --- |
+| **`POST /v1/rooms`** | **JWT required** (`401` gateway) | Looks up **`catalogEpisodeId`** in **Catalog**, writes **`youtubeVideoId`**, binds **`hostSub = JWT.sub`** |
+| **`GET /v1/rooms/{roomId}`** | Anonymous | Reads room snapshot (**client merges catalog** if needed). |
+| **`PATCH /v1/rooms/{roomId}`** | JWT | **`403`** unless **`JWT.sub === room.hostSub`**; optimistic **`version`** check (`409`). |
+| **`GET /v1/lobby`** | Anonymous (`X-Session-Id` ignored here—reserved for quotas later) | **Query** **`PublicLobbyIndex`** + **`FilterExpression`** hides stale rows (**`lastActivityAt ≤ now − STALE_ROOM_MS`**). Default **`STALE_ROOM_MS`** = **`45 × 60 × 1000`**; synth/deploy **`--context staleRoomMs=…`** or Lambda env **`STALE_ROOM_MS`**. Hydrates **`catalog`** preview via **`BatchGetItem`**. Outputs **`staleRoomMsHint`**, **`cutoffActivityAfter`**. |
+
+**WebSocket**: outputs **`WebSocketUrl`** (**`wss://…/{staging|prod}`**). Contracts: **`../../docs/contracts.websocket.md`**. **`execute-api:ManageConnections`** attaches only to this stack’s WebSocket API (**`…/*/*/@connections/*`**, parameterized by **`WebSocketApiId`**), not arbitrary `*` resources.
+
+**Housekeeping:** lobby staleness uses **read-time filtering** (**US-P0-08**) — optional EventBridge TTL/sweeper deferred.
 
 ### Fan Cognito + Facebook Hosted UI (M5+)
 
@@ -112,7 +139,7 @@ Full server IAM (Lambda, API Gateway, EventBridge, DynamoDB, Cognito, Secrets Ma
 
 - **`RiffSyncStatic-*` —** **S3 bucket policy** statements: deny insecure transport; allow **`s3:GetObject`** for **CloudFront** via OAC (**resource-based**, not a standalone IAM role).
 - **`RiffSyncStatic-*` —** **CloudFront** service-managed roles for the distribution (implicit in **`AWS::CloudFront::Distribution`**).
-- **`RiffSyncApi-*` —** **HTTP API** + **DynamoDB** read (**catalog list/get**); **DynamoDB** read/write + **Secrets Manager** + **EventBridge** for **TMDB reconcile**; **`cloudwatch:PutMetricData`** not required when using **EMF** in **`stdout`** ( **`infra/cdk/README.md`** TMDB §).
+- **`RiffSyncApi-*` —** **HTTP API** (**catalog**, **rooms**, **lobby**) + **WebSocket API**; **JWT** (**HTTP** + **`aws-jwt-verify`** on **`$connect`**); DynamoDB (**catalog**, **rooms**, **connections**); **`execute-api:ManageConnections`** on **this stack’s WebSocket API** only; **TMDB** reconcile (**Secrets Manager**, **EventBridge**); **`cloudwatch:PutMetricData`** optional when emitting **EMF** in **`stdout`**.
 - **`RiffSyncFanAuth-*` —** **Cognito User Pool** + **UserPoolDomain** + **Facebook** `UserPoolIdentityProvider` + **UserPoolClient** (OAuth) + **Secrets Manager** secret for Meta app secret.
 
 Older milestone copy: **M1** alone only created the static stack.
@@ -147,7 +174,8 @@ After **`cdk deploy`**, the deploy workflows read **CloudFormation outputs** fro
 | **`BucketName`** | `aws s3 sync apps/web/dist/ s3://$Bucket/` (**`--delete`** keeps the bucket aligned with the latest build) |
 | **`DistributionId`** | `aws cloudfront create-invalidation --paths "/*"` |
 | **`DistributionDomainName`** | **Staging** build-time **`VITE_PUBLIC_ORIGIN`** (`https://<distribution>`) so client-side absolute URLs match the live host. **Production** uses **`https://riffsync.tv`** until a follow-up wires **ACM** + **DNS** at the distribution (then keep **`VITE_PUBLIC_ORIGIN`** aligned with the public hostname operators configure). |
-| **`HttpApiUrl`** ( **`RiffSyncApi-staging` / `RiffSyncApi-prod`** ) | **`VITE_PUBLIC_API_BASE_URL`** for the fan SPA — catalog **`fetch`** targets **`GET /v1/catalog`** (deploy workflows read this output after **`cdk deploy`**). |
+| **`HttpApiUrl`** ( **`RiffSyncApi-*`** ) | **`VITE_PUBLIC_API_BASE_URL`** — catalog + rooms REST |
+| **`WebSocketUrl`** ( **`RiffSyncApi-*`** ) | Build-time **`VITE_PUBLIC_WS_URL`** (**`wss://…`**) once SPA subscribes to realtime (**`contracts.websocket`**). |
 
 **IAM for the GitHub OIDC deploy role** must allow, in addition to CDK/CloudFormation permissions:
 

--- a/infra/cdk/bin/riffsync.ts
+++ b/infra/cdk/bin/riffsync.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { ApiCatalogStack } from '../lib/api-catalog-stack';
+import { FanAuthStack } from '../lib/fan-auth-stack';
 import { StaticSiteStack } from '../lib/static-site-stack';
 
 const app = new cdk.App();
@@ -24,6 +25,15 @@ new ApiCatalogStack(app, `RiffSyncApi-${environment}`, {
 
 new StaticSiteStack(app, `RiffSyncStatic-${environment}`, {
   description: `RiffSync static SPA hosting (${environment}) — S3 (private) + CloudFront OAC`,
+  environment,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+
+new FanAuthStack(app, `RiffSyncFanAuth-${environment}`, {
+  description: `RiffSync fan Cognito (${environment}) — Hosted UI + Facebook IdP (host JWT)`,
   environment,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/infra/cdk/bin/riffsync.ts
+++ b/infra/cdk/bin/riffsync.ts
@@ -14,9 +14,20 @@ if (typeof raw !== 'string' || (raw !== 'staging' && raw !== 'prod')) {
 }
 const environment = raw as 'staging' | 'prod';
 
-new ApiCatalogStack(app, `RiffSyncApi-${environment}`, {
-  description: `RiffSync HTTP API + Catalog (${environment}) — DynamoDB + Lambda`,
+const fanAuth = new FanAuthStack(app, `RiffSyncFanAuth-${environment}`, {
+  description: `RiffSync fan Cognito (${environment}) — Hosted UI + Facebook IdP (host JWT)`,
   environment,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+
+new ApiCatalogStack(app, `RiffSyncApi-${environment}`, {
+  description: `RiffSync HTTP API + Catalog + Rooms + WebSocket (${environment}) — DynamoDB + Lambda`,
+  environment,
+  fanUserPool: fanAuth.fanUserPool,
+  fanUserPoolClient: fanAuth.fanUserPoolClient,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,
@@ -25,15 +36,6 @@ new ApiCatalogStack(app, `RiffSyncApi-${environment}`, {
 
 new StaticSiteStack(app, `RiffSyncStatic-${environment}`, {
   description: `RiffSync static SPA hosting (${environment}) — S3 (private) + CloudFront OAC`,
-  environment,
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
-});
-
-new FanAuthStack(app, `RiffSyncFanAuth-${environment}`, {
-  description: `RiffSync fan Cognito (${environment}) — Hosted UI + Facebook IdP (host JWT)`,
   environment,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/infra/cdk/lambda/cognito-jwt.ts
+++ b/infra/cdk/lambda/cognito-jwt.ts
@@ -1,0 +1,34 @@
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+
+let verifier: ReturnType<typeof CognitoJwtVerifier.create> | undefined;
+
+export function getAccessTokenVerifier(): ReturnType<typeof CognitoJwtVerifier.create> {
+  if (verifier) return verifier;
+  const userPoolId = process.env.COGNITO_USER_POOL_ID;
+  const clientId = process.env.COGNITO_CLIENT_ID;
+  if (!userPoolId || !clientId) {
+    throw new Error('Missing COGNITO_USER_POOL_ID or COGNITO_CLIENT_ID');
+  }
+  verifier = CognitoJwtVerifier.create({
+    userPoolId,
+    tokenUse: 'access',
+    clientId,
+  });
+  return verifier;
+}
+
+export async function verifyAccessToken(bearerHeader: string | undefined): Promise<{
+  sub: string;
+} | null> {
+  if (!bearerHeader?.toLowerCase().startsWith('bearer ')) return null;
+  const token = bearerHeader.slice(7).trim();
+  if (!token) return null;
+  try {
+    const payload = await getAccessTokenVerifier().verify(token);
+    const sub = payload.sub;
+    if (typeof sub !== 'string' || sub === '') return null;
+    return { sub };
+  } catch {
+    return null;
+  }
+}

--- a/infra/cdk/lambda/lobby-get.ts
+++ b/infra/cdk/lambda/lobby-get.ts
@@ -1,0 +1,106 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  BatchGetCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { defaultStaleRoomMs, LOBBY_PARTITION } from './room-shared';
+import { projectEpisode } from './catalog-shared';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+const LOBBY_PAGE = 75;
+
+export const handler: APIGatewayProxyHandlerV2 = async (_event) => {
+  const roomsTable = process.env.ROOMS_TABLE_NAME;
+  const catalogTable = process.env.CATALOG_TABLE_NAME;
+  if (!roomsTable || !catalogTable) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing table env' }) };
+  }
+
+  const staleMs = defaultStaleRoomMs();
+  const cutoff = Date.now() - staleMs;
+
+  const q = await client.send(
+    new QueryCommand({
+      TableName: roomsTable,
+      IndexName: 'PublicLobbyIndex',
+      KeyConditionExpression: 'lobbyPk = :pk',
+      ExpressionAttributeValues: {
+        ':pk': LOBBY_PARTITION,
+        ':cutoff': cutoff,
+      },
+      FilterExpression: 'lastActivityAt > :cutoff',
+      ScanIndexForward: false,
+      Limit: LOBBY_PAGE,
+    }),
+  );
+
+  const rows = (q.Items ?? []) as Record<string, unknown>[];
+  const episodeIdSet = new Set<string>();
+  for (const r of rows) {
+    const id = r.catalogEpisodeId;
+    if (typeof id === 'string' && id !== '') episodeIdSet.add(id);
+  }
+  const episodeIds = [...episodeIdSet];
+  const catMap = new Map<string, Record<string, unknown>>();
+  let remaining = [...episodeIds];
+  while (remaining.length) {
+    const batch = remaining.slice(0, 100);
+    remaining = remaining.slice(100);
+    const bg = await client.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [catalogTable]: { Keys: batch.map((id) => ({ id })) },
+        },
+      }),
+    );
+    for (const it of bg.Responses?.[catalogTable] ?? []) {
+      const raw = it as Record<string, unknown>;
+      const id = raw.id;
+      if (typeof id === 'string') catMap.set(id, raw);
+    }
+  }
+
+  const roomsOut = [];
+  for (const r of rows) {
+    const catalogEpisodeId = String(r.catalogEpisodeId ?? '');
+    const catRow = catMap.get(catalogEpisodeId);
+    let projection: Record<string, unknown> | null = null;
+    if (catRow) {
+      try {
+        const ep = projectEpisode(catRow as Record<string, unknown>);
+        projection = {
+          id: ep.id,
+          experimentNumber: ep.experimentNumber,
+          title: ep.title,
+          era: ep.era,
+          posterImageUrl: ep.posterImageUrl,
+          youtubeVideoId: ep.youtubeVideoId,
+        };
+      } catch {
+        projection = null;
+      }
+    }
+    roomsOut.push({
+      roomId: r.roomId,
+      playbackExpectation: r.playbackExpectation,
+      lastActivityAt: r.lastActivityAt,
+      catalogEpisodeId,
+      youtubeVideoId: r.youtubeVideoId,
+      ...(projection !== null ? { catalog: projection } : {}),
+    });
+  }
+
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      version: 1,
+      staleRoomMsHint: staleMs,
+      cutoffActivityAfter: cutoff,
+      rooms: roomsOut,
+    }),
+  };
+};

--- a/infra/cdk/lambda/room-create.ts
+++ b/infra/cdk/lambda/room-create.ts
@@ -1,0 +1,129 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  lobbySortKey,
+  LOBBY_PARTITION,
+  parsePlaybackExpectation,
+  parseVisibility,
+} from './room-shared';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+interface JwtClaims {
+  sub?: string;
+}
+
+function getJwtSub(event: Parameters<APIGatewayProxyHandlerV2>[0]): string | undefined {
+  const claims = (
+    event.requestContext as unknown as {
+      authorizer?: { jwt?: { claims?: JwtClaims } };
+    }
+  ).authorizer?.jwt?.claims;
+  return typeof claims?.sub === 'string' ? claims.sub : undefined;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const roomsTable = process.env.ROOMS_TABLE_NAME;
+  const catalogTable = process.env.CATALOG_TABLE_NAME;
+  if (!roomsTable || !catalogTable) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing table env' }) };
+  }
+
+  const hostSub = getJwtSub(event);
+  if (!hostSub) {
+    return {
+      statusCode: 401,
+      body: JSON.stringify({ error: 'Unauthorized — host JWT missing or invalid' }),
+    };
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(event.body ?? '{}') as Record<string, unknown>;
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON body' }) };
+  }
+
+  const catalogEpisodeId = typeof body.catalogEpisodeId === 'string' ? body.catalogEpisodeId : '';
+  if (!catalogEpisodeId) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'catalogEpisodeId is required (string)' }),
+    };
+  }
+
+  const playbackExpectation = parsePlaybackExpectation(body.playbackExpectation);
+  if (!playbackExpectation) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'playbackExpectation must be "free" or "premium"' }),
+    };
+  }
+
+  const visibility = parseVisibility(body.visibility) ?? 'public';
+
+  const cat = await client.send(
+    new GetCommand({
+      TableName: catalogTable,
+      Key: { id: catalogEpisodeId },
+    }),
+  );
+  const row = cat.Item as Record<string, unknown> | undefined;
+  if (!row || typeof row.youtubeVideoId !== 'string' || row.youtubeVideoId === '') {
+    return {
+      statusCode: 404,
+      body: JSON.stringify({ error: `Unknown catalog episode: ${catalogEpisodeId}` }),
+    };
+  }
+
+  const youtubeVideoId = row.youtubeVideoId as string;
+
+  const now = Date.now();
+  const roomId = crypto.randomUUID();
+  const version = 1;
+
+  const item: Record<string, unknown> = {
+    roomId,
+    hostSub,
+    catalogEpisodeId,
+    youtubeVideoId,
+    playbackExpectation,
+    visibility,
+    lastActivityAt: now,
+    version,
+    createdAt: now,
+  };
+
+  if (visibility === 'public') {
+    item.lobbyPk = LOBBY_PARTITION;
+    item.lobbySk = lobbySortKey(now, roomId);
+  }
+
+  await client.send(
+    new PutCommand({
+      TableName: roomsTable,
+      Item: item,
+      ConditionExpression: 'attribute_not_exists(roomId)',
+    }),
+  );
+
+  return {
+    statusCode: 201,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      roomId,
+      hostSub,
+      catalogEpisodeId,
+      youtubeVideoId,
+      playbackExpectation,
+      visibility,
+      lastActivityAt: now,
+      version,
+    }),
+  };
+};

--- a/infra/cdk/lambda/room-get.ts
+++ b/infra/cdk/lambda/room-get.ts
@@ -1,0 +1,46 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const tableName = process.env.ROOMS_TABLE_NAME;
+  if (!tableName) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing ROOMS_TABLE_NAME' }) };
+  }
+
+  const roomId = event.pathParameters?.roomId;
+  if (!roomId) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Missing roomId' }) };
+  }
+
+  const out = await client.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { roomId },
+    }),
+  );
+
+  if (!out.Item) {
+    return { statusCode: 404, body: JSON.stringify({ error: 'Room not found' }) };
+  }
+
+  const row = out.Item as Record<string, unknown>;
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      room: {
+        roomId: row.roomId,
+        hostSub: row.hostSub,
+        catalogEpisodeId: row.catalogEpisodeId,
+        youtubeVideoId: row.youtubeVideoId,
+        playbackExpectation: row.playbackExpectation,
+        visibility: row.visibility,
+        lastActivityAt: row.lastActivityAt,
+        version: row.version,
+      },
+    }),
+  };
+};

--- a/infra/cdk/lambda/room-patch.ts
+++ b/infra/cdk/lambda/room-patch.ts
@@ -1,0 +1,224 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { lobbySortKey, LOBBY_PARTITION, parsePlaybackExpectation, parseVisibility } from './room-shared';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+interface JwtClaims {
+  sub?: string;
+}
+
+function getJwtSub(event: Parameters<APIGatewayProxyHandlerV2>[0]): string | undefined {
+  const claims = (
+    event.requestContext as unknown as {
+      authorizer?: { jwt?: { claims?: JwtClaims } };
+    }
+  ).authorizer?.jwt?.claims;
+  return typeof claims?.sub === 'string' ? claims.sub : undefined;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const roomsTable = process.env.ROOMS_TABLE_NAME;
+  const catalogTable = process.env.CATALOG_TABLE_NAME;
+  if (!roomsTable || !catalogTable) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing table env' }) };
+  }
+
+  const jwtSub = getJwtSub(event);
+  if (!jwtSub) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  const roomId = event.pathParameters?.roomId;
+  if (!roomId) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Missing roomId' }) };
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(event.body ?? '{}') as Record<string, unknown>;
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON body' }) };
+  }
+
+  const existing = await client.send(
+    new GetCommand({
+      TableName: roomsTable,
+      Key: { roomId },
+    }),
+  );
+
+  const room = existing.Item as Record<string, unknown> | undefined;
+  if (!room || typeof room.hostSub !== 'string') {
+    return { statusCode: 404, body: JSON.stringify({ error: 'Room not found' }) };
+  }
+
+  if (room.hostSub !== jwtSub) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden — not room host' }) };
+  }
+
+  const version = typeof room.version === 'number' ? room.version : 1;
+  let visibility: 'public' | 'private' = parseVisibility(room.visibility) ?? 'private';
+
+  if (typeof body.visibility === 'string') {
+    const v = parseVisibility(body.visibility);
+    if (!v) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'visibility must be "public" or "private"' }),
+      };
+    }
+    visibility = v;
+  }
+
+  let catalogEpisodeId = String(room.catalogEpisodeId ?? '');
+  let youtubeVideoId = String(room.youtubeVideoId ?? '');
+  if (typeof body.catalogEpisodeId === 'string' && body.catalogEpisodeId !== catalogEpisodeId) {
+    catalogEpisodeId = body.catalogEpisodeId;
+    const cat = await client.send(
+      new GetCommand({
+        TableName: catalogTable,
+        Key: { id: catalogEpisodeId },
+      }),
+    );
+    const row = cat.Item as Record<string, unknown> | undefined;
+    if (
+      !row ||
+      typeof row.youtubeVideoId !== 'string' ||
+      (row.youtubeVideoId as string) === ''
+    ) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({ error: `Unknown catalog episode: ${catalogEpisodeId}` }),
+      };
+    }
+    youtubeVideoId = row.youtubeVideoId as string;
+  }
+
+  let playbackExpectationPatch: ReturnType<typeof parsePlaybackExpectation> | undefined;
+  if (typeof body.playbackExpectation === 'string') {
+    const pe = parsePlaybackExpectation(body.playbackExpectation);
+    if (!pe) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'playbackExpectation must be "free" or "premium"' }),
+      };
+    }
+    playbackExpectationPatch = pe;
+  }
+
+  let broadcastCapturePatch: boolean | null | undefined;
+  if (Object.prototype.hasOwnProperty.call(body, 'broadcastCaptureActive')) {
+    if (body.broadcastCaptureActive === null) {
+      broadcastCapturePatch = null;
+    } else if (typeof body.broadcastCaptureActive === 'boolean') {
+      broadcastCapturePatch = body.broadcastCaptureActive;
+    } else {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'broadcastCaptureActive must be boolean or null' }),
+      };
+    }
+  }
+
+  const now = Math.max(
+    Date.now(),
+    typeof room.lastActivityAt === 'number' ? room.lastActivityAt : 0,
+  );
+
+  const names: Record<string, string> = {
+    '#host': 'hostSub',
+    '#vat': 'lastActivityAt',
+    '#ver': 'version',
+    '#ceid': 'catalogEpisodeId',
+    '#yt': 'youtubeVideoId',
+    '#visibility': 'visibility',
+    '#lpk': 'lobbyPk',
+    '#lsk': 'lobbySk',
+  };
+
+  const values: Record<string, unknown> = {
+    ':jwt': jwtSub,
+    ':vcur': version,
+    ':vat': now,
+    ':vnext': version + 1,
+    ':visibility': visibility,
+    ':ceid': catalogEpisodeId,
+    ':yt': youtubeVideoId,
+  };
+
+  const setParts = [
+    '#ceid = :ceid',
+    '#yt = :yt',
+    '#visibility = :visibility',
+    '#vat = :vat',
+    '#ver = :vnext',
+  ];
+
+  if (playbackExpectationPatch !== undefined) {
+    names['#pe'] = 'playbackExpectation';
+    values[':pe'] = playbackExpectationPatch;
+    setParts.push('#pe = :pe');
+  }
+
+  if (broadcastCapturePatch !== undefined) {
+    names['#bc'] = 'broadcastCaptureActive';
+    values[':bc'] = broadcastCapturePatch;
+    setParts.push('#bc = :bc');
+  }
+
+  let updateExpression: string;
+
+  if (visibility === 'public') {
+    values[':lobbyPk'] = LOBBY_PARTITION;
+    values[':lobbySk'] = lobbySortKey(now, roomId);
+    setParts.push('#lpk = :lobbyPk', '#lsk = :lobbySk');
+    updateExpression = `SET ${setParts.join(', ')}`;
+  } else {
+    updateExpression = `SET ${setParts.join(', ')} REMOVE #lpk, #lsk`;
+  }
+
+  try {
+    await client.send(
+      new UpdateCommand({
+        TableName: roomsTable,
+        Key: { roomId },
+        UpdateExpression: updateExpression,
+        ExpressionAttributeNames: names,
+        ExpressionAttributeValues: values,
+        ConditionExpression: '#host = :jwt AND #ver = :vcur',
+      }),
+    );
+  } catch (err: unknown) {
+    const name =
+      typeof err === 'object' && err !== null && 'name' in err
+        ? String((err as { name: unknown }).name)
+        : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return {
+        statusCode: 409,
+        body: JSON.stringify({ error: 'Conflict — stale version', version }),
+      };
+    }
+    throw err;
+  }
+
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({
+      ok: true,
+      roomId,
+      version: version + 1,
+      catalogEpisodeId,
+      youtubeVideoId,
+      visibility,
+      lastActivityAt: now,
+    }),
+  };
+};

--- a/infra/cdk/lambda/room-shared.test.ts
+++ b/infra/cdk/lambda/room-shared.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  defaultStaleRoomMs,
+  lobbySortKey,
+  LOBBY_PARTITION,
+  parsePlaybackExpectation,
+  parseVisibility,
+} from './room-shared';
+
+describe('room-shared', () => {
+  describe('parsePlaybackExpectation', () => {
+    it('accepts valid values', () => {
+      expect(parsePlaybackExpectation('free')).toBe('free');
+      expect(parsePlaybackExpectation('premium')).toBe('premium');
+    });
+    it('rejects junk', () => {
+      expect(parsePlaybackExpectation('ad_supported')).toBeNull();
+      expect(parsePlaybackExpectation(null)).toBeNull();
+    });
+  });
+
+  describe('parseVisibility', () => {
+    it('accepts public/private', () => {
+      expect(parseVisibility('public')).toBe('public');
+      expect(parseVisibility('private')).toBe('private');
+    });
+  });
+
+  describe('lobbySortKey', () => {
+    it('ties break with roomId', () => {
+      expect(lobbySortKey(1, 'a')).not.toBe(lobbySortKey(1, 'b'));
+      expect(lobbySortKey(1, 'a')).toContain('a');
+    });
+  });
+
+  describe('defaultStaleRoomMs', () => {
+    const prev = process.env.STALE_ROOM_MS;
+
+    afterEach(() => {
+      if (prev === undefined) delete process.env.STALE_ROOM_MS;
+      else process.env.STALE_ROOM_MS = prev;
+    });
+
+    beforeEach(() => {
+      delete process.env.STALE_ROOM_MS;
+    });
+
+    it('defaults to 45 minutes', () => {
+      expect(defaultStaleRoomMs()).toBe(45 * 60 * 1000);
+    });
+
+    it('reads env', () => {
+      process.env.STALE_ROOM_MS = '60000';
+      expect(defaultStaleRoomMs()).toBe(60000);
+    });
+  });
+});
+
+describe('LOBBY_PARTITION', () => {
+  it('constant', () => {
+    expect(LOBBY_PARTITION).toBe('PUBLIC');
+  });
+});

--- a/infra/cdk/lambda/room-shared.ts
+++ b/infra/cdk/lambda/room-shared.ts
@@ -1,0 +1,27 @@
+/** Server-side room document (Dynamo single-table). */
+
+export type RoomVisibility = 'public' | 'private';
+export type PlaybackExpectation = 'free' | 'premium';
+
+export const LOBBY_PARTITION = 'PUBLIC';
+
+export function lobbySortKey(lastActivityAt: number, roomId: string): string {
+  return `${String(lastActivityAt).padStart(20, '0')}#${roomId}`;
+}
+
+export function parsePlaybackExpectation(v: unknown): PlaybackExpectation | null {
+  if (v === 'free' || v === 'premium') return v;
+  return null;
+}
+
+export function parseVisibility(v: unknown): RoomVisibility | null {
+  if (v === 'public' || v === 'private') return v;
+  return null;
+}
+
+export function defaultStaleRoomMs(): number {
+  const raw = process.env.STALE_ROOM_MS;
+  if (raw === undefined || raw === '') return 45 * 60 * 1000;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 45 * 60 * 1000;
+}

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -30,7 +30,16 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
     return { statusCode: 404, body: 'Room not found' };
   }
 
-  const authHdr = event.headers?.Authorization ?? event.headers?.authorization;
+  /** Browsers cannot set `Authorization` on WebSocket handshakes; accept raw JWT query as fallback (see `docs/contracts.websocket.md`). */
+  const qpToken = event.queryStringParameters?.accessToken;
+  const headerAuth = event.headers?.Authorization ?? event.headers?.authorization;
+  const authHdr =
+    typeof qpToken === 'string' && qpToken.trim().length > 0
+      ? qpToken.startsWith('Bearer ')
+        ? qpToken
+        : `Bearer ${qpToken.trim()}`
+      : headerAuth;
+
   const jwtUser = await verifyAccessToken(authHdr);
   let hostSub: string | undefined;
   if (jwtUser) {

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -1,0 +1,61 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { verifyAccessToken } from './cognito-jwt';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
+  const roomsTable = process.env.ROOMS_TABLE_NAME;
+  const connTable = process.env.CONNECTIONS_TABLE_NAME;
+  if (!roomsTable || !connTable) {
+    return { statusCode: 500, body: 'Missing table env' };
+  }
+
+  const connectionId = event.requestContext.connectionId;
+  const roomId = event.queryStringParameters?.roomId;
+  const sessionId = event.queryStringParameters?.sessionId;
+  if (!roomId || !sessionId || roomId.trim() === '' || sessionId.trim() === '') {
+    return { statusCode: 400, body: 'Missing roomId or sessionId query parameter' };
+  }
+
+  const roomOut = await client.send(
+    new GetCommand({
+      TableName: roomsTable,
+      Key: { roomId },
+    }),
+  );
+  const room = roomOut.Item as Record<string, unknown> | undefined;
+  if (!room || typeof room.hostSub !== 'string') {
+    return { statusCode: 404, body: 'Room not found' };
+  }
+
+  const authHdr = event.headers?.Authorization ?? event.headers?.authorization;
+  const jwtUser = await verifyAccessToken(authHdr);
+  let hostSub: string | undefined;
+  if (jwtUser) {
+    if (jwtUser.sub !== room.hostSub) {
+      return { statusCode: 403, body: 'JWT.sub does not match room hostSub' };
+    }
+    hostSub = jwtUser.sub;
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const ttl = nowSec + 7 * 24 * 3600;
+
+  await client.send(
+    new PutCommand({
+      TableName: connTable,
+      Item: {
+        connectionId,
+        roomId,
+        sessionId,
+        ...(hostSub ? { hostSub } : {}),
+        connectedAt: nowSec,
+        expiresAt: ttl,
+      },
+    }),
+  );
+
+  return { statusCode: 200, body: 'Connected' };
+};

--- a/infra/cdk/lambda/ws-disconnect.ts
+++ b/infra/cdk/lambda/ws-disconnect.ts
@@ -1,0 +1,22 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
+  const connTable = process.env.CONNECTIONS_TABLE_NAME;
+  if (!connTable) {
+    return { statusCode: 500, body: 'Missing CONNECTIONS_TABLE_NAME' };
+  }
+
+  const connectionId = event.requestContext.connectionId;
+  await client.send(
+    new DeleteCommand({
+      TableName: connTable,
+      Key: { connectionId },
+    }),
+  );
+
+  return { statusCode: 200, body: 'Disconnected' };
+};

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -1,0 +1,132 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { TextEncoder } from 'node:util';
+import { lobbySortKey, LOBBY_PARTITION } from './room-shared';
+import { postToConnections, queryConnectionsForRoom, wsManagementClient } from './ws-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const encoder = new TextEncoder();
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
+  let routeKey = event.requestContext.routeKey;
+  const roomsTable = process.env.ROOMS_TABLE_NAME;
+  const connTable = process.env.CONNECTIONS_TABLE_NAME;
+  if (!roomsTable || !connTable) {
+    return { statusCode: 500, body: 'Missing table env' };
+  }
+
+  const connectionId = event.requestContext.connectionId;
+
+  const connOut = await doc.send(
+    new GetCommand({
+      TableName: connTable,
+      Key: { connectionId },
+    }),
+  );
+  const conn = connOut.Item as Record<string, unknown> | undefined;
+  if (!conn || typeof conn.roomId !== 'string') {
+    return { statusCode: 410, body: 'Unknown connection' };
+  }
+  const roomId = conn.roomId;
+  const sessionId = typeof conn.sessionId === 'string' ? conn.sessionId : '';
+
+  const roomOut = await doc.send(
+    new GetCommand({
+      TableName: roomsTable,
+      Key: { roomId },
+    }),
+  );
+  const room = roomOut.Item as Record<string, unknown> | undefined;
+  if (!room || typeof room.hostSub !== 'string') {
+    return { statusCode: 410, body: 'Room missing' };
+  }
+
+  let body: Record<string, unknown> = {};
+  if (event.body) {
+    try {
+      body = JSON.parse(event.body) as Record<string, unknown>;
+    } catch {
+      return { statusCode: 400, body: 'Invalid JSON' };
+    }
+  }
+  if (routeKey === '$default') {
+    const a = body.action;
+    if (typeof a === 'string') {
+      routeKey = a;
+    }
+  }
+
+  if (routeKey === 'ping') {
+    const now = Math.max(
+      Date.now(),
+      typeof room.lastActivityAt === 'number' ? room.lastActivityAt : 0,
+    );
+    const names: Record<string, string> = {
+      '#vat': 'lastActivityAt',
+      '#lsk': 'lobbySk',
+    };
+    const values: Record<string, unknown> = { ':vat': now };
+    let update = 'SET #vat = :vat';
+    if (room.visibility === 'public' && room.lobbyPk === LOBBY_PARTITION) {
+      values[':lsk'] = lobbySortKey(now, roomId);
+      update += ', #lsk = :lsk';
+    }
+    await doc.send(
+      new UpdateCommand({
+        TableName: roomsTable,
+        Key: { roomId },
+        UpdateExpression: update,
+        ExpressionAttributeNames: names,
+        ExpressionAttributeValues: values,
+      }),
+    );
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  if (routeKey === 'chat') {
+    const text = typeof body.text === 'string' ? body.text.trim() : '';
+    if (text === '' || text.length > 2000) {
+      return { statusCode: 400, body: 'text required, max 2000 chars' };
+    }
+    const mgmt = wsManagementClient();
+    const ids = await queryConnectionsForRoom(doc, connTable, roomId);
+    const out = {
+      type: 'chat',
+      roomId,
+      sessionId,
+      text,
+      ts: Date.now(),
+    };
+    const buf = encoder.encode(JSON.stringify(out));
+    await postToConnections(mgmt, doc, connTable, ids, buf);
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  if (routeKey === 'signaling') {
+    const hostSub = typeof conn.hostSub === 'string' ? conn.hostSub : undefined;
+    if (!hostSub || hostSub !== room.hostSub) {
+      return { statusCode: 403, body: 'Publisher JWT required' };
+    }
+    const envelope = body.envelope;
+    if (envelope === undefined) {
+      return { statusCode: 400, body: 'envelope required' };
+    }
+    const mgmt = wsManagementClient();
+    const ids = await queryConnectionsForRoom(doc, connTable, roomId);
+    const out = {
+      type: 'signaling',
+      roomId,
+      envelope,
+    };
+    const buf = encoder.encode(JSON.stringify(out));
+    await postToConnections(mgmt, doc, connTable, ids, buf, connectionId);
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  return { statusCode: 400, body: `Unknown route ${routeKey}` };
+};

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -108,19 +108,35 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
   }
 
   if (routeKey === 'signaling') {
-    const hostSub = typeof conn.hostSub === 'string' ? conn.hostSub : undefined;
-    if (!hostSub || hostSub !== room.hostSub) {
-      return { statusCode: 403, body: 'Publisher JWT required' };
-    }
     const envelope = body.envelope;
     if (envelope === undefined) {
       return { statusCode: 400, body: 'envelope required' };
     }
+
+    const hostSubConn = typeof conn.hostSub === 'string' ? conn.hostSub : undefined;
+    const isPublisher = Boolean(hostSubConn && hostSubConn === room.hostSub);
+
+    let allowGuestRelay = false;
+    if (
+      envelope !== null &&
+      typeof envelope === 'object' &&
+      (envelope as { guestSignaling?: unknown }).guestSignaling === true
+    ) {
+      const kind = (envelope as { kind?: unknown }).kind;
+      allowGuestRelay = kind === 'ready' || kind === 'answer' || kind === 'ice';
+    }
+
+    if (!isPublisher && !allowGuestRelay) {
+      return { statusCode: 403, body: 'Publisher JWT required (or guest ready/answer/ice only)' };
+    }
+
     const mgmt = wsManagementClient();
     const ids = await queryConnectionsForRoom(doc, connTable, roomId);
     const out = {
       type: 'signaling',
       roomId,
+      fromSessionId: sessionId,
+      role: isPublisher ? 'host' : 'guest',
       envelope,
     };
     const buf = encoder.encode(JSON.stringify(out));

--- a/infra/cdk/lambda/ws-shared.ts
+++ b/infra/cdk/lambda/ws-shared.ts
@@ -1,0 +1,62 @@
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+import { DynamoDBDocumentClient, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+export function wsManagementClient(): ApiGatewayManagementApiClient {
+  const endpoint = process.env.WS_MANAGEMENT_API_ENDPOINT;
+  if (!endpoint) {
+    throw new Error('Missing WS_MANAGEMENT_API_ENDPOINT');
+  }
+  return new ApiGatewayManagementApiClient({ endpoint });
+}
+
+export async function queryConnectionsForRoom(
+  doc: DynamoDBDocumentClient,
+  table: string,
+  roomId: string,
+): Promise<string[]> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: table,
+      IndexName: 'RoomConnectionsIndex',
+      KeyConditionExpression: 'roomId = :r',
+      ExpressionAttributeValues: { ':r': roomId },
+      ProjectionExpression: 'connectionId',
+    }),
+  );
+  const ids: string[] = [];
+  for (const it of out.Items ?? []) {
+    const cid = (it as { connectionId?: string }).connectionId;
+    if (typeof cid === 'string') ids.push(cid);
+  }
+  return ids;
+}
+
+export async function postToConnections(
+  client: ApiGatewayManagementApiClient,
+  doc: DynamoDBDocumentClient,
+  connectionsTable: string,
+  ids: readonly string[],
+  payload: Uint8Array,
+  except?: string,
+): Promise<void> {
+  for (const id of ids) {
+    if (id === except) continue;
+    try {
+      await client.send(
+        new PostToConnectionCommand({
+          ConnectionId: id,
+          Data: payload,
+        }),
+      );
+    } catch (err) {
+      if (err instanceof GoneException || (err as { name?: string }).name === 'GoneException') {
+        await doc.send(
+          new DeleteCommand({
+            TableName: connectionsTable,
+            Key: { connectionId: id },
+          }),
+        ).catch(() => undefined);
+      }
+    }
+  }
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -1,5 +1,7 @@
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as apigwv2Auth from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
@@ -17,6 +19,11 @@ export interface ApiCatalogStackProps extends cdk.StackProps {
    * Comma-separated in CDK context `catalogCorsOrigins`.
    */
   readonly extraCorsOrigins?: string[];
+  /**
+   * Fan Cognito pool + SPA client for HTTP / WebSocket JWT validation (**M5**).
+   */
+  readonly fanUserPool: cognito.IUserPool;
+  readonly fanUserPoolClient: cognito.IUserPoolClient;
 }
 
 function parseOriginsFromContext(scope: Construct): string[] {
@@ -28,6 +35,17 @@ function parseOriginsFromContext(scope: Construct): string[] {
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+function staleRoomMsFromContext(scope: Construct): number {
+  const raw = scope.node.tryGetContext('staleRoomMs');
+  const n =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string'
+        ? Number.parseInt(raw, 10)
+        : Number.NaN;
+  return Number.isFinite(n) && n > 0 ? n : 45 * 60 * 1000;
 }
 
 function corsAllowOrigins(environment: 'staging' | 'prod', extras: string[]): string[] {
@@ -44,24 +62,29 @@ function corsAllowOrigins(environment: 'staging' | 'prod', extras: string[]): st
   return [...new Set([...base, ...extras])];
 }
 
+const sharedLambdaBundle = {
+  externalModules: ['@aws-sdk/*'],
+};
+
 /**
- * DynamoDB **Catalog** table + HTTP API **`GET /v1/catalog`** and **`GET /v1/catalog/{id}`**.
- *
- * **Access:** partition key **`id`** (stable episode slug). **`GET /v1/catalog`** uses **`Scan`**
- * (acceptable for MVP catalog size); **`GET /v1/catalog/{id}`** uses **`GetItem`**.
- * For large catalogs, add a GSI or snapshot/cache; see **`docs/architecture.server.md`**.
+ * DynamoDB **Catalog** + **Rooms** + **Connections**, HTTP API (catalog, rooms, lobby),
+ * WebSocket API (realtime), TMDB reconcile — see **`docs/architecture.server.md`**.
  */
 export class ApiCatalogStack extends cdk.Stack {
   public readonly catalogTable: dynamodb.Table;
+  public readonly roomsTable: dynamodb.Table;
+  public readonly connectionsTable: dynamodb.Table;
   public readonly httpApi: apigwv2.HttpApi;
+  public readonly webSocketApi: apigwv2.WebSocketApi;
   public readonly tmdbApiTokenSecret: secretsmanager.ISecret;
 
   constructor(scope: Construct, id: string, props: ApiCatalogStackProps) {
     super(scope, id, props);
 
-    const { environment, extraCorsOrigins = [] } = props;
+    const { environment, extraCorsOrigins = [], fanUserPool, fanUserPoolClient } = props;
     const contextExtras = parseOriginsFromContext(this);
     const allowOrigins = corsAllowOrigins(environment, [...extraCorsOrigins, ...contextExtras]);
+    const staleRoomMs = staleRoomMsFromContext(this);
 
     cdk.Tags.of(this).add('Project', 'RiffSync');
     cdk.Tags.of(this).add('Environment', environment);
@@ -74,6 +97,33 @@ export class ApiCatalogStack extends cdk.Stack {
         environment === 'prod' ? { pointInTimeRecoveryEnabled: true } : undefined,
     });
 
+    this.roomsTable = new dynamodb.Table(this, 'RoomsTable', {
+      partitionKey: { name: 'roomId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      pointInTimeRecoverySpecification:
+        environment === 'prod' ? { pointInTimeRecoveryEnabled: true } : undefined,
+    });
+    this.roomsTable.addGlobalSecondaryIndex({
+      indexName: 'PublicLobbyIndex',
+      partitionKey: { name: 'lobbyPk', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'lobbySk', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    this.connectionsTable = new dynamodb.Table(this, 'ConnectionsTable', {
+      partitionKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'expiresAt',
+    });
+    this.connectionsTable.addGlobalSecondaryIndex({
+      indexName: 'RoomConnectionsIndex',
+      partitionKey: { name: 'roomId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    });
+
     this.tmdbApiTokenSecret = new secretsmanager.Secret(this, 'TmdbApiToken', {
       secretName: `riffsync/${environment}/tmdb-api-token`,
       description:
@@ -84,10 +134,11 @@ export class ApiCatalogStack extends cdk.Stack {
 
     const catalogListFn = new lambdaNodejs.NodejsFunction(this, 'CatalogListFn', {
       runtime: lambda.Runtime.NODEJS_24_X,
-      entry: path.join(__dirname, '../lambda/catalog-list.ts'),
-      handler: 'handler',
       timeout: cdk.Duration.seconds(29),
       memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/catalog-list.ts'),
+      handler: 'handler',
       environment: {
         CATALOG_TABLE_NAME: this.catalogTable.tableName,
         NODE_OPTIONS: '--enable-source-maps',
@@ -96,10 +147,11 @@ export class ApiCatalogStack extends cdk.Stack {
 
     const catalogGetFn = new lambdaNodejs.NodejsFunction(this, 'CatalogGetFn', {
       runtime: lambda.Runtime.NODEJS_24_X,
-      entry: path.join(__dirname, '../lambda/catalog-get.ts'),
-      handler: 'handler',
       timeout: cdk.Duration.seconds(10),
       memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/catalog-get.ts'),
+      handler: 'handler',
       environment: {
         CATALOG_TABLE_NAME: this.catalogTable.tableName,
         NODE_OPTIONS: '--enable-source-maps',
@@ -130,6 +182,7 @@ export class ApiCatalogStack extends cdk.Stack {
       handler: 'handler',
       timeout: cdk.Duration.minutes(5),
       memorySize: 512,
+      bundling: sharedLambdaBundle,
       environment: {
         CATALOG_TABLE_NAME: this.catalogTable.tableName,
         TMDB_SECRET_ARN: this.tmdbApiTokenSecret.secretArn,
@@ -151,12 +204,162 @@ export class ApiCatalogStack extends cdk.Stack {
       reconcileRule.addTarget(new eventsTargets.LambdaFunction(tmdbReconcileFn));
     }
 
+    const fanIssuer = `https://cognito-idp.${this.region}.amazonaws.com/${fanUserPool.userPoolId}`;
+    const fanJwtAuthorizer = new apigwv2Auth.HttpJwtAuthorizer('FanJwtAuthorizer', fanIssuer, {
+      jwtAudience: [fanUserPoolClient.userPoolClientId],
+      authorizerName: `riffsync-fan-${environment}`,
+    });
+
+    const jwtEnvShared = {
+      NODE_OPTIONS: '--enable-source-maps',
+    };
+
+    const roomCreateFn = new lambdaNodejs.NodejsFunction(this, 'RoomCreateFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/room-create.ts'),
+      handler: 'handler',
+      environment: {
+        ROOMS_TABLE_NAME: this.roomsTable.tableName,
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        ...jwtEnvShared,
+      },
+    });
+    const roomPatchFn = new lambdaNodejs.NodejsFunction(this, 'RoomPatchFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/room-patch.ts'),
+      handler: 'handler',
+      environment: {
+        ROOMS_TABLE_NAME: this.roomsTable.tableName,
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        ...jwtEnvShared,
+      },
+    });
+    const roomGetFn = new lambdaNodejs.NodejsFunction(this, 'RoomGetFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/room-get.ts'),
+      handler: 'handler',
+      environment: {
+        ROOMS_TABLE_NAME: this.roomsTable.tableName,
+        ...jwtEnvShared,
+      },
+    });
+    const lobbyGetFn = new lambdaNodejs.NodejsFunction(this, 'LobbyGetFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/lobby-get.ts'),
+      handler: 'handler',
+      environment: {
+        ROOMS_TABLE_NAME: this.roomsTable.tableName,
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        STALE_ROOM_MS: String(staleRoomMs),
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+
+    this.roomsTable.grantReadWriteData(roomCreateFn);
+    this.roomsTable.grantReadWriteData(roomPatchFn);
+    this.catalogTable.grantReadData(roomCreateFn);
+    this.catalogTable.grantReadData(roomPatchFn);
+    this.catalogTable.grantReadData(lobbyGetFn);
+    this.roomsTable.grantReadData(roomGetFn);
+    this.roomsTable.grantReadData(lobbyGetFn);
+
+    /** WebSocket management URL (HTTPS) for `PostToConnection`. */
+    this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
+      apiName: `riffsync-${environment}-ws`,
+      description: `RiffSync WebSocket (${environment}) — ping, chat, signaling`,
+      routeSelectionExpression: '$request.body.action',
+    });
+
+    const wsStage = new apigwv2.WebSocketStage(this, 'WebSocketStage', {
+      webSocketApi: this.webSocketApi,
+      stageName: environment,
+      autoDeploy: true,
+    });
+
+    const wsMgmtEndpoint = `https://${this.webSocketApi.apiId}.execute-api.${this.region}.amazonaws.com/${wsStage.stageName}`;
+
+    const wsSharedEnv = {
+      ROOMS_TABLE_NAME: this.roomsTable.tableName,
+      CONNECTIONS_TABLE_NAME: this.connectionsTable.tableName,
+      COGNITO_USER_POOL_ID: fanUserPool.userPoolId,
+      COGNITO_CLIENT_ID: fanUserPoolClient.userPoolClientId,
+      WS_MANAGEMENT_API_ENDPOINT: wsMgmtEndpoint,
+      NODE_OPTIONS: '--enable-source-maps',
+    };
+
+    const wsConnectFn = new lambdaNodejs.NodejsFunction(this, 'WsConnectFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/ws-connect.ts'),
+      handler: 'handler',
+      environment: wsSharedEnv,
+    });
+    const wsDisconnectFn = new lambdaNodejs.NodejsFunction(this, 'WsDisconnectFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/ws-disconnect.ts'),
+      handler: 'handler',
+      environment: { CONNECTIONS_TABLE_NAME: this.connectionsTable.tableName, NODE_OPTIONS: '--enable-source-maps' },
+    });
+    const wsRouteFn = new lambdaNodejs.NodejsFunction(this, 'WsRouteFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(25),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/ws-route.ts'),
+      handler: 'handler',
+      environment: wsSharedEnv,
+    });
+
+    this.catalogTable.grantReadData(wsConnectFn);
+    this.roomsTable.grantReadData(wsConnectFn);
+    this.connectionsTable.grantReadWriteData(wsConnectFn);
+
+    this.connectionsTable.grantReadWriteData(wsDisconnectFn);
+
+    this.roomsTable.grantReadWriteData(wsRouteFn);
+    this.connectionsTable.grantReadWriteData(wsRouteFn);
+    this.webSocketApi.grantManageConnections(wsRouteFn);
+
+    const wsConnectInt = new integrations.WebSocketLambdaIntegration('WsConnectInt', wsConnectFn);
+    const wsDisconnectInt = new integrations.WebSocketLambdaIntegration('WsDisconnectInt', wsDisconnectFn);
+    const wsRouteInt = new integrations.WebSocketLambdaIntegration('WsRouteInt', wsRouteFn);
+
+    this.webSocketApi.addRoute('$connect', { integration: wsConnectInt });
+    this.webSocketApi.addRoute('$disconnect', { integration: wsDisconnectInt });
+    for (const key of ['ping', 'chat', 'signaling'] as const) {
+      this.webSocketApi.addRoute(key, { integration: wsRouteInt });
+    }
+    this.webSocketApi.addRoute('$default', { integration: wsRouteInt });
+
     this.httpApi = new apigwv2.HttpApi(this, 'HttpApi', {
       apiName: `riffsync-${environment}-http`,
       description: `RiffSync public HTTP API (${environment})`,
       corsPreflight: {
-        allowHeaders: ['content-type', 'authorization'],
-        allowMethods: [apigwv2.CorsHttpMethod.GET, apigwv2.CorsHttpMethod.OPTIONS],
+        allowHeaders: ['content-type', 'authorization', 'x-session-id'],
+        allowMethods: [
+          apigwv2.CorsHttpMethod.GET,
+          apigwv2.CorsHttpMethod.POST,
+          apigwv2.CorsHttpMethod.PATCH,
+          apigwv2.CorsHttpMethod.PUT,
+          apigwv2.CorsHttpMethod.OPTIONS,
+        ],
         allowOrigins,
         maxAge: cdk.Duration.days(1),
       },
@@ -170,6 +373,10 @@ export class ApiCatalogStack extends cdk.Stack {
       'CatalogGetIntegration',
       catalogGetFn,
     );
+    const roomCreateIntegration = new integrations.HttpLambdaIntegration('RoomCreateInt', roomCreateFn);
+    const roomPatchIntegration = new integrations.HttpLambdaIntegration('RoomPatchInt', roomPatchFn);
+    const roomGetIntegration = new integrations.HttpLambdaIntegration('RoomGetInt', roomGetFn);
+    const lobbyGetIntegration = new integrations.HttpLambdaIntegration('LobbyGetInt', lobbyGetFn);
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -183,18 +390,61 @@ export class ApiCatalogStack extends cdk.Stack {
       integration: getIntegration,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/rooms',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: roomCreateIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/rooms/{roomId}',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: roomGetIntegration,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/rooms/{roomId}',
+      methods: [apigwv2.HttpMethod.PATCH],
+      integration: roomPatchIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/lobby',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: lobbyGetIntegration,
+    });
+
     new cdk.CfnOutput(this, 'CatalogTableName', {
       value: this.catalogTable.tableName,
       description: 'DynamoDB Catalog table — partition key `id` (episode slug).',
     });
 
+    new cdk.CfnOutput(this, 'RoomsTableName', {
+      value: this.roomsTable.tableName,
+    });
+
+    new cdk.CfnOutput(this, 'ConnectionsTableName', {
+      value: this.connectionsTable.tableName,
+    });
+
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
-      description: 'HTTP API base URL (HTTPS). Append `/v1/catalog`.',
+      description: 'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {
       value: this.httpApi.httpApiId,
+    });
+
+    new cdk.CfnOutput(this, 'WebSocketUrl', {
+      value: wsStage.url,
+      description: 'WebSocket **`wss://`** URL.',
+    });
+
+    new cdk.CfnOutput(this, 'WebSocketApiId', {
+      value: this.webSocketApi.apiId,
     });
 
     new cdk.CfnOutput(this, 'TmdbApiTokenSecretArn', {
@@ -205,6 +455,11 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'TmdbReconcileFnName', {
       value: tmdbReconcileFn.functionName,
       description: 'Invoke manually: aws lambda invoke --function-name … out.json',
+    });
+
+    new cdk.CfnOutput(this, 'StaleRoomMs', {
+      value: String(staleRoomMs),
+      description: '`GET /v1/lobby` excludes rows with `lastActivityAt` older than this (ms). Override: `--context staleRoomMs=…`.',
     });
   }
 }

--- a/infra/cdk/lib/fan-auth-stack.ts
+++ b/infra/cdk/lib/fan-auth-stack.ts
@@ -1,0 +1,178 @@
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as cdk from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+
+export interface FanAuthStackProps extends cdk.StackProps {
+  readonly environment: 'staging' | 'prod';
+  /**
+   * Meta (Facebook) App ID (public). CI uses a placeholder; set a real value for deploy.
+   * Example: `--context facebookAppId=1234567890123456`
+   */
+  readonly facebookAppId?: string;
+  /**
+   * Extra OAuth callback / sign-out URLs (e.g. staging CloudFront `https://dxxxx.cloudfront.net/`).
+   * Comma-separated in CDK context `fanAuthOAuthExtras`.
+   */
+  readonly extraOAuthUrls?: string[];
+  /**
+   * Override Cognito hosted domain prefix (must be unique per region). Default `riffsync-fan-{environment}`.
+   */
+  readonly cognitoDomainPrefix?: string;
+}
+
+function parseExtrasFromContext(scope: Construct): string[] {
+  const raw = scope.node.tryGetContext('fanAuthOAuthExtras');
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function resolveFacebookAppId(scope: Construct, explicit: string | undefined): string {
+  if (typeof explicit === 'string' && explicit.trim() !== '') {
+    return explicit.trim();
+  }
+  const ctx = scope.node.tryGetContext('facebookAppId');
+  if (typeof ctx === 'string' && ctx.trim() !== '') {
+    return ctx.trim();
+  }
+  return '0000000000000000';
+}
+
+/**
+ * **Fan-facing** Cognito user pool — **Hosted UI + Facebook federation** only (no native password sign-in).
+ *
+ * Aligns with **`.forge/integration/authorization.md`** (host JWT **`sub`** → **`hostSub`**). Staff pool stays out of scope.
+ */
+export class FanAuthStack extends cdk.Stack {
+  public readonly fanUserPool: cognito.UserPool;
+  public readonly fanUserPoolClient: cognito.UserPoolClient;
+
+  constructor(scope: Construct, id: string, props: FanAuthStackProps) {
+    super(scope, id, props);
+
+    const { environment, facebookAppId: facebookAppIdProp, cognitoDomainPrefix } = props;
+    const contextExtras = parseExtrasFromContext(this);
+    const extraOAuthUrls = [...(props.extraOAuthUrls ?? []), ...contextExtras];
+
+    const facebookAppId = resolveFacebookAppId(this, facebookAppIdProp);
+
+    cdk.Tags.of(this).add('Project', 'RiffSync');
+    cdk.Tags.of(this).add('Environment', environment);
+
+    const facebookAppSecret = new secretsmanager.Secret(this, 'FacebookAppSecretForCognito', {
+      secretName: `riffsync/${environment}/facebook-app-secret`,
+      description:
+        'Meta (Facebook) app secret referenced by Cognito Facebook IdP (never embed in SPA; rotate via Secrets Manager)',
+      secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_WITH_META_APP_SECRET'),
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
+    /** MVP:** federated Hosted UI only — **no Cognito-native password/SRP**. */
+    const selfSignUpEnabled = false;
+
+    this.fanUserPool = new cognito.UserPool(this, 'FanUserPool', {
+      userPoolName: `riffsync-fan-${environment}`,
+      selfSignUpEnabled,
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      deletionProtection: environment === 'prod',
+      signInAliases: { email: true },
+      standardAttributes: { email: { required: false, mutable: true } },
+    });
+
+    new cognito.UserPoolIdentityProviderFacebook(this, 'FacebookIdp', {
+      userPool: this.fanUserPool,
+      clientId: facebookAppId,
+      clientSecret: facebookAppSecret.secretValue.toString(),
+      scopes: ['public_profile', 'email'],
+    });
+
+    const stagingCallbackLogoutBase = [
+      'https://riffsync.tv/',
+      'https://riffsync.tv/callback',
+      'https://staging.riffsync.tv/',
+      'https://staging.riffsync.tv/callback',
+      'http://localhost:5173/',
+      'http://localhost:5173/callback',
+      'http://127.0.0.1:5173/',
+      'http://127.0.0.1:5173/callback',
+      'http://localhost:3000/',
+      'http://localhost:3000/callback',
+    ];
+    const prodCallbackLogoutBase = ['https://riffsync.tv/', 'https://riffsync.tv/callback'];
+
+    const callbackUrls =
+      environment === 'prod'
+        ? [...prodCallbackLogoutBase, ...extraOAuthUrls]
+        : [...new Set([...stagingCallbackLogoutBase, ...prodCallbackLogoutBase, ...extraOAuthUrls])];
+
+    const logoutUrls = callbackUrls;
+
+    const domainPrefixRaw =
+      typeof cognitoDomainPrefix === 'string' && cognitoDomainPrefix.trim() !== ''
+        ? cognitoDomainPrefix.trim().toLowerCase()
+        : (this.node.tryGetContext('fanAuthCognitoDomainPrefix') as string | undefined);
+    const domainPrefix =
+      typeof domainPrefixRaw === 'string' && domainPrefixRaw.trim() !== ''
+        ? domainPrefixRaw.trim().toLowerCase()
+        : `riffsync-fan-${environment}`;
+
+    this.fanUserPool.addDomain('FanHostedUiDomain', {
+      cognitoDomain: { domainPrefix },
+    });
+
+    this.fanUserPoolClient = this.fanUserPool.addClient('FanWebSpaClient', {
+      userPoolClientName: `riffsync-fan-web-${environment}`,
+      generateSecret: false,
+      authFlows: {
+        userSrp: false,
+        userPassword: false,
+        adminUserPassword: false,
+      },
+      oAuth: {
+        flows: { authorizationCodeGrant: true },
+        scopes: [
+          cognito.OAuthScope.OPENID,
+          cognito.OAuthScope.EMAIL,
+          cognito.OAuthScope.PROFILE,
+        ],
+        callbackUrls,
+        logoutUrls,
+      },
+      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.FACEBOOK],
+    });
+
+    new cdk.CfnOutput(this, 'FanUserPoolId', {
+      value: this.fanUserPool.userPoolId,
+      description: 'Fan Cognito pool id — JWT issuer for hosts (JWT authorizer **`sub`** = **`hostSub`**).',
+    });
+
+    new cdk.CfnOutput(this, 'FanUserPoolArn', {
+      value: this.fanUserPool.userPoolArn,
+    });
+
+    new cdk.CfnOutput(this, 'FanUserPoolClientId', {
+      value: this.fanUserPoolClient.userPoolClientId,
+      description: 'SPA / Hosted UI OAuth app client **(public)**.',
+    });
+
+    new cdk.CfnOutput(this, 'FanHostedUiDomainPrefix', {
+      value: domainPrefix,
+      description: 'Cognito Hosted UI domain prefix (**{prefix}.auth.<region>.amazoncognito.com**).',
+    });
+
+    new cdk.CfnOutput(this, 'FanFacebookAppSecretSecretArn', {
+      value: facebookAppSecret.secretArn,
+      description: 'Put Meta app **`client_secret`** here before relying on Hosted UI (**never** paste into SPA)',
+    });
+
+    new cdk.CfnOutput(this, 'FanHostedUiBaseUrl', {
+      value: `https://${domainPrefix}.auth.${cdk.Stack.of(this).region}.amazoncognito.com`,
+      description: 'Base URL for Hosted UI (**append** **`/oauth2/authorize`** with query params from docs).',
+    });
+  }
+}

--- a/infra/cdk/lib/fan-auth-stack.ts
+++ b/infra/cdk/lib/fan-auth-stack.ts
@@ -102,6 +102,8 @@ export class FanAuthStack extends cdk.Stack {
       'http://127.0.0.1:5173/callback',
       'http://localhost:3000/',
       'http://localhost:3000/callback',
+      'https://localhost:5173/',
+      'https://localhost:5173/callback',
     ];
     const prodCallbackLogoutBase = ['https://riffsync.tv/', 'https://riffsync.tv/callback'];
 

--- a/infra/cdk/package-lock.json
+++ b/infra/cdk/package-lock.json
@@ -8,10 +8,12 @@
       "name": "@riffsync/infra-cdk",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.1041.0",
         "@aws-sdk/client-dynamodb": "^3.726.1",
         "@aws-sdk/client-secrets-manager": "^3.726.1",
         "@aws-sdk/lib-dynamodb": "^3.726.1",
         "aws-cdk-lib": "^2.173.4",
+        "aws-jwt-verify": "^5.1.1",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -199,6 +201,56 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1041.0.tgz",
+      "integrity": "sha512-5L8KKT6/ad2lHF32EI4GtfmEOyOh9h1v/PlHKl0erUF6a9pJQ9EC5qyKxE8KBbS/8k93EOjRjCoe7+0D7uy50w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
@@ -2946,6 +2998,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.1.1.tgz",
+      "integrity": "sha512-j6whGdGJmQ27agk4ijY8RPv6itb8JLb7SCJ86fEnneTcSBrpxuwL8kLq6y5WVH95aIknyAloEqAsaOLS1J8ITQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bowser": {

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -26,10 +26,12 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.1041.0",
     "@aws-sdk/client-dynamodb": "^3.726.1",
     "@aws-sdk/client-secrets-manager": "^3.726.1",
     "@aws-sdk/lib-dynamodb": "^3.726.1",
     "aws-cdk-lib": "^2.173.4",
+    "aws-jwt-verify": "^5.1.1",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
## Summary

Delivers the [M5 SPA / watch party MVP](https://github.com/StacksOnTheRacks/riffsync/issues/17) on `feature/issue-5`: **`/lobby`**, **`/room/:roomId`**, anonymous **`sessionId`** + **`X-Session-Id`**, catalog **Start party** with Cognito **Hosted UI PKCE**, WebSocket chat/ping with reconnect, and **WebRTC** tab-capture host → guest **`MediaStream`** (signaling over WS).

Also updates **`$connect`** so browsers can pass the host JWT as query **`accessToken`** (handshake cannot set **`Authorization`**), documented in **`docs/contracts.websocket.md`**.

## User stories (scenario notes)

| Story | Notes |
| --- | --- |
| **US-P0-02 / 02b / 03** | **Sign in to host** via Facebook IdP (**`identity_provider: Facebook`**) PKCE → tokens in **`localStorage`**; **`POST /v1/rooms`** used from catalog. |
| **US-P0-04** | Lobby lists public rooms (**`GET /v1/lobby`**); join navigates to **`/room/:id`**. Guest session minted on lobby/room entry. |
| **US-P0-05** | Host sees **IFrame API** **`SoloYouTubePlayer`** for room **`youtubeVideoId`** after explicit **Play**. |
| **US-P0-06** | Chat round-trip over WebSocket (**`action: chat`**) — server shape **`sessionId`**, **`text`**, **`ts`**. |
| **US-P0-07** | **Playback expectation** badge on lobby rows and room (mapped from **`free`/`premium`** room fields). |
| **US-P0-09** | Host **episode** `<select>` loads catalog and **`PATCH /v1/rooms/:id`**; room snapshot polled ~5s for guests. |

**Guests** without JWT: HTTP **`PATCH`** is not offered in UI — server remains authoritative (**403** if attempted).

## Config

See **`apps/web/.env.example`**: **`VITE_PUBLIC_API_BASE_URL`**, **`VITE_PUBLIC_WS_URL`**, **`VITE_COGNITO_*`**, optional **`VITE_WEBRTC_ICE_SERVERS_JSON`**.

## Test plan

Same as issue #17 (two browsers):

1. Host: sign in → catalog → **Start party** → **Share tab** → play embed.
2. Guest: **`/lobby`** → join room → explicit **Play** if needed → chat ↔ host → host switches episode.

**CI:** `cd apps/web && npm run build && npm run lint`; CDK **`npm run build`**.

Closes #17
