### PR TITLE
feat(cdk): M10 observability EMF and safe logging (#59, #60)

### DIFF
--- a/infra/cdk/lambda/fan-avatar-post.ts
+++ b/infra/cdk/lambda/fan-avatar-post.ts
@@ -15,11 +15,23 @@ import {
   validateAvatarBytes,
 } from './fan-profile-avatar';
 import { getJwtSub, headerValue } from './fan-profile-shared';
+import { logRiffsyncDiagError, recordApiRoute, type FanAvatarUploadOutcome } from './riffsync-observability';
 
 const s3 = new S3Client({});
 const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 const jsonHeaders = { 'content-type': 'application/json; charset=utf-8' };
+
+function finish(outcome: FanAvatarUploadOutcome, statusCode: number, body: Record<string, unknown>, extras?: {
+  fileSizeBytes?: number;
+}) {
+  recordApiRoute('FanAvatarUpload', outcome, extras);
+  return {
+    statusCode,
+    headers: jsonHeaders,
+    body: JSON.stringify(body),
+  };
+}
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const bucket = process.env.FAN_AVATARS_BUCKET_NAME;
@@ -27,20 +39,16 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const profilesTable = process.env.FAN_PROFILES_TABLE_NAME;
 
   if (!bucket || !publicBaseUrl || !profilesTable) {
-    return {
-      statusCode: 500,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: 'misconfigured_avatar_upload' }),
-    };
+    return finish('misconfigured', 500, { error: 'misconfigured_avatar_upload' });
   }
 
   const jwtSub = getJwtSub(event);
   if (!jwtSub) {
-    return { statusCode: 401, headers: jsonHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+    return finish('unauthorized', 401, { error: 'Unauthorized' });
   }
 
   if (!assertSafeSubForS3Key(jwtSub)) {
-    return { statusCode: 400, headers: jsonHeaders, body: JSON.stringify({ error: 'invalid_sub' }) };
+    return finish('validation_error', 400, { error: 'invalid_sub' });
   }
 
   const contentType = headerValue(event.headers, 'content-type');
@@ -53,76 +61,71 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     maxBytes: FAN_AVATAR_MAX_BYTES,
   });
   if (!parsed.ok) {
-    return {
-      statusCode: parsed.statusCode,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: parsed.error }),
-    };
+    return finish('validation_error', parsed.statusCode, { error: parsed.error });
   }
 
   const validated = validateAvatarBytes(parsed.file, parsed.partContentType);
   if (!validated.ok) {
-    return {
-      statusCode: validated.statusCode,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: validated.error }),
-    };
+    return finish('validation_error', validated.statusCode, { error: validated.error });
   }
 
   const ext = extensionForMime(validated.mime);
   const objectKey = avatarObjectKey(jwtSub, ext);
   const avatarUpdatedAt = Date.now();
 
-  const existing = await dynamo.send(
-    new GetCommand({
-      TableName: profilesTable,
-      Key: { sub: jwtSub },
-    }),
-  );
-  const priorUrl =
-    typeof existing.Item?.avatarUrl === 'string' ? existing.Item.avatarUrl.trim() : undefined;
-  const priorKey = priorUrl ? objectKeyFromAvatarUrl(priorUrl, publicBaseUrl) : null;
+  try {
+    const existing = await dynamo.send(
+      new GetCommand({
+        TableName: profilesTable,
+        Key: { sub: jwtSub },
+      }),
+    );
+    const priorUrl =
+      typeof existing.Item?.avatarUrl === 'string' ? existing.Item.avatarUrl.trim() : undefined;
+    const priorKey = priorUrl ? objectKeyFromAvatarUrl(priorUrl, publicBaseUrl) : null;
 
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: objectKey,
-      Body: parsed.file,
-      ContentType: validated.mime,
-      CacheControl: 'public, max-age=31536000, immutable',
-    }),
-  );
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: objectKey,
+        Body: parsed.file,
+        ContentType: validated.mime,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }),
+    );
 
