### PR TITLE
M8: WebSocket react route and chat reactions (epic #30)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -46,6 +46,12 @@ import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/m
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatEmojiPicker } from '../room/ChatEmojiPicker'
+import { ChatReactionsStrip } from '../room/ChatReactionsStrip'
+import {
+  applyChatReactionEvent,
+  canAcceptReactionAdd,
+  type ReactionsByMessage,
+} from '../room/chatReactions'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
 
 const DISPLAY_TITLE_MAX_LEN = 120
@@ -55,6 +61,7 @@ const SFU_RELAY_URL_MISSING_MSG =
   'Video relay URL is missing. Fix: (1) Redeploy RiffSyncApi-prod so POST /v1/webrtc/sfu-token returns wsUrl (from CDK context / signaling hostname). (2) Or set VITE_PUBLIC_SFU_WS_URL in the environment when you run npm run build (Vite bakes it in then, not from S3 at runtime). For https fan sites use wss via CDK context sfuPublicWsUrl or the same Vite variable.'
 
 type ChatMsg = {
+  messageId?: string
   sessionId: string
   text: string
   ts: number
@@ -122,6 +129,7 @@ export function RoomPage() {
   const [roomErr, setRoomErr] = useState<string | null>(null)
   const [catalogEp, setCatalogEp] = useState<CatalogEpisode | null>(null)
   const [chat, setChat] = useState<ChatMsg[]>([])
+  const [chatReactions, setChatReactions] = useState<ReactionsByMessage>({})
   const [chatDraft, setChatDraft] = useState('')
   const [patchErr, setPatchErr] = useState<string | null>(null)
   const [shareHint, setShareHint] = useState<string | null>(null)
@@ -505,16 +513,41 @@ export function RoomPage() {
         const ts = typeof data.ts === 'number' ? data.ts : Date.now()
         const dn = typeof data.displayName === 'string' ? data.displayName : undefined
         const avatarUrl = parseInboundAvatarUrl(data.avatarUrl)
+        const rawMessageId = typeof data.messageId === 'string' ? data.messageId.trim() : ''
+        const messageId = rawMessageId !== '' && rawMessageId.length <= 64 ? rawMessageId : undefined
         setChat((prev) => [
           ...prev,
           {
             sessionId: data.sessionId as string,
             text: String(data.text),
             ts,
+            ...(messageId !== undefined ? { messageId } : {}),
             ...(dn !== undefined && dn !== '' ? { displayName: dn } : {}),
             ...(avatarUrl !== undefined ? { avatarUrl } : {}),
           },
         ])
+        return
+      }
+      if (
+        t === 'chat_reaction' &&
+        typeof data.messageId === 'string' &&
+        typeof data.emoji === 'string' &&
+        (data.action === 'add' || data.action === 'remove') &&
+        typeof data.sessionId === 'string'
+      ) {
+        const messageId = data.messageId.trim()
+        const emoji = data.emoji.trim()
+        if (messageId === '' || emoji === '') return
+        setChatReactions((prev) =>
+          applyChatReactionEvent(
+            prev,
+            messageId,
+            emoji,
+            data.action as 'add' | 'remove',
+            data.sessionId as string,
+            sessionId,
+          ),
+        )
         return
       }
       if (t === 'presence' && typeof data.roomId === 'string') {
@@ -605,7 +638,15 @@ export function RoomPage() {
         .catch(() => undefined)
       return
     },
-    [captureStream, getIceServers, guestSignalingRefs, isPublisher, canonicalRoomId, sessionId, sfuEnabled],
+    [
+      captureStream,
+      getIceServers,
+      guestSignalingRefs,
+      isPublisher,
+      canonicalRoomId,
+      sessionId,
+      sfuEnabled,
+    ],
   )
 
   const { status: wsStatus, sendJson: wsSendJson } = useRoomWebSocket({
@@ -1016,6 +1057,32 @@ export function RoomPage() {
     setChatDraft('')
   }
 
+  const sendChatReaction = useCallback(
+    (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => {
+      if (!fanToken) return
+      const trimmedEmoji = emoji.trim()
+      if (trimmedEmoji === '') return
+      if (reactionAction === 'add') {
+        const chips = chatReactions[messageId] ?? {}
+        if (!canAcceptReactionAdd(chips, trimmedEmoji)) return
+      }
+      sendJson({
+        action: 'react',
+        messageId,
+        emoji: trimmedEmoji,
+        reactionAction,
+      })
+    },
+    [fanToken, chatReactions, sendJson],
+  )
+
+  const toggleChatReaction = useCallback(
+    (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => {
+      sendChatReaction(messageId, emoji, reactionAction)
+    },
+    [sendChatReaction],
+  )
+
   const saveProfileDisplayName = () => {
     if (!fanToken) return
     const trimmed = profileDraft.trim().slice(0, FAN_DISPLAY_NAME_MAX_LEN)
@@ -1357,17 +1424,31 @@ export function RoomPage() {
                         sessionId,
                         myAvatarUrl,
                       )
+                      const rowKey =
+                        m.messageId ?? `${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`
+                      const reactionChips =
+                        m.messageId !== undefined ? (chatReactions[m.messageId] ?? {}) : {}
                       return (
-                        <li key={`${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`}>
-                          <span className="riffsync-room-chat-log__who">
-                            <FanAvatarThumb
-                              displayName={chatDisplayName}
-                              avatarUrl={chatAvatarUrl}
+                        <li key={rowKey} className="riffsync-room-chat-log__row">
+                          <div className="riffsync-room-chat-log__line">
+                            <span className="riffsync-room-chat-log__who">
+                              <FanAvatarThumb
+                                displayName={chatDisplayName}
+                                avatarUrl={chatAvatarUrl}
+                              />
+                              <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
+                            </span>
+                            {': '}
+                            {m.text}
+                          </div>
+                          {m.messageId !== undefined ? (
+                            <ChatReactionsStrip
+                              messageId={m.messageId}
+                              chips={reactionChips}
+                              canReact={Boolean(fanToken)}
+                              onToggleReaction={toggleChatReaction}
                             />
-                            <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
-                          </span>
-                          {': '}
-                          {m.text}
+                          ) : null}
                         </li>
                       )
                     })}

--- a/apps/web/src/room/ChatReactionPicker.tsx
+++ b/apps/web/src/room/ChatReactionPicker.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import 'emoji-picker-element'
+
+type EmojiClickEvent = CustomEvent<{ unicode: string }>
+
+export type ChatReactionPickerProps = {
+  onEmojiSelected: (emoji: string) => void
+}
+
+export function ChatReactionPicker({ onEmojiSelected }: ChatReactionPickerProps) {
+  const [open, setOpen] = useState(false)
+  const popoverId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+  const pickerRef = useRef<HTMLElement | null>(null)
+
+  const selectEmoji = useCallback(
+    (unicode: string) => {
+      onEmojiSelected(unicode)
+      setOpen(false)
+      toggleRef.current?.focus()
+    },
+    [onEmojiSelected],
+  )
+
+  useEffect(() => {
+    if (!open) return
+    const picker = pickerRef.current
+    if (!picker) return
+    const onEmoji = (event: Event) => {
+      const detail = (event as EmojiClickEvent).detail
+      if (typeof detail?.unicode === 'string' && detail.unicode.length > 0) {
+        selectEmoji(detail.unicode)
+      }
+    }
+    picker.addEventListener('emoji-click', onEmoji)
+    return () => picker.removeEventListener('emoji-click', onEmoji)
+  }, [open, selectEmoji])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+      if (!root || !(event.target instanceof Node)) return
+      if (!root.contains(event.target)) {
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="riffsync-room-chat-reaction-picker">
+      <button
+        ref={toggleRef}
+        type="button"
+        className="riffsync-room-chat-reaction-add gen-button"
+        aria-label="Add reaction"
+        aria-expanded={open}
+        aria-controls={open ? popoverId : undefined}
+        onClick={() => setOpen((was) => !was)}
+      >
+        <span aria-hidden="true">+</span>
+      </button>
+      {open ? (
+        <div
+          id={popoverId}
+          className="riffsync-room-chat-emoji-popover riffsync-room-chat-reaction-popover"
+          role="dialog"
+          aria-label="Reaction emoji picker"
+        >
+          <emoji-picker ref={pickerRef} className="riffsync-room-chat-emoji-picker" />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/ChatReactionsStrip.tsx
+++ b/apps/web/src/room/ChatReactionsStrip.tsx
@@ -1,0 +1,67 @@
+import {
+  canAcceptReactionAdd,
+  reactionActionForToggle,
+  type ReactionChip,
+} from './chatReactions'
+import { ChatReactionPicker } from './ChatReactionPicker'
+
+export type ChatReactionsStripProps = {
+  messageId: string
+  chips: Record<string, ReactionChip>
+  canReact: boolean
+  onToggleReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
+}
+
+export function ChatReactionsStrip({
+  messageId,
+  chips,
+  canReact,
+  onToggleReaction,
+}: ChatReactionsStripProps) {
+  const entries = Object.entries(chips).filter(([, chip]) => chip.count > 0)
+  const showStrip = entries.length > 0 || canReact
+
+  if (!showStrip) return null
+
+  const handleChipClick = (emoji: string, reactedByMe: boolean) => {
+    if (!canReact) return
+    onToggleReaction(messageId, emoji, reactionActionForToggle(reactedByMe))
+  }
+
+  const handlePickerEmoji = (emoji: string) => {
+    if (!canReact) return
+    const existing = chips[emoji]
+    if (existing) {
+      onToggleReaction(messageId, emoji, reactionActionForToggle(existing.reactedByMe))
+      return
+    }
+    if (!canAcceptReactionAdd(chips, emoji)) return
+    onToggleReaction(messageId, emoji, 'add')
+  }
+
+  return (
+    <div className="riffsync-room-chat-reactions" role="group" aria-label="Message reactions">
+      {entries.map(([emoji, chip]) => (
+        <button
+          key={emoji}
+          type="button"
+          className={`riffsync-room-chat-reaction-chip${chip.reactedByMe ? ' riffsync-room-chat-reaction-chip--mine' : ''}`}
+          disabled={!canReact}
+          aria-pressed={chip.reactedByMe}
+          aria-label={
+            canReact
+              ? `${chip.reactedByMe ? 'Remove' : 'Add'} reaction ${emoji}, ${chip.count} total`
+              : `${emoji} reaction, ${chip.count}`
+          }
+          onClick={() => handleChipClick(emoji, chip.reactedByMe)}
+        >
+          <span className="riffsync-room-chat-reaction-chip__emoji" aria-hidden="true">
+            {emoji}
+          </span>
+          <span className="riffsync-room-chat-reaction-chip__count">{chip.count}</span>
+        </button>
+      ))}
+      {canReact ? <ChatReactionPicker onEmojiSelected={handlePickerEmoji} /> : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/chatReactions.test.ts
+++ b/apps/web/src/room/chatReactions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_DISTINCT_EMOJI_PER_MESSAGE,
+  applyChatReactionEvent,
+  canAcceptReactionAdd,
+  reactionActionForToggle,
+  type ReactionChip,
+  type ReactionsByMessage,
+} from './chatReactions'
+
+const MY = 'session-me'
+const OTHER = 'session-other'
+
+describe('reactionActionForToggle', () => {
+  it('returns remove when already reacted', () => {
+    expect(reactionActionForToggle(true)).toBe('remove')
+  })
+
+  it('returns add when not reacted', () => {
+    expect(reactionActionForToggle(false)).toBe('add')
+  })
+})
+
+describe('canAcceptReactionAdd', () => {
+  it('allows add when under distinct-emoji cap', () => {
+    const chips: Record<string, ReactionChip> = {}
+    for (let i = 0; i < MAX_DISTINCT_EMOJI_PER_MESSAGE - 1; i += 1) {
+      chips[`e${i}`] = { count: 1, reactedByMe: false }
+    }
+    expect(canAcceptReactionAdd(chips, '🆕')).toBe(true)
+  })
+
+  it('blocks new emoji at cap unless that emoji already exists', () => {
+    const chips: Record<string, ReactionChip> = {}
+    for (let i = 0; i < MAX_DISTINCT_EMOJI_PER_MESSAGE; i += 1) {
+      chips[`e${i}`] = { count: 1, reactedByMe: false }
+    }
+    expect(canAcceptReactionAdd(chips, '🆕')).toBe(false)
+    expect(canAcceptReactionAdd(chips, 'e0')).toBe(true)
+  })
+})
+
+describe('applyChatReactionEvent', () => {
+  it('aggregates add from multiple sessions', () => {
+    let state: ReactionsByMessage = {}
+    state = applyChatReactionEvent(state, 'm1', '👍', 'add', MY, MY)
+    state = applyChatReactionEvent(state, 'm1', '👍', 'add', OTHER, MY)
+    expect(state.m1?.['👍']).toEqual({ count: 2, reactedByMe: true })
+  })
+
+  it('marks reactedByMe only for the local session', () => {
+    let state: ReactionsByMessage = {}
+    state = applyChatReactionEvent(state, 'm1', '❤️', 'add', OTHER, MY)
+    expect(state.m1?.['❤️']).toEqual({ count: 1, reactedByMe: false })
+  })
+
+  it('removes chip when count reaches zero', () => {
+    let state: ReactionsByMessage = {}
+    state = applyChatReactionEvent(state, 'm1', '🔥', 'add', MY, MY)
+    state = applyChatReactionEvent(state, 'm1', '🔥', 'remove', MY, MY)
+    expect(state.m1).toBeUndefined()
+  })
+
+  it('clears reactedByMe for local session on remove', () => {
+    let state: ReactionsByMessage = {}
+    state = applyChatReactionEvent(state, 'm1', '👏', 'add', MY, MY)
+    state = applyChatReactionEvent(state, 'm1', '👏', 'add', OTHER, MY)
+    state = applyChatReactionEvent(state, 'm1', '👏', 'remove', MY, MY)
+    expect(state.m1?.['👏']).toEqual({ count: 1, reactedByMe: false })
+  })
+
+  it('keeps reactedByMe when another session removes theirs', () => {
+    let state: ReactionsByMessage = {}
+    state = applyChatReactionEvent(state, 'm1', '🎉', 'add', MY, MY)
+    state = applyChatReactionEvent(state, 'm1', '🎉', 'add', OTHER, MY)
+    state = applyChatReactionEvent(state, 'm1', '🎉', 'remove', OTHER, MY)
+    expect(state.m1?.['🎉']).toEqual({ count: 1, reactedByMe: true })
+  })
+})

--- a/apps/web/src/room/chatReactions.ts
+++ b/apps/web/src/room/chatReactions.ts
@@ -1,0 +1,60 @@
+export const MAX_DISTINCT_EMOJI_PER_MESSAGE = 12
+
+export type ReactionChip = {
+  count: number
+  reactedByMe: boolean
+}
+
+/** messageId → emoji → aggregated chip */
+export type ReactionsByMessage = Record<string, Record<string, ReactionChip>>
+
+export function reactionActionForToggle(reactedByMe: boolean): 'add' | 'remove' {
+  return reactedByMe ? 'remove' : 'add'
+}
+
+export function distinctEmojiCount(chips: Record<string, ReactionChip>): number {
+  return Object.keys(chips).length
+}
+
+/** Client gate before sending `react` add when the distinct-emoji cap applies. */
+export function canAcceptReactionAdd(
+  chips: Record<string, ReactionChip>,
+  emoji: string,
+): boolean {
+  if (chips[emoji] !== undefined) return true
+  return distinctEmojiCount(chips) < MAX_DISTINCT_EMOJI_PER_MESSAGE
+}
+
+export function applyChatReactionEvent(
+  prev: ReactionsByMessage,
+  messageId: string,
+  emoji: string,
+  action: 'add' | 'remove',
+  sessionId: string,
+  mySessionId: string,
+): ReactionsByMessage {
+  const perMessage = { ...(prev[messageId] ?? {}) }
+  const chip = perMessage[emoji] ?? { count: 0, reactedByMe: false }
+
+  if (action === 'add') {
+    const count = chip.count + 1
+    const reactedByMe = chip.reactedByMe || sessionId === mySessionId
+    perMessage[emoji] = { count, reactedByMe }
+  } else {
+    const count = Math.max(0, chip.count - 1)
+    const reactedByMe = sessionId === mySessionId ? false : chip.reactedByMe
+    if (count <= 0) {
+      const rest = { ...perMessage }
+      delete rest[emoji]
+      if (Object.keys(rest).length === 0) {
+        const next = { ...prev }
+        delete next[messageId]
+        return next
+      }
+      return { ...prev, [messageId]: rest }
+    }
+    perMessage[emoji] = { count, reactedByMe }
+  }
+
+  return { ...prev, [messageId]: perMessage }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1356,6 +1356,72 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   margin-top: 0.35rem;
 }
 
+.riffsync-room-chat-log__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.riffsync-room-chat-log__line {
+  word-break: break-word;
+}
+
+.riffsync-room-chat-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  padding-left: 0.15rem;
+}
+
+.riffsync-room-chat-reaction-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  background: rgb(255 255 255 / 0.05);
+  color: inherit;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.riffsync-room-chat-reaction-chip:disabled {
+  cursor: default;
+  opacity: 0.95;
+}
+
+.riffsync-room-chat-reaction-chip--mine {
+  border-color: rgb(120 180 255 / 0.55);
+  background: rgb(120 180 255 / 0.14);
+}
+
+.riffsync-room-chat-reaction-chip__count {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.88;
+  font-size: 0.75rem;
+}
+
+.riffsync-room-chat-reaction-picker {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.riffsync-room-chat-reaction-add {
+  min-width: 1.65rem;
+  padding: 0.1rem 0.35rem;
+  line-height: 1.1;
+  font-size: 0.85rem;
+  border-radius: 999px;
+}
+
+.riffsync-room-chat-reaction-popover {
+  left: 0;
+  right: auto;
+}
+
 .riffsync-room-chat-log__who {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/types/emoji-picker-element-jsx.d.ts
+++ b/apps/web/src/types/emoji-picker-element-jsx.d.ts
@@ -1,5 +1,7 @@
 import type { DetailedHTMLProps, HTMLAttributes } from 'react'
 
+declare module 'emoji-picker-element' {}
+
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -17,7 +17,7 @@ On **`$connect`**, the server stores **`expiresAt`** on the connections row (**a
 
 ## Route selection (`$request.body.action`)
 
-Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, `signaling`, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
+Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, **`react`**, `signaling`, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
 
 | **`action`** | Purpose | Auth |
 | --- | --- | --- |
@@ -26,6 +26,7 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 | **`leave`** | Best-effort client goodbye — deletes this **`connectionId`** from the connections table and fan-outs **`presence`** (same pattern as **`$disconnect`**). Clients may send on **`pagehide`** when teardown is uncertain; safe if the row is already gone. | **Guest OK** once connected. |
 | **`share_state`** | Host announces screen-share lifecycle so guests can reset the guest **video** surface without inferring teardown only from WebRTC. Body: **`state`**: **`started`** \| **`stopped`**; optional **`shareGeneration`** (non-negative int, matches v1 signaling generations). | **Host (publisher JWT)** only. Fan-out shape below. |
 | **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars). |
+| **`react`** | Fan-out ephemeral emoji reaction toggle on a chat line. | Guests + host (same MVP auth as **`chat`**; SPA gates toggles on **`fanToken`**). Body: **`messageId`** (**required**, non-empty, ≤ 64 chars), **`emoji`** (**required**, trimmed non-empty, ≤ 32 chars), **`reactionAction`**: **`add`** \| **`remove`** (not the route **`action`** field). No Dynamo persistence. |
 | **`signaling`** | WebRTC relay to peers (`**envelope`** JSON). | **Host:** publisher **`JWT`** on **`$connect`**. **Guest:** only **`guestSignaling`** with **`kind`** **`ready`**, **`answer`**, or **`ice`** (see below). |
 
 ## Server → client fan-out (`PostToConnection`)
@@ -47,6 +48,27 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 **`displayName`** matches the sender’s connections-row label (same rules as roster: optional nickname from **`$connect`**, else **`Guest (sessionId-prefix…)`**).
 
 **`avatarUrl`** (optional): HTTPS URL read from **FanProfiles** for the sender’s **`fanSub`** when **`$connect`** stored one. Omitted when the fan has no avatar or connected as a guest. Inbound **`chat`** bodies MUST NOT supply **`avatarUrl`**; the server ignores client-supplied image URLs.
+
+Outbound **`chat`** / **`chat_gif`** will include a stable **`messageId`** per line in **[#31](https://github.com/StacksOnTheRacks/riffsync/issues/31)**; the **`react`** route echoes the client-supplied **`messageId`** and does not verify that the message exists server-side.
+
+### Chat reaction (ephemeral fan-out)
+
+Broadcast to **every** connection in **`roomId`** when a client sends **`react`**. Reactions are **not** stored in Dynamo.
+
+```json
+{
+  "type": "chat_reaction",
+  "roomId": "<id>",
+  "messageId": "<client uuid>",
+  "emoji": "👍",
+  "action": "add",
+  "sessionId": "<sender>",
+  "displayName": "…",
+  "ts": 0
+}
+```
+
+**`displayName`** uses the same rules as **`chat`** (connections-row nickname from **`$connect`**, else **`Guest (…)`**). **`action`** is **`add`** or **`remove`** (from inbound **`reactionAction`**).
 
 ### Presence (roster snapshot)
 

--- a/infra/cdk/lambda/ws-route.react.test.ts
+++ b/infra/cdk/lambda/ws-route.react.test.ts
@@ -1,0 +1,155 @@
+import type { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  queryConnectionsForRoom: vi.fn(),
+  postToConnections: vi.fn(),
+  wsManagementClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+vi.mock('./ws-shared', () => ({
+  broadcastRoomPresence: vi.fn(),
+  broadcastRoomPresenceNow: vi.fn(),
+  postToConnections: (...args: unknown[]) => mocks.postToConnections(...args),
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+  queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
+  resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
+  wsManagementClient: () => mocks.wsManagementClient(),
+}));
+
+import { handler } from './ws-route';
+
+function baseEvent(overrides: {
+  routeKey?: string;
+  body?: string;
+  connectionId?: string;
+}): APIGatewayProxyWebsocketEventV2 {
+  return {
+    body: overrides.body,
+    requestContext: {
+      routeKey: overrides.routeKey ?? 'react',
+      connectionId: overrides.connectionId ?? 'conn-abc',
+      requestId: 'req-1',
+      apiId: 'api-1',
+      stage: 'dev',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      eventType: 'MESSAGE',
+      extendedRequestId: 'ext-1',
+      requestTime: '01/Jan/2026:00:00:00 +0000',
+      requestTimeEpoch: 0,
+      messageDirection: 'IN',
+      messageId: 'msg-1',
+      connectedAt: 0,
+    },
+    isBase64Encoded: false,
+  } as APIGatewayProxyWebsocketEventV2;
+}
+
+function stubConnectedRoom() {
+  mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: { TableName?: string } }) => {
+    const table = cmd.input?.TableName;
+    if (table === 'connections') {
+      return {
+        Item: {
+          roomId: 'room-1',
+          sessionId: 'sess-1',
+          presenceKey: 'sess-1#conn-abc',
+          displayName: 'Fan One',
+        },
+      };
+    }
+    if (table === 'rooms') {
+      return { Item: { hostSub: 'host-sub-1' } };
+    }
+    return {};
+  });
+}
+
+describe('ws-route react', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOMS_TABLE_NAME = 'rooms';
+    process.env.CONNECTIONS_TABLE_NAME = 'connections';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    mocks.wsManagementClient.mockReturnValue({ client: true });
+    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc', 'conn-other']);
+    mocks.postToConnections.mockResolvedValue(undefined);
+    stubConnectedRoom();
+  });
+
+  it('fans out chat_reaction on valid react body', async () => {
+    const body = JSON.stringify({
+      action: 'react',
+      messageId: '11111111-1111-4111-8111-111111111111',
+      emoji: '👍',
+      reactionAction: 'add',
+    });
+    const result = await handler(baseEvent({ routeKey: 'react', body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.postToConnections).toHaveBeenCalledTimes(1);
+    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      type: 'chat_reaction',
+      roomId: 'room-1',
+      messageId: '11111111-1111-4111-8111-111111111111',
+      emoji: '👍',
+      action: 'add',
+      sessionId: 'sess-1',
+      displayName: 'Fan One',
+    });
+    expect(typeof parsed.ts).toBe('number');
+  });
+
+  it('maps $default route when body.action is react', async () => {
+    const body = JSON.stringify({
+      action: 'react',
+      messageId: 'msg-id-1',
+      emoji: '🔥',
+      reactionAction: 'remove',
+    });
+    const result = await handler(baseEvent({ routeKey: '$default', body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
+    expect(parsed.action).toBe('remove');
+  });
+
+  it('returns 400 for missing messageId without fan-out', async () => {
+    const body = JSON.stringify({ action: 'react', emoji: '👍', reactionAction: 'add' });
+    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 400, body: 'messageId required, max 64 chars' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid reactionAction without fan-out', async () => {
+    const body = JSON.stringify({
+      action: 'react',
+      messageId: 'msg-1',
+      emoji: '👍',
+      reactionAction: 'toggle',
+    });
+    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 400, body: 'reactionAction must be add or remove' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -229,6 +229,37 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     return { statusCode: 200, body: 'OK' };
   }
 
+  if (routeKey === 'react') {
+    const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
+    if (messageId === '' || messageId.length > 64) {
+      return { statusCode: 400, body: 'messageId required, max 64 chars' };
+    }
+    const emoji = typeof body.emoji === 'string' ? body.emoji.trim() : '';
+    if (emoji === '' || emoji.length > 32) {
+      return { statusCode: 400, body: 'emoji required, max 32 chars' };
+    }
+    const reactionAction = body.reactionAction;
+    if (reactionAction !== 'add' && reactionAction !== 'remove') {
+      return { statusCode: 400, body: 'reactionAction must be add or remove' };
+    }
+    const mgmt = wsManagementClient();
+    const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
+    const displayName = presenceDisplayNameForSession(sessionId, conn.displayName);
+    const out: Record<string, unknown> = {
+      type: 'chat_reaction',
+      roomId,
+      messageId,
+      emoji,
+      action: reactionAction,
+      sessionId,
+      displayName,
+      ts: Date.now(),
+    };
+    const buf = encoder.encode(JSON.stringify(out));
+    await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    return { statusCode: 200, body: 'OK' };
+  }
+
   if (routeKey === 'signaling') {
     const envelope = body.envelope;
     if (envelope === undefined) {

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -540,7 +540,7 @@ export class ApiCatalogStack extends cdk.Stack {
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
-      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, signaling, share_state, leave`,
+      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, react, signaling, share_state, leave`,
       routeSelectionExpression: '$request.body.action',
     });
 
@@ -628,6 +628,7 @@ export class ApiCatalogStack extends cdk.Stack {
       'ping',
       'presence_request',
       'chat',
+      'react',
       'signaling',
       'share_state',
       'leave',


### PR DESCRIPTION
## Summary

M8 chat reactions epic (#30) on `feature/issue-30`:

- **#44** — API Gateway `react` route, `ws-route` validation/fan-out, and `docs/contracts.websocket.md` updates.
- **#45** — SPA ephemeral reaction UI: in-memory aggregation, `chat_reaction` handling, reaction chips + emoji picker for signed-in fans; guests view-only. Reactions attach only when chat lines include `messageId` (depends on #31 / #46 / #47).

## Test plan

- [x] `cd infra/cdk && npm ci && npm test`
- [x] `cd apps/web && npm ci && npm test && npm run lint && npm run build`
- [ ] Manual: two browsers in `/room/:id` after `messageId` lands on `type: chat` — signed-in fan toggles reactions; guest sees chips without controls

Closes #44
Closes #45