### PR TITLE
[M9] Giphy secret, GET /v1/giphy/search proxy, and rate limits

### DIFF
--- a/infra/cdk/lambda/giphy-search-shared.ts
+++ b/infra/cdk/lambda/giphy-search-shared.ts
@@ -1,0 +1,214 @@
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type GiphySearchResult = {
+  giphyId: string;
+  title?: string;
+  previewUrl: string;
+  renditionUrl: string;
+  width?: number;
+  height?: number;
+};
+
+export type GiphySearchQuery = {
+  q: string;
+  limit: number;
+  offset: number;
+};
+
+const GIPHY_SEARCH_BASE = 'https://api.giphy.com/v1/gifs/search';
+const GIPHY_CDN_HOST_SUFFIX = '.giphy.com';
+
+export function jsonResponse(statusCode: number, body: Record<string, unknown>) {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+export function parseGiphyApiKey(secretString: string): string | null {
+  const t = secretString.trim();
+  if (t.length === 0) return null;
+  if (t.startsWith('{')) {
+    try {
+      const j = JSON.parse(t) as { apiKey?: string; api_key?: string; key?: string };
+      const v = j.apiKey ?? j.api_key ?? j.key;
+      if (typeof v === 'string' && v.trim().length > 0) return v.trim();
+    } catch {
+      /* plain text */
+    }
+  }
+  if (t.includes('REPLACE')) return null;
+  return t;
+}
+
+export function parseGiphySearchQuery(
+  rawQuery: Record<string, string | undefined> | undefined,
+): { ok: true; query: GiphySearchQuery } | { ok: false } {
+  const qRaw = rawQuery?.q;
+  if (typeof qRaw !== 'string') {
+    return { ok: false };
+  }
+  const q = qRaw.trim();
+  if (q.length < 1 || q.length > 50) {
+    return { ok: false };
+  }
+
+  let limit = 20;
+  const limitRaw = rawQuery?.limit;
+  if (limitRaw !== undefined && limitRaw !== '') {
+    const n = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(n) || n < 1 || n > 25) {
+      return { ok: false };
+    }
+    limit = n;
+  }
+
+  let offset = 0;
+  const offsetRaw = rawQuery?.offset;
+  if (offsetRaw !== undefined && offsetRaw !== '') {
+    const n = Number.parseInt(offsetRaw, 10);
+    if (!Number.isFinite(n) || n < 0 || n > 4999) {
+      return { ok: false };
+    }
+    offset = n;
+  }
+
+  return { ok: true, query: { q, limit, offset } };
+}
+
+function isHttpsGiphyCdnUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return false;
+    const host = u.hostname.toLowerCase();
+    return host === 'giphy.com' || host.endsWith(GIPHY_CDN_HOST_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
+function parseDimension(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+  if (typeof value === 'string') {
+    const n = Number.parseInt(value, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return undefined;
+}
+
+type GiphyImageVariant = {
+  url?: string;
+  width?: string | number;
+  height?: string | number;
+};
+
+type GiphyGifPayload = {
+  id?: string;
+  title?: string;
+  images?: Record<string, GiphyImageVariant | undefined>;
+};
+
+function pickImageVariant(
+  images: Record<string, GiphyImageVariant | undefined> | undefined,
+  keys: string[],
+): GiphyImageVariant | undefined {
+  if (!images) return undefined;
+  for (const key of keys) {
+    const v = images[key];
+    if (v && typeof v.url === 'string' && v.url.trim() !== '') {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+export function normalizeGiphySearchPayload(payload: unknown): GiphySearchResult[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const data = (payload as { data?: unknown }).data;
+  if (!Array.isArray(data)) return [];
+
+  const results: GiphySearchResult[] = [];
+  for (const item of data) {
+    if (!item || typeof item !== 'object') continue;
+    const gif = item as GiphyGifPayload;
+    const giphyId = typeof gif.id === 'string' ? gif.id.trim() : '';
+    if (!giphyId) continue;
+
+    const preview = pickImageVariant(gif.images, ['fixed_height_small', 'preview_gif', 'downsized']);
+    const rendition = pickImageVariant(gif.images, ['fixed_height', 'downsized_medium', 'original']);
+    const previewUrl = preview?.url?.trim() ?? '';
+    const renditionUrl = rendition?.url?.trim() ?? '';
+    if (!isHttpsGiphyCdnUrl(previewUrl) || !isHttpsGiphyCdnUrl(renditionUrl)) {
+      continue;
+    }
+
+    const title =
+      typeof gif.title === 'string' && gif.title.trim() !== '' ? gif.title.trim().slice(0, 200) : undefined;
+
+    const width = parseDimension(rendition?.width ?? preview?.width);
+    const height = parseDimension(rendition?.height ?? preview?.height);
+
+    const entry: GiphySearchResult = {
+      giphyId,
+      previewUrl,
+      renditionUrl,
+    };
+    if (title) entry.title = title;
+    if (width !== undefined) entry.width = width;
+    if (height !== undefined) entry.height = height;
+    results.push(entry);
+  }
+
+  return results;
+}
+
+export function minuteBucketEpochMs(nowMs: number = Date.now()): number {
+  return Math.floor(nowMs / 60_000) * 60_000;
+}
+
+export function giphyRateLimitKey(sub: string, bucketMs: number): { pk: string; sk: string } {
+  return { pk: `giphy-rate#${sub}`, sk: String(bucketMs) };
+}
+
+export async function fetchGiphySearch(
+  apiKey: string,
+  query: GiphySearchQuery,
+  fetchImpl: FetchLike,
+): Promise<{ ok: true; results: GiphySearchResult[] } | { ok: false; status: 502 | 503 }> {
+  const url = new URL(GIPHY_SEARCH_BASE);
+  url.searchParams.set('api_key', apiKey);
+  url.searchParams.set('q', query.q);
+  url.searchParams.set('limit', String(query.limit));
+  url.searchParams.set('offset', String(query.offset));
+  url.searchParams.set('rating', 'pg-13');
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url.toString(), {
+      headers: { accept: 'application/json' },
+    });
+  } catch (e) {
+    console.error('Giphy search request failed', e);
+    return { ok: false, status: 502 };
+  }
+
+  if (res.status === 429 || res.status >= 500) {
+    return { ok: false, status: res.status === 503 ? 503 : 502 };
+  }
+
+  if (!res.ok) {
+    console.error('Giphy search unexpected status', res.status);
+    return { ok: false, status: 502 };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await res.json();
+  } catch (e) {
+    console.error('Giphy search JSON parse failed', e);
+    return { ok: false, status: 502 };
+  }
+
+  return { ok: true, results: normalizeGiphySearchPayload(payload) };
+}

--- a/infra/cdk/lambda/giphy-search.test.ts
+++ b/infra/cdk/lambda/giphy-search.test.ts
@@ -1,0 +1,243 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  secretsSend: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: vi.fn(),
+  GetSecretValueCommand: vi.fn((input: unknown) => ({ input, kind: 'GetSecret' })),
+}));
+
+import { enforceGiphyRateLimit, handler } from './giphy-search';
+import {
+  fetchGiphySearch,
+  giphyRateLimitKey,
+  minuteBucketEpochMs,
+  normalizeGiphySearchPayload,
+  parseGiphySearchQuery,
+} from './giphy-search-shared';
+
+describe('parseGiphySearchQuery', () => {
+  it('requires trimmed q between 1 and 50 characters', () => {
+    expect(parseGiphySearchQuery({ q: '  hi  ' })).toEqual({
+      ok: true,
+      query: { q: 'hi', limit: 20, offset: 0 },
+    });
+    expect(parseGiphySearchQuery({ q: '' }).ok).toBe(false);
+    expect(parseGiphySearchQuery({ q: '   ' }).ok).toBe(false);
+    expect(parseGiphySearchQuery({ q: 'x'.repeat(51) }).ok).toBe(false);
+    expect(parseGiphySearchQuery(undefined).ok).toBe(false);
+  });
+
+  it('validates limit and offset bounds', () => {
+    expect(parseGiphySearchQuery({ q: 'a', limit: '25' })).toEqual({
+      ok: true,
+      query: { q: 'a', limit: 25, offset: 0 },
+    });
+    expect(parseGiphySearchQuery({ q: 'a', limit: '26' }).ok).toBe(false);
+    expect(parseGiphySearchQuery({ q: 'a', offset: '4999' })).toEqual({
+      ok: true,
+      query: { q: 'a', limit: 20, offset: 4999 },
+    });
+    expect(parseGiphySearchQuery({ q: 'a', offset: '5000' }).ok).toBe(false);
+  });
+});
+
+describe('normalizeGiphySearchPayload', () => {
+  it('maps Giphy data to normalized HTTPS CDN results', () => {
+    const results = normalizeGiphySearchPayload({
+      data: [
+        {
+          id: 'abc123',
+          title: 'Wave',
+          images: {
+            fixed_height_small: {
+              url: 'https://media0.giphy.com/media/abc123/100.gif',
+              width: '100',
+              height: '80',
+            },
+            fixed_height: {
+              url: 'https://media1.giphy.com/media/abc123/200.gif',
+              width: '200',
+              height: '160',
+            },
+          },
+        },
+        {
+          id: 'skip-http',
+          images: {
+            fixed_height_small: { url: 'http://media0.giphy.com/media/x/1.gif' },
+            fixed_height: { url: 'https://media1.giphy.com/media/x/2.gif' },
+          },
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        giphyId: 'abc123',
+        title: 'Wave',
+        previewUrl: 'https://media0.giphy.com/media/abc123/100.gif',
+        renditionUrl: 'https://media1.giphy.com/media/abc123/200.gif',
+        width: 200,
+        height: 160,
+      },
+    ]);
+  });
+});
+
+describe('fetchGiphySearch', () => {
+  it('calls Giphy with fixed rating and normalizes success payloads', async () => {
+    mocks.fetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'gif1',
+              images: {
+                preview_gif: { url: 'https://media2.giphy.com/media/gif1/p.gif' },
+                fixed_height: { url: 'https://media2.giphy.com/media/gif1/r.gif' },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const out = await fetchGiphySearch('test-key', { q: 'cats', limit: 5, offset: 10 }, mocks.fetch);
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.results).toHaveLength(1);
+      expect(out.results[0]?.giphyId).toBe('gif1');
+    }
+
+    const calledUrl = String(mocks.fetch.mock.calls[0]?.[0]);
+    expect(calledUrl).toContain('api.giphy.com/v1/gifs/search');
+    expect(calledUrl).toContain('api_key=test-key');
+    expect(calledUrl).toContain('q=cats');
+    expect(calledUrl).toContain('limit=5');
+    expect(calledUrl).toContain('offset=10');
+    expect(calledUrl).toContain('rating=pg-13');
+  });
+
+  it('maps upstream 5xx to 502/503 without leaking bodies', async () => {
+    mocks.fetch.mockResolvedValue(new Response('upstream error', { status: 503 }));
+    const out503 = await fetchGiphySearch('k', { q: 'x', limit: 1, offset: 0 }, mocks.fetch);
+    expect(out503).toEqual({ ok: false, status: 503 });
+
+    mocks.fetch.mockResolvedValue(new Response('bad', { status: 418 }));
+    const out502 = await fetchGiphySearch('k', { q: 'x', limit: 1, offset: 0 }, mocks.fetch);
+    expect(out502).toEqual({ ok: false, status: 502 });
+  });
+});
+
+describe('enforceGiphyRateLimit', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.GIPHY_RATE_LIMIT_TABLE_NAME = 'GiphyRateLimits';
+  });
+
+  it('uses sub + minute bucket keys and allows under the limit', async () => {
+    mocks.docSend.mockResolvedValue({});
+    const now = 1_700_000_123_456;
+    const bucket = minuteBucketEpochMs(now);
+    const ok = await enforceGiphyRateLimit('GiphyRateLimits', 'sub-1', 30, now);
+    expect(ok).toBe(true);
+    expect(mocks.docSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          TableName: 'GiphyRateLimits',
+          Key: giphyRateLimitKey('sub-1', bucket),
+          ConditionExpression: 'attribute_not_exists(requestCount) OR requestCount < :limit',
+        }),
+      }),
+    );
+  });
+
+  it('returns false when DynamoDB conditional check fails', async () => {
+    mocks.docSend.mockRejectedValue({ name: 'ConditionalCheckFailedException' });
+    const ok = await enforceGiphyRateLimit('GiphyRateLimits', 'sub-1', 30);
+    expect(ok).toBe(false);
+  });
+});
+
+describe('giphy-search handler', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mocks.fetch);
+    mocks.docSend.mockReset();
+    mocks.secretsSend.mockReset();
+    mocks.fetch.mockReset();
+    process.env.GIPHY_SECRET_ARN = 'arn:aws:secretsmanager:us-east-1:123:secret:giphy';
+    process.env.GIPHY_RATE_LIMIT_TABLE_NAME = 'GiphyRateLimits';
+    process.env.GIPHY_RATE_LIMIT_PER_MINUTE = '30';
+  });
+
+  function fanEvent(query?: Record<string, string>): APIGatewayProxyEventV2 {
+    return {
+      version: '2.0',
+      routeKey: 'GET /v1/giphy/search',
+      rawPath: '/v1/giphy/search',
+      rawQueryString: '',
+      headers: {},
+      queryStringParameters: query,
+      requestContext: {
+        accountId: '123',
+        apiId: 'api',
+        domainName: 'example.com',
+        domainPrefix: 'example',
+        http: {
+          method: 'GET',
+          path: '/v1/giphy/search',
+          protocol: 'HTTP/1.1',
+          sourceIp: '127.0.0.1',
+          userAgent: 'vitest',
+        },
+        requestId: 'req',
+        routeKey: 'GET /v1/giphy/search',
+        stage: 'prod',
+        time: '01/Jan/2025:00:00:00 +0000',
+        timeEpoch: 0,
+        authorizer: {
+          jwt: {
+            claims: { sub: 'fan-sub-99' },
+          },
+        },
+      } as APIGatewayProxyEventV2['requestContext'],
+      isBase64Encoded: false,
+    };
+  }
+
+  it('returns 401 without jwt sub', async () => {
+    const event = fanEvent({ q: 'hello' });
+    (event.requestContext as { authorizer?: unknown }).authorizer = undefined;
+    const res = await handler(event, {} as never, () => undefined);
+    expect(res?.statusCode).toBe(401);
+  });
+
+  it('returns 400 for invalid query', async () => {
+    const res = await handler(fanEvent({ q: '' }), {} as never, () => undefined);
+    expect(res?.statusCode).toBe(400);
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    mocks.docSend.mockRejectedValue({ name: 'ConditionalCheckFailedException' });
+    const res = await handler(fanEvent({ q: 'hello' }), {} as never, () => undefined);
+    expect(res?.statusCode).toBe(429);
+  });
+});

