### PR TITLE
feat(web): M7 profile upload and avatar thumbnails in chat/presence (#27)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "happy-dom": "^17.4.4",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.10",
@@ -2897,6 +2898,20 @@
         "url": "https://opencollective.com/mediasoup"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "17.6.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.6.3.tgz",
+      "integrity": "sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4439,6 +4454,26 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "happy-dom": "^17.4.4",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.10",

--- a/apps/web/src/api/fanProfileApi.test.ts
+++ b/apps/web/src/api/fanProfileApi.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  FAN_AVATAR_MAX_BYTES,
+  uploadFanProfileAvatar,
+  validateFanAvatarFile,
+} from './fanProfileApi'
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.example.test',
+}))
+
+describe('validateFanAvatarFile', () => {
+  it('accepts allowed image types within size limit', () => {
+    const file = new File([new Uint8Array(100)], 'a.png', { type: 'image/png' })
+    expect(validateFanAvatarFile(file)).toBeNull()
+  })
+
+  it('rejects disallowed mime types without network', () => {
+    const file = new File([new Uint8Array(100)], 'a.gif', { type: 'image/gif' })
+    expect(validateFanAvatarFile(file)).toMatch(/JPEG, PNG, or WebP/i)
+  })
+
+  it('rejects files larger than 2 MiB without network', () => {
+    const file = new File([new Uint8Array(FAN_AVATAR_MAX_BYTES + 1)], 'big.png', {
+      type: 'image/png',
+    })
+    expect(validateFanAvatarFile(file)).toMatch(/2 MB/i)
+  })
+})
+
+describe('uploadFanProfileAvatar', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts multipart file on happy path', async () => {
+    const bytes = new Uint8Array(8)
+    const file = new File([bytes], 'avatar.png', { type: 'image/png' })
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        avatarUrl: 'https://cdn.example.test/avatars/sub/avatar.png',
+        avatarUpdatedAt: 1_700_000_000_000,
+      }),
+    })
+
+    const result = await uploadFanProfileAvatar('token-abc', file)
+
+    expect(result.avatarUrl).toContain('avatar.png')
+    expect(result.avatarUpdatedAt).toBe(1_700_000_000_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/fans/me/avatar')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer token-abc',
+      Accept: 'application/json',
+    })
+    const body = init.body as FormData
+    expect(body.get('file')).toBe(file)
+  })
+
+  it('surfaces 401 from the API', async () => {
+    const file = new File([new Uint8Array(8)], 'avatar.png', { type: 'image/png' })
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => '',
+    })
+
+    await expect(uploadFanProfileAvatar('bad-token', file)).rejects.toThrow(/Sign in again/i)
+  })
+
+  it('does not call fetch when client validation fails', async () => {
+    const file = new File([new Uint8Array(FAN_AVATAR_MAX_BYTES + 1)], 'big.png', {
+      type: 'image/png',
+    })
+
+    await expect(uploadFanProfileAvatar('token-abc', file)).rejects.toThrow(/2 MB/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/api/fanProfileApi.ts
+++ b/apps/web/src/api/fanProfileApi.ts
@@ -1,23 +1,63 @@
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 
+/** Matches Lambda `FAN_AVATAR_MAX_BYTES` in `infra/cdk/lambda/fan-profile-avatar.ts`. */
+export const FAN_AVATAR_MAX_BYTES = 2 * 1024 * 1024
+
+/** Multipart field name for `POST /v1/fans/me/avatar` (Lambda `FAN_AVATAR_FORM_FIELD`). */
+export const FAN_AVATAR_FORM_FIELD = 'file'
+
+const FAN_AVATAR_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+
 export interface FanProfilePayload {
   displayName: string | null
   updatedAt: number | null
+  avatarUrl: string | null
+  avatarUpdatedAt: number | null
+}
+
+export type FanAvatarUploadResult = Pick<FanProfilePayload, 'avatarUrl' | 'avatarUpdatedAt'>
+
+export function validateFanAvatarFile(file: File): string | null {
+  if (!FAN_AVATAR_MIME_TYPES.has(file.type)) {
+    return 'Choose a JPEG, PNG, or WebP image.'
+  }
+  if (file.size > FAN_AVATAR_MAX_BYTES) {
+    return 'Image must be 2 MB or smaller.'
+  }
+  return null
+}
+
+function fanProfileAuthHeaders(accessToken: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+  }
+}
+
+function formatFanProfileHttpError(prefix: string, status: number, bodyText: string): string {
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: string; message?: string }
+    const detail = parsed.error ?? parsed.message
+    if (typeof detail === 'string' && detail.trim() !== '') {
+      return `${prefix} (${status}): ${detail}`
+    }
+  } catch {
+    /* use raw body */
+  }
+  const trimmed = bodyText.trim()
+  return trimmed ? `${prefix} (${status}): ${trimmed}` : `${prefix} (${status})`
 }
 
 export async function fetchFanProfile(accessToken: string): Promise<FanProfilePayload> {
   const base = getPublicApiBaseUrl()
   if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
   const res = await fetch(`${base}/v1/fans/me`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/json',
-    },
+    headers: fanProfileAuthHeaders(accessToken),
   })
   if (res.status === 401) throw new Error('Sign in again — token rejected')
   if (!res.ok) {
     const t = await res.text()
-    throw new Error(`Fan profile read failed (${res.status}): ${t}`)
+    throw new Error(formatFanProfileHttpError('Fan profile read failed', res.status, t))
   }
   return (await res.json()) as FanProfilePayload
 }