-  if (priorKey && priorKey !== objectKey) {
-    try {
-      await s3.send(
-        new DeleteObjectCommand({
-          Bucket: bucket,
-          Key: priorKey,
-        }),
-      );
-    } catch {
-      // Best-effort cleanup; new avatar URL is already valid.
+    if (priorKey && priorKey !== objectKey) {
+      try {
+        await s3.send(
+          new DeleteObjectCommand({
+            Bucket: bucket,
+            Key: priorKey,
+          }),
+        );
+      } catch {
+        // Best-effort cleanup; new avatar URL is already valid.
+      }
     }
+
+    const avatarUrl = publicAvatarUrl(publicBaseUrl, objectKey);
+
+    await dynamo.send(
+      new UpdateCommand({
+        TableName: profilesTable,
+        Key: { sub: jwtSub },
+        UpdateExpression: 'SET avatarUrl = :url, avatarUpdatedAt = :at',
+        ExpressionAttributeValues: {
+          ':url': avatarUrl,
+          ':at': avatarUpdatedAt,
+        },
+      }),
+    );
+  } catch (e) {
+    logRiffsyncDiagError('fan_avatar_upload_failed', e);
+    return finish('server_error', 500, { error: 'avatar_upload_failed' });
   }
 
-  const avatarUrl = publicAvatarUrl(publicBaseUrl, objectKey);
-
-  await dynamo.send(
-    new UpdateCommand({
-      TableName: profilesTable,
-      Key: { sub: jwtSub },
-      UpdateExpression: 'SET avatarUrl = :url, avatarUpdatedAt = :at',
-      ExpressionAttributeValues: {
-        ':url': avatarUrl,
-        ':at': avatarUpdatedAt,
-      },
-    }),
-  );
-
-  return {
-    statusCode: 200,
-    headers: jsonHeaders,
-    body: JSON.stringify({ avatarUrl, avatarUpdatedAt }),
-  };
+  return finish('success', 200, { avatarUrl: publicAvatarUrl(publicBaseUrl, objectKey), avatarUpdatedAt }, {
+    fileSizeBytes: parsed.file.length,
+  });
 };

--- a/infra/cdk/lambda/fan-profile-avatar.test.ts
+++ b/infra/cdk/lambda/fan-profile-avatar.test.ts
@@ -133,6 +133,7 @@ describe('fan-avatar-post handler', () => {
   });
 
   it('returns 401 without JWT sub', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const { handler } = await import('./fan-avatar-post');
     const res = await handler({
       headers: { 'content-type': 'multipart/form-data; boundary=b' },
@@ -140,9 +141,15 @@ describe('fan-avatar-post handler', () => {
       requestContext: {},
     } as APIGatewayProxyEventV2);
     expect(res.statusCode).toBe(401);
+    const emf = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(emf.Route).toBe('FanAvatarUpload');
+    expect(emf.Outcome).toBe('unauthorized');
+    logSpy.mockRestore();
   });
 
-  it('uploads png and returns avatarUrl', async () => {
+  it('uploads png and returns avatarUrl with EMF success', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const { handler } = await import('./fan-avatar-post');
     const boundary = 'xyz';
     const body = buildMultipartBody(boundary, 'file', 'me.png', 'image/png', PNG_1X1);
@@ -164,5 +171,19 @@ describe('fan-avatar-post handler', () => {
     expect(typeof payload.avatarUpdatedAt).toBe('number');
     expect(s3Send).toHaveBeenCalled();
     expect(dynamoSend).toHaveBeenCalled();
+
+    const emf = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(emf.Route).toBe('FanAvatarUpload');
+    expect(emf.Outcome).toBe('success');
+    const infoLine = JSON.parse(infoSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(infoLine).toMatchObject({
+      riffsyncDiag: 'api',
+      route: 'FanAvatarUpload',
+      outcome: 'success',
+      fileSizeBytes: PNG_1X1.length,
+    });
+    expect(infoLine.avatarUrl).toBeUndefined();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
   });
 });

--- a/infra/cdk/lambda/giphy-search.test.ts
+++ b/infra/cdk/lambda/giphy-search.test.ts
@@ -19,7 +19,7 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
 }));
 
 vi.mock('@aws-sdk/client-secrets-manager', () => ({
-  SecretsManagerClient: vi.fn(),
+  SecretsManagerClient: vi.fn(() => ({ send: mocks.secretsSend })),
   GetSecretValueCommand: vi.fn((input: unknown) => ({ input, kind: 'GetSecret' })),
 }));
 