--- a/infra/cdk/lambda/giphy-search.ts
+++ b/infra/cdk/lambda/giphy-search.ts
@@ -1,0 +1,116 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+import { getJwtSub } from './fan-profile-shared';
+import {
+  fetchGiphySearch,
+  giphyRateLimitKey,
+  jsonResponse,
+  minuteBucketEpochMs,
+  parseGiphyApiKey,
+  parseGiphySearchQuery,
+} from './giphy-search-shared';
+
+const secrets = new SecretsManagerClient({});
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+let cachedApiKey: { value: string; loadedAt: number } | undefined;
+const API_KEY_CACHE_MS = 5 * 60_000;
+
+function rateLimitPerMinute(): number {
+  const raw = process.env.GIPHY_RATE_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : 30;
+  return Number.isFinite(n) && n > 0 ? n : 30;
+}
+
+async function loadGiphyApiKey(secretArn: string): Promise<string | null> {
+  const now = Date.now();
+  if (cachedApiKey && now - cachedApiKey.loadedAt < API_KEY_CACHE_MS) {
+    return cachedApiKey.value;
+  }
+
+  let raw: string | undefined;
+  try {
+    const out = await secrets.send(new GetSecretValueCommand({ SecretId: secretArn }));
+    raw = out.SecretString;
+  } catch (e) {
+    console.error('Giphy secret read failed', e);
+    return null;
+  }
+
+  const key = raw ? parseGiphyApiKey(raw) : null;
+  if (!key) return null;
+  cachedApiKey = { value: key, loadedAt: now };
+  return key;
+}
+
+export async function enforceGiphyRateLimit(
+  tableName: string,
+  sub: string,
+  limit: number,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  const { pk, sk } = giphyRateLimitKey(sub, bucketMs);
+  const expiresAt = Math.floor(nowMs / 1000) + 120;
+
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { pk, sk },
+        UpdateExpression: 'ADD requestCount :one SET expiresAt = :expiresAt',
+        ConditionExpression: 'attribute_not_exists(requestCount) OR requestCount < :limit',
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':limit': limit,
+          ':expiresAt': expiresAt,
+        },
+      }),
+    );
+    return true;
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return false;
+    }
+    console.error('Giphy rate limit update failed', e);
+    throw e;
+  }
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const secretArn = process.env.GIPHY_SECRET_ARN;
+  const rateTable = process.env.GIPHY_RATE_LIMIT_TABLE_NAME;
+  if (!secretArn || !rateTable) {
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  const jwtSub = getJwtSub(event);
+  if (!jwtSub) {
+    return jsonResponse(401, { error: 'Unauthorized' });
+  }
+
+  const parsed = parseGiphySearchQuery(event.queryStringParameters);
+  if (!parsed.ok) {
+    return jsonResponse(400, { error: 'Invalid query parameters' });
+  }
+
+  const allowed = await enforceGiphyRateLimit(rateTable, jwtSub, rateLimitPerMinute());
+  if (!allowed) {
+    return jsonResponse(429, { error: 'Giphy search rate limit exceeded' });
+  }
+
+  const apiKey = await loadGiphyApiKey(secretArn);
+  if (!apiKey) {
+    return jsonResponse(503, { error: 'Giphy search is temporarily unavailable' });
+  }
+
+  const upstream = await fetchGiphySearch(apiKey, parsed.query, fetch);
+  if (!upstream.ok) {
+    return jsonResponse(upstream.status, { error: 'Giphy search is temporarily unavailable' });
+  }
+
+  return jsonResponse(200, { results: upstream.results });
+};

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -147,6 +147,7 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly httpApi: apigwv2.HttpApi;
   public readonly webSocketApi: apigwv2.WebSocketApi;
   public readonly tmdbApiTokenSecret: secretsmanager.ISecret;
