### PR TITLE
feat(ws+web): require and use chat messageId

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -52,6 +52,7 @@ import {
   canAcceptReactionAdd,
   type ReactionsByMessage,
 } from '../room/chatReactions'
+import { createChatMessageId, parseInboundChatMessageId } from '../room/chatMessageId'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
 
 const DISPLAY_TITLE_MAX_LEN = 120
@@ -61,7 +62,7 @@ const SFU_RELAY_URL_MISSING_MSG =
   'Video relay URL is missing. Fix: (1) Redeploy RiffSyncApi-prod so POST /v1/webrtc/sfu-token returns wsUrl (from CDK context / signaling hostname). (2) Or set VITE_PUBLIC_SFU_WS_URL in the environment when you run npm run build (Vite bakes it in then, not from S3 at runtime). For https fan sites use wss via CDK context sfuPublicWsUrl or the same Vite variable.'
 
 type ChatMsg = {
-  messageId?: string
+  messageId: string
   sessionId: string
   text: string
   ts: number
@@ -510,18 +511,18 @@ export function RoomPage() {
     (data: Record<string, unknown>) => {
       const t = data.type
       if (t === 'chat' && typeof data.sessionId === 'string' && typeof data.text === 'string') {
+        const messageId = parseInboundChatMessageId(data.messageId)
+        if (messageId === null) return
         const ts = typeof data.ts === 'number' ? data.ts : Date.now()
         const dn = typeof data.displayName === 'string' ? data.displayName : undefined
         const avatarUrl = parseInboundAvatarUrl(data.avatarUrl)
-        const rawMessageId = typeof data.messageId === 'string' ? data.messageId.trim() : ''
-        const messageId = rawMessageId !== '' && rawMessageId.length <= 64 ? rawMessageId : undefined
         setChat((prev) => [
           ...prev,
           {
             sessionId: data.sessionId as string,
             text: String(data.text),
             ts,
-            ...(messageId !== undefined ? { messageId } : {}),
+            messageId,
             ...(dn !== undefined && dn !== '' ? { displayName: dn } : {}),
             ...(avatarUrl !== undefined ? { avatarUrl } : {}),
           },
@@ -1053,7 +1054,7 @@ export function RoomPage() {
     if (!fanToken) return
     const txt = chatDraft.trim()
     if (!txt) return
-    sendJson({ action: 'chat', text: txt })
+    sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
     setChatDraft('')
   }
 
@@ -1424,12 +1425,9 @@ export function RoomPage() {
                         sessionId,
                         myAvatarUrl,
                       )
-                      const rowKey =
-                        m.messageId ?? `${m.sessionId}:${m.ts}:${m.text.slice(0, 12)}`
-                      const reactionChips =
-                        m.messageId !== undefined ? (chatReactions[m.messageId] ?? {}) : {}
+                      const reactionChips = chatReactions[m.messageId] ?? {}
                       return (
-                        <li key={rowKey} className="riffsync-room-chat-log__row">
+                        <li key={m.messageId} className="riffsync-room-chat-log__row">
                           <div className="riffsync-room-chat-log__line">
                             <span className="riffsync-room-chat-log__who">
                               <FanAvatarThumb
@@ -1441,14 +1439,12 @@ export function RoomPage() {
                             {': '}
                             {m.text}
                           </div>
-                          {m.messageId !== undefined ? (
-                            <ChatReactionsStrip
-                              messageId={m.messageId}
-                              chips={reactionChips}
-                              canReact={Boolean(fanToken)}
-                              onToggleReaction={toggleChatReaction}
-                            />
-                          ) : null}
+                          <ChatReactionsStrip
+                            messageId={m.messageId}
+                            chips={reactionChips}
+                            canReact={Boolean(fanToken)}
+                            onToggleReaction={toggleChatReaction}
+                          />
                         </li>
                       )
                     })}

--- a/apps/web/src/room/chatMessageId.test.ts
+++ b/apps/web/src/room/chatMessageId.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createChatMessageId, parseInboundChatMessageId } from './chatMessageId'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseInboundChatMessageId', () => {
+  it('returns trimmed message id for valid values', () => {
+    expect(parseInboundChatMessageId(' abc-123 ')).toBe('abc-123')
+  })
+
+  it('returns null for non-string values', () => {
+    expect(parseInboundChatMessageId(null)).toBeNull()
+    expect(parseInboundChatMessageId(42)).toBeNull()
+  })
+
+  it('returns null for empty message id', () => {
+    expect(parseInboundChatMessageId('   ')).toBeNull()
+  })
+
+  it('returns null for message id longer than max length', () => {
+    expect(parseInboundChatMessageId('x'.repeat(65))).toBeNull()
+  })
+})
+
+describe('createChatMessageId', () => {
+  it('uses crypto.randomUUID', () => {
+    const randomUUID = vi.fn(() => 'uuid-value')
+    vi.stubGlobal('crypto', { randomUUID } as unknown as Crypto)
+
+    expect(createChatMessageId()).toBe('uuid-value')
+    expect(randomUUID).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/room/chatMessageId.ts
+++ b/apps/web/src/room/chatMessageId.ts
@@ -1,0 +1,12 @@
+const CHAT_MESSAGE_ID_MAX_LEN = 64
+
+export function createChatMessageId(): string {
+  return crypto.randomUUID()
+}
+
+export function parseInboundChatMessageId(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed === '' || trimmed.length > CHAT_MESSAGE_ID_MAX_LEN) return null
+  return trimmed
+}

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -25,7 +25,7 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 | **`presence_request`** | Ask the server to fan out a fresh **`presence`** roster snapshot to **all** connections in this room (no body). Use after connect/reconnect or when the UI suspects a stale roster; idempotent. | **Guest OK** once connected. |
 | **`leave`** | Best-effort client goodbye — deletes this **`connectionId`** from the connections table and fan-outs **`presence`** (same pattern as **`$disconnect`**). Clients may send on **`pagehide`** when teardown is uncertain; safe if the row is already gone. | **Guest OK** once connected. |
 | **`share_state`** | Host announces screen-share lifecycle so guests can reset the guest **video** surface without inferring teardown only from WebRTC. Body: **`state`**: **`started`** \| **`stopped`**; optional **`shareGeneration`** (non-negative int, matches v1 signaling generations). | **Host (publisher JWT)** only. Fan-out shape below. |
-| **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars). |
+| **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars), **`messageId`** (**required**, UUID RFC 4122 string). |
 | **`react`** | Fan-out ephemeral emoji reaction toggle on a chat line. | Guests + host (same MVP auth as **`chat`**; SPA gates toggles on **`fanToken`**). Body: **`messageId`** (**required**, non-empty, ≤ 64 chars), **`emoji`** (**required**, trimmed non-empty, ≤ 32 chars), **`reactionAction`**: **`add`** \| **`remove`** (not the route **`action`** field). No Dynamo persistence. |
 | **`signaling`** | WebRTC relay to peers (`**envelope`** JSON). | **Host:** publisher **`JWT`** on **`$connect`**. **Guest:** only **`guestSignaling`** with **`kind`** **`ready`**, **`answer`**, or **`ice`** (see below). |
 
@@ -40,6 +40,7 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
   "sessionId": "<sender>",
   "displayName": "…",
   "text": "…",
+  "messageId": "<client uuid>",
   "ts": 0,
   "avatarUrl": "https://…"
 }
@@ -49,7 +50,9 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 
 **`avatarUrl`** (optional): HTTPS URL read from **FanProfiles** for the sender’s **`fanSub`** when **`$connect`** stored one. Omitted when the fan has no avatar or connected as a guest. Inbound **`chat`** bodies MUST NOT supply **`avatarUrl`**; the server ignores client-supplied image URLs.
 
-Outbound **`chat`** / **`chat_gif`** will include a stable **`messageId`** per line in **[#31](https://github.com/StacksOnTheRacks/riffsync/issues/31)**; the **`react`** route echoes the client-supplied **`messageId`** and does not verify that the message exists server-side.
+Inbound **`chat`** now requires a client-generated **`messageId`** UUID, and outbound **`chat`** / **`chat_gif`** fan-out includes the same stable **`messageId`** per line in **[#31](https://github.com/StacksOnTheRacks/riffsync/issues/31)**.
+
+For compatibility during rollout, treat **`messageId`** as required for new clients. Older clients that do not send a UUID will receive **`400`** from the **`chat`** route.
 
 ### Chat reaction (ephemeral fan-out)
 
@@ -146,4 +149,4 @@ Clients MAY include on **`envelope`**:
 
 When **`protocolVersion`** is absent or **`shareGeneration`** is missing / `0`, peers treat the message as **legacy** and apply only pre-v1 behavior.
 
-**`chat`** payloads are unchanged (**`Date.now()`** server timestamp).
+**`chat`** payloads include client-provided **`messageId`** plus server **`Date.now()`** timestamp.

--- a/infra/cdk/lambda/ws-route-chat.test.ts
+++ b/infra/cdk/lambda/ws-route-chat.test.ts
@@ -1,0 +1,155 @@
+import type { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  queryConnectionsForRoom: vi.fn(),
+  postToConnections: vi.fn(),
+  wsManagementClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+vi.mock('./ws-shared', () => ({
+  broadcastRoomPresence: vi.fn(),
+  broadcastRoomPresenceNow: vi.fn(),
+  postToConnections: (...args: unknown[]) => mocks.postToConnections(...args),
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+  queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
+  resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
+  wsManagementClient: () => mocks.wsManagementClient(),
+}));
+
+import { handler, isUuidMessageId } from './ws-route';
+
+function baseEvent(overrides: {
+  routeKey?: string;
+  body?: string;
+  connectionId?: string;
+}): APIGatewayProxyWebsocketEventV2 {
+  return {
+    body: overrides.body,
+    requestContext: {
+      routeKey: overrides.routeKey ?? 'chat',
+      connectionId: overrides.connectionId ?? 'conn-abc',
+      requestId: 'req-1',
+      apiId: 'api-1',
+      stage: 'dev',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      eventType: 'MESSAGE',
+      extendedRequestId: 'ext-1',
+      requestTime: '01/Jan/2026:00:00:00 +0000',
+      requestTimeEpoch: 0,
+      messageDirection: 'IN',
+      messageId: 'msg-1',
+      connectedAt: 0,
+    },
+    isBase64Encoded: false,
+  } as APIGatewayProxyWebsocketEventV2;
+}
+
+function stubConnectedRoom() {
+  mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: { TableName?: string } }) => {
+    const table = cmd.input?.TableName;
+    if (table === 'connections') {
+      return {
+        Item: {
+          roomId: 'room-1',
+          sessionId: 'sess-1',
+          presenceKey: 'sess-1#conn-abc',
+          displayName: 'Fan One',
+        },
+      };
+    }
+    if (table === 'rooms') {
+      return { Item: { hostSub: 'host-sub-1' } };
+    }
+    return {};
+  });
+}
+
+describe('ws-route chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOMS_TABLE_NAME = 'rooms';
+    process.env.CONNECTIONS_TABLE_NAME = 'connections';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    mocks.wsManagementClient.mockReturnValue({ client: true });
+    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc', 'conn-other']);
+    mocks.postToConnections.mockResolvedValue(undefined);
+    stubConnectedRoom();
+  });
+
+  it('accepts valid uuid messageId and fans out chat', async () => {
+    const body = JSON.stringify({
+      action: 'chat',
+      text: 'hi',
+      messageId: '11111111-1111-4111-8111-111111111111',
+    });
+
+    const result = await handler(baseEvent({ routeKey: 'chat', body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.postToConnections).toHaveBeenCalledTimes(1);
+
+    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      type: 'chat',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      displayName: 'Fan One',
+      text: 'hi',
+      messageId: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(typeof parsed.ts).toBe('number');
+  });
+
+  it('returns 400 for missing messageId without fan-out', async () => {
+    const body = JSON.stringify({ action: 'chat', text: 'hello' });
+    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 400, body: 'messageId must be a valid UUID' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for blank messageId without fan-out', async () => {
+    const body = JSON.stringify({ action: 'chat', text: 'hello', messageId: '   ' });
+    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 400, body: 'messageId must be a valid UUID' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for malformed messageId without fan-out', async () => {
+    const body = JSON.stringify({ action: 'chat', text: 'hello', messageId: 'not-a-uuid' });
+    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 400, body: 'messageId must be a valid UUID' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+});
+
+describe('isUuidMessageId', () => {
+  it('accepts canonical UUID format', () => {
+    expect(isUuidMessageId('11111111-1111-4111-8111-111111111111')).toBe(true);
+  });
+
+  it('rejects malformed values', () => {
+    expect(isUuidMessageId('')).toBe(false);
+    expect(isUuidMessageId('msg-123')).toBe(false);
+    expect(isUuidMessageId('11111111-1111-4111-8111-11111111111')).toBe(false);
+  });
+});

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -24,6 +24,11 @@ import {
 
 const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const encoder = new TextEncoder();
+const UUID_MESSAGE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuidMessageId(value: string): boolean {
+  return UUID_MESSAGE_ID_RE.test(value);
+}
 
 function summarizeCaughtErr(err: unknown): { errorType: string; errorMessage: string } {
   if (typeof err !== 'object' || err === null) {
@@ -208,6 +213,10 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     if (text === '' || text.length > 2000) {
       return { statusCode: 400, body: 'text required, max 2000 chars' };
     }
+    const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
+    if (!isUuidMessageId(messageId)) {
+      return { statusCode: 400, body: 'messageId must be a valid UUID' };
+    }
     const mgmt = wsManagementClient();
     const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
     const displayName = presenceDisplayNameForSession(sessionId, conn.displayName);
@@ -219,6 +228,7 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
       sessionId,
       displayName,
       text,
+      messageId,
       ts: Date.now(),
     };
     if (avatarUrl) {


### PR DESCRIPTION
## Summary
- require a UUID `messageId` on inbound websocket `chat` payloads and fan it out unchanged
- generate client-side `messageId` values for outbound room chat sends and require valid inbound `messageId` before appending scrollback lines
- key room chat rows by `messageId` and add focused web unit coverage for message-id parsing/generation

Closes #47
Part of #31

## Test plan
- cd riffsync/infra/cdk && npm test
- cd riffsync/infra/cdk && npm run build
- cd riffsync/apps/web && npm test
- cd riffsync/apps/web && npm run lint
- cd riffsync/apps/web && npm run build