@@ -236,8 +236,60 @@ describe('giphy-search handler', () => {
   });
 
   it('returns 429 when rate limit is exceeded', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     mocks.docSend.mockRejectedValue({ name: 'ConditionalCheckFailedException' });
     const res = await handler(fanEvent({ q: 'hello' }), {} as never, () => undefined);
     expect(res?.statusCode).toBe(429);
+
+    const emf = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(emf.Route).toBe('GiphySearch');
+    expect(emf.Outcome).toBe('rate_limited');
+    const infoLine = JSON.parse(infoSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(infoLine).toMatchObject({ riffsyncDiag: 'api', route: 'GiphySearch', outcome: 'rate_limited' });
+    expect(infoLine.q).toBeUndefined();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it('returns 200 with EMF success on happy path', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    mocks.docSend.mockResolvedValue({});
+    mocks.secretsSend.mockResolvedValue({ SecretString: JSON.stringify({ apiKey: 'test-key' }) });
+    mocks.fetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'gif1',
+              images: {
+                preview_gif: { url: 'https://media2.giphy.com/media/gif1/p.gif' },
+                fixed_height: { url: 'https://media2.giphy.com/media/gif1/r.gif' },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const res = await handler(fanEvent({ q: 'cats' }), {} as never, () => undefined);
+    expect(res?.statusCode).toBe(200);
+
+    const emf = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(emf.Route).toBe('GiphySearch');
+    expect(emf.Outcome).toBe('success');
+    const infoLine = JSON.parse(infoSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(infoLine).toMatchObject({
+      riffsyncDiag: 'api',
+      route: 'GiphySearch',
+      outcome: 'success',
+      queryLength: 4,
+      resultCount: 1,
+    });
+    expect(infoLine.q).toBeUndefined();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
   });
 });

--- a/infra/cdk/lambda/giphy-search.ts
+++ b/infra/cdk/lambda/giphy-search.ts
@@ -11,6 +11,11 @@ import {
   parseGiphyApiKey,
   parseGiphySearchQuery,
 } from './giphy-search-shared';
+import {
+  logRiffsyncDiagError,
+  recordApiRoute,
+  type GiphySearchOutcome,
+} from './riffsync-observability';
 
 const secrets = new SecretsManagerClient({});
 const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -35,7 +40,7 @@ async function loadGiphyApiKey(secretArn: string): Promise<string | null> {
     const out = await secrets.send(new GetSecretValueCommand({ SecretId: secretArn }));
     raw = out.SecretString;
   } catch (e) {
-    console.error('Giphy secret read failed', e);
+    logRiffsyncDiagError('giphy_secret_read_failed', e);
     return null;
   }
 
@@ -75,42 +80,55 @@ export async function enforceGiphyRateLimit(
     if (name === 'ConditionalCheckFailedException') {
       return false;
     }
-    console.error('Giphy rate limit update failed', e);
+    logRiffsyncDiagError('giphy_rate_limit_update_failed', e);
     throw e;
   }
+}
+
+function finish(
+  outcome: GiphySearchOutcome,
+  statusCode: number,
+  body: Record<string, unknown>,
+  extras?: { queryLength?: number; resultCount?: number },
+) {
+  recordApiRoute('GiphySearch', outcome, extras);
+  return jsonResponse(statusCode, body);
 }
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const secretArn = process.env.GIPHY_SECRET_ARN;
   const rateTable = process.env.GIPHY_RATE_LIMIT_TABLE_NAME;
   if (!secretArn || !rateTable) {
-    return jsonResponse(500, { error: 'Server misconfigured' });
+    return finish('misconfigured', 500, { error: 'Server misconfigured' });
   }
 
   const jwtSub = getJwtSub(event);
   if (!jwtSub) {
-    return jsonResponse(401, { error: 'Unauthorized' });
+    return finish('unauthorized', 401, { error: 'Unauthorized' });
   }
 
   const parsed = parseGiphySearchQuery(event.queryStringParameters);
   if (!parsed.ok) {
-    return jsonResponse(400, { error: 'Invalid query parameters' });
+    return finish('validation_error', 400, { error: 'Invalid query parameters' });
   }
 
   const allowed = await enforceGiphyRateLimit(rateTable, jwtSub, rateLimitPerMinute());
   if (!allowed) {
-    return jsonResponse(429, { error: 'Giphy search rate limit exceeded' });
+    return finish('rate_limited', 429, { error: 'Giphy search rate limit exceeded' });
   }
 
   const apiKey = await loadGiphyApiKey(secretArn);
   if (!apiKey) {
-    return jsonResponse(503, { error: 'Giphy search is temporarily unavailable' });
+    return finish('secret_unavailable', 503, { error: 'Giphy search is temporarily unavailable' });
   }
 
   const upstream = await fetchGiphySearch(apiKey, parsed.query, fetch);
   if (!upstream.ok) {
-    return jsonResponse(upstream.status, { error: 'Giphy search is temporarily unavailable' });
+    return finish('upstream_error', upstream.status, { error: 'Giphy search is temporarily unavailable' });
   }
 