+  public readonly giphyApiKeySecret: secretsmanager.ISecret;
   public readonly turnSharedSecret: secretsmanager.ISecret;
 
   constructor(scope: Construct, id: string, props: ApiCatalogStackProps) {
@@ -245,6 +246,22 @@ export class ApiCatalogStack extends cdk.Stack {
         'TMDB API bearer token for catalog reconcile (replace via AWS Console or put-secret-value).',
       secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_WITH_TMDB_BEARER_TOKEN'),
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.giphyApiKeySecret = new secretsmanager.Secret(this, 'GiphyApiKey', {
+      secretName: `riffsync/${environment}/giphy-api-key`,
+      description:
+        'Giphy API key for GET /v1/giphy/search (replace via AWS Console or put-secret-value).',
+      secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_WITH_GIPHY_API_KEY'),
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    const giphyRateLimitTable = new dynamodb.Table(this, 'GiphyRateLimitTable', {
+      partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      timeToLiveAttribute: 'expiresAt',
     });
 
     const privacyRoutingSecret = new secretsmanager.Secret(this, 'PrivacyRemovalRouting', {
@@ -519,6 +536,23 @@ export class ApiCatalogStack extends cdk.Stack {
     this.fanProfilesTable.grantReadData(fanProfileGetFn);
     this.fanProfilesTable.grantReadWriteData(fanProfilePatchFn);
 
+    const giphySearchFn = new lambdaNodejs.NodejsFunction(this, 'GiphySearchFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/giphy-search.ts'),
+      handler: 'handler',
+      environment: {
+        GIPHY_SECRET_ARN: this.giphyApiKeySecret.secretArn,
+        GIPHY_RATE_LIMIT_TABLE_NAME: giphyRateLimitTable.tableName,
+        GIPHY_RATE_LIMIT_PER_MINUTE: '30',
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.giphyApiKeySecret.grantRead(giphySearchFn);
+    giphyRateLimitTable.grantReadWriteData(giphySearchFn);
+
     const fanAvatarPostFn = new lambdaNodejs.NodejsFunction(this, 'FanAvatarPostFn', {
       runtime: lambda.Runtime.NODEJS_24_X,
       timeout: cdk.Duration.seconds(29),
@@ -684,6 +718,10 @@ export class ApiCatalogStack extends cdk.Stack {
       'FanAvatarPostInt',
       fanAvatarPostFn,
     );
+    const giphySearchIntegration = new integrations.HttpLambdaIntegration(
+      'GiphySearchInt',
+      giphySearchFn,
+    );
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -762,6 +800,13 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: fanJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/giphy/search',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: giphySearchIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -818,7 +863,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {
@@ -837,6 +882,16 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'TmdbApiTokenSecretArn', {
       value: this.tmdbApiTokenSecret.secretArn,
       description: 'Set to a real TMDB bearer token (not a v3 api_key query param in git).',
+    });
+
+    new cdk.CfnOutput(this, 'GiphyApiKeySecretArn', {
+      value: this.giphyApiKeySecret.secretArn,
+      description: 'Set to a real Giphy API key for GET /v1/giphy/search (secret name riffsync/prod/giphy-api-key).',
+    });
+
+    new cdk.CfnOutput(this, 'GiphyRateLimitTableName', {
+      value: giphyRateLimitTable.tableName,
+      description: 'Per-fan Giphy search rate limit counters (TTL attribute expiresAt).',
     });
 
     new cdk.CfnOutput(this, 'PrivacyRemovalRoutingSecretArn', {


### PR DESCRIPTION
## Summary

- Adds Secrets Manager secret `riffsync/prod/giphy-api-key` and `GiphySearchFn` to proxy Giphy search server-side.
- Registers `GET /v1/giphy/search` on the HTTP API with `FanJwtAuthorizer`, query validation, normalized HTTPS CDN results, and safe upstream error mapping.
- Enforces a configurable per-`sub` rate limit (default 30/min) using a DynamoDB counter table with TTL.

## Test plan

- [x] `cd infra/cdk && npm ci && npm test`
- [x] `cd infra/cdk && npm run synth`
- [ ] After deploy: set real Giphy API key on `riffsync/prod/giphy-api-key`
- [ ] Manual curl with fan JWT returns 200 normalized `results`
- [ ] Missing JWT returns 401; invalid `q` returns 400; >30/min returns 429

Closes #32