### PR TITLE
[M6] Jump to latest when scrolled up and new messages arrive

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -153,7 +153,12 @@ export function RoomPage() {
   const fanToken = getFanAccessToken()
   const roomChatTabActive =
     (!fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab) === 'chat'
-  const chatLogRef = useChatLogStickToBottom(chat.length, roomChatTabActive)
+  const {
+    logRef: chatLogRef,
+    showJumpToLatest,
+    jumpToLatestLabel,
+    jumpToLatest,
+  } = useChatLogStickToBottom(chat.length, roomChatTabActive)
   const isPublisher = Boolean(room && fanToken && cognitoSub(fanToken) === room.hostSub)
 
   /** Prefer the room document id so WebSocket presence matches server fan-out even if the route param differed. */
@@ -1258,6 +1263,16 @@ export function RoomPage() {
                     ))}
                   </ul>
                   <div className="riffsync-room-chat-compose-holder">
+                    {showJumpToLatest ? (
+                      <button
+                        type="button"
+                        className="riffsync-room-chat-jump-latest gen-button"
+                        aria-label="Jump to latest messages"
+                        onClick={jumpToLatest}
+                      >
+                        {jumpToLatestLabel}
+                      </button>
+                    ) : null}
                     <div
                       className={`riffsync-room-chat-compose${fanToken ? '' : ' riffsync-room-chat-compose--inactive'}`}
                     >

--- a/apps/web/src/room/chatLogPending.test.ts
+++ b/apps/web/src/room/chatLogPending.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  countNewChatLines,
+  jumpToLatestButtonLabel,
+  nextPendingBelowCount,
+  pendingCountAfterNearBottomScroll,
+  shouldShowJumpToLatest,
+} from './chatLogPending'
+
+describe('countNewChatLines', () => {
+  it('returns zero when length is unchanged or shrinks', () => {
+    expect(countNewChatLines(5, 5)).toBe(0)
+    expect(countNewChatLines(6, 4)).toBe(0)
+  })
+
+  it('returns the positive delta when messages are added', () => {
+    expect(countNewChatLines(10, 11)).toBe(1)
+    expect(countNewChatLines(0, 3)).toBe(3)
+  })
+})
+
+describe('nextPendingBelowCount', () => {
+  it('resets pending when the user was near the bottom', () => {
+    expect(nextPendingBelowCount(4, 2, true)).toBe(0)
+  })
+
+  it('accumulates new lines when scrolled up', () => {
+    expect(nextPendingBelowCount(0, 1, false)).toBe(1)
+    expect(nextPendingBelowCount(2, 3, false)).toBe(5)
+  })
+
+  it('ignores zero new lines', () => {
+    expect(nextPendingBelowCount(3, 0, false)).toBe(3)
+  })
+})
+
+describe('pendingCountAfterNearBottomScroll', () => {
+  it('clears pending when near bottom', () => {
+    expect(pendingCountAfterNearBottomScroll(true, 7)).toBe(0)
+  })
+
+  it('keeps pending when still scrolled up', () => {
+    expect(pendingCountAfterNearBottomScroll(false, 7)).toBe(7)
+  })
+})
+
+describe('jumpToLatestButtonLabel', () => {
+  it('uses singular copy for zero or one pending line', () => {
+    expect(jumpToLatestButtonLabel(0)).toBe('New messages')
+    expect(jumpToLatestButtonLabel(1)).toBe('New messages')
+  })
+
+  it('appends the count when more than one line is pending', () => {
+    expect(jumpToLatestButtonLabel(2)).toBe('New messages (2)')
+    expect(jumpToLatestButtonLabel(12)).toBe('New messages (12)')
+  })
+})
+
+describe('shouldShowJumpToLatest', () => {
+  it('shows only when pending and not near bottom', () => {
+    expect(shouldShowJumpToLatest(1, false)).toBe(true)
+    expect(shouldShowJumpToLatest(0, false)).toBe(false)
+    expect(shouldShowJumpToLatest(3, true)).toBe(false)
+  })
+})

--- a/apps/web/src/room/chatLogPending.ts
+++ b/apps/web/src/room/chatLogPending.ts
@@ -1,0 +1,33 @@
+/** Count inbound chat lines added in a single update (ignores shrink/clear). */
+export function countNewChatLines(prevLength: number, nextLength: number): number {
+  const delta = nextLength - prevLength
+  return delta > 0 ? delta : 0
+}
+
+/** Pending lines below the viewport when the user is reading history. */
+export function nextPendingBelowCount(
+  currentPending: number,
+  newLineCount: number,
+  wasNearBottom: boolean,
+): number {
+  if (newLineCount <= 0) return currentPending
+  if (wasNearBottom) return 0
+  return currentPending + newLineCount
+}
+
+/** Clears pending when the user scrolls back within the stick threshold. */
+export function pendingCountAfterNearBottomScroll(
+  wasNearBottom: boolean,
+  currentPending: number,
+): number {
+  return wasNearBottom ? 0 : currentPending
+}
+
+export function jumpToLatestButtonLabel(pendingCount: number): string {
+  if (pendingCount <= 1) return 'New messages'
+  return `New messages (${pendingCount})`
+}
+
+export function shouldShowJumpToLatest(pendingCount: number, isNearBottom: boolean): boolean {
+  return pendingCount > 0 && !isNearBottom
+}