-  return jsonResponse(200, { results: upstream.results });
+  return finish('success', 200, { results: upstream.results }, {
+    queryLength: parsed.query.q.length,
+    resultCount: upstream.results.length,
+  });
 };

--- a/infra/cdk/lambda/riffsync-observability.test.ts
+++ b/infra/cdk/lambda/riffsync-observability.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  emitApiEmf,
   emitWsRealtimeEmf,
+  logApiAction,
+  logRiffsyncDiagError,
   logWsAction,
+  recordApiRoute,
   recordWsRealtimeRoute,
   riffsyncEnvironment,
   wsRealtimeOutcomeFromStatus,
@@ -11,6 +15,7 @@ describe('riffsync-observability', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     delete process.env.RIFFSYNC_ENVIRONMENT;
   });
 
@@ -99,5 +104,77 @@ describe('riffsync-observability', () => {
     >;
     expect(logLine.connectionIdTail).toBe('efghijklmnop');
     expect(logLine.roomIdHead).toBe('room-xyz');
+  });
+
+  it('emits API EMF with RiffSync/Api namespace and dimensions', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'prod';
+    emitApiEmf('GiphySearch', 'success');
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    const line = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const aws = parsed._aws as {
+      CloudWatchMetrics: Array<{
+        Namespace: string;
+        Dimensions: string[][];
+        Metrics: Array<{ Name: string; Unit: string }>;
+      }>;
+    };
+
+    expect(aws.CloudWatchMetrics[0].Namespace).toBe('RiffSync/Api');
+    expect(aws.CloudWatchMetrics[0].Dimensions).toEqual([['Environment', 'Route', 'Outcome']]);
+    expect(parsed.Environment).toBe('prod');
+    expect(parsed.Route).toBe('GiphySearch');
+    expect(parsed.Outcome).toBe('success');
+    expect(parsed.Requests).toBe(1);
+  });
+
+  it('logs API actions without query text or avatar URLs', () => {
+    logApiAction({
+      route: 'GiphySearch',
+      outcome: 'success',
+      queryLength: 4,
+      resultCount: 2,
+    });
+
+    expect(console.info).toHaveBeenCalledTimes(1);
+    const line = (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      riffsyncDiag: 'api',
+      route: 'GiphySearch',
+      outcome: 'success',
+      queryLength: 4,
+      resultCount: 2,
+    });
+    expect(parsed.q).toBeUndefined();
+    expect(parsed.avatarUrl).toBeUndefined();
+  });
+
+  it('recordApiRoute emits EMF and log together', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'staging';
+    recordApiRoute('FanAvatarUpload', 'validation_error', { fileSizeBytes: 1024 });
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.info).toHaveBeenCalledTimes(1);
+    const emf = JSON.parse((console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(emf.Route).toBe('FanAvatarUpload');
+    expect(emf.Outcome).toBe('validation_error');
+  });
+
+  it('logRiffsyncDiagError emits structured JSON without raw Error dumps', () => {
+    logRiffsyncDiagError('giphy_secret_read_failed', new Error('AccessDenied'));
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    const line = (console.error as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      riffsyncDiag: 'giphy_secret_read_failed',
+      errorType: 'Error',
+      errorMessage: 'AccessDenied',
+    });
   });
 });

