### PR TITLE
[M9] Giphy chat: WebSocket route + SPA picker (#51, #52)

### DIFF
--- a/apps/web/src/api/giphySearchApi.test.ts
+++ b/apps/web/src/api/giphySearchApi.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { searchGiphy } from './giphySearchApi'
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.example.test',
+}))
+
+describe('searchGiphy', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns normalized results on success', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        results: [
+          {
+            giphyId: 'abc',
+            title: 'Cat',
+            previewUrl: 'https://media0.giphy.com/media/abc/p.gif',
+            renditionUrl: 'https://media0.giphy.com/media/abc/r.gif',
+            width: 200,
+            height: 150,
+          },
+        ],
+      }),
+    })
+
+    const out = await searchGiphy('token-abc', { q: 'cats', limit: 10, offset: 5 })
+
+    expect(out.results).toHaveLength(1)
+    expect(out.results[0]?.giphyId).toBe('abc')
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/giphy/search?q=cats&limit=10&offset=5')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer token-abc',
+      Accept: 'application/json',
+    })
+  })
+
+  it('surfaces 401 from the API', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => '',
+    })
+
+    await expect(searchGiphy('bad-token', { q: 'hi' })).rejects.toThrow(/Sign in again/i)
+  })
+
+  it('surfaces 400 from the API', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ error: 'Invalid query parameters' }),
+    })
+
+    await expect(searchGiphy('token', { q: 'hi' })).rejects.toThrow(/Invalid query parameters/i)
+  })
+
+  it('surfaces 429 from the API', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => JSON.stringify({ error: 'Giphy search rate limit exceeded' }),
+    })
+
+    await expect(searchGiphy('token', { q: 'hi' })).rejects.toThrow(/rate limit exceeded/i)
+  })
+
+  it('rejects empty query without network', async () => {
+    await expect(searchGiphy('token', { q: '   ' })).rejects.toThrow(/search term/i)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/api/giphySearchApi.ts
+++ b/apps/web/src/api/giphySearchApi.ts
@@ -1,0 +1,73 @@
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+
+export type GiphySearchResult = {
+  giphyId: string
+  title?: string
+  previewUrl: string
+  renditionUrl: string
+  width?: number
+  height?: number
+}
+
+export type GiphySearchParams = {
+  q: string
+  limit?: number
+  offset?: number
+}
+
+function giphyAuthHeaders(accessToken: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+  }
+}
+
+function formatGiphyHttpError(prefix: string, status: number, bodyText: string): string {
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: string; message?: string }
+    const detail = parsed.error ?? parsed.message
+    if (typeof detail === 'string' && detail.trim() !== '') {
+      return `${prefix} (${status}): ${detail}`
+    }
+  } catch {
+    /* use raw body */
+  }
+  const trimmed = bodyText.trim()
+  return trimmed ? `${prefix} (${status}): ${trimmed}` : `${prefix} (${status})`
+}
+
+export async function searchGiphy(
+  accessToken: string,
+  params: GiphySearchParams,
+): Promise<{ results: GiphySearchResult[] }> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+
+  const q = params.q.trim()
+  if (q === '') throw new Error('Enter a search term.')
+
+  const search = new URLSearchParams({ q })
+  if (params.limit !== undefined) search.set('limit', String(params.limit))
+  if (params.offset !== undefined) search.set('offset', String(params.offset))
+
+  const res = await fetch(`${base}/v1/giphy/search?${search.toString()}`, {
+    headers: giphyAuthHeaders(accessToken),
+  })
+
+  if (res.status === 401) throw new Error('Sign in again — token rejected')
+  if (res.status === 400) {
+    const t = await res.text()
+    throw new Error(formatGiphyHttpError('Giphy search failed', 400, t))
+  }
+  if (res.status === 429) {
+    const t = await res.text()
+    throw new Error(formatGiphyHttpError('Giphy search rate limit exceeded', 429, t))
+  }
+  if (!res.ok) {
+    const t = await res.text()
+    throw new Error(formatGiphyHttpError('Giphy search failed', res.status, t))
+  }
+
+  const payload = (await res.json()) as { results?: GiphySearchResult[] }
+  return { results: Array.isArray(payload.results) ? payload.results : [] }
+}

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -46,6 +46,9 @@ import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/m
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatEmojiPicker } from '../room/ChatEmojiPicker'
+import { ChatGiphyPicker } from '../room/ChatGiphyPicker'
+import type { GiphySearchResult } from '../api/giphySearchApi'
+import { parseInboundChatGifMessage } from '../room/chatGifMessage'
 import { ChatReactionsStrip } from '../room/ChatReactionsStrip'
 import {
   applyChatReactionEvent,
@@ -61,7 +64,8 @@ const DISPLAY_TITLE_MAX_LEN = 120
 const SFU_RELAY_URL_MISSING_MSG =
   'Video relay URL is missing. Fix: (1) Redeploy RiffSyncApi-prod so POST /v1/webrtc/sfu-token returns wsUrl (from CDK context / signaling hostname). (2) Or set VITE_PUBLIC_SFU_WS_URL in the environment when you run npm run build (Vite bakes it in then, not from S3 at runtime). For https fan sites use wss via CDK context sfuPublicWsUrl or the same Vite variable.'
 
-type ChatMsg = {
+type ChatTextLine = {
+  kind: 'text'
   messageId: string
   sessionId: string
   text: string
@@ -69,6 +73,22 @@ type ChatMsg = {
   displayName?: string
   avatarUrl?: string
 }
+
+type ChatGifLine = {
+  kind: 'gif'
+  messageId: string
+  sessionId: string
+  giphyId: string
+  renditionUrl: string
+  title?: string
+  width?: number
+  height?: number
+  ts: number
+  displayName?: string
+  avatarUrl?: string
+}
+
+type ChatLine = ChatTextLine | ChatGifLine
 
 type PresenceMember = {
   sessionId: string
@@ -129,7 +149,7 @@ export function RoomPage() {
   const [room, setRoom] = useState<RoomSnapshot | null | undefined>(undefined)
   const [roomErr, setRoomErr] = useState<string | null>(null)
   const [catalogEp, setCatalogEp] = useState<CatalogEpisode | null>(null)
-  const [chat, setChat] = useState<ChatMsg[]>([])
+  const [chat, setChat] = useState<ChatLine[]>([])
   const [chatReactions, setChatReactions] = useState<ReactionsByMessage>({})
   const [chatDraft, setChatDraft] = useState('')
   const [patchErr, setPatchErr] = useState<string | null>(null)
@@ -519,6 +539,7 @@ export function RoomPage() {
         setChat((prev) => [
           ...prev,
           {
+            kind: 'text',
             sessionId: data.sessionId as string,
             text: String(data.text),
             ts,
@@ -527,6 +548,12 @@ export function RoomPage() {
             ...(avatarUrl !== undefined ? { avatarUrl } : {}),
           },
         ])
+        return
+      }
+      if (t === 'chat_gif') {
+        const gifLine = parseInboundChatGifMessage(data)
+        if (gifLine === null) return
+        setChat((prev) => [...prev, { kind: 'gif', ...gifLine }])
         return
       }
       if (
@@ -1058,6 +1085,22 @@ export function RoomPage() {
     setChatDraft('')
   }
 
+  const sendChatGif = useCallback(
+    (result: GiphySearchResult) => {
+      if (!fanToken) return
+      sendJson({
+        action: 'chat_gif',
+        messageId: createChatMessageId(),
+        giphyId: result.giphyId,
+        renditionUrl: result.renditionUrl,
+        ...(result.title !== undefined && result.title.trim() !== '' ? { title: result.title.trim() } : {}),
+        ...(result.width !== undefined ? { width: result.width } : {}),
+        ...(result.height !== undefined ? { height: result.height } : {}),
+      })
+    },
+    [fanToken, sendJson],
+  )
+
   const sendChatReaction = useCallback(
     (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => {
       if (!fanToken) return
@@ -1428,17 +1471,37 @@ export function RoomPage() {
                       const reactionChips = chatReactions[m.messageId] ?? {}
                       return (
                         <li key={m.messageId} className="riffsync-room-chat-log__row">
-                          <div className="riffsync-room-chat-log__line">
-                            <span className="riffsync-room-chat-log__who">
-                              <FanAvatarThumb
-                                displayName={chatDisplayName}
-                                avatarUrl={chatAvatarUrl}
+                          {m.kind === 'gif' ? (
+                            <div className="riffsync-room-chat-log__gif">
+                              <div className="riffsync-room-chat-log__gif-who">
+                                <FanAvatarThumb
+                                  displayName={chatDisplayName}
+                                  avatarUrl={chatAvatarUrl}
+                                />
+                                <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
+                              </div>
+                              <img
+                                className="riffsync-room-chat-log__gif-img"
+                                src={m.renditionUrl}
+                                alt={m.title?.trim() || 'GIF'}
+                                loading="lazy"
+                                width={m.width}
+                                height={m.height}
                               />
-                              <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
-                            </span>
-                            {': '}
-                            {m.text}
-                          </div>
+                            </div>
+                          ) : (
+                            <div className="riffsync-room-chat-log__line">
+                              <span className="riffsync-room-chat-log__who">
+                                <FanAvatarThumb
+                                  displayName={chatDisplayName}
+                                  avatarUrl={chatAvatarUrl}
+                                />
+                                <span className="riffsync-room-chat-log__who-name">{chatDisplayName}</span>
+                              </span>
+                              {': '}
+                              {m.text}
+                            </div>
+                          )}
                           <ChatReactionsStrip
                             messageId={m.messageId}
                             chips={reactionChips}
@@ -1464,11 +1527,14 @@ export function RoomPage() {
                       className={`riffsync-room-chat-compose${fanToken ? '' : ' riffsync-room-chat-compose--inactive'}`}
                     >
                       {fanToken ? (
-                        <ChatEmojiPicker
-                          draft={chatDraft}
-                          onDraftChange={setChatDraft}
-                          inputRef={chatInputRef}
-                        />
+                        <>
+                          <ChatEmojiPicker
+                            draft={chatDraft}
+                            onDraftChange={setChatDraft}
+                            inputRef={chatInputRef}
+                          />
+                          <ChatGiphyPicker accessToken={fanToken} onSelect={sendChatGif} />
+                        </>
                       ) : null}
                       <input
                         ref={chatInputRef}

--- a/apps/web/src/room/ChatGiphyPicker.test.tsx
+++ b/apps/web/src/room/ChatGiphyPicker.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChatGiphyPicker } from './ChatGiphyPicker'
+import * as giphySearchApi from '../api/giphySearchApi'
+
+vi.mock('../api/giphySearchApi', () => ({
+  searchGiphy: vi.fn(),
+}))
+
+const searchGiphyMock = vi.mocked(giphySearchApi.searchGiphy)
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function renderPicker(el: HTMLElement, onSelect: (result: giphySearchApi.GiphySearchResult) => void): Root {
+  const root = createRoot(el)
+  act(() => {
+    root.render(<ChatGiphyPicker accessToken="token-abc" onSelect={onSelect} />)
+  })
+  return root
+}
+
+describe('ChatGiphyPicker', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    searchGiphyMock.mockReset()
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+    vi.useRealTimers()
+  })
+
+  it('opens popover and runs debounced search', async () => {
+    searchGiphyMock.mockResolvedValue({
+      results: [
+        {
+          giphyId: 'gif-1',
+          previewUrl: 'https://media0.giphy.com/media/gif-1/p.gif',
+          renditionUrl: 'https://media0.giphy.com/media/gif-1/r.gif',
+          title: 'Wave',
+        },
+      ],
+    })
+
+    container = document.createElement('div')
+    const onSelect = vi.fn()
+    root = renderPicker(container, onSelect)
+
+    const toggle = container.querySelector('.riffsync-room-chat-giphy-toggle') as HTMLButtonElement
+    act(() => {
+      toggle.click()
+    })
+
+    const search = container.querySelector('.riffsync-room-chat-giphy-search') as HTMLInputElement
+    act(() => {
+      setInputValue(search, 'wave')
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+
+    expect(searchGiphyMock).toHaveBeenCalledWith('token-abc', { q: 'wave', limit: 20 })
+
+    const resultBtn = container.querySelector('.riffsync-room-chat-giphy-result') as HTMLButtonElement
+    act(() => {
+      resultBtn.click()
+    })
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ giphyId: 'gif-1', renditionUrl: expect.stringContaining('gif-1') }),
+    )
+    expect(container.querySelector('.riffsync-room-chat-giphy-popover')).toBeNull()
+  })
+
+  it('dismisses on Escape', () => {
+    container = document.createElement('div')
+    root = renderPicker(container, vi.fn())
+
+    const toggle = container.querySelector('.riffsync-room-chat-giphy-toggle') as HTMLButtonElement
+    act(() => {
+      toggle.click()
+    })
+    expect(container.querySelector('.riffsync-room-chat-giphy-popover')).not.toBeNull()
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(container.querySelector('.riffsync-room-chat-giphy-popover')).toBeNull()
+  })
+})

--- a/apps/web/src/room/ChatGiphyPicker.tsx
+++ b/apps/web/src/room/ChatGiphyPicker.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { searchGiphy, type GiphySearchResult } from '../api/giphySearchApi'
+
+const SEARCH_DEBOUNCE_MS = 300
+const SEARCH_LIMIT = 20
+
+export type ChatGiphyPickerProps = {
+  accessToken: string
+  onSelect: (result: GiphySearchResult) => void
+}
+
+export function ChatGiphyPicker({ accessToken, onSelect }: ChatGiphyPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<GiphySearchResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searchErr, setSearchErr] = useState<string | null>(null)
+  const popoverId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const searchSeqRef = useRef(0)
+
+  const runSearch = useCallback(
+    async (q: string, seq: number) => {
+      const trimmed = q.trim()
+      if (trimmed === '') {
+        setResults([])
+        setSearching(false)
+        setSearchErr(null)
+        return
+      }
+      setSearching(true)
+      setSearchErr(null)
+      try {
+        const { results: next } = await searchGiphy(accessToken, { q: trimmed, limit: SEARCH_LIMIT })
+        if (searchSeqRef.current !== seq) return
+        setResults(next)
+      } catch (e) {
+        if (searchSeqRef.current !== seq) return
+        setResults([])
+        setSearchErr(e instanceof Error ? e.message : 'Giphy search failed.')
+      } finally {
+        if (searchSeqRef.current === seq) setSearching(false)
+      }
+    },
+    [accessToken],
+  )
+
+  useEffect(() => {
+    if (!open) return
+    const seq = ++searchSeqRef.current
+    const handle = window.setTimeout(() => {
+      void runSearch(query, seq)
+    }, SEARCH_DEBOUNCE_MS)
+    return () => window.clearTimeout(handle)
+  }, [open, query, runSearch])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      const root = rootRef.current
+      if (!root || !(event.target instanceof Node)) return
+      if (!root.contains(event.target)) {
+        setOpen(false)
+        toggleRef.current?.focus()
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    requestAnimationFrame(() => searchInputRef.current?.focus())
+  }, [open])
+
+  const handleToggle = () => {
+    setOpen((was) => {
+      const next = !was
+      if (!next) {
+        setQuery('')
+        setResults([])
+        setSearchErr(null)
+        searchSeqRef.current += 1
+      }
+      return next
+    })
+  }
+
+  const handleSelect = (result: GiphySearchResult) => {
+    onSelect(result)
+    setOpen(false)
+    setQuery('')
+    setResults([])
+    setSearchErr(null)
+    searchSeqRef.current += 1
+    toggleRef.current?.focus()
+  }
+
+  return (
+    <div ref={rootRef} className="riffsync-room-chat-giphy">
+      <button
+        ref={toggleRef}
+        type="button"
+        className="riffsync-room-chat-giphy-toggle gen-button"
+        aria-label="Insert GIF"
+        aria-expanded={open}
+        aria-controls={open ? popoverId : undefined}
+        onClick={handleToggle}
+      >
+        <span aria-hidden="true">GIF</span>
+      </button>
+      {open ? (
+        <div
+          id={popoverId}
+          className="riffsync-room-chat-giphy-popover"
+          role="dialog"
+          aria-label="Giphy picker"
+        >
+          <input
+            ref={searchInputRef}
+            type="search"
+            className="riffsync-room-chat-giphy-search"
+            value={query}
+            placeholder="Search Giphy…"
+            aria-label="Search Giphy"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          {searchErr ? (
+            <p className="riffsync-room-chat-giphy-status riffsync-room-chat-giphy-status--err" role="alert">
+              {searchErr}
+            </p>
+          ) : searching ? (
+            <p className="riffsync-room-chat-giphy-status" role="status">
+              Searching…
+            </p>
+          ) : query.trim() === '' ? (
+            <p className="riffsync-room-chat-giphy-status riffsync-muted">Type to search GIFs.</p>
+          ) : results.length === 0 ? (
+            <p className="riffsync-room-chat-giphy-status riffsync-muted">No GIFs found.</p>
+          ) : null}
+          <ul className="riffsync-room-chat-giphy-results" aria-label="Giphy search results">
+            {results.map((result) => (
+              <li key={result.giphyId}>
+                <button
+                  type="button"
+                  className="riffsync-room-chat-giphy-result"
+                  onClick={() => handleSelect(result)}
+                >
+                  <img
+                    src={result.previewUrl}
+                    alt={result.title?.trim() || 'GIF'}
+                    loading="lazy"
+                    className="riffsync-room-chat-giphy-result__thumb"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+          <p className="riffsync-room-chat-giphy-attribution">
+            <a href="https://giphy.com/" target="_blank" rel="noopener noreferrer">
+              Powered by GIPHY
+            </a>
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/chatGifMessage.test.ts
+++ b/apps/web/src/room/chatGifMessage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { parseInboundChatGifMessage } from './chatGifMessage'
+
+describe('parseInboundChatGifMessage', () => {
+  it('parses a valid chat_gif fan-out payload', () => {
+    const parsed = parseInboundChatGifMessage({
+      type: 'chat_gif',
+      sessionId: 'sess-1',
+      messageId: 'msg-uuid',
+      giphyId: 'abc123',
+      renditionUrl: 'https://media0.giphy.com/media/abc123/giphy.gif',
+      title: 'Wave',
+      width: 480,
+      height: 270,
+      ts: 1_700_000_000_000,
+      displayName: 'Fan',
+      avatarUrl: 'https://cdn.example.test/a.png',
+    })
+
+    expect(parsed).toEqual({
+      messageId: 'msg-uuid',
+      sessionId: 'sess-1',
+      giphyId: 'abc123',
+      renditionUrl: 'https://media0.giphy.com/media/abc123/giphy.gif',
+      title: 'Wave',
+      width: 480,
+      height: 270,
+      ts: 1_700_000_000_000,
+      displayName: 'Fan',
+      avatarUrl: 'https://cdn.example.test/a.png',
+    })
+  })
+
+  it('returns null when messageId is invalid', () => {
+    expect(
+      parseInboundChatGifMessage({
+        sessionId: 'sess-1',
+        messageId: '',
+        giphyId: 'x',
+        renditionUrl: 'https://media0.giphy.com/media/x/giphy.gif',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when giphyId or renditionUrl is missing', () => {
+    expect(
+      parseInboundChatGifMessage({
+        sessionId: 'sess-1',
+        messageId: 'id-1',
+        giphyId: '  ',
+        renditionUrl: 'https://media0.giphy.com/media/x/giphy.gif',
+      }),
+    ).toBeNull()
+    expect(
+      parseInboundChatGifMessage({
+        sessionId: 'sess-1',
+        messageId: 'id-1',
+        giphyId: 'x',
+        renditionUrl: '',
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/room/chatGifMessage.ts
+++ b/apps/web/src/room/chatGifMessage.ts
@@ -1,0 +1,69 @@
+import { parseInboundChatMessageId } from './chatMessageId'
+
+const CHAT_GIF_TITLE_MAX = 200
+const CHAT_GIF_DIMENSION_MAX = 4096
+
+export type InboundChatGifLine = {
+  messageId: string
+  sessionId: string
+  giphyId: string
+  renditionUrl: string
+  title?: string
+  width?: number
+  height?: number
+  ts: number
+  displayName?: string
+  avatarUrl?: string
+}
+
+function parseOptionalTitle(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  if (trimmed === '' || trimmed.length > CHAT_GIF_TITLE_MAX) return undefined
+  return trimmed
+}
+
+function parseOptionalDimension(raw: unknown): number | undefined {
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0 || raw > CHAT_GIF_DIMENSION_MAX) {
+    return undefined
+  }
+  return raw
+}
+
+export function parseInboundChatGifMessage(data: Record<string, unknown>): InboundChatGifLine | null {
+  if (typeof data.sessionId !== 'string') return null
+
+  const messageId = parseInboundChatMessageId(data.messageId)
+  if (messageId === null) return null
+
+  const giphyId = typeof data.giphyId === 'string' ? data.giphyId.trim() : ''
+  if (giphyId === '') return null
+
+  const renditionUrl = typeof data.renditionUrl === 'string' ? data.renditionUrl.trim() : ''
+  if (renditionUrl === '') return null
+
+  const ts = typeof data.ts === 'number' ? data.ts : Date.now()
+  const displayName =
+    typeof data.displayName === 'string' && data.displayName.trim() !== ''
+      ? data.displayName
+      : undefined
+  const avatarUrl =
+    typeof data.avatarUrl === 'string' && data.avatarUrl.trim() !== '' ? data.avatarUrl.trim() : undefined
+
+  const title = parseOptionalTitle(data.title)
+  const width = parseOptionalDimension(data.width)
+  const height = parseOptionalDimension(data.height)
+
+  return {
+    messageId,
+    sessionId: data.sessionId,
+    giphyId,
+    renditionUrl,
+    ts,
+    ...(title !== undefined ? { title } : {}),
+    ...(width !== undefined ? { width } : {}),
+    ...(height !== undefined ? { height } : {}),
+    ...(displayName !== undefined ? { displayName } : {}),
+    ...(avatarUrl !== undefined ? { avatarUrl } : {}),
+  }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1352,6 +1352,127 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   height: 16.5rem;
 }
 
+.riffsync-room-chat-giphy {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.riffsync-room-chat-giphy-toggle {
+  min-width: 2.25rem;
+  padding: 0.35rem 0.45rem;
+  line-height: 1;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.riffsync-room-chat-giphy-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.35rem);
+  z-index: 4;
+  width: min(100vw - 1rem, 16.5rem);
+  max-height: min(70vh, 22rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.45rem;
+  border-radius: 8px;
+  background: rgb(12 16 22);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.55);
+  border: 1px solid rgb(255 255 255 / 0.1);
+}
+
+.riffsync-room-chat-giphy-search {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.35rem 0.45rem;
+  border-radius: 4px;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  background: rgb(255 255 255 / 0.06);
+  color: inherit;
+}
+
+.riffsync-room-chat-giphy-status {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.riffsync-room-chat-giphy-status--err {
+  color: rgb(255 140 140);
+}
+
+.riffsync-room-chat-giphy-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.3rem;
+  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.riffsync-room-chat-giphy-result {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  overflow: hidden;
+  cursor: pointer;
+  background: rgb(255 255 255 / 0.04);
+}
+
+.riffsync-room-chat-giphy-result:focus-visible {
+  outline: 2px solid rgb(120 180 255 / 0.85);
+  outline-offset: 1px;
+}
+
+.riffsync-room-chat-giphy-result__thumb {
+  display: block;
+  width: 100%;
+  height: 4.25rem;
+  object-fit: cover;
+}
+
+.riffsync-room-chat-giphy-attribution {
+  margin: 0;
+  font-size: 0.68rem;
+  text-align: right;
+  opacity: 0.85;
+}
+
+.riffsync-room-chat-giphy-attribution a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.riffsync-room-chat-giphy-attribution a:hover {
+  text-decoration: underline;
+}
+
+.riffsync-room-chat-log__gif {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.riffsync-room-chat-log__gif-who {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: min(100%, 14rem);
+}
+
+.riffsync-room-chat-log__gif-img {
+  display: block;
+  max-width: min(240px, 100%);
+  height: auto;
+  border-radius: 6px;
+}
+
 .riffsync-room-page__chat .riffsync-room-chat-log li + li {
   margin-top: 0.35rem;
 }

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -17,7 +17,7 @@ On **`$connect`**, the server stores **`expiresAt`** on the connections row (**a
 
 ## Route selection (`$request.body.action`)
 
-Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, **`react`**, `signaling`, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
+Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, **`chat_gif`**, **`react`**, `signaling`, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
 
 | **`action`** | Purpose | Auth |
 | --- | --- | --- |
@@ -26,6 +26,7 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 | **`leave`** | Best-effort client goodbye — deletes this **`connectionId`** from the connections table and fan-outs **`presence`** (same pattern as **`$disconnect`**). Clients may send on **`pagehide`** when teardown is uncertain; safe if the row is already gone. | **Guest OK** once connected. |
 | **`share_state`** | Host announces screen-share lifecycle so guests can reset the guest **video** surface without inferring teardown only from WebRTC. Body: **`state`**: **`started`** \| **`stopped`**; optional **`shareGeneration`** (non-negative int, matches v1 signaling generations). | **Host (publisher JWT)** only. Fan-out shape below. |
 | **`chat`** | Fan-out text to sockets in **`roomId`**. | Guests + host. Body: **`text`** (**required**, ≤ 2000 chars), **`messageId`** (**required**, UUID RFC 4122 string). |
+| **`chat_gif`** | Fan-out Giphy GIF post to sockets in **`roomId`**. | **Signed-in fan only** (**`fanSub`** on connection from **`$connect`**). **403** when absent. Body: **`messageId`** (**required**, UUID), **`giphyId`** (**required**, non-empty), **`renditionUrl`** (**required**, HTTPS URL on Giphy CDN, e.g. **`media*.giphy.com`**, **`i.giphy.com`**), optional **`title`** (≤ 200 chars), **`width`** / **`height`** (positive integers, ≤ 4096). Clients MUST NOT upload GIF bytes or supply arbitrary image URLs. |
 | **`react`** | Fan-out ephemeral emoji reaction toggle on a chat line. | Guests + host (same MVP auth as **`chat`**; SPA gates toggles on **`fanToken`**). Body: **`messageId`** (**required**, non-empty, ≤ 64 chars), **`emoji`** (**required**, trimmed non-empty, ≤ 32 chars), **`reactionAction`**: **`add`** \| **`remove`** (not the route **`action`** field). No Dynamo persistence. |
 | **`signaling`** | WebRTC relay to peers (`**envelope`** JSON). | **Host:** publisher **`JWT`** on **`$connect`**. **Guest:** only **`guestSignaling`** with **`kind`** **`ready`**, **`answer`**, or **`ice`** (see below). |
 
@@ -53,6 +54,27 @@ Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gatew
 Inbound **`chat`** now requires a client-generated **`messageId`** UUID, and outbound **`chat`** / **`chat_gif`** fan-out includes the same stable **`messageId`** per line in **[#31](https://github.com/StacksOnTheRacks/riffsync/issues/31)**.
 
 For compatibility during rollout, treat **`messageId`** as required for new clients. Older clients that do not send a UUID will receive **`400`** from the **`chat`** route.
+
+### Chat GIF
+
+```json
+{
+  "type": "chat_gif",
+  "roomId": "<id>",
+  "sessionId": "<sender>",
+  "displayName": "…",
+  "messageId": "<client uuid>",
+  "giphyId": "<giphy id>",
+  "renditionUrl": "https://…",
+  "title": "…",
+  "width": 480,
+  "height": 270,
+  "ts": 0,
+  "avatarUrl": "https://…"
+}
+```
+
+**`displayName`** / **`avatarUrl`** enrichment matches **`chat`** (**`presenceDisplayNameForSession`**, **`resolveChatOutboundAvatarUrl`**). Inbound bodies MUST NOT supply **`avatarUrl`**. **`title`**, **`width`**, and **`height`** are omitted when not sent or empty.
 
 ### Chat reaction (ephemeral fan-out)
 

--- a/infra/cdk/lambda/giphy-search-shared.ts
+++ b/infra/cdk/lambda/giphy-search-shared.ts
@@ -77,7 +77,7 @@ export function parseGiphySearchQuery(
   return { ok: true, query: { q, limit, offset } };
 }
 
-function isHttpsGiphyCdnUrl(url: string): boolean {
+export function isHttpsGiphyCdnUrl(url: string): boolean {
   try {
     const u = new URL(url);
     if (u.protocol !== 'https:') return false;

--- a/infra/cdk/lambda/ws-route-chat-gif.test.ts
+++ b/infra/cdk/lambda/ws-route-chat-gif.test.ts
@@ -1,0 +1,214 @@
+import type { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  queryConnectionsForRoom: vi.fn(),
+  postToConnections: vi.fn(),
+  wsManagementClient: vi.fn(),
+  resolveChatOutboundAvatarUrl: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+vi.mock('./ws-shared', () => ({
+  broadcastRoomPresence: vi.fn(),
+  broadcastRoomPresenceNow: vi.fn(),
+  postToConnections: (...args: unknown[]) => mocks.postToConnections(...args),
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+  queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
+  resolveChatOutboundAvatarUrl: (...args: unknown[]) => mocks.resolveChatOutboundAvatarUrl(...args),
+  wsManagementClient: () => mocks.wsManagementClient(),
+}));
+
+import { handler } from './ws-route';
+
+const VALID_MESSAGE_ID = '11111111-1111-4111-8111-111111111111';
+const VALID_GIPHY_URL = 'https://media.giphy.com/media/abc123/giphy.gif';
+
+function baseEvent(overrides: { routeKey?: string; body?: string }): APIGatewayProxyWebsocketEventV2 {
+  return {
+    body: overrides.body,
+    requestContext: {
+      routeKey: overrides.routeKey ?? 'chat_gif',
+      connectionId: 'conn-abc',
+      requestId: 'req-1',
+      apiId: 'api-1',
+      stage: 'dev',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      eventType: 'MESSAGE',
+      extendedRequestId: 'ext-1',
+      requestTime: '01/Jan/2026:00:00:00 +0000',
+      requestTimeEpoch: 0,
+      messageDirection: 'IN',
+      messageId: 'msg-1',
+      connectedAt: 0,
+    },
+    isBase64Encoded: false,
+  } as APIGatewayProxyWebsocketEventV2;
+}
+
+function validBody(extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    action: 'chat_gif',
+    messageId: VALID_MESSAGE_ID,
+    giphyId: 'abc123',
+    renditionUrl: VALID_GIPHY_URL,
+    ...extra,
+  });
+}
+
+function stubConnectedRoom(connOverrides: Record<string, unknown> = {}) {
+  mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: { TableName?: string } }) => {
+    const table = cmd.input?.TableName;
+    if (table === 'connections') {
+      return {
+        Item: {
+          roomId: 'room-1',
+          sessionId: 'sess-1',
+          presenceKey: 'sess-1#conn-abc',
+          displayName: 'Fan One',
+          fanSub: 'fan-sub-1',
+          ...connOverrides,
+        },
+      };
+    }
+    if (table === 'rooms') {
+      return { Item: { hostSub: 'host-sub-1' } };
+    }
+    return {};
+  });
+}
+
+describe('ws-route chat_gif', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOMS_TABLE_NAME = 'rooms';
+    process.env.CONNECTIONS_TABLE_NAME = 'connections';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    mocks.wsManagementClient.mockReturnValue({ client: true });
+    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc', 'conn-other']);
+    mocks.postToConnections.mockResolvedValue(undefined);
+    mocks.resolveChatOutboundAvatarUrl.mockResolvedValue('https://cdn.example/avatar.png');
+    stubConnectedRoom();
+  });
+
+  it('fans out chat_gif with enrichment for signed-in fan', async () => {
+    const result = await handler(
+      baseEvent({
+        body: validBody({ title: '  wave  ', width: 480, height: 270 }),
+      }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.postToConnections).toHaveBeenCalledTimes(1);
+
+    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      type: 'chat_gif',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      displayName: 'Fan One',
+      messageId: VALID_MESSAGE_ID,
+      giphyId: 'abc123',
+      renditionUrl: VALID_GIPHY_URL,
+      title: 'wave',
+      width: 480,
+      height: 270,
+      avatarUrl: 'https://cdn.example/avatar.png',
+    });
+    expect(typeof parsed.ts).toBe('number');
+  });
+
+  it('returns 403 without fanSub and does not fan-out', async () => {
+    stubConnectedRoom({ fanSub: undefined });
+    const result = await handler(baseEvent({ body: validBody() }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 403, body: 'Fan JWT required for chat_gif' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for blank fanSub', async () => {
+    stubConnectedRoom({ fanSub: '   ' });
+    const result = await handler(baseEvent({ body: validBody() }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 403, body: 'Fan JWT required for chat_gif' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid messageId', async () => {
+    const result = await handler(
+      baseEvent({ body: validBody({ messageId: 'not-a-uuid' }) }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 400, body: 'messageId must be a valid UUID' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing giphyId', async () => {
+    const result = await handler(
+      baseEvent({
+        body: JSON.stringify({
+          action: 'chat_gif',
+          messageId: VALID_MESSAGE_ID,
+          renditionUrl: VALID_GIPHY_URL,
+        }),
+      }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 400, body: 'giphyId required' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for non-HTTPS renditionUrl', async () => {
+    const result = await handler(
+      baseEvent({
+        body: validBody({ renditionUrl: 'http://media.giphy.com/media/x/giphy.gif' }),
+      }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 400, body: 'renditionUrl must be HTTPS Giphy CDN URL' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for disallowed renditionUrl host', async () => {
+    const result = await handler(
+      baseEvent({
+        body: validBody({ renditionUrl: 'https://evil.example/giphy.gif' }),
+      }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 400, body: 'renditionUrl must be HTTPS Giphy CDN URL' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid width', async () => {
+    const result = await handler(
+      baseEvent({ body: validBody({ width: 0 }) }),
+      {} as never,
+      () => undefined,
+    );
+    expect(result).toEqual({ statusCode: 400, body: 'width must be a positive integer' });
+    expect(mocks.postToConnections).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -11,6 +11,7 @@ import {
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { TextEncoder } from 'node:util';
+import { isHttpsGiphyCdnUrl } from './giphy-search-shared';
 import { lobbySortKey, LOBBY_PARTITION } from './room-shared';
 import {
   broadcastRoomPresence,
@@ -28,6 +29,16 @@ const UUID_MESSAGE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9
 
 export function isUuidMessageId(value: string): boolean {
   return UUID_MESSAGE_ID_RE.test(value);
+}
+
+const CHAT_GIF_TITLE_MAX = 200;
+const CHAT_GIF_DIMENSION_MAX = 4096;
+
+function parseOptionalChatGifDimension(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0 || value > CHAT_GIF_DIMENSION_MAX) {
+    return undefined;
+  }
+  return value;
 }
 
 function summarizeCaughtErr(err: unknown): { errorType: string; errorMessage: string } {
@@ -231,6 +242,75 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
       messageId,
       ts: Date.now(),
     };
+    if (avatarUrl) {
+      out.avatarUrl = avatarUrl;
+    }
+    const buf = encoder.encode(JSON.stringify(out));
+    await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  if (routeKey === 'chat_gif') {
+    const fanSub = typeof conn.fanSub === 'string' ? conn.fanSub.trim() : '';
+    if (fanSub === '') {
+      return { statusCode: 403, body: 'Fan JWT required for chat_gif' };
+    }
+    const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
+    if (!isUuidMessageId(messageId)) {
+      return { statusCode: 400, body: 'messageId must be a valid UUID' };
+    }
+    const giphyId = typeof body.giphyId === 'string' ? body.giphyId.trim() : '';
+    if (giphyId === '') {
+      return { statusCode: 400, body: 'giphyId required' };
+    }
+    const renditionUrl = typeof body.renditionUrl === 'string' ? body.renditionUrl.trim() : '';
+    if (renditionUrl === '' || !isHttpsGiphyCdnUrl(renditionUrl)) {
+      return { statusCode: 400, body: 'renditionUrl must be HTTPS Giphy CDN URL' };
+    }
+    let title: string | undefined;
+    if (body.title !== undefined) {
+      if (typeof body.title !== 'string') {
+        return { statusCode: 400, body: 'title must be a string' };
+      }
+      const trimmed = body.title.trim();
+      if (trimmed.length > CHAT_GIF_TITLE_MAX) {
+        return { statusCode: 400, body: `title max ${CHAT_GIF_TITLE_MAX} chars` };
+      }
+      if (trimmed !== '') {
+        title = trimmed;
+      }
+    }
+    const width = parseOptionalChatGifDimension(body.width);
+    if (body.width !== undefined && width === undefined) {
+      return { statusCode: 400, body: 'width must be a positive integer' };
+    }
+    const height = parseOptionalChatGifDimension(body.height);
+    if (body.height !== undefined && height === undefined) {
+      return { statusCode: 400, body: 'height must be a positive integer' };
+    }
+    const mgmt = wsManagementClient();
+    const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
+    const displayName = presenceDisplayNameForSession(sessionId, conn.displayName);
+    const avatarUrl = await resolveChatOutboundAvatarUrl(doc, process.env.FAN_PROFILES_TABLE_NAME, fanSub);
+    const out: Record<string, unknown> = {
+      type: 'chat_gif',
+      roomId,
+      sessionId,
+      displayName,
+      messageId,
+      giphyId,
+      renditionUrl,
+      ts: Date.now(),
+    };
+    if (title !== undefined) {
+      out.title = title;
+    }
+    if (width !== undefined) {
+      out.width = width;
+    }
+    if (height !== undefined) {
+      out.height = height;
+    }
     if (avatarUrl) {
       out.avatarUrl = avatarUrl;
     }

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -574,7 +574,7 @@ export class ApiCatalogStack extends cdk.Stack {
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
-      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, react, signaling, share_state, leave`,
+      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, chat_gif, react, signaling, share_state, leave`,
       routeSelectionExpression: '$request.body.action',
     });
 
@@ -662,6 +662,7 @@ export class ApiCatalogStack extends cdk.Stack {
       'ping',
       'presence_request',
       'chat',
+      'chat_gif',
       'react',
       'signaling',
       'share_state',


### PR DESCRIPTION
## Summary

Parent epic #33 (Giphy in chat) on `feature/issue-33`:

- **#51** — `chat_gif` WebSocket route with fan JWT enforcement, Giphy CDN URL validation, fan-out enrichment, CDK route registration, and contract docs.
- **#52** — SPA Giphy compose picker, `GET /v1/giphy/search` client, `chat_gif` send path, and inline GIF rendering in room chat scrollback (signed-in send; guests view-only).

## Test plan

- [x] `cd infra/cdk && npm ci && npm test`
- [x] `cd infra/cdk && npm run synth`
- [x] `cd apps/web && npm ci && npm test && npm run lint && npm run build`
- [ ] Deployed stack: signed-in fan searches Giphy, sends `chat_gif`, all clients see inline GIF; guest send returns **403**
- [ ] Network tab: search uses JWT only (no Giphy API key in browser bundle)

Closes #51
Closes #52
Part of #33