### PR TITLE
feat(cdk): M7 fan avatars infra + API (#26)

### DIFF
--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -147,6 +147,27 @@ Deployed with **`RiffSyncApi-prod`** (same CloudFormation stack as catalog). Dep
 
 **Housekeeping:** lobby staleness uses **read-time filtering** (**US-P0-08**) — optional EventBridge TTL/sweeper deferred.
 
+### Fan avatars (S3 + CloudFront, M7)
+
+Provisioned in **`RiffSyncApi-prod`** ([`lib/api-catalog-stack.ts`](lib/api-catalog-stack.ts)):
+
+| Resource | Notes |
+| --- | --- |
+| **`FanAvatarsBucket`** | Private **S3** (**block public access**). Object keys **`avatars/{cognitoSub}/…`** (replace-on-upload per fan). **No** bucket CORS in MVP (upload via Lambda proxy, not browser **PUT**). |
+| **`FanAvatarsDistribution`** | **CloudFront** + **origin access control (OAC)** — same pattern as [`lib/static-site-stack.ts`](lib/static-site-stack.ts). Anonymous guests read avatars over **HTTPS** only. |
+| **`FanAvatarPostFn`** | **`FAN_AVATARS_BUCKET_NAME`**, **`FAN_AVATARS_PUBLIC_BASE_URL`** (HTTPS base, **no** trailing slash). **`s3:PutObject`** / **`s3:DeleteObject`** on **`avatars/*`**. **`POST /v1/fans/me/avatar`** HTTP route lands in a follow-up issue. |
+
+**Stack outputs:** **`FanAvatarsBucketName`**, **`FanAvatarsPublicBaseUrl`**, **`FanAvatarsDistributionId`**, **`FanAvatarPostFnName`**.
+
+**Verify after deploy:**
+
+```bash
+aws cloudformation describe-stacks --stack-name RiffSyncApi-prod \
+  --query "Stacks[0].Outputs[?contains(OutputKey,'FanAvatar')].[OutputKey,OutputValue]" --output table
+```
+
+Optional smoke: upload a test object under **`avatars/<sub>/test.png`**, then **`curl -I`** **`{FanAvatarsPublicBaseUrl}/avatars/<sub>/test.png`** and expect **200**.
+
 ### Self-hosted media (coturn TURN + mediasoup SFU on EC2)
 
 One account, **one CloudFormation stack** **`RiffSyncTurn`** ([`lib/media-server-stack.ts`](lib/media-server-stack.ts)): **one VPC**, **coturn** on **`t3.small`** + **mediasoup** on **`t3.medium`**, **two** Elastic IPs, **`riffsync/turn-static-auth-secret`**, S3 **BucketDeployment** of [`services/riffsync-sfu`](../../services/riffsync-sfu), and Route 53 **`A`** → SFU EIP when **`sfuProdSignalingHostname`** is set. ICE Lambdas use the TURN secret and **`turnHost`** (TURN EIP or DNS).
@@ -286,7 +307,7 @@ Full server IAM (Lambda, API Gateway, EventBridge, DynamoDB, Cognito, Secrets Ma
 
 - **`RiffSyncStatic-prod` —** **S3 bucket policy** statements: deny insecure transport; allow **`s3:GetObject`** for **CloudFront** via OAC (**resource-based**, not a standalone IAM role).
 - **`RiffSyncStatic-prod` —** **CloudFront** service-managed roles for the distribution (implicit in **`AWS::CloudFront::Distribution`**).
-- **`RiffSyncApi-prod` —** **HTTP API** (**catalog**, **rooms**, **lobby**) + **WebSocket API**; **JWT** (**HTTP** + **`aws-jwt-verify`** on **`$connect`**); DynamoDB (**catalog**, **rooms**, **connections**); **`execute-api:ManageConnections`** on **this stack’s WebSocket API** only; **TMDB** reconcile (**Secrets Manager**, **EventBridge**); **`cloudwatch:PutMetricData`** optional when emitting **EMF** in **`stdout`**.
+- **`RiffSyncApi-prod` —** **HTTP API** (**catalog**, **rooms**, **lobby**) + **WebSocket API**; **JWT** (**HTTP** + **`aws-jwt-verify`** on **`$connect`**); DynamoDB (**catalog**, **rooms**, **connections**, **fan profiles**); **fan avatars** private **S3** + **CloudFront OAC**; **`execute-api:ManageConnections`** on **this stack’s WebSocket API** only; **TMDB** reconcile (**Secrets Manager**, **EventBridge**); **`cloudwatch:PutMetricData`** optional when emitting **EMF** in **`stdout`**.
 - **`RiffSyncFanAuth-prod` —** **Cognito User Pool** + **UserPoolDomain** + **UserPoolClient** (OAuth authorization code grant for the SPA). Pool **`EmailConfiguration`** sends verification / recovery mail through **Amazon SES** (**`DEVELOPER`** / **`SourceArn`** `identity/<domain>`); verify that identity **in the deploy Region** before go-live. **SES configuration set + SNS topic** for outbound reputation events (**outputs** **`SesSendingEventsTopicArn`**, **`SesSendingConfigurationSetName`**).
 - **`RiffSyncSesInbound` —** shared **SNS** topic + **SES** **`ReceiptRuleSet`** / **`ReceiptRule`** + **`AwsCustomResource`** (**`ses:SetActiveReceiptRuleSet`**) + optional Route 53 **MX** when hosted-zone context aligns with **`sesInboundMailDomain`**. Deploy role needs **`ses:*`** receipt-rule APIs for your organization policies.
 

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -155,7 +155,7 @@ Provisioned in **`RiffSyncApi-prod`** ([`lib/api-catalog-stack.ts`](lib/api-cata
 | --- | --- |
 | **`FanAvatarsBucket`** | Private **S3** (**block public access**). Object keys **`avatars/{cognitoSub}/…`** (replace-on-upload per fan). **No** bucket CORS in MVP (upload via Lambda proxy, not browser **PUT**). |
 | **`FanAvatarsDistribution`** | **CloudFront** + **origin access control (OAC)** — same pattern as [`lib/static-site-stack.ts`](lib/static-site-stack.ts). Anonymous guests read avatars over **HTTPS** only. |
-| **`FanAvatarPostFn`** | **`FAN_AVATARS_BUCKET_NAME`**, **`FAN_AVATARS_PUBLIC_BASE_URL`** (HTTPS base, **no** trailing slash). **`s3:PutObject`** / **`s3:DeleteObject`** on **`avatars/*`**. **`POST /v1/fans/me/avatar`** HTTP route lands in a follow-up issue. |
+| **`FanAvatarPostFn`** | **`POST /v1/fans/me/avatar`** (multipart field **`file`**, fan JWT). **`FAN_AVATARS_*`**, **`FAN_PROFILES_TABLE_NAME`**. **`s3:PutObject`** / **`s3:DeleteObject`** on **`avatars/*`**. |
 
 **Stack outputs:** **`FanAvatarsBucketName`**, **`FanAvatarsPublicBaseUrl`**, **`FanAvatarsDistributionId`**, **`FanAvatarPostFnName`**.
 

--- a/infra/cdk/lambda/fan-avatar-post.ts
+++ b/infra/cdk/lambda/fan-avatar-post.ts
@@ -1,11 +1,128 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 
-/**
- * Placeholder until POST /v1/fans/me/avatar is wired (fan profile avatar API issue).
- * Infrastructure grants S3 put/delete on `avatars/{sub}/` and sets FAN_AVATARS_* env vars.
- */
-export const handler: APIGatewayProxyHandlerV2 = async () => ({
-  statusCode: 501,
-  headers: { 'content-type': 'application/json; charset=utf-8' },
-  body: JSON.stringify({ error: 'avatar_upload_not_implemented' }),
-});
+import {
+  assertSafeSubForS3Key,
+  avatarObjectKey,
+  extensionForMime,
+  FAN_AVATAR_FORM_FIELD,
+  FAN_AVATAR_MAX_BYTES,
+  objectKeyFromAvatarUrl,
+  parseMultipartSingleFile,
+  publicAvatarUrl,
+  validateAvatarBytes,
+} from './fan-profile-avatar';
+import { getJwtSub, headerValue } from './fan-profile-shared';
+
+const s3 = new S3Client({});
+const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+const jsonHeaders = { 'content-type': 'application/json; charset=utf-8' };
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const bucket = process.env.FAN_AVATARS_BUCKET_NAME;
+  const publicBaseUrl = process.env.FAN_AVATARS_PUBLIC_BASE_URL;
+  const profilesTable = process.env.FAN_PROFILES_TABLE_NAME;
+
+  if (!bucket || !publicBaseUrl || !profilesTable) {
+    return {
+      statusCode: 500,
+      headers: jsonHeaders,
+      body: JSON.stringify({ error: 'misconfigured_avatar_upload' }),
+    };
+  }
+
+  const jwtSub = getJwtSub(event);
+  if (!jwtSub) {
+    return { statusCode: 401, headers: jsonHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  if (!assertSafeSubForS3Key(jwtSub)) {
+    return { statusCode: 400, headers: jsonHeaders, body: JSON.stringify({ error: 'invalid_sub' }) };
+  }
+
+  const contentType = headerValue(event.headers, 'content-type');
+  const rawBody = event.isBase64Encoded
+    ? Buffer.from(event.body ?? '', 'base64')
+    : Buffer.from(event.body ?? '', 'utf8');
+
+  const parsed = parseMultipartSingleFile(rawBody, contentType, {
+    fieldName: FAN_AVATAR_FORM_FIELD,
+    maxBytes: FAN_AVATAR_MAX_BYTES,
+  });
+  if (!parsed.ok) {
+    return {
+      statusCode: parsed.statusCode,
+      headers: jsonHeaders,
+      body: JSON.stringify({ error: parsed.error }),
+    };
+  }
+
+  const validated = validateAvatarBytes(parsed.file, parsed.partContentType);
+  if (!validated.ok) {
+    return {
+      statusCode: validated.statusCode,
+      headers: jsonHeaders,
+      body: JSON.stringify({ error: validated.error }),
+    };
+  }
+
+  const ext = extensionForMime(validated.mime);
+  const objectKey = avatarObjectKey(jwtSub, ext);
+  const avatarUpdatedAt = Date.now();
+
+  const existing = await dynamo.send(
+    new GetCommand({
+      TableName: profilesTable,
+      Key: { sub: jwtSub },
+    }),
+  );
+  const priorUrl =
+    typeof existing.Item?.avatarUrl === 'string' ? existing.Item.avatarUrl.trim() : undefined;
+  const priorKey = priorUrl ? objectKeyFromAvatarUrl(priorUrl, publicBaseUrl) : null;
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: objectKey,
+      Body: parsed.file,
+      ContentType: validated.mime,
+      CacheControl: 'public, max-age=31536000, immutable',
+    }),
+  );
+
+  if (priorKey && priorKey !== objectKey) {
+    try {
+      await s3.send(
+        new DeleteObjectCommand({
+          Bucket: bucket,
+          Key: priorKey,
+        }),
+      );
+    } catch {
+      // Best-effort cleanup; new avatar URL is already valid.
+    }
+  }
+
+  const avatarUrl = publicAvatarUrl(publicBaseUrl, objectKey);
+
+  await dynamo.send(
+    new UpdateCommand({
+      TableName: profilesTable,
+      Key: { sub: jwtSub },
+      UpdateExpression: 'SET avatarUrl = :url, avatarUpdatedAt = :at',
+      ExpressionAttributeValues: {
+        ':url': avatarUrl,
+        ':at': avatarUpdatedAt,
+      },
+    }),
+  );
+
+  return {
+    statusCode: 200,
+    headers: jsonHeaders,
+    body: JSON.stringify({ avatarUrl, avatarUpdatedAt }),
+  };
+};

--- a/infra/cdk/lambda/fan-avatar-post.ts
+++ b/infra/cdk/lambda/fan-avatar-post.ts
@@ -1,0 +1,11 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+
+/**
+ * Placeholder until POST /v1/fans/me/avatar is wired (fan profile avatar API issue).
+ * Infrastructure grants S3 put/delete on `avatars/{sub}/` and sets FAN_AVATARS_* env vars.
+ */
+export const handler: APIGatewayProxyHandlerV2 = async () => ({
+  statusCode: 501,
+  headers: { 'content-type': 'application/json; charset=utf-8' },
+  body: JSON.stringify({ error: 'avatar_upload_not_implemented' }),
+});

--- a/infra/cdk/lambda/fan-profile-avatar.test.ts
+++ b/infra/cdk/lambda/fan-profile-avatar.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+
+import {
+  FAN_AVATAR_MAX_BYTES,
+  parseMultipartSingleFile,
+  publicAvatarUrl,
+  sniffImageMime,
+  validateAvatarBytes,
+} from './fan-profile-avatar';
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function buildMultipartBody(
+  boundary: string,
+  fieldName: string,
+  filename: string,
+  contentType: string,
+  data: Buffer,
+): Buffer {
+  const preamble = Buffer.from(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="${fieldName}"; filename="${filename}"\r\n` +
+      `Content-Type: ${contentType}\r\n\r\n`,
+  );
+  const closing = Buffer.from(`\r\n--${boundary}--\r\n`);
+  return Buffer.concat([preamble, data, closing]);
+}
+
+describe('fan-profile-avatar', () => {
+  describe('sniffImageMime', () => {
+    it('accepts png magic bytes', () => {
+      expect(sniffImageMime(PNG_1X1)).toBe('image/png');
+    });
+
+    it('rejects non-image bytes', () => {
+      expect(sniffImageMime(Buffer.from('not an image'))).toBeNull();
+    });
+  });
+
+  describe('validateAvatarBytes', () => {
+    it('rejects unsupported declared type', () => {
+      const out = validateAvatarBytes(PNG_1X1, 'image/gif');
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        expect(out.statusCode).toBe(415);
+      }
+    });
+
+    it('accepts png with matching content type', () => {
+      const out = validateAvatarBytes(PNG_1X1, 'image/png');
+      expect(out.ok).toBe(true);
+      if (out.ok) {
+        expect(out.mime).toBe('image/png');
+      }
+    });
+  });
+
+  describe('parseMultipartSingleFile', () => {
+    it('rejects oversize payload', () => {
+      const boundary = 'testboundary';
+      const huge = Buffer.alloc(FAN_AVATAR_MAX_BYTES + 1, 0x41);
+      const body = buildMultipartBody(boundary, 'file', 'big.png', 'image/png', huge);
+      const out = parseMultipartSingleFile(body, `multipart/form-data; boundary=${boundary}`, {
+        fieldName: 'file',
+        maxBytes: FAN_AVATAR_MAX_BYTES,
+      });
+      expect(out.ok).toBe(false);
+      if (!out.ok) {
+        expect(out.statusCode).toBe(413);
+      }
+    });
+
+    it('parses file field', () => {
+      const boundary = 'abc123';
+      const body = buildMultipartBody(boundary, 'file', 'a.png', 'image/png', PNG_1X1);
+      const out = parseMultipartSingleFile(body, `multipart/form-data; boundary=${boundary}`, {
+        fieldName: 'file',
+        maxBytes: FAN_AVATAR_MAX_BYTES,
+      });
+      expect(out.ok).toBe(true);
+      if (out.ok) {
+        expect(out.file.equals(PNG_1X1)).toBe(true);
+      }
+    });
+  });
+
+  describe('publicAvatarUrl', () => {
+    it('joins base and key without double slashes', () => {
+      expect(publicAvatarUrl('https://d111.cloudfront.net', 'avatars/sub/avatar.png')).toBe(
+        'https://d111.cloudfront.net/avatars/sub/avatar.png',
+      );
+    });
+  });
+});
+
+const dynamoSend = vi.fn();
+const s3Send = vi.fn();
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {
+    send = s3Send;
+  },
+  PutObjectCommand: vi.fn((input: unknown) => ({ input, kind: 'put' })),
+  DeleteObjectCommand: vi.fn((input: unknown) => ({ input, kind: 'del' })),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: () => ({ send: dynamoSend }),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'update' })),
+}));
+
+describe('fan-avatar-post handler', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    dynamoSend.mockReset();
+    s3Send.mockReset();
+    process.env.FAN_AVATARS_BUCKET_NAME = 'avatars-bucket';
+    process.env.FAN_AVATARS_PUBLIC_BASE_URL = 'https://cdn.example.com';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    dynamoSend.mockResolvedValue({ Item: undefined });
+    s3Send.mockResolvedValue({});
+  });
+
+  it('returns 401 without JWT sub', async () => {
+    const { handler } = await import('./fan-avatar-post');
+    const res = await handler({
+      headers: { 'content-type': 'multipart/form-data; boundary=b' },
+      body: '',
+      requestContext: {},
+    } as APIGatewayProxyEventV2);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('uploads png and returns avatarUrl', async () => {
+    const { handler } = await import('./fan-avatar-post');
+    const boundary = 'xyz';
+    const body = buildMultipartBody(boundary, 'file', 'me.png', 'image/png', PNG_1X1);
+    const res = await handler({
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body: body.toString('base64'),
+      isBase64Encoded: true,
+      requestContext: {
+        authorizer: { jwt: { claims: { sub: 'user-sub-1' } } },
+      },
+    } as APIGatewayProxyEventV2);
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body ?? '{}') as {
+      avatarUrl?: string;
+      avatarUpdatedAt?: number;
+    };
+    expect(payload.avatarUrl).toBe('https://cdn.example.com/avatars/user-sub-1/avatar.png');
+    expect(typeof payload.avatarUpdatedAt).toBe('number');
+    expect(s3Send).toHaveBeenCalled();
+    expect(dynamoSend).toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/fan-profile-avatar.ts
+++ b/infra/cdk/lambda/fan-profile-avatar.ts
@@ -1,0 +1,171 @@
+/** Max upload size for fan avatar multipart POST (2 MiB). */
+export const FAN_AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+
+export const FAN_AVATAR_FORM_FIELD = 'file';
+
+export type AllowedAvatarMime = 'image/jpeg' | 'image/png' | 'image/webp';
+
+export function sniffImageMime(buf: Uint8Array): AllowedAvatarMime | null {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf[4] === 0x0d &&
+    buf[5] === 0x0a &&
+    buf[6] === 0x1a &&
+    buf[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+export function extensionForMime(mime: AllowedAvatarMime): string {
+  switch (mime) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
+  }
+}
+
+export function assertSafeSubForS3Key(sub: string): boolean {
+  return sub.length > 0 && !sub.includes('/') && !sub.includes('..');
+}
+
+export function avatarObjectKey(sub: string, ext: string): string {
+  return `avatars/${sub}/avatar.${ext}`;
+}
+
+export function publicAvatarUrl(publicBaseUrl: string, objectKey: string): string {
+  const base = publicBaseUrl.replace(/\/$/, '');
+  return `${base}/${objectKey}`;
+}
+
+export function objectKeyFromAvatarUrl(avatarUrl: string, publicBaseUrl: string): string | null {
+  const prefix = `${publicBaseUrl.replace(/\/$/, '')}/`;
+  if (!avatarUrl.startsWith(prefix)) {
+    return null;
+  }
+  const key = avatarUrl.slice(prefix.length);
+  return key.length > 0 ? key : null;
+}
+
+export function declaredMimeAllowed(declared: string | undefined): declared is AllowedAvatarMime {
+  return declared === 'image/jpeg' || declared === 'image/png' || declared === 'image/webp';
+}
+
+export type MultipartFileResult =
+  | { ok: true; file: Buffer; partContentType?: string }
+  | { ok: false; statusCode: number; error: string };
+
+/**
+ * Parses a single `multipart/form-data` file field (MVP: one file part only).
+ */
+export function parseMultipartSingleFile(
+  rawBody: Buffer,
+  contentType: string | undefined,
+  options: { fieldName: string; maxBytes: number },
+): MultipartFileResult {
+  if (!contentType?.toLowerCase().includes('multipart/form-data')) {
+    return { ok: false, statusCode: 400, error: 'expected_multipart_form_data' };
+  }
+
+  const boundaryMatch = /boundary=(?:"([^"]+)"|([^;\s]+))/i.exec(contentType);
+  const boundary = boundaryMatch?.[1] ?? boundaryMatch?.[2];
+  if (!boundary) {
+    return { ok: false, statusCode: 400, error: 'missing_multipart_boundary' };
+  }
+
+  const delimiter = Buffer.from(`--${boundary}`);
+  let searchFrom = 0;
+
+  while (searchFrom < rawBody.length) {
+    const start = rawBody.indexOf(delimiter, searchFrom);
+    if (start < 0) {
+      break;
+    }
+    let partStart = start + delimiter.length;
+    if (rawBody[partStart] === 0x2d && rawBody[partStart + 1] === 0x2d) {
+      break;
+    }
+    if (rawBody[partStart] === 0x0d && rawBody[partStart + 1] === 0x0a) {
+      partStart += 2;
+    } else if (rawBody[partStart] === 0x0a) {
+      partStart += 1;
+    }
+
+    const nextDelimiter = rawBody.indexOf(delimiter, partStart);
+    const partEnd = nextDelimiter < 0 ? rawBody.length : nextDelimiter;
+    const part = rawBody.subarray(partStart, partEnd);
+    const headerEnd = part.indexOf(Buffer.from('\r\n\r\n'));
+    if (headerEnd < 0) {
+      searchFrom = partStart + 1;
+      continue;
+    }
+
+    const headerBlock = part.subarray(0, headerEnd).toString('utf8');
+    const disposition = headerBlock.match(/content-disposition:\s*form-data[^;]*;\s*name="([^"]+)"/i);
+    const name = disposition?.[1];
+    if (name !== options.fieldName) {
+      searchFrom = partStart + 1;
+      continue;
+    }
+
+    let bodyStart = headerEnd + 4;
+    let bodyEnd = part.length;
+    if (bodyEnd >= 2 && part[bodyEnd - 2] === 0x0d && part[bodyEnd - 1] === 0x0a) {
+      bodyEnd -= 2;
+    }
+    const file = part.subarray(bodyStart, bodyEnd);
+    if (file.length > options.maxBytes) {
+      return { ok: false, statusCode: 413, error: 'file_too_large' };
+    }
+    if (file.length === 0) {
+      return { ok: false, statusCode: 400, error: 'empty_file' };
+    }
+
+    const typeMatch = headerBlock.match(/content-type:\s*([^\r\n]+)/i);
+    const partContentType = typeMatch?.[1]?.trim().toLowerCase();
+    return { ok: true, file: Buffer.from(file), partContentType };
+  }
+
+  return { ok: false, statusCode: 400, error: 'file_field_missing' };
+}
+
+export function validateAvatarBytes(
+  file: Buffer,
+  partContentType: string | undefined,
+): { ok: true; mime: AllowedAvatarMime } | { ok: false; statusCode: number; error: string } {
+  const sniffed = sniffImageMime(file);
+  if (!sniffed) {
+    return { ok: false, statusCode: 415, error: 'unsupported_image_type' };
+  }
+  if (partContentType && declaredMimeAllowed(partContentType) && partContentType !== sniffed) {
+    return { ok: false, statusCode: 415, error: 'content_type_mismatch' };
+  }
+  if (partContentType && !declaredMimeAllowed(partContentType)) {
+    return { ok: false, statusCode: 415, error: 'unsupported_image_type' };
+  }
+  return { ok: true, mime: sniffed };
+}

--- a/infra/cdk/lambda/fan-profile-get.ts
+++ b/infra/cdk/lambda/fan-profile-get.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { FAN_DISPLAY_NAME_MAX_LEN, getJwtSub } from './fan-profile-shared';
+import { getJwtSub, serializeFanProfile } from './fan-profile-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -23,23 +23,11 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     }),
   );
 
-  const item = out.Item as Record<string, unknown> | undefined;
-  if (!item) {
-    return {
-      statusCode: 200,
-      headers: { 'content-type': 'application/json; charset=utf-8' },
-      body: JSON.stringify({ displayName: null, updatedAt: null }),
-    };
-  }
-
-  const dn = item.displayName;
-  const ua = item.updatedAt;
-  const displayName = typeof dn === 'string' && dn.trim() !== '' ? dn.trim().slice(0, FAN_DISPLAY_NAME_MAX_LEN) : null;
-  const updatedAt = typeof ua === 'number' && Number.isFinite(ua) ? ua : null;
+  const profile = serializeFanProfile(out.Item as Record<string, unknown> | undefined);
 
   return {
     statusCode: 200,
     headers: { 'content-type': 'application/json; charset=utf-8' },
-    body: JSON.stringify({ displayName, updatedAt }),
+    body: JSON.stringify(profile),
   };
 };

--- a/infra/cdk/lambda/fan-profile-patch.ts
+++ b/infra/cdk/lambda/fan-profile-patch.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { FAN_DISPLAY_NAME_MAX_LEN, getJwtSub } from './fan-profile-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -46,12 +46,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const updatedAt = Date.now();
 
   await client.send(
-    new PutCommand({
+    new UpdateCommand({
       TableName: table,
-      Item: {
-        sub: jwtSub,
-        displayName,
-        updatedAt,
+      Key: { sub: jwtSub },
+      UpdateExpression: 'SET displayName = :dn, updatedAt = :ua',
+      ExpressionAttributeValues: {
+        ':dn': displayName,
+        ':ua': updatedAt,
       },
     }),
   );

--- a/infra/cdk/lambda/fan-profile-shared.ts
+++ b/infra/cdk/lambda/fan-profile-shared.ts
@@ -14,3 +14,51 @@ export function getJwtSub(event: Parameters<APIGatewayProxyHandlerV2>[0]): strin
   ).authorizer?.jwt?.claims;
   return typeof claims?.sub === 'string' ? claims.sub : undefined;
 }
+
+export type FanProfileResponse = {
+  displayName: string | null;
+  updatedAt: number | null;
+  avatarUrl: string | null;
+  avatarUpdatedAt: number | null;
+};
+
+export function serializeFanProfile(item: Record<string, unknown> | undefined): FanProfileResponse {
+  if (!item) {
+    return {
+      displayName: null,
+      updatedAt: null,
+      avatarUrl: null,
+      avatarUpdatedAt: null,
+    };
+  }
+
+  const dn = item.displayName;
+  const ua = item.updatedAt;
+  const displayName =
+    typeof dn === 'string' && dn.trim() !== '' ? dn.trim().slice(0, FAN_DISPLAY_NAME_MAX_LEN) : null;
+  const updatedAt = typeof ua === 'number' && Number.isFinite(ua) ? ua : null;
+
+  const au = item.avatarUrl;
+  const avatarUrl = typeof au === 'string' && au.trim() !== '' ? au.trim() : null;
+
+  const aua = item.avatarUpdatedAt;
+  const avatarUpdatedAt = typeof aua === 'number' && Number.isFinite(aua) ? aua : null;
+
+  return { displayName, updatedAt, avatarUrl, avatarUpdatedAt };
+}
+
+export function headerValue(
+  headers: Record<string, string | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -1,8 +1,11 @@
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as apigwv2Auth from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -124,6 +127,9 @@ const sharedLambdaBundle = {
   externalModules: ['@aws-sdk/*'],
 };
 
+/** S3 object keys: `avatars/{cognitoSub}/…` (one prefix per signed-in fan). */
+const FAN_AVATAR_S3_KEY_PREFIX = 'avatars/';
+
 /**
  * DynamoDB **Catalog** + **Rooms** + **Connections**, HTTP API (catalog, rooms, lobby),
  * WebSocket API (realtime), TMDB reconcile — see **`docs/architecture.server.md`**.
@@ -134,6 +140,10 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly connectionsTable: dynamodb.Table;
   public readonly roomPresenceTable: dynamodb.Table;
   public readonly fanProfilesTable: dynamodb.Table;
+  public readonly fanAvatarsBucket: s3.Bucket;
+  public readonly fanAvatarsDistribution: cloudfront.Distribution;
+  /** HTTPS origin for avatar object keys (no trailing slash). */
+  public readonly fanAvatarsPublicBaseUrl: string;
   public readonly httpApi: apigwv2.HttpApi;
   public readonly webSocketApi: apigwv2.WebSocketApi;
   public readonly tmdbApiTokenSecret: secretsmanager.ISecret;
@@ -199,6 +209,35 @@ export class ApiCatalogStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
+
+    this.fanAvatarsBucket = new s3.Bucket(this, 'FanAvatarsBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    const fanAvatarsOac = new cloudfront.S3OriginAccessControl(this, 'FanAvatarsOac', {
+      signing: cloudfront.Signing.SIGV4_ALWAYS,
+      originAccessControlName: 'riffsync-prod-fan-avatars-oac',
+    });
+
+    this.fanAvatarsDistribution = new cloudfront.Distribution(this, 'FanAvatarsDistribution', {
+      comment: 'RiffSync prod fan avatars (private S3, public HTTPS via OAC)',
+      httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.fanAvatarsBucket, {
+          originAccessControl: fanAvatarsOac,
+        }),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
+        compress: true,
+      },
+    });
+
+    this.fanAvatarsPublicBaseUrl = `https://${this.fanAvatarsDistribution.distributionDomainName}`;
 
     this.tmdbApiTokenSecret = new secretsmanager.Secret(this, 'TmdbApiToken', {
       secretName: `riffsync/${environment}/tmdb-api-token`,
@@ -480,6 +519,22 @@ export class ApiCatalogStack extends cdk.Stack {
     this.fanProfilesTable.grantReadData(fanProfileGetFn);
     this.fanProfilesTable.grantReadWriteData(fanProfilePatchFn);
 
+    const fanAvatarPostFn = new lambdaNodejs.NodejsFunction(this, 'FanAvatarPostFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(29),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/fan-avatar-post.ts'),
+      handler: 'handler',
+      environment: {
+        FAN_AVATARS_BUCKET_NAME: this.fanAvatarsBucket.bucketName,
+        FAN_AVATARS_PUBLIC_BASE_URL: this.fanAvatarsPublicBaseUrl,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.fanAvatarsBucket.grantPut(fanAvatarPostFn, `${FAN_AVATAR_S3_KEY_PREFIX}*`);
+    this.fanAvatarsBucket.grantDelete(fanAvatarPostFn, `${FAN_AVATAR_S3_KEY_PREFIX}*`);
+
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
@@ -719,6 +774,28 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'FanProfilesTableName', {
       value: this.fanProfilesTable.tableName,
       description: 'DynamoDB FanProfiles — partition key `sub` (Cognito subject).',
+    });
+
+    new cdk.CfnOutput(this, 'FanAvatarsBucketName', {
+      value: this.fanAvatarsBucket.bucketName,
+      description: `Private S3 bucket for fan avatars (keys under \`${FAN_AVATAR_S3_KEY_PREFIX}{sub}/\`).`,
+    });
+
+    new cdk.CfnOutput(this, 'FanAvatarsPublicBaseUrl', {
+      value: this.fanAvatarsPublicBaseUrl,
+      description:
+        'HTTPS base URL for avatar objects (append object key path; no trailing slash). Anonymous guests read via CloudFront only.',
+    });
+
+    new cdk.CfnOutput(this, 'FanAvatarsDistributionId', {
+      value: this.fanAvatarsDistribution.distributionId,
+      description: 'CloudFront distribution serving fan avatar objects (OAC to FanAvatarsBucket).',
+    });
+
+    new cdk.CfnOutput(this, 'FanAvatarPostFnName', {
+      value: fanAvatarPostFn.functionName,
+      description:
+        'Avatar upload Lambda (POST /v1/fans/me/avatar route wired in a follow-up issue). Env: FAN_AVATARS_BUCKET_NAME, FAN_AVATARS_PUBLIC_BASE_URL.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiUrl', {

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -529,11 +529,13 @@ export class ApiCatalogStack extends cdk.Stack {
       environment: {
         FAN_AVATARS_BUCKET_NAME: this.fanAvatarsBucket.bucketName,
         FAN_AVATARS_PUBLIC_BASE_URL: this.fanAvatarsPublicBaseUrl,
+        FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
     this.fanAvatarsBucket.grantPut(fanAvatarPostFn, `${FAN_AVATAR_S3_KEY_PREFIX}*`);
     this.fanAvatarsBucket.grantDelete(fanAvatarPostFn, `${FAN_AVATAR_S3_KEY_PREFIX}*`);
+    this.fanProfilesTable.grantReadWriteData(fanAvatarPostFn);
 
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
@@ -674,6 +676,10 @@ export class ApiCatalogStack extends cdk.Stack {
       'FanProfilePatchInt',
       fanProfilePatchFn,
     );
+    const fanAvatarPostIntegration = new integrations.HttpLambdaIntegration(
+      'FanAvatarPostInt',
+      fanAvatarPostFn,
+    );
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -745,6 +751,13 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: fanJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/fans/me/avatar',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: fanAvatarPostIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -795,7 +808,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'FanAvatarPostFnName', {
       value: fanAvatarPostFn.functionName,
       description:
-        'Avatar upload Lambda (POST /v1/fans/me/avatar route wired in a follow-up issue). Env: FAN_AVATARS_BUCKET_NAME, FAN_AVATARS_PUBLIC_BASE_URL.',
+        'Avatar upload Lambda for POST /v1/fans/me/avatar (multipart file field). Env: FAN_AVATARS_*, FAN_PROFILES_TABLE_NAME.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiUrl', {


### PR DESCRIPTION
## Summary

- **#37** — `FanAvatarsBucket`, CloudFront OAC, stack outputs, `FanAvatarPostFn` IAM/env.
- **#38** — `GET`/`PATCH /v1/fans/me` avatar fields; merge-safe `PATCH`; `POST /v1/fans/me/avatar` (multipart `file`, ≤2 MiB, jpeg/png/webp); Vitest coverage.

Parent epic: **#26**.

Closes #37.
Closes #38.

## Test plan

- [x] `npm ci --prefix infra/cdk`
- [x] `npm run test --prefix infra/cdk`
- [x] `npm run synth --prefix infra/cdk`
- [ ] Deploy `RiffSyncApi-prod`; smoke `POST /v1/fans/me/avatar` with fan JWT
- [ ] `curl -I` returned `avatarUrl` (anonymous **200**)