--- a/infra/cdk/lambda/riffsync-observability.test.ts
+++ b/infra/cdk/lambda/riffsync-observability.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emitWsRealtimeEmf,
+  logWsAction,
+  recordWsRealtimeRoute,
+  riffsyncEnvironment,
+  wsRealtimeOutcomeFromStatus,
+} from './riffsync-observability';
+
+describe('riffsync-observability', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    delete process.env.RIFFSYNC_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps HTTP status codes to outcomes', () => {
+    expect(wsRealtimeOutcomeFromStatus(200)).toBe('success');
+    expect(wsRealtimeOutcomeFromStatus(400)).toBe('validation_error');
+    expect(wsRealtimeOutcomeFromStatus(403)).toBe('auth_forbidden');
+    expect(wsRealtimeOutcomeFromStatus(500)).toBe('server_error');
+    expect(wsRealtimeOutcomeFromStatus(410)).toBe('server_error');
+  });
+
+  it('uses RIFFSYNC_ENVIRONMENT when set', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'prod';
+    expect(riffsyncEnvironment()).toBe('prod');
+  });
+
+  it('emits EMF with RiffSync/Realtime namespace and dimensions', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'dev';
+    emitWsRealtimeEmf('chat', 'success');
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    const line = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const aws = parsed._aws as {
+      CloudWatchMetrics: Array<{
+        Namespace: string;
+        Dimensions: string[][];
+        Metrics: Array<{ Name: string; Unit: string }>;
+      }>;
+    };
+
+    expect(aws.CloudWatchMetrics[0].Namespace).toBe('RiffSync/Realtime');
+    expect(aws.CloudWatchMetrics[0].Dimensions).toEqual([['Environment', 'Route', 'Outcome']]);
+    expect(aws.CloudWatchMetrics[0].Metrics).toEqual([{ Name: 'Requests', Unit: 'Count' }]);
+    expect(parsed.Environment).toBe('dev');
+    expect(parsed.Route).toBe('chat');
+    expect(parsed.Outcome).toBe('success');
+    expect(parsed.Requests).toBe(1);
+  });
+
+  it('logs safe fields without message content', () => {
+    logWsAction({
+      route: 'chat_gif',
+      outcome: 'validation_error',
+      connectionIdTail: 'conn-tail-12',
+      roomIdHead: 'room-abc',
+      hasGiphyId: false,
+    });
+
+    expect(console.info).toHaveBeenCalledTimes(1);
+    const line = (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      riffsyncDiag: 'ws_realtime',
+      route: 'chat_gif',
+      outcome: 'validation_error',
+      connectionIdTail: 'conn-tail-12',
+      roomIdHead: 'room-abc',
+      hasGiphyId: false,
+    });
+    expect(parsed.text).toBeUndefined();
+    expect(parsed.renditionUrl).toBeUndefined();
+    expect(parsed.emoji).toBeUndefined();
+  });
+
+  it('recordWsRealtimeRoute emits EMF and log together', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'staging';
+    recordWsRealtimeRoute('react', 200, 'abcdefghijklmnop', 'room-xyz-1', {});
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.info).toHaveBeenCalledTimes(1);
+    const emf = JSON.parse((console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(emf.Route).toBe('react');
+    expect(emf.Outcome).toBe('success');
+
+    const logLine = JSON.parse((console.info as ReturnType<typeof vi.fn>).mock.calls[0][0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(logLine.connectionIdTail).toBe('efghijklmnop');
+    expect(logLine.roomIdHead).toBe('room-xyz');
+  });
+});

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -6,7 +6,28 @@ export type WsRealtimeOutcome =
   | 'auth_forbidden'
   | 'server_error';
 
+export type ApiRoute = 'GiphySearch' | 'FanAvatarUpload';
+
+export type GiphySearchOutcome =
+  | 'success'
+  | 'unauthorized'
+  | 'validation_error'
+  | 'rate_limited'
+  | 'misconfigured'
+  | 'upstream_error'
+  | 'secret_unavailable';
+
+export type FanAvatarUploadOutcome =
+  | 'success'
+  | 'unauthorized'
+  | 'validation_error'
+  | 'misconfigured'
+  | 'server_error';
+
+export type ApiOutcome = GiphySearchOutcome | FanAvatarUploadOutcome;
+
 const REALTIME_METRIC_NAME = 'Requests';