@@ -31,16 +71,40 @@ export async function patchFanProfileDisplayName(
   const res = await fetch(`${base}/v1/fans/me`, {
     method: 'PATCH',
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      ...fanProfileAuthHeaders(accessToken),
       'Content-Type': 'application/json',
-      Accept: 'application/json',
     },
     body: JSON.stringify({ displayName }),
   })
   if (res.status === 401) throw new Error('Sign in again — token rejected')
   if (!res.ok) {
     const t = await res.text()
-    throw new Error(`Fan profile update failed (${res.status}): ${t}`)
+    throw new Error(formatFanProfileHttpError('Fan profile update failed', res.status, t))
   }
   return (await res.json()) as FanProfilePayload
+}
+
+export async function uploadFanProfileAvatar(
+  accessToken: string,
+  file: File,
+): Promise<FanAvatarUploadResult> {
+  const validationErr = validateFanAvatarFile(file)
+  if (validationErr) {
+    throw new Error(validationErr)
+  }
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const body = new FormData()
+  body.append(FAN_AVATAR_FORM_FIELD, file)
+  const res = await fetch(`${base}/v1/fans/me/avatar`, {
+    method: 'POST',
+    headers: fanProfileAuthHeaders(accessToken),
+    body,
+  })
+  if (res.status === 401) throw new Error('Sign in again — token rejected')
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(formatFanProfileHttpError('Avatar upload failed', res.status, t))
+  }
+  return (await res.json()) as FanAvatarUploadResult
 }