--- a/apps/web/src/room/useChatLogStickToBottom.ts
+++ b/apps/web/src/room/useChatLogStickToBottom.ts
@@ -1,21 +1,51 @@
-import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import {
+  countNewChatLines,
+  jumpToLatestButtonLabel,
+  nextPendingBelowCount,
+  pendingCountAfterNearBottomScroll,
+  shouldShowJumpToLatest,
+} from './chatLogPending'
 import { isChatLogNearBottom, scrollChatLogToBottom } from './chatLogScroll'
 
+export type UseChatLogStickToBottomResult = {
+  logRef: RefObject<HTMLUListElement | null>
+  pendingBelowCount: number
+  showJumpToLatest: boolean
+  jumpToLatestLabel: string
+  jumpToLatest: () => void
+}
+
 /**
- * Keeps the room chat log scrolled to the latest line when the user is near the bottom.
- * Only runs while the Chat tab is active.
+ * Keeps the room chat log scrolled to the latest line when the user is near the bottom,
+ * and tracks pending messages with a jump-to-latest affordance when scrolled up.
  */
 export function useChatLogStickToBottom(
   chatLength: number,
   chatTabActive: boolean,
-): RefObject<HTMLUListElement | null> {
+): UseChatLogStickToBottomResult {
   const logRef = useRef<HTMLUListElement>(null)
   const stickToBottomRef = useRef(true)
+  const prevChatLengthRef = useRef(chatLength)
+  const [pendingBelowCount, setPendingBelowCount] = useState(0)
+  const [isNearBottom, setIsNearBottom] = useState(true)
 
   const syncStickState = useCallback(() => {
     const el = logRef.current
     if (!el) return
-    stickToBottomRef.current = isChatLogNearBottom(el)
+    const near = isChatLogNearBottom(el)
+    stickToBottomRef.current = near
+    setIsNearBottom(near)
+    setPendingBelowCount((pending) => pendingCountAfterNearBottomScroll(near, pending))
+  }, [])
+
+  const jumpToLatest = useCallback(() => {
+    const el = logRef.current
+    if (!el) return
+    scrollChatLogToBottom(el)
+    stickToBottomRef.current = true
+    setIsNearBottom(true)
+    setPendingBelowCount(0)
   }, [])
 
   useLayoutEffect(() => {
@@ -33,6 +63,17 @@ export function useChatLogStickToBottom(
   }, [syncStickState])
 
   useLayoutEffect(() => {
+    const prevLength = prevChatLengthRef.current
+    const newLines = countNewChatLines(prevLength, chatLength)
+    prevChatLengthRef.current = chatLength
+
+    if (newLines > 0) {
+      const wasNearBottom = stickToBottomRef.current
+      setPendingBelowCount((pending) => nextPendingBelowCount(pending, newLines, wasNearBottom))
+    }
+  }, [chatLength])
+
+  useLayoutEffect(() => {
     if (!chatTabActive) return
     const el = logRef.current
     if (!el) return
@@ -43,5 +84,13 @@ export function useChatLogStickToBottom(
     syncStickState()
   }, [chatLength, chatTabActive, syncStickState])
 
-  return logRef
+  const showJumpToLatest = chatTabActive && shouldShowJumpToLatest(pendingBelowCount, isNearBottom)
+
+  return {
+    logRef,
+    pendingBelowCount,
+    showJumpToLatest,
+    jumpToLatestLabel: jumpToLatestButtonLabel(pendingBelowCount),
+    jumpToLatest,
+  }
 }

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1210,6 +1210,18 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   flex-shrink: 0;
 }
 
+.riffsync-room-chat-jump-latest {
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  z-index: 3;
+  margin-bottom: 0.45rem;
+  padding: 0.35rem 0.75rem;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 0.45);
+}
+
 .riffsync-room-chat-compose--inactive input:disabled,
 .riffsync-room-chat-compose--inactive .gen-button:disabled {
   opacity: 0.45;


### PR DESCRIPTION
## Summary

Implements **US-P0-06d** jump-to-latest for the room chat log on top of #24 stick-to-bottom behavior.

- Tracks pending messages when the user is scrolled up beyond the **48px** threshold.
- Shows a **New messages** button above compose (with **(N)** when **N > 1**).
- Clicking scrolls to the latest line, clears pending, and honors `prefers-reduced-motion`.
- Manual scroll within **48px** of the bottom clears pending without a click.

## Changes

- `apps/web/src/room/chatLogPending.ts` + unit tests for pending-count logic
- Extended `useChatLogStickToBottom` with jump affordance state
- `RoomPage.tsx` chip UI; `riffsync-app.css` positioning above compose holder

## Test plan

- [x] `cd apps/web && npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: scroll up in a busy room, receive messages, use jump chip, scroll to bottom to clear

Closes #25