+const API_METRIC_NAME = 'Requests';
 
 export function wsRealtimeOutcomeFromStatus(statusCode: number): WsRealtimeOutcome {
   if (statusCode === 200) {
@@ -91,4 +112,80 @@ export function recordWsRealtimeRoute(
     roomIdHead: roomId.slice(0, 8),
     ...extras,
   });
+}
+
+/** EMF counter for HTTP API routes via stdout (no PutMetricData IAM required). */
+export function emitApiEmf(route: ApiRoute, outcome: ApiOutcome): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Api',
+            Dimensions: [['Environment', 'Route', 'Outcome']],
+            Metrics: [{ Name: API_METRIC_NAME, Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Route: route,
+      Outcome: outcome,
+      [API_METRIC_NAME]: 1,
+    }),
+  );
+}
+
+export type ApiLogFields = {
+  route: ApiRoute;
+  outcome: ApiOutcome;
+  queryLength?: number;
+  resultCount?: number;
+  fileSizeBytes?: number;
+};
+
+/** Content-safe structured INFO log for HTTP API handlers. */
+export function logApiAction(fields: ApiLogFields): void {
+  const payload: Record<string, unknown> = {
+    riffsyncDiag: 'api',
+    route: fields.route,
+    outcome: fields.outcome,
+  };
+  if (fields.queryLength !== undefined) {
+    payload.queryLength = fields.queryLength;
+  }
+  if (fields.resultCount !== undefined) {
+    payload.resultCount = fields.resultCount;
+  }
+  if (fields.fileSizeBytes !== undefined) {
+    payload.fileSizeBytes = fields.fileSizeBytes;
+  }
+  console.info(JSON.stringify(payload));
+}
+
+/** Structured error log without secrets or request bodies. */
+export function logRiffsyncDiagError(diag: string, err: unknown): void {
+  const name =
+    err && typeof err === 'object' && 'name' in err ? String((err as { name: string }).name) : 'Error';
+  const message =
+    err && typeof err === 'object' && 'message' in err
+      ? String((err as { message: string }).message)
+      : String(err);
+  console.error(
+    JSON.stringify({
+      riffsyncDiag: diag,
+      errorType: name,
+      errorMessage: message.slice(0, 200),
+    }),
+  );
+}
+
+export function recordApiRoute(
+  route: ApiRoute,
+  outcome: ApiOutcome,
+  extras?: Pick<ApiLogFields, 'queryLength' | 'resultCount' | 'fileSizeBytes'>,
+): void {
+  emitApiEmf(route, outcome);
+  logApiAction({ route, outcome, ...extras });
 }

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -1,0 +1,94 @@
+export type WsRealtimeRoute = 'chat' | 'chat_gif' | 'react';
+
+export type WsRealtimeOutcome =
+  | 'success'
+  | 'validation_error'
+  | 'auth_forbidden'
+  | 'server_error';
+
+const REALTIME_METRIC_NAME = 'Requests';
+
+export function wsRealtimeOutcomeFromStatus(statusCode: number): WsRealtimeOutcome {
+  if (statusCode === 200) {
+    return 'success';
+  }
+  if (statusCode === 400) {
+    return 'validation_error';
+  }
+  if (statusCode === 403) {
+    return 'auth_forbidden';
+  }
+  return 'server_error';
+}
+
+export function riffsyncEnvironment(): string {
+  return process.env.RIFFSYNC_ENVIRONMENT?.trim() || 'unknown';
+}
+
+/** EMF counter via stdout (no PutMetricData IAM required). */
+export function emitWsRealtimeEmf(route: WsRealtimeRoute, outcome: WsRealtimeOutcome): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Realtime',
+            Dimensions: [['Environment', 'Route', 'Outcome']],
+            Metrics: [{ Name: REALTIME_METRIC_NAME, Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Route: route,
+      Outcome: outcome,
+      [REALTIME_METRIC_NAME]: 1,
+    }),
+  );
+}
+
+export type WsRealtimeLogFields = {
+  route: WsRealtimeRoute;
+  outcome: WsRealtimeOutcome;
+  connectionIdTail: string;
+  roomIdHead: string;
+  textLength?: number;
+  hasGiphyId?: boolean;
+};
+
+/** Content-safe structured INFO log (no chat text, GIF URLs, or reaction payloads). */
+export function logWsAction(fields: WsRealtimeLogFields): void {
+  const payload: Record<string, unknown> = {
+    riffsyncDiag: 'ws_realtime',
+    route: fields.route,
+    outcome: fields.outcome,
+    connectionIdTail: fields.connectionIdTail,
+    roomIdHead: fields.roomIdHead,
+  };
+  if (fields.textLength !== undefined) {
+    payload.textLength = fields.textLength;
+  }
+  if (fields.hasGiphyId !== undefined) {
+    payload.hasGiphyId = fields.hasGiphyId;
+  }
+  console.info(JSON.stringify(payload));
+}
+
+export function recordWsRealtimeRoute(
+  route: WsRealtimeRoute,
+  statusCode: number,
+  connectionId: string,
+  roomId: string,
+  extras?: Pick<WsRealtimeLogFields, 'textLength' | 'hasGiphyId'>,
+): void {
+  const outcome = wsRealtimeOutcomeFromStatus(statusCode);
+  emitWsRealtimeEmf(route, outcome);
+  logWsAction({
+    route,
+    outcome,
+    connectionIdTail: connectionId.slice(-12),
+    roomIdHead: roomId.slice(0, 8),
+    ...extras,
+  });
+}