--- a/apps/web/src/components/FanAvatarThumb.test.tsx
+++ b/apps/web/src/components/FanAvatarThumb.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FanAvatarThumb, type FanAvatarThumbProps } from './FanAvatarThumb'
+
+function renderThumb(el: HTMLElement, props: FanAvatarThumbProps): Root {
+  const root = createRoot(el)
+  act(() => {
+    root.render(<FanAvatarThumb {...props} />)
+  })
+  return root
+}
+
+describe('FanAvatarThumb', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+  })
+
+  it('renders initials when avatarUrl is missing', () => {
+    container = document.createElement('div')
+    root = renderThumb(container, { displayName: '  ada lovelace ' })
+    const initials = container.querySelector('.riffsync-fan-avatar-thumb--initials')
+    expect(initials?.textContent).toBe('A')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('renders img for https avatarUrl', () => {
+    container = document.createElement('div')
+    root = renderThumb(container, {
+      displayName: 'Fan',
+      avatarUrl: 'https://cdn.example.test/avatars/u.png',
+    })
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('https://cdn.example.test/avatars/u.png')
+    expect(img?.getAttribute('alt')).toBe('Fan')
+    expect(img?.getAttribute('loading')).toBe('lazy')
+    expect(img?.getAttribute('referrerpolicy')).toBe('no-referrer')
+  })
+
+  it('falls back to initials when image fails to load', () => {
+    container = document.createElement('div')
+    root = renderThumb(container, {
+      displayName: 'Broken',
+      avatarUrl: 'https://cdn.example.test/missing.png',
+    })
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    act(() => {
+      img?.dispatchEvent(new Event('error'))
+    })
+    const initials = container.querySelector('.riffsync-fan-avatar-thumb--initials')
+    expect(initials?.textContent).toBe('B')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('uses initials for non-https avatarUrl', () => {
+    container = document.createElement('div')
+    root = renderThumb(container, {
+      displayName: 'Guest',
+      avatarUrl: 'http://insecure.example/avatar.png',
+    })
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('.riffsync-fan-avatar-thumb--initials')?.textContent).toBe('G')
+  })
+})

--- a/apps/web/src/components/FanAvatarThumb.tsx
+++ b/apps/web/src/components/FanAvatarThumb.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { avatarInitialFromDisplayName, isHttpsAvatarUrl } from './fanAvatarDisplay'
+
+export type FanAvatarThumbProps = {
+  displayName: string
+  avatarUrl?: string | null
+  sizePx?: number
+}
+
+export function FanAvatarThumb({ displayName, avatarUrl, sizePx = 28 }: FanAvatarThumbProps) {
+  const [imageFailed, setImageFailed] = useState(false)
+  const initial = avatarInitialFromDisplayName(displayName)
+  const showImage = isHttpsAvatarUrl(avatarUrl) && !imageFailed
+
+  const sizeStyle = { width: sizePx, height: sizePx, fontSize: Math.max(10, Math.round(sizePx * 0.42)) }
+
+  if (showImage) {
+    return (
+      <img
+        className="riffsync-fan-avatar-thumb riffsync-fan-avatar-thumb--img"
+        src={avatarUrl.trim()}
+        alt={displayName}
+        width={sizePx}
+        height={sizePx}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        style={sizeStyle}
+        onError={() => setImageFailed(true)}
+      />
+    )
+  }
+
+  return (
+    <span
+      className="riffsync-fan-avatar-thumb riffsync-fan-avatar-thumb--initials"
+      aria-hidden
+      style={sizeStyle}
+    >
+      {initial}
+    </span>
+  )
+}

--- a/apps/web/src/components/fanAvatarDisplay.test.ts
+++ b/apps/web/src/components/fanAvatarDisplay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { avatarInitialFromDisplayName, isHttpsAvatarUrl } from './fanAvatarDisplay'
+
+describe('fanAvatarDisplay', () => {
+  it('avatarInitialFromDisplayName uses first grapheme uppercased', () => {
+    expect(avatarInitialFromDisplayName('  ada ')).toBe('A')
+    expect(avatarInitialFromDisplayName('')).toBe('?')
+  })
+
+  it('isHttpsAvatarUrl accepts https only', () => {
+    expect(isHttpsAvatarUrl('https://cdn.example/a.png')).toBe(true)
+    expect(isHttpsAvatarUrl('http://cdn.example/a.png')).toBe(false)
+    expect(isHttpsAvatarUrl('')).toBe(false)
+    expect(isHttpsAvatarUrl(undefined)).toBe(false)
+  })
+})

--- a/apps/web/src/components/fanAvatarDisplay.ts
+++ b/apps/web/src/components/fanAvatarDisplay.ts
@@ -1,0 +1,19 @@
+/** First grapheme of trimmed display name, uppercased; neutral fallback when empty. */
+export function avatarInitialFromDisplayName(displayName: string): string {
+  const trimmed = displayName.trim()
+  if (!trimmed) return '?'
+  const chars = [...trimmed]
+  return chars[0]!.toLocaleUpperCase('en-US')
+}
+
+/** Server-supplied avatar URLs must be non-empty HTTPS (client never sends URLs on the wire). */
+export function isHttpsAvatarUrl(url: string | undefined | null): url is string {
+  if (url == null) return false
+  const trimmed = url.trim()
+  if (trimmed === '') return false
+  try {
+    return new URL(trimmed).protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -1,7 +1,11 @@
 import { Link, useParams } from 'react-router-dom'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import type { RoomSnapshot } from '../api/roomsApi'
-import { fetchFanProfile, patchFanProfileDisplayName } from '../api/fanProfileApi'
+import {
+  fetchFanProfile,
+  patchFanProfileDisplayName,
+  uploadFanProfileAvatar,
+} from '../api/fanProfileApi'
 import { fetchRoom, patchRoom } from '../api/roomsApi'
 import { fetchCatalogEpisodeById } from '../catalog/catalogApi'
 import type { CatalogEpisode } from '../catalog/catalogTypes'
@@ -116,6 +120,12 @@ export function RoomPage() {
   const [profileDraft, setProfileDraft] = useState('')
   const [profileSaveErr, setProfileSaveErr] = useState<string | null>(null)
   const [profileSaving, setProfileSaving] = useState(false)
+  const [profileAvatarUrl, setProfileAvatarUrl] = useState<string | null>(null)
+  const [profileAvatarLoading, setProfileAvatarLoading] = useState(false)
+  const [profileAvatarUploading, setProfileAvatarUploading] = useState(false)
+  const [profileAvatarErr, setProfileAvatarErr] = useState<string | null>(null)
+  const profileTabLoadedRef = useRef(false)
+  const profileAvatarInputRef = useRef<HTMLInputElement>(null)
 
   const [guestFsmPollTick, setGuestFsmPollTick] = useState(0)
   const guestInboundHealthRef = useRef(false)
@@ -347,9 +357,33 @@ export function RoomPage() {
     if (roomSidebarTab === 'profile' && prevRoomSidebarTabRef.current !== 'profile') {
       setProfileDraft(displayName)
       setProfileSaveErr(null)
+      setProfileAvatarErr(null)
     }
     prevRoomSidebarTabRef.current = roomSidebarTab
   }, [roomSidebarTab, displayName])
+
+  useEffect(() => {
+    if (roomSidebarTab !== 'profile' || !fanToken || profileTabLoadedRef.current) return
+    profileTabLoadedRef.current = true
+    let cancelled = false
+    setProfileAvatarLoading(true)
+    setProfileAvatarErr(null)
+    void fetchFanProfile(fanToken)
+      .then((p) => {
+        if (cancelled) return
+        setProfileAvatarUrl(p.avatarUrl)
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setProfileAvatarErr(e instanceof Error ? e.message : 'Could not load profile.')
+      })
+      .finally(() => {
+        if (!cancelled) setProfileAvatarLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [roomSidebarTab, fanToken])
 
   const icePromiseByRoomRef = useRef<{ roomId: string; promise: Promise<RTCIceServer[]> } | null>(null)
   const getIceServers = useCallback((): Promise<RTCIceServer[]> => {
@@ -952,16 +986,36 @@ export function RoomPage() {
     setProfileSaving(true)
     setProfileSaveErr(null)
     void patchFanProfileDisplayName(fanToken, trimmed)
-      .then(() => {
+      .then((p) => {
         const applied = setGuestDisplayName(trimmed)
         setDisplayName(applied)
         setProfileDraft(applied)
+        setProfileAvatarUrl(p.avatarUrl)
       })
       .catch((e) => {
         setProfileSaveErr(e instanceof Error ? e.message : 'Could not save profile.')
       })
       .finally(() => {
         setProfileSaving(false)
+      })
+  }
+
+  const onProfileAvatarSelected = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!fanToken) return
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    setProfileAvatarUploading(true)
+    setProfileAvatarErr(null)
+    void uploadFanProfileAvatar(fanToken, file)
+      .then((p) => {
+        setProfileAvatarUrl(p.avatarUrl)
+      })
+      .catch((err) => {
+        setProfileAvatarErr(err instanceof Error ? err.message : 'Could not upload avatar.')
+      })
+      .finally(() => {
+        setProfileAvatarUploading(false)
       })
   }
 
@@ -1369,6 +1423,52 @@ export function RoomPage() {
                   <p className="riffsync-muted riffsync-room-page__profile-lede">
                     This name appears in chat, the viewer list, and across devices when you&apos;re signed in.
                   </p>
+                  <div className="riffsync-room-page__profile-avatar-block">
+                    <span className="riffsync-room-page__profile-label" id="riffsync-profile-avatar-label">
+                      Avatar
+                    </span>
+                    <div
+                      className="riffsync-room-page__profile-avatar-preview"
+                      aria-labelledby="riffsync-profile-avatar-label"
+                      aria-busy={profileAvatarLoading || profileAvatarUploading}
+                    >
+                      {profileAvatarUrl ? (
+                        <img
+                          src={profileAvatarUrl}
+                          alt=""
+                          className="riffsync-room-page__profile-avatar-img"
+                        />
+                      ) : (
+                        <span className="riffsync-room-page__profile-avatar-placeholder" aria-hidden>
+                          ?
+                        </span>
+                      )}
+                    </div>
+                    <input
+                      ref={profileAvatarInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      className="riffsync-room-page__profile-avatar-input"
+                      onChange={onProfileAvatarSelected}
+                    />
+                    <button
+                      type="button"
+                      className="gen-button riffsync-room-page__profile-avatar-btn"
+                      disabled={profileAvatarLoading || profileAvatarUploading}
+                      onClick={() => profileAvatarInputRef.current?.click()}
+                    >
+                      {profileAvatarUploading
+                        ? 'Uploading…'
+                        : profileAvatarUrl
+                          ? 'Replace image'
+                          : 'Choose image'}
+                    </button>
+                    {profileAvatarErr ? (
+                      <p className="riffsync-room-page__profile-err" role="alert">
+                        {profileAvatarErr}
+                      </p>
+                    ) : null}
+                  </div>
                   <label className="riffsync-room-page__profile-label" htmlFor="riffsync-profile-display-name">
                     Display name
                   </label>

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -45,6 +45,7 @@ import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/mediasoupSfuFeature'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
+import { FanAvatarThumb } from '../components/FanAvatarThumb'
 
 const DISPLAY_TITLE_MAX_LEN = 120
 
@@ -52,12 +53,36 @@ const DISPLAY_TITLE_MAX_LEN = 120
 const SFU_RELAY_URL_MISSING_MSG =
   'Video relay URL is missing. Fix: (1) Redeploy RiffSyncApi-prod so POST /v1/webrtc/sfu-token returns wsUrl (from CDK context / signaling hostname). (2) Or set VITE_PUBLIC_SFU_WS_URL in the environment when you run npm run build (Vite bakes it in then, not from S3 at runtime). For https fan sites use wss via CDK context sfuPublicWsUrl or the same Vite variable.'
 
-type ChatMsg = { sessionId: string; text: string; ts: number; displayName?: string }
+type ChatMsg = {
+  sessionId: string
+  text: string
+  ts: number
+  displayName?: string
+  avatarUrl?: string
+}
 
 type PresenceMember = {
   sessionId: string
   displayName: string
   isHost: boolean
+  avatarUrl?: string
+}
+
+function parseInboundAvatarUrl(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  return trimmed !== '' ? trimmed : undefined
+}
+
+function resolveMemberAvatarUrl(
+  memberSessionId: string,
+  serverAvatarUrl: string | undefined,
+  mySessionId: string,
+  myAvatarUrl: string | null,
+): string | undefined {
+  if (serverAvatarUrl) return serverAvatarUrl
+  if (memberSessionId === mySessionId && myAvatarUrl) return myAvatarUrl
+  return undefined
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -121,6 +146,8 @@ export function RoomPage() {
   const [profileSaveErr, setProfileSaveErr] = useState<string | null>(null)
   const [profileSaving, setProfileSaving] = useState(false)
   const [profileAvatarUrl, setProfileAvatarUrl] = useState<string | null>(null)
+  /** Local avatar for this session (chat / People) before the next server presence or chat fan-out. */
+  const [myAvatarUrl, setMyAvatarUrl] = useState<string | null>(null)
   const [profileAvatarLoading, setProfileAvatarLoading] = useState(false)
   const [profileAvatarUploading, setProfileAvatarUploading] = useState(false)
   const [profileAvatarErr, setProfileAvatarErr] = useState<string | null>(null)
@@ -343,9 +370,11 @@ export function RoomPage() {
       .then((p) => {
         if (cancelled) return
         const dn = p.displayName?.trim()
-        if (!dn) return
-        const applied = setGuestDisplayName(dn)
-        setDisplayName(applied)
+        if (dn) {
+          const applied = setGuestDisplayName(dn)
+          setDisplayName(applied)
+        }
+        setMyAvatarUrl(p.avatarUrl)
       })
       .catch(() => {})
     return () => {
@@ -372,6 +401,7 @@ export function RoomPage() {
       .then((p) => {
         if (cancelled) return
         setProfileAvatarUrl(p.avatarUrl)
+        setMyAvatarUrl(p.avatarUrl)
       })
       .catch((e) => {
         if (cancelled) return
@@ -472,6 +502,7 @@ export function RoomPage() {
       if (t === 'chat' && typeof data.sessionId === 'string' && typeof data.text === 'string') {
         const ts = typeof data.ts === 'number' ? data.ts : Date.now()
         const dn = typeof data.displayName === 'string' ? data.displayName : undefined
+        const avatarUrl = parseInboundAvatarUrl(data.avatarUrl)
         setChat((prev) => [
           ...prev,
           {
@@ -479,6 +510,7 @@ export function RoomPage() {
             text: String(data.text),
             ts,
             ...(dn !== undefined && dn !== '' ? { displayName: dn } : {}),
+            ...(avatarUrl !== undefined ? { avatarUrl } : {}),
           },
         ])
         return
@@ -493,7 +525,13 @@ export function RoomPage() {
           const sid = m.sessionId
           const dn = m.displayName
           if (typeof sid !== 'string' || typeof dn !== 'string') continue
-          members.push({ sessionId: sid, displayName: dn, isHost: Boolean(m.isHost) })
+          const avatarUrl = parseInboundAvatarUrl(m.avatarUrl)
+          members.push({
+            sessionId: sid,
+            displayName: dn,
+            isHost: Boolean(m.isHost),
+            ...(avatarUrl !== undefined ? { avatarUrl } : {}),
+          })
         }
         setPresenceRoster({ roomId: data.roomId as string, members })
         return
@@ -991,6 +1029,7 @@ export function RoomPage() {
         setDisplayName(applied)
         setProfileDraft(applied)
         setProfileAvatarUrl(p.avatarUrl)
+        setMyAvatarUrl(p.avatarUrl)
       })
       .catch((e) => {
         setProfileSaveErr(e instanceof Error ? e.message : 'Could not save profile.')
@@ -1010,6 +1049,7 @@ export function RoomPage() {
     void uploadFanProfileAvatar(fanToken, file)
       .then((p) => {
         setProfileAvatarUrl(p.avatarUrl)
+        setMyAvatarUrl(p.avatarUrl)
       })
       .catch((err) => {
         setProfileAvatarErr(err instanceof Error ? err.message : 'Could not upload avatar.')
@@ -1303,18 +1343,32 @@ export function RoomPage() {
               {activeSidebarTab === 'chat' ? (
                 <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--chat">
                   <ul ref={chatLogRef} className="riffsync-room-chat-log">
-                    {chat.map((m) => (
-                      <li key={`${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`}>
-                        <span className="riffsync-room-chat-log__who">
-                          {(m.displayName && m.displayName.trim() !== ''
-                            ? m.displayName
-                            : chatMemberLabels.get(m.sessionId)) ??
-                            `${m.sessionId.slice(0, 6)}…`}
-                        </span>
-                        {': '}
-                        {m.text}
-                      </li>
-                    ))}
+                    {chat.map((m) => {
+                      const chatDisplayName =
+                        (m.displayName && m.displayName.trim() !== ''
+                          ? m.displayName
+                          : chatMemberLabels.get(m.sessionId)) ??
+                        `${m.sessionId.slice(0, 6)}…`
+                      const chatAvatarUrl = resolveMemberAvatarUrl(
+                        m.sessionId,
+                        m.avatarUrl,
+                        sessionId,
+                        myAvatarUrl,
+                      )
+                      return (
+                        <li key={`${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`}>
+                          <span className="riffsync-room-chat-log__who">
+                            <FanAvatarThumb
+                              displayName={chatDisplayName}
+                              avatarUrl={chatAvatarUrl}
+                            />
+                            <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
+                          </span>
+                          {': '}
+                          {m.text}
+                        </li>
+                      )
+                    })}
                   </ul>
                   <div className="riffsync-room-chat-compose-holder">
                     {showJumpToLatest ? (
@@ -1370,28 +1424,39 @@ export function RoomPage() {
               {activeSidebarTab === 'people' ? (
                 <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--people">
                   <ul className="riffsync-room-page__people-list" aria-label="People currently connected">
-                    {peopleShown.map((p) => (
-                      <li
-                        key={p.sessionId}
-                        className={`riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}`}
-                      >
-                        <span className="riffsync-room-page__person-label">
-                          {p.isHost ? (
-                            <>
-                              <strong>{p.displayName}</strong>
-                              <span className="riffsync-room-page__host-badge" aria-label="Host">
-                                Host
-                              </span>
-                            </>
-                          ) : (
-                            p.displayName
-                          )}
-                          {p.sessionId === sessionId ? (
-                            <span className="riffsync-muted"> · you</span>
-                          ) : null}
-                        </span>
-                      </li>
-                    ))}
+                    {peopleShown.map((p) => {
+                      const peopleAvatarUrl = resolveMemberAvatarUrl(
+                        p.sessionId,
+                        p.avatarUrl,
+                        sessionId,
+                        myAvatarUrl,
+                      )
+                      return (
+                        <li
+                          key={p.sessionId}
+                          className={`riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}`}
+                        >
+                          <span className="riffsync-room-page__person-label">
+                            <FanAvatarThumb displayName={p.displayName} avatarUrl={peopleAvatarUrl} />
+                            <span className="riffsync-room-page__person-name">
+                              {p.isHost ? (
+                                <>
+                                  <strong>{p.displayName}</strong>
+                                  <span className="riffsync-room-page__host-badge" aria-label="Host">
+                                    Host
+                                  </span>
+                                </>
+                              ) : (
+                                p.displayName
+                              )}
+                              {p.sessionId === sessionId ? (
+                                <span className="riffsync-muted"> · you</span>
+                              ) : null}
+                            </span>
+                          </span>
+                        </li>
+                      )
+                    })}
                   </ul>
                 </div>
               ) : null}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1053,6 +1053,20 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   background: rgb(255 255 255 / 0.035);
 }
 
+.riffsync-room-page__person-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.riffsync-room-page__person-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .riffsync-room-page__people-row--host {
   border-left: 3px solid var(--primary-color);
   background: rgb(255 255 255 / 0.07);
@@ -1302,6 +1316,50 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 
 .riffsync-room-page__chat .riffsync-room-chat-log li + li {
   margin-top: 0.35rem;
+}
+
+.riffsync-room-chat-log__who {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: min(100%, 14rem);
+  vertical-align: top;
+}
+
+.riffsync-room-chat-log__who-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.riffsync-fan-avatar-thumb {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
+.riffsync-fan-avatar-thumb--img {
+  object-fit: cover;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  background: rgb(255 255 255 / 0.06);
+}
+
+.riffsync-fan-avatar-thumb--initials {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: rgb(230 235 245 / 0.92);
+  background: rgb(255 255 255 / 0.1);
+  border: 1px solid rgb(255 255 255 / 0.14);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .riffsync-fan-avatar-thumb--img {
+    transition: none;
+  }
 }
 
 .gen-button.gen-button-wide {

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1118,6 +1118,56 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   margin-top: 0.35rem;
 }
 
+.riffsync-room-page__profile-avatar-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.riffsync-room-page__profile-avatar-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  background: rgb(7 10 14 / 0.85);
+}
+
+.riffsync-room-page__profile-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.riffsync-room-page__profile-avatar-placeholder {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: rgb(255 255 255 / 0.45);
+  line-height: 1;
+}
+
+.riffsync-room-page__profile-avatar-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.riffsync-room-page__profile-avatar-btn {
+  align-self: flex-start;
+}
+
 .riffsync-room-page__ws-banner {
   margin: 0;
   padding: 0.45rem 0.65rem 0.65rem;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 })


### PR DESCRIPTION
## Summary

Delivers the **M7 SPA slice** for parent [#27](https://github.com/StacksOnTheRacks/riffsync/issues/27): signed-in fans can upload/replace a profile avatar and see **trusted server-supplied** thumbnails beside display names in the room **Chat** log and **People** list.

- **#39** — Profile tab: multipart upload, preview, `fanProfileApi` (2 MiB, JPEG/PNG/WebP client validation)
- **#40** — `FanAvatarThumb`, inbound `avatarUrl` on `chat` / `presence`, local `myAvatarUrl` after upload; outbound chat does not send URLs

**Depends on (deployed separately):** [#26](https://github.com/StacksOnTheRacks/riffsync/issues/26) / #37 / #38 (profile API + CDN URL), [#28](https://github.com/StacksOnTheRacks/riffsync/issues/28) (WebSocket `avatarUrl` enrichment). Manual thumbnail visibility across peers requires #28 in the target environment.

Closes #27
Closes #39
Closes #40

## Test plan

- [x] `npm test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [x] CI: `web-app`, `infra-cdk`
- [ ] Manual: sign in, Profile tab upload/replace; `GET /v1/fans/me` returns `avatarUrl`
- [ ] Manual: chat + People show thumbnails when WS payloads include `avatarUrl` (#28)
- [ ] Manual: guest sees others' avatars; guest cannot upload
- [ ] Manual: missing/broken image URL falls back to initials without layout break