### PR TITLE
[M8] Emoji picker on chat compose (signed-in)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.100.9",
+        "emoji-picker-element": "^1.29.1",
         "mediasoup-client": "^3.20.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -2444,6 +2445,12 @@
       "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-picker-element": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-element/-/emoji-picker-element-1.29.1.tgz",
+      "integrity": "sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.9",
+    "emoji-picker-element": "^1.29.1",
     "mediasoup-client": "^3.20.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -45,6 +45,7 @@ import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/mediasoupSfuFeature'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
+import { ChatEmojiPicker } from '../room/ChatEmojiPicker'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
 
 const DISPLAY_TITLE_MAX_LEN = 120
@@ -175,6 +176,7 @@ export function RoomPage() {
   const sfuSessionRef = useRef<{ close: () => void } | null>(null)
   const isPublisherRef = useRef(false)
   const prevRoomSidebarTabRef = useRef<'chat' | 'people' | 'room' | 'profile'>('chat')
+  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const guestSignalingRefs = useMemo<GuestSignalingRefs>(
     () => ({
@@ -1384,7 +1386,15 @@ export function RoomPage() {
                     <div
                       className={`riffsync-room-chat-compose${fanToken ? '' : ' riffsync-room-chat-compose--inactive'}`}
                     >
+                      {fanToken ? (
+                        <ChatEmojiPicker
+                          draft={chatDraft}
+                          onDraftChange={setChatDraft}
+                          inputRef={chatInputRef}
+                        />
+                      ) : null}
                       <input
+                        ref={chatInputRef}
                         type="text"
                         maxLength={2000}
                         value={fanToken ? chatDraft : ''}

--- a/apps/web/src/room/ChatEmojiPicker.tsx
+++ b/apps/web/src/room/ChatEmojiPicker.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import 'emoji-picker-element'
+import { insertTextAtCaret } from './insertTextAtCaret'
+
+const CHAT_TEXT_MAX_LEN = 2000
+
+type EmojiClickEvent = CustomEvent<{ unicode: string }>
+
+export type ChatEmojiPickerProps = {
+  draft: string
+  onDraftChange: (next: string) => void
+  inputRef: React.RefObject<HTMLInputElement | null>
+  maxLength?: number
+}
+
+export function ChatEmojiPicker({
+  draft,
+  onDraftChange,
+  inputRef,
+  maxLength = CHAT_TEXT_MAX_LEN,
+}: ChatEmojiPickerProps) {
+  const [open, setOpen] = useState(false)
+  const popoverId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+  const pickerRef = useRef<HTMLElement | null>(null)
+
+  const applyEmoji = useCallback(
+    (unicode: string) => {
+      const input = inputRef.current
+      const { value, caret } = insertTextAtCaret(
+        draft,
+        unicode,
+        input?.selectionStart ?? null,
+        input?.selectionEnd ?? null,
+        maxLength,
+      )
+      onDraftChange(value)
+      requestAnimationFrame(() => {
+        const el = inputRef.current
+        if (!el) return
+        el.focus()
+        el.setSelectionRange(caret, caret)
+      })
+    },
+    [draft, inputRef, maxLength, onDraftChange],
+  )
+
+  useEffect(() => {
+    if (!open) return
+    const picker = pickerRef.current
+    if (!picker) return
+    const onEmoji = (event: Event) => {
+      const detail = (event as EmojiClickEvent).detail
+      if (typeof detail?.unicode === 'string' && detail.unicode.length > 0) {
+        applyEmoji(detail.unicode)
+      }
+    }
+    picker.addEventListener('emoji-click', onEmoji)
+    return () => picker.removeEventListener('emoji-click', onEmoji)
+  }, [applyEmoji, open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+      if (!root || !(event.target instanceof Node)) return
+      if (!root.contains(event.target)) {
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="riffsync-room-chat-emoji">
+      <button
+        ref={toggleRef}
+        type="button"
+        className="riffsync-room-chat-emoji-toggle gen-button"
+        aria-label="Insert emoji"
+        aria-expanded={open}
+        aria-controls={open ? popoverId : undefined}
+        onClick={() => setOpen((was) => !was)}
+      >
+        <span aria-hidden="true">😀</span>
+      </button>
+      {open ? (
+        <div
+          id={popoverId}
+          className="riffsync-room-chat-emoji-popover"
+          role="dialog"
+          aria-label="Emoji picker"
+        >
+          <emoji-picker ref={pickerRef} className="riffsync-room-chat-emoji-picker" />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/insertTextAtCaret.test.ts
+++ b/apps/web/src/room/insertTextAtCaret.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { insertTextAtCaret } from './insertTextAtCaret'
+
+describe('insertTextAtCaret', () => {
+  it('appends when selection is null', () => {
+    expect(insertTextAtCaret('hi', '😀', null, null, 2000)).toEqual({
+      value: 'hi😀',
+      caret: 4,
+    })
+  })
+
+  it('inserts at caret between existing text', () => {
+    expect(insertTextAtCaret('hello', '😀', 2, 2, 2000)).toEqual({
+      value: 'he😀llo',
+      caret: 4,
+    })
+  })
+
+  it('replaces a selection range', () => {
+    expect(insertTextAtCaret('hello world', '👋', 0, 5, 2000)).toEqual({
+      value: '👋 world',
+      caret: 2,
+    })
+  })
+
+  it('does not insert a partial emoji when only one code unit remains', () => {
+    expect(insertTextAtCaret('12345', '😀', 5, 5, 6)).toEqual({
+      value: '12345',
+      caret: 5,
+    })
+  })
+
+  it('inserts a full emoji when maxLength allows two code units', () => {
+    expect(insertTextAtCaret('12345', '😀', 5, 5, 7)).toEqual({
+      value: '12345😀',
+      caret: 7,
+    })
+  })
+
+  it('returns unchanged text when there is no room', () => {
+    expect(insertTextAtCaret('123456', '😀', 6, 6, 6)).toEqual({
+      value: '123456',
+      caret: 6,
+    })
+  })
+})

--- a/apps/web/src/room/insertTextAtCaret.ts
+++ b/apps/web/src/room/insertTextAtCaret.ts
@@ -1,0 +1,35 @@
+/** Truncate `text` to at most `maxUnits` UTF-16 code units without splitting a surrogate pair. */
+function truncateToMaxCodeUnits(text: string, maxUnits: number): string {
+  if (text.length <= maxUnits) return text
+  if (maxUnits <= 0) return ''
+  let end = maxUnits
+  while (end > 0) {
+    const head = text.charCodeAt(end - 1)
+    const tail = text.charCodeAt(end)
+    if (head >= 0xd800 && head <= 0xdbff && tail >= 0xdc00 && tail <= 0xdfff) {
+      end -= 1
+      continue
+    }
+    return text.slice(0, end)
+  }
+  return ''
+}
+
+/** Insert `insertion` into `current` at the selection, respecting `maxLength` (UTF-16, like HTML maxLength). */
+export function insertTextAtCaret(
+  current: string,
+  insertion: string,
+  selectionStart: number | null,
+  selectionEnd: number | null,
+  maxLength: number,
+): { value: string; caret: number } {
+  const start = selectionStart ?? current.length
+  const end = selectionEnd ?? start
+  const room = maxLength - (current.length - (end - start))
+  const fitting = room >= insertion.length ? insertion : truncateToMaxCodeUnits(insertion, room)
+  if (!fitting) {
+    return { value: current, caret: start }
+  }
+  const value = current.slice(0, start) + fitting + current.slice(end)
+  return { value, caret: start + fitting.length }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1314,6 +1314,44 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   color: inherit;
 }
 
+.riffsync-room-chat-emoji {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.riffsync-room-chat-emoji-toggle {
+  min-width: 2.25rem;
+  padding: 0.35rem 0.45rem;
+  line-height: 1;
+}
+
+.riffsync-room-chat-emoji-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.35rem);
+  z-index: 4;
+  max-width: min(100vw - 1rem, 20rem);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.55);
+  border: 1px solid rgb(255 255 255 / 0.1);
+}
+
+.riffsync-room-chat-emoji-picker {
+  --emoji-size: 1.35rem;
+  --num-columns: 8;
+  --background: rgb(12 16 22);
+  --border-color: rgb(255 255 255 / 0.08);
+  --button-active-background: rgb(255 255 255 / 0.12);
+  --button-hover-background: rgb(255 255 255 / 0.08);
+  --category-button-color: rgb(255 255 255 / 0.65);
+  --input-border-color: rgb(255 255 255 / 0.15);
+  --input-font-color: inherit;
+  --outline-color: rgb(120 180 255 / 0.85);
+  width: min(100vw - 1rem, 18.5rem);
+  height: 16.5rem;
+}
+
 .riffsync-room-page__chat .riffsync-room-chat-log li + li {
   margin-top: 0.35rem;
 }

--- a/apps/web/src/types/emoji-picker-element-jsx.d.ts
+++ b/apps/web/src/types/emoji-picker-element-jsx.d.ts
@@ -1,0 +1,9 @@
+import type { DetailedHTMLProps, HTMLAttributes } from 'react'
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'emoji-picker': DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a signed-in-only emoji control on the room **Chat** compose row. Selecting an emoji inserts Unicode at the text caret (or appends when the field is not focused) and respects the existing 2000-character limit. Guests still see read-only chat with the sign-in overlay; no backend changes.

Closes #29

## Changes

- `ChatEmojiPicker` using `emoji-picker-element` (popover, Escape / outside click to dismiss)
- `insertTextAtCaret` helper with surrogate-safe truncation (matches HTML `maxLength`)
- Room compose layout: emoji toggle, input, send

## Test plan

- [x] `cd apps/web && npm ci && npm test && npm run lint && npm run build`
- [ ] Manual: signed-in fan opens picker, inserts emoji at caret, sends over WS; guest sees messages without picker
- [ ] Manual: Escape and outside click close picker; draft stays within 2000 chars