--- a/infra/cdk/lambda/ws-route-chat.test.ts
+++ b/infra/cdk/lambda/ws-route-chat.test.ts
@@ -99,6 +99,8 @@ describe('ws-route chat', () => {
   });
 
   it('accepts valid uuid messageId and fans out chat', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const body = JSON.stringify({
       action: 'chat',
       text: 'hi',
@@ -108,6 +110,16 @@ describe('ws-route chat', () => {
     const result = await handler(baseEvent({ routeKey: 'chat', body }), {} as never, () => undefined);
     expect(result).toEqual({ statusCode: 200, body: 'OK' });
     expect(mocks.postToConnections).toHaveBeenCalledTimes(1);
+
+    expect(logSpy).toHaveBeenCalled();
+    const emf = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(emf.Route).toBe('chat');
+    expect(emf.Outcome).toBe('success');
+    const infoLine = JSON.parse(infoSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(infoLine).toMatchObject({ riffsyncDiag: 'ws_realtime', route: 'chat', outcome: 'success', textLength: 2 });
+    expect(infoLine.text).toBeUndefined();
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
 
     const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
     const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -13,6 +13,7 @@ import {
 import { TextEncoder } from 'node:util';
 import { isHttpsGiphyCdnUrl } from './giphy-search-shared';
 import { lobbySortKey, LOBBY_PARTITION } from './room-shared';
+import { recordWsRealtimeRoute } from './riffsync-observability';
 import {
   broadcastRoomPresence,
   broadcastRoomPresenceNow,
@@ -236,14 +237,17 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
   if (routeKey === 'chat') {
     const fanSubDenied = requireFanSub(conn, 'chat');
     if (fanSubDenied) {
+      recordWsRealtimeRoute('chat', 403, connectionId, roomId);
       return fanSubDenied;
     }
     const text = typeof body.text === 'string' ? body.text.trim() : '';
     if (text === '' || text.length > 2000) {
+      recordWsRealtimeRoute('chat', 400, connectionId, roomId);
       return { statusCode: 400, body: 'text required, max 2000 chars' };
     }
     const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
     if (!isUuidMessageId(messageId)) {
+      recordWsRealtimeRoute('chat', 400, connectionId, roomId);
       return { statusCode: 400, body: 'messageId must be a valid UUID' };
     }
     const mgmt = wsManagementClient();
@@ -265,34 +269,41 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     }
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    recordWsRealtimeRoute('chat', 200, connectionId, roomId, { textLength: text.length });
     return { statusCode: 200, body: 'OK' };
   }
 
   if (routeKey === 'chat_gif') {
     const fanSubDenied = requireFanSub(conn, 'chat_gif');
     if (fanSubDenied) {
+      recordWsRealtimeRoute('chat_gif', 403, connectionId, roomId);
       return fanSubDenied;
     }
     const fanSub = fanSubFromConn(conn);
     const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
     if (!isUuidMessageId(messageId)) {
+      recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId);
       return { statusCode: 400, body: 'messageId must be a valid UUID' };
     }
     const giphyId = typeof body.giphyId === 'string' ? body.giphyId.trim() : '';
     if (giphyId === '') {
+      recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: false });
       return { statusCode: 400, body: 'giphyId required' };
     }
     const renditionUrl = typeof body.renditionUrl === 'string' ? body.renditionUrl.trim() : '';
     if (renditionUrl === '' || !isHttpsGiphyCdnUrl(renditionUrl)) {
+      recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: true });
       return { statusCode: 400, body: 'renditionUrl must be HTTPS Giphy CDN URL' };
     }
     let title: string | undefined;
     if (body.title !== undefined) {
       if (typeof body.title !== 'string') {
+        recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: true });
         return { statusCode: 400, body: 'title must be a string' };
       }
       const trimmed = body.title.trim();
       if (trimmed.length > CHAT_GIF_TITLE_MAX) {
+        recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: true });
         return { statusCode: 400, body: `title max ${CHAT_GIF_TITLE_MAX} chars` };
       }
       if (trimmed !== '') {
@@ -301,10 +312,12 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     }
     const width = parseOptionalChatGifDimension(body.width);
     if (body.width !== undefined && width === undefined) {
+      recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: true });
       return { statusCode: 400, body: 'width must be a positive integer' };
     }
     const height = parseOptionalChatGifDimension(body.height);
     if (body.height !== undefined && height === undefined) {
+      recordWsRealtimeRoute('chat_gif', 400, connectionId, roomId, { hasGiphyId: true });
       return { statusCode: 400, body: 'height must be a positive integer' };
     }
     const mgmt = wsManagementClient();
