### PR TITLE
[M7] Server enriches outbound chat and presence with avatarUrl

### DIFF
--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -9,9 +9,9 @@ Fan clients connect to **`RiffSyncApi-{env}`** **`WebSocketUrl`** (**`wss://…`
 | **Query** `roomId` | Target room (**must exist**). |
 | **Query** `sessionId` | Opaque anonymous session (**`authorization.md`**). |
 | **Query** `displayName` | Optional nickname for **`People`** in the SPA (**≤ 48** chars after trim server-side); blank → generic **`Guest (…)`** in roster payloads. |
-| **Header** `Authorization` OR **Query** `accessToken` | **`Bearer <Cognito access token>`** (**header**) or bare/minimal raw token (**query**) only when claiming **publisher** (**`JWT.sub`** must equal **`room.hostSub`**). Browsers normally **cannot** set WebSocket **`Authorization`**; the SPA MUST pass **`accessToken`** (**URL-encoded JWT**) — avoid logging query strings containing tokens. |
+| **Header** `Authorization` OR **Query** `accessToken` | **`Bearer <Cognito access token>`** (**header**) or bare/minimal raw token (**query**) when the client is signed in. Browsers normally **cannot** set WebSocket **`Authorization`**; the SPA MUST pass **`accessToken`** (**URL-encoded JWT**) for signed-in fans — avoid logging query strings containing tokens. A valid fan JWT stores **`fanSub`** on the connection row. When **`JWT.sub`** equals **`room.hostSub`**, the socket is also marked as the **publisher** (**`hostSub`** on the row, **`isHost`** in roster payloads). |
 
-Malformed or mismatched JWT → **`403`**; missing room/session → **`400`**.
+Invalid or unverifiable JWT is ignored (guest connect). Missing room/session → **`400`**.
 
 On **`$connect`**, the server stores **`expiresAt`** on the connections row (**about 90 minutes** ahead, refreshed on every **`ping`**) so orphaned rows eventually disappear if **`$disconnect`** is not delivered.
 
@@ -39,11 +39,14 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
   "sessionId": "<sender>",
   "displayName": "…",
   "text": "…",
-  "ts": 0
+  "ts": 0,
+  "avatarUrl": "https://…"
 }
 ```
 
 **`displayName`** matches the sender’s connections-row label (same rules as roster: optional nickname from **`$connect`**, else **`Guest (sessionId-prefix…)`**).
+
+**`avatarUrl`** (optional): HTTPS URL read from **FanProfiles** for the sender’s **`fanSub`** when **`$connect`** stored one. Omitted when the fan has no avatar or connected as a guest. Inbound **`chat`** bodies MUST NOT supply **`avatarUrl`**; the server ignores client-supplied image URLs.
 
 ### Presence (roster snapshot)
 
@@ -55,11 +58,12 @@ Optional **`displayName`** on **`$connect`** exists only on the WebSocket connec
 {
   "type": "presence",
   "roomId": "<id>",
-  "members": [{ "sessionId": "<opaque>", "displayName": "…", "isHost": false }]
+  "members": [{ "sessionId": "<opaque>", "displayName": "…", "isHost": false, "avatarUrl": "https://…" }]
 }
 ```
 
 - **`isHost`**: **`true`** when **`$connect`** verified **`accessToken`** and **`JWT.sub`** matched **`rooms.hostSub`** for that publisher socket.
+- **`avatarUrl`** (optional per member): server-trusted **FanProfiles** HTTPS URL when that member’s session maps to a **`fanSub`** with an avatar; omitted otherwise.
 
 ### Share state (host fan-out)
 

