### PR TITLE
[M6] Bounded chat log with stick-to-bottom scroll (#24)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -40,6 +40,7 @@ import {
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/mediasoupSfuFeature'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
+import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 
 const DISPLAY_TITLE_MAX_LEN = 120
 
@@ -150,6 +151,9 @@ export function RoomPage() {
 
   const wsBase = getPublicWsUrl()
   const fanToken = getFanAccessToken()
+  const roomChatTabActive =
+    (!fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab) === 'chat'
+  const chatLogRef = useChatLogStickToBottom(chat.length, roomChatTabActive)
   const isPublisher = Boolean(room && fanToken && cognitoSub(fanToken) === room.hostSub)
 
   /** Prefer the room document id so WebSocket presence matches server fan-out even if the route param differed. */
@@ -1239,7 +1243,7 @@ export function RoomPage() {
 
               {activeSidebarTab === 'chat' ? (
                 <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--chat">
-                  <ul className="riffsync-room-chat-log">
+                  <ul ref={chatLogRef} className="riffsync-room-chat-log">
                     {chat.map((m) => (
                       <li key={`${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`}>
                         <span className="riffsync-room-chat-log__who">

--- a/apps/web/src/room/chatLogScroll.test.ts
+++ b/apps/web/src/room/chatLogScroll.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CHAT_LOG_STICK_THRESHOLD_PX,
+  chatLogScrollBehavior,
+  isChatLogNearBottom,
+  prefersReducedMotion,
+} from './chatLogScroll'
+
+function metrics(scrollTop: number, clientHeight: number, scrollHeight: number) {
+  return { scrollTop, clientHeight, scrollHeight }
+}
+
+describe('isChatLogNearBottom', () => {
+  it('uses the default 48px threshold', () => {
+    const el = metrics(104, 200, 352)
+    expect(isChatLogNearBottom(el)).toBe(true)
+    expect(isChatLogNearBottom(metrics(103, 200, 352))).toBe(false)
+  })
+
+  it('honors a custom threshold', () => {
+    const el = metrics(90, 200, 352)
+    expect(isChatLogNearBottom(el, 64)).toBe(true)
+    expect(isChatLogNearBottom(el, 32)).toBe(false)
+  })
+
+  it('is true when the log is empty or not scrollable', () => {
+    expect(isChatLogNearBottom(metrics(0, 200, 200))).toBe(true)
+  })
+
+  it('exports the contract threshold constant', () => {
+    expect(CHAT_LOG_STICK_THRESHOLD_PX).toBe(48)
+  })
+})
+
+describe('prefersReducedMotion / chatLogScrollBehavior', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns false when matchMedia is unavailable', () => {
+    vi.stubGlobal('window', {})
+    expect(prefersReducedMotion()).toBe(false)
+    expect(chatLogScrollBehavior()).toBe('smooth')
+  })
+
+  it('uses auto scroll when reduce motion is preferred', () => {
+    vi.stubGlobal('window', {
+      matchMedia: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+      }),
+    })
+    expect(prefersReducedMotion()).toBe(true)
+    expect(chatLogScrollBehavior()).toBe('auto')
+  })
+
+  it('uses smooth scroll otherwise', () => {
+    vi.stubGlobal('window', {
+      matchMedia: () => ({ matches: false, media: '' }),
+    })
+    expect(chatLogScrollBehavior()).toBe('smooth')
+  })
+})

--- a/apps/web/src/room/chatLogScroll.ts
+++ b/apps/web/src/room/chatLogScroll.ts
@@ -1,0 +1,24 @@
+/** Stick-to-bottom threshold for room chat log (see `.forge/interface/presentation.md`). */
+export const CHAT_LOG_STICK_THRESHOLD_PX = 48
+
+export type ChatLogScrollMetrics = Pick<HTMLElement, 'scrollTop' | 'clientHeight' | 'scrollHeight'>
+
+export function isChatLogNearBottom(
+  el: ChatLogScrollMetrics,
+  thresholdPx: number = CHAT_LOG_STICK_THRESHOLD_PX,
+): boolean {
+  return el.scrollTop + el.clientHeight >= el.scrollHeight - thresholdPx
+}
+
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function chatLogScrollBehavior(): ScrollBehavior {
+  return prefersReducedMotion() ? 'auto' : 'smooth'
+}
+
+export function scrollChatLogToBottom(el: HTMLElement): void {
+  el.scrollTo({ top: el.scrollHeight, behavior: chatLogScrollBehavior() })
+}

--- a/apps/web/src/room/useChatLogStickToBottom.ts
+++ b/apps/web/src/room/useChatLogStickToBottom.ts
@@ -36,10 +36,11 @@ export function useChatLogStickToBottom(
     if (!chatTabActive) return
     const el = logRef.current
     if (!el) return
-    syncStickState()
-    if (stickToBottomRef.current) {
+    const shouldStick = stickToBottomRef.current
+    if (shouldStick) {
       scrollChatLogToBottom(el)
     }
+    syncStickState()
   }, [chatLength, chatTabActive, syncStickState])
 
   return logRef

--- a/apps/web/src/room/useChatLogStickToBottom.ts
+++ b/apps/web/src/room/useChatLogStickToBottom.ts
@@ -1,0 +1,46 @@
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
+import { isChatLogNearBottom, scrollChatLogToBottom } from './chatLogScroll'
+
+/**
+ * Keeps the room chat log scrolled to the latest line when the user is near the bottom.
+ * Only runs while the Chat tab is active.
+ */
+export function useChatLogStickToBottom(
+  chatLength: number,
+  chatTabActive: boolean,
+): RefObject<HTMLUListElement | null> {
+  const logRef = useRef<HTMLUListElement>(null)
+  const stickToBottomRef = useRef(true)
+
+  const syncStickState = useCallback(() => {
+    const el = logRef.current
+    if (!el) return
+    stickToBottomRef.current = isChatLogNearBottom(el)
+  }, [])
+
+  useLayoutEffect(() => {
+    const el = logRef.current
+    if (!el) return
+    const onScroll = () => syncStickState()
+    const onResize = () => syncStickState()
+    el.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onResize)
+    syncStickState()
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [syncStickState])
+
+  useLayoutEffect(() => {
+    if (!chatTabActive) return
+    const el = logRef.current
+    if (!el) return
+    syncStickState()
+    if (stickToBottomRef.current) {
+      scrollChatLogToBottom(el)
+    }
+  }, [chatLength, chatTabActive, syncStickState])
+
+  return logRef
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -966,6 +966,17 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   }
 }
 
+@media (min-width: 992px) {
+  .riffsync-room-page__chat-column {
+    max-height: calc(100dvh - 7.5rem);
+    min-height: 0;
+  }
+
+  .riffsync-room-page__chat {
+    max-height: 100%;
+  }
+}
+
 .riffsync-room-page__chat-toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Bound the room sidebar chat so only `.riffsync-room-chat-log` scrolls; tabs and compose stay fixed.
- Auto-scroll to the latest message when the viewer is within 48px of the bottom (incoming WebSocket chat and while on the Chat tab).
- Preserve scroll position when reading history; honor `prefers-reduced-motion` for programmatic scroll.
- Cap desktop chat panel height (`≥992px`) so long history does not grow the stage.

## Implementation

- `apps/web/src/room/chatLogScroll.ts` — near-bottom detection and scroll helpers (Vitest).
- `apps/web/src/room/useChatLogStickToBottom.ts` — hook wired from `RoomPage.tsx`.
- `apps/web/src/styles/riffsync-app.css` — desktop `max-height` on chat column/panel.

## Test plan

- [x] `npm test` (includes `chatLogScroll.test.ts`)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: overflow chat log, stick-to-bottom at bottom, no yank when scrolled up, reduced motion, desktop/mobile viewports

Closes #24