@@ -335,24 +348,29 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     }
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    recordWsRealtimeRoute('chat_gif', 200, connectionId, roomId, { hasGiphyId: true });
     return { statusCode: 200, body: 'OK' };
   }
 
   if (routeKey === 'react') {
     const fanSubDenied = requireFanSub(conn, 'react');
     if (fanSubDenied) {
+      recordWsRealtimeRoute('react', 403, connectionId, roomId);
       return fanSubDenied;
     }
     const messageId = typeof body.messageId === 'string' ? body.messageId.trim() : '';
     if (messageId === '' || messageId.length > 64) {
+      recordWsRealtimeRoute('react', 400, connectionId, roomId);
       return { statusCode: 400, body: 'messageId required, max 64 chars' };
     }
     const emoji = typeof body.emoji === 'string' ? body.emoji.trim() : '';
     if (emoji === '' || emoji.length > 32) {
+      recordWsRealtimeRoute('react', 400, connectionId, roomId);
       return { statusCode: 400, body: 'emoji required, max 32 chars' };
     }
     const reactionAction = body.reactionAction;
     if (reactionAction !== 'add' && reactionAction !== 'remove') {
+      recordWsRealtimeRoute('react', 400, connectionId, roomId);
       return { statusCode: 400, body: 'reactionAction must be add or remove' };
     }
     const mgmt = wsManagementClient();
@@ -370,6 +388,7 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     };
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    recordWsRealtimeRoute('react', 200, connectionId, roomId);
     return { statusCode: 200, body: 'OK' };
   }
 

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -547,6 +547,7 @@ export class ApiCatalogStack extends cdk.Stack {
         GIPHY_SECRET_ARN: this.giphyApiKeySecret.secretArn,
         GIPHY_RATE_LIMIT_TABLE_NAME: giphyRateLimitTable.tableName,
         GIPHY_RATE_LIMIT_PER_MINUTE: '30',
+        RIFFSYNC_ENVIRONMENT: environment,
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
@@ -564,6 +565,7 @@ export class ApiCatalogStack extends cdk.Stack {
         FAN_AVATARS_BUCKET_NAME: this.fanAvatarsBucket.bucketName,
         FAN_AVATARS_PUBLIC_BASE_URL: this.fanAvatarsPublicBaseUrl,
         FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
+        RIFFSYNC_ENVIRONMENT: environment,
         NODE_OPTIONS: '--enable-source-maps',
       },
     });

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -594,6 +594,7 @@ export class ApiCatalogStack extends cdk.Stack {
       COGNITO_USER_POOL_ID: fanUserPool.userPoolId,
       COGNITO_CLIENT_ID: fanUserPoolClient.userPoolClientId,
       WS_MANAGEMENT_API_ENDPOINT: wsMgmtEndpoint,
+      RIFFSYNC_ENVIRONMENT: environment,
       NODE_OPTIONS: '--enable-source-maps',
     };
 


### PR DESCRIPTION
## Summary

Implements [#59](https://github.com/StacksOnTheRacks/riffsync/issues/59) and [#60](https://github.com/StacksOnTheRacks/riffsync/issues/60) on parent branch `feature/issue-36` for [#36](https://github.com/StacksOnTheRacks/riffsync/issues/36).

- Adds `riffsync-observability.ts` with EMF and content-safe structured INFO logs
- **WS (`RiffSync/Realtime`):** records metrics for `chat`, `chat_gif`, and `react` on success and handled 400/403 paths
- **HTTP (`RiffSync/Api`):** records metrics for `GiphySearch` and `FanAvatarUpload` with safe `queryLength` / `resultCount` / `fileSizeBytes` fields
- Replaces plaintext Giphy secret/rate-limit errors with structured `riffsyncDiag` JSON
- Wires `RIFFSYNC_ENVIRONMENT` into WebSocket, Giphy search, and avatar upload Lambda env (EMF via stdout; no extra `PutMetricData` IAM)

Closes #59
Closes #60

## Test plan

- [x] `cd infra/cdk && npm test`
- [x] `cd infra/cdk && npm run synth`
- [ ] After deploy: confirm CloudWatch log streams for `ws-route`, `giphy-search`, and `fan-avatar-post` show EMF under `RiffSync/Realtime` / `RiffSync/Api` with no raw chat text, search queries, or avatar bytes at INFO