--- a/infra/cdk/lambda/fan-profile-shared.test.ts
+++ b/infra/cdk/lambda/fan-profile-shared.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+import { avatarUrlFromStoredProfile, batchAvatarUrlsByFanSub } from './fan-profile-shared';
+
+describe('avatarUrlFromStoredProfile', () => {
+  it('returns trimmed https URL when set', () => {
+    expect(avatarUrlFromStoredProfile({ avatarUrl: '  https://cdn.example/a.png  ' })).toBe(
+      'https://cdn.example/a.png',
+    );
+  });
+
+  it('returns undefined for blank or missing avatarUrl', () => {
+    expect(avatarUrlFromStoredProfile({ avatarUrl: '   ' })).toBeUndefined();
+    expect(avatarUrlFromStoredProfile(undefined)).toBeUndefined();
+  });
+});
+
+describe('batchAvatarUrlsByFanSub', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+  });
+
+  it('batch-reads avatar URLs keyed by fan sub', async () => {
+    send.mockResolvedValue({
+      Responses: {
+        FanProfiles: [
+          { sub: 'fan-a', avatarUrl: 'https://cdn.example/a.png' },
+          { sub: 'fan-b', avatarUrl: '' },
+        ],
+      },
+    });
+
+    const doc = { send } as unknown as DynamoDBDocumentClient;
+    const map = await batchAvatarUrlsByFanSub(doc, 'FanProfiles', ['fan-a', 'fan-b', 'fan-a']);
+
+    expect(map.size).toBe(1);
+    expect(map.get('fan-a')).toBe('https://cdn.example/a.png');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/infra/cdk/lambda/fan-profile-shared.ts
+++ b/infra/cdk/lambda/fan-profile-shared.ts
@@ -1,4 +1,6 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { BatchGetCommand } from '@aws-sdk/lib-dynamodb';
 
 export const FAN_DISPLAY_NAME_MAX_LEN = 48;
 
@@ -45,6 +47,50 @@ export function serializeFanProfile(item: Record<string, unknown> | undefined): 
   const avatarUpdatedAt = typeof aua === 'number' && Number.isFinite(aua) ? aua : null;
 
   return { displayName, updatedAt, avatarUrl, avatarUpdatedAt };
+}
+
+/** Trusted HTTPS avatar URL from a FanProfiles row (omitted when unset). */
+export function avatarUrlFromStoredProfile(item: Record<string, unknown> | undefined): string | undefined {
+  const au = item?.avatarUrl;
+  return typeof au === 'string' && au.trim() !== '' ? au.trim() : undefined;
+}
+
+/** Batch-read `avatarUrl` for fan Cognito subs (DynamoDB keys: `{ sub }`). */
+export async function batchAvatarUrlsByFanSub(
+  doc: DynamoDBDocumentClient,
+  table: string,
+  fanSubs: readonly string[],
+): Promise<Map<string, string>> {
+  const unique = [...new Set(fanSubs.filter((s) => s.length > 0))];
+  const result = new Map<string, string>();
+  if (unique.length === 0) {
+    return result;
+  }
+
+  for (let i = 0; i < unique.length; i += 100) {
+    const chunk = unique.slice(i, i + 100);
+    const out = await doc.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [table]: {
+            Keys: chunk.map((sub) => ({ sub })),
+            ProjectionExpression: '#sub, avatarUrl',
+            ExpressionAttributeNames: { '#sub': 'sub' },
+          },
+        },
+      }),
+    );
+    const items = (out.Responses?.[table] ?? []) as Record<string, unknown>[];
+    for (const item of items) {
+      const sub = typeof item.sub === 'string' ? item.sub : '';
+      const url = avatarUrlFromStoredProfile(item);
+      if (sub && url) {
+        result.set(sub, url);
+      }
+    }
+  }
+
+  return result;
 }
 
 export function headerValue(

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -65,21 +65,12 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
 
   const jwtUser = await verifyAccessToken(authHdr);
   let hostSub: string | undefined;
+  let fanSub: string | undefined;
   if (jwtUser) {
-    if (jwtUser.sub !== room.hostSub) {
-      console.warn(
-        JSON.stringify({
-          riffsyncDiag: 'ws_connect',
-          outcome: 'forbidden_jwt_sub_mismatch_room_host',
-          connectionIdTail: connectionId.slice(-12),
-          roomIdHead: roomId.slice(0, 8),
-          apiStage,
-          jwtVerified: true,
-        }),
-      );
-      return { statusCode: 403, body: 'JWT.sub does not match room hostSub' };
+    fanSub = jwtUser.sub;
+    if (jwtUser.sub === room.hostSub) {
+      hostSub = jwtUser.sub;
     }
-    hostSub = jwtUser.sub;
   }
 
   const nowSec = Math.floor(Date.now() / 1000);
@@ -93,6 +84,7 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
     presenceKey,
     sessionId,
     ...(displayName ? { displayName } : {}),
+    ...(fanSub ? { fanSub } : {}),
     ...(hostSub ? { hostSub } : {}),
     connectedAt: nowSec,
     lastSeenAt: nowSec,
@@ -128,6 +120,7 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
       apiStage,
       bearerPresent: Boolean(authHdr && authHdr.length > 'Bearer '.length),
       jwtVerifiedOk: jwtUser !== null,
+      dynamoStoresFanSub: Boolean(fanSub),
       dynamoStoresPublisherRole: Boolean(hostSub),
     }),
   );

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -18,6 +18,7 @@ import {
   postToConnections,
   presenceDisplayNameForSession,
   queryConnectionsForRoom,
+  resolveChatOutboundAvatarUrl,
   wsManagementClient,
 } from './ws-shared';
 
@@ -210,7 +211,9 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     const mgmt = wsManagementClient();
     const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
     const displayName = presenceDisplayNameForSession(sessionId, conn.displayName);
-    const out = {
+    const fanSub = typeof conn.fanSub === 'string' && conn.fanSub.length > 0 ? conn.fanSub : undefined;
+    const avatarUrl = await resolveChatOutboundAvatarUrl(doc, process.env.FAN_PROFILES_TABLE_NAME, fanSub);
+    const out: Record<string, unknown> = {
       type: 'chat',
       roomId,
       sessionId,
@@ -218,6 +221,9 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
       text,
       ts: Date.now(),
     };
+    if (avatarUrl) {
+      out.avatarUrl = avatarUrl;
+    }
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
     return { statusCode: 200, body: 'OK' };

--- a/infra/cdk/lambda/ws-shared.test.ts
+++ b/infra/cdk/lambda/ws-shared.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+import {
+  enrichRosterMembersWithAvatarUrls,
+  rosterFromConnectionItems,
+  type PresenceBroadcastMember,
+} from './ws-shared';
+
+vi.mock('./fan-profile-shared', () => ({
+  batchAvatarUrlsByFanSub: vi.fn(),
+}));
+
+import { batchAvatarUrlsByFanSub } from './fan-profile-shared';
+
+const batchMock = vi.mocked(batchAvatarUrlsByFanSub);
+
+describe('rosterFromConnectionItems', () => {
+  it('merges tabs by sessionId and tracks fanSub for avatar enrichment', () => {
+    const { members, fanSubBySessionId } = rosterFromConnectionItems([
+      {
+        sessionId: 'sess-a',
+        displayName: 'Alice',
+        fanSub: 'fan-1',
+      },
+      {
+        sessionId: 'sess-a',
+        displayName: 'Alice tab 2',
+        fanSub: 'fan-1',
+      },
+      {
+        sessionId: 'sess-guest',
+      },
+      {
+        sessionId: 'sess-host',
+        hostSub: 'host-sub',
+        fanSub: 'host-sub',
+      },
+    ]);
+
+    expect(members).toHaveLength(3);
+    expect(fanSubBySessionId.get('sess-a')).toBe('fan-1');
+    expect(fanSubBySessionId.get('sess-host')).toBe('host-sub');
+    expect(fanSubBySessionId.has('sess-guest')).toBe(false);
+
+    const host = members.find((m) => m.sessionId === 'sess-host');
+    expect(host?.isHost).toBe(true);
+    expect(host?.avatarUrl).toBeUndefined();
+
+    const guest = members.find((m) => m.sessionId === 'sess-guest');
+    expect(guest?.isHost).toBe(false);
+    expect(guest?.displayName).toMatch(/^Guest/);
+  });
+});
+
+describe('enrichRosterMembersWithAvatarUrls', () => {
+  it('adds avatarUrl only for members with a profile URL', async () => {
+    batchMock.mockResolvedValue(new Map([['fan-1', 'https://cdn.example/avatars/fan-1.png']]));
+
+    const members: PresenceBroadcastMember[] = [
+      { sessionId: 'sess-a', displayName: 'Alice', isHost: false },
+      { sessionId: 'sess-guest', displayName: 'Guest', isHost: false },
+    ];
+    const fanSubBySessionId = new Map([['sess-a', 'fan-1']]);
+
+    const enriched = await enrichRosterMembersWithAvatarUrls(
+      {} as DynamoDBDocumentClient,
+      'FanProfiles',
+      members,
+      fanSubBySessionId,
+    );
+
+    expect(enriched[0]?.avatarUrl).toBe('https://cdn.example/avatars/fan-1.png');
+    expect(enriched[1]?.avatarUrl).toBeUndefined();
+    expect(batchMock).toHaveBeenCalledWith({}, 'FanProfiles', ['fan-1']);
+  });
+});

--- a/infra/cdk/lambda/ws-shared.ts
+++ b/infra/cdk/lambda/ws-shared.ts
@@ -1,6 +1,7 @@
 import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
 import { DynamoDBDocumentClient, DeleteCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { TextEncoder } from 'node:util';
+import { batchAvatarUrlsByFanSub } from './fan-profile-shared';
 
 const encoder = new TextEncoder();
 
@@ -127,6 +128,20 @@ export type PresenceBroadcastMember = {
   sessionId: string;
   displayName: string;
   isHost: boolean;
+  /** Server-trusted FanProfiles HTTPS URL; omitted when the fan has no avatar. */
+  avatarUrl?: string;
+};
+
+type RosterAccumulator = {
+  sessionId: string;
+  displayName: string;
+  isHost: boolean;
+  fanSub?: string;
+};
+
+export type RosterFromConnectionsResult = {
+  members: PresenceBroadcastMember[];
+  fanSubBySessionId: Map<string, string>;
 };
 
 function guestLabelFallback(sessionId: string): string {
@@ -142,13 +157,14 @@ export function presenceDisplayNameForSession(sessionId: string, displayNameAttr
 }
 
 /** Collapse multiple connections that share `sessionId` (e.g. two tabs): host flag dominates; keep a stable label. */
-export function rosterFromConnectionItems(items: readonly Record<string, unknown>[]): PresenceBroadcastMember[] {
-  const merged = new Map<string, PresenceBroadcastMember>();
+export function rosterFromConnectionItems(items: readonly Record<string, unknown>[]): RosterFromConnectionsResult {
+  const merged = new Map<string, RosterAccumulator>();
 
   for (const it of items) {
     const sessionId = typeof it.sessionId === 'string' ? it.sessionId : '';
     if (sessionId === '') continue;
     const isHostConn = typeof it.hostSub === 'string' && (it.hostSub as string).length > 0;
+    const fanSubConn = typeof it.fanSub === 'string' && it.fanSub.length > 0 ? it.fanSub : undefined;
     let label = presenceDisplayNameForSession(sessionId, it.displayName);
 
     const cur = merged.get(sessionId);
@@ -157,6 +173,7 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
         sessionId,
         displayName: label,
         isHost: isHostConn,
+        ...(fanSubConn ? { fanSub: fanSubConn } : {}),
       });
     } else {
       if (!isHostConn) label = cur.displayName || label;
@@ -164,6 +181,7 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
         sessionId,
         displayName: label,
         isHost: cur.isHost || isHostConn,
+        fanSub: cur.fanSub ?? fanSubConn,
       });
     }
   }
@@ -173,7 +191,51 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
     if (a.isHost !== b.isHost) return a.isHost ? -1 : 1;
     return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' });
   });
-  return list;
+
+  const fanSubBySessionId = new Map<string, string>();
+  const members: PresenceBroadcastMember[] = list.map(({ sessionId, displayName, isHost, fanSub }) => {
+    if (fanSub) {
+      fanSubBySessionId.set(sessionId, fanSub);
+    }
+    return { sessionId, displayName, isHost };
+  });
+
+  return { members, fanSubBySessionId };
+}
+
+/** Attach optional `avatarUrl` from FanProfiles (batch read). */
+export async function enrichRosterMembersWithAvatarUrls(
+  doc: DynamoDBDocumentClient,
+  profilesTable: string,
+  members: PresenceBroadcastMember[],
+  fanSubBySessionId: Map<string, string>,
+): Promise<PresenceBroadcastMember[]> {
+  if (fanSubBySessionId.size === 0) {
+    return members;
+  }
+
+  const avatarByFanSub = await batchAvatarUrlsByFanSub(doc, profilesTable, [...fanSubBySessionId.values()]);
+  if (avatarByFanSub.size === 0) {
+    return members;
+  }
+
+  return members.map((member) => {
+    const fanSub = fanSubBySessionId.get(member.sessionId);
+    const avatarUrl = fanSub ? avatarByFanSub.get(fanSub) : undefined;
+    return avatarUrl ? { ...member, avatarUrl } : member;
+  });
+}
+
+export async function resolveChatOutboundAvatarUrl(
+  doc: DynamoDBDocumentClient,
+  profilesTable: string | undefined,
+  fanSub: string | undefined,
+): Promise<string | undefined> {
+  if (!profilesTable || !fanSub) {
+    return undefined;
+  }
+  const map = await batchAvatarUrlsByFanSub(doc, profilesTable, [fanSub]);
+  return map.get(fanSub);
 }
 
 /** Fan-out current room roster after connect/disconnect. */
@@ -193,7 +255,12 @@ export async function broadcastRoomPresence(params: {
       if (typeof cid === 'string') ids.push(cid);
     }
 
-    const members = rosterFromConnectionItems(items);
+    const { members: rosterMembers, fanSubBySessionId } = rosterFromConnectionItems(items);
+    const profilesTable = process.env.FAN_PROFILES_TABLE_NAME;
+    const members =
+      profilesTable && fanSubBySessionId.size > 0
+        ? await enrichRosterMembersWithAvatarUrls(doc, profilesTable, rosterMembers, fanSubBySessionId)
+        : rosterMembers;
     const buf = encoder.encode(JSON.stringify({ type: 'presence', roomId, members }));
     const mgmt = wsManagementClient();
 

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -556,6 +556,7 @@ export class ApiCatalogStack extends cdk.Stack {
       ROOMS_TABLE_NAME: this.roomsTable.tableName,
       CONNECTIONS_TABLE_NAME: this.connectionsTable.tableName,
       ROOM_PRESENCE_TABLE_NAME: this.roomPresenceTable.tableName,
+      FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
       COGNITO_USER_POOL_ID: fanUserPool.userPoolId,
       COGNITO_CLIENT_ID: fanUserPoolClient.userPoolClientId,
       WS_MANAGEMENT_API_ENDPOINT: wsMgmtEndpoint,
@@ -598,6 +599,7 @@ export class ApiCatalogStack extends cdk.Stack {
     this.roomsTable.grantReadData(wsConnectFn);
     this.connectionsTable.grantReadWriteData(wsConnectFn);
     this.roomPresenceTable.grantReadWriteData(wsConnectFn);
+    this.fanProfilesTable.grantReadData(wsConnectFn);
 
     this.connectionsTable.grantReadWriteData(wsDisconnectFn);
     this.roomPresenceTable.grantReadWriteData(wsDisconnectFn);
@@ -605,6 +607,7 @@ export class ApiCatalogStack extends cdk.Stack {
     this.roomsTable.grantReadWriteData(wsRouteFn);
     this.connectionsTable.grantReadWriteData(wsRouteFn);
     this.roomPresenceTable.grantReadWriteData(wsRouteFn);
+    this.fanProfilesTable.grantReadData(wsRouteFn);
     this.webSocketApi.grantManageConnections(wsRouteFn);
 
     // WebSocketLambdaIntegration can leave InvokeFunction scoped to only one route (IAM showed SourceArn ending in *ping).


### PR DESCRIPTION
## Summary

- WebSocket `$connect` stores `fanSub` for any verified fan JWT; publisher `hostSub` is set only when `JWT.sub` matches `room.hostSub` (non-host fans no longer get 403).
- Outbound `chat` and `presence.members[]` include optional server-trusted `avatarUrl` from FanProfiles (batch read; client-supplied URLs ignored).
- WS Lambdas receive `FAN_PROFILES_TABLE_NAME` and DynamoDB read IAM; `docs/contracts.websocket.md` updated.

Closes #28

## Test plan

- [x] `npm run verify:push:cdk` (unit tests + synth)
- [ ] Deployed smoke: fan with avatar sends `chat` and appears in `presence` with `avatarUrl` for guests
- [ ] Signed-in non-host fan can `$connect` without 403
- [ ] Client `avatarUrl` in `chat` body is ignored on fan-out