### PR TITLE
[M11][#63] StaffAuthStack (RiffSyncStaffAuth-prod) — #68

### DIFF
--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -18,6 +18,7 @@ The CDK app **no longer defines** `RiffSyncFanAuth-staging`, `RiffSyncApi-stagin
 | `lib/api-catalog-stack.ts` | **Catalog** + **Rooms** + **Connections** Dynamo tables, **HTTP API** (catalog, rooms, lobby), **JWT** (**fan pool**), **WebSocket API** (ping/chat/signaling), **TMDB reconcile** + schedules |
 | `lib/media-server-stack.ts` | **Singleton** **`RiffSyncTurn`** — **one VPC**, **coturn** (**`t3.small`**) + **mediasoup SFU** (**`t3.medium`**), two EIPs, **`riffsync/turn-static-auth-secret`**, S3 bundle deploy for **`services/riffsync-sfu`**, **`riffsync/sfu-join-hmac-secret`** (reference by name) |
 | `lib/fan-auth-stack.ts` | **Fan** Cognito **User Pool** + **Hosted UI** domain + SPA app client (**local** email/password sign-up & sign-in, OAuth code + PKCE) |
+| `lib/staff-auth-stack.ts` | **Staff** Cognito **User Pool** (invite-only) + **Hosted UI** + SPA app client (**`/admin/*`** OAuth callbacks, **`admin`** / **`curator`** groups) |
 | `lib/ses-inbound-stack.ts` | Shared **SES inbound** receipt rule → **SNS** (+ optional Route 53 **MX**) |
 | `lambda/catalog-*.ts` | Catalog read handlers (**`Scan`** / **`GetItem`**) |
 | `lambda/room-*.ts` | **`POST/PATCH`** room + **`GET`** lobby/read (**`authorization.md`**) |
@@ -230,7 +231,7 @@ Advanced overrides (**`stunServersJson`**, etc.) use CDK context keys in **`api-
 
 ### Fan Cognito Hosted UI (M5+)
 
-Hosted stack **`RiffSyncFanAuth-prod`** provisions a **fan-only** pool suitable for **`POST /v1/rooms`** and room-admin JWTs per **`.ai/integration/authorization.md`** (stable **`sub`** for **`hostSub`**). **Staff** `/v1/admin/*` pool remains a **separate** future stack.
+Hosted stack **`RiffSyncFanAuth-prod`** provisions a **fan-only** pool suitable for **`POST /v1/rooms`** and room-admin JWTs per **`.ai/integration/authorization.md`** (stable **`sub`** for **`hostSub`**). **Staff** **`/v1/admin/*`** uses a **separate** pool in **`RiffSyncStaffAuth-prod`** (see **Staff Cognito Hosted UI** below).
 
 | Decision | Choice |
 | --- | --- |
@@ -257,6 +258,45 @@ Hosted stack **`RiffSyncFanAuth-prod`** provisions a **fan-only** pool suitable 
 **Smoke (prod pool):** build the **`/oauth2/authorize`** link with **PKCE** (response_type **`code`**, client_id **`FanUserPoolClientId`**, redirect_uri **must** match an allowlisted SPA URL, scope **`openid email profile`** — **omit** **`identity_provider`** so Hosted UI shows the pool sign-in / sign-up pages). Complete sign-up, verify email, sign in, exchange the code at **`/oauth2/token`**, then inspect **`access_token`** (`sub` is the host id). **Do not** commit tokens.
 
 **Deploy IAM:** the OIDC deploy role needs **Cognito** create/update permissions for this stack (extend the role if **`cdk deploy`** fails on **`cognito-idp:*`**).
+
+### Staff Cognito Hosted UI (M11+)
+
+Hosted stack **`RiffSyncStaffAuth-prod`** provisions an **invite-only** operator pool distinct from **`riffsync-fan-prod`**. Synthesized **after** **`RiffSyncFanAuth-prod`** so outbound mail reuses the shared SES configuration set **`riffsync-ses-send-prod`** (no duplicate SES resources in the staff stack).
+
+| Decision | Choice |
+| --- | --- |
+| **Sign-up / sign-in** | **Hosted UI** — **`selfSignUpEnabled: false`** (console invite only). First operator account is a **manual console invite** ([#67](https://github.com/StacksOnTheRacks/riffsync/issues/67)); **no** IaC bootstrap user in this stack. |
+| **Outbound sending events** | Reuses **`riffsync-ses-send-prod`** from **`RiffSyncFanAuth-prod`** (**`UserPoolEmail.withSES`**). |
+| **Transactional email** | Same SES identity defaults as fan (**`riffsync.tv`**, **`noreply@riffsync.tv`**, **`RiffSync`**) via optional **`staffAuthSes*`** context keys. |
+| **App client** | **Public** SPA client **`riffsync-staff-web-prod`**; OAuth authorization code + PKCE; **COGNITO** IdP only. |
+| **Callback / sign-out URLs** | **`https://<host>/admin/auth/callback`** and **`https://<host>/admin/login`** for prod hostnames (**`riffsync.tv`**, **`www`**, **`fanWebAlternateDomainNames`**, optional **`staffAuthOAuthExtras`**). Local dev: **`localhost:5173`**, **`127.0.0.1:5173`**, **`localhost:3000`**, **`https://localhost:5173`** with **`/admin/*`** paths. |
+| **Hosted domain prefix** | Default **`riffsync-staff-prod`**. Override: **`--context staffAuthCognitoDomainPrefix=your-prefix`**. |
+| **Groups** | **`admin`**, **`curator`** (**`CfnUserPoolGroup`**) for **`cognito:groups`** on staff JWTs. |
+| **MFA** | **`OPTIONAL`** at pool level (MVP). |
+
+**Optional CDK context** (all strings):
+
+| Context key | Purpose |
+| --- | --- |
+| **`staffAuthSesVerifiedDomain`** | SES verified domain (**default `riffsync.tv`**) |
+| **`staffAuthSesFromEmail`** | Local-part must live on that domain (**default `noreply@<domain>`**) |
+| **`staffAuthSesFromName`** | Display name (**default `RiffSync`**) |
+| **`staffAuthSesRegion`** | SES identity Region if different from stack Region |
+| **`staffAuthOAuthExtras`** | Comma-separated extra callback / logout URLs |
+| **`staffAuthCognitoDomainPrefix`** | Hosted UI domain prefix override |
+
+**Stack outputs:** **`StaffUserPoolId`**, **`StaffUserPoolArn`**, **`StaffUserPoolClientId`**, **`StaffHostedUiDomainPrefix`**, **`StaffHostedUiBaseUrl`**.
+
+**Smoke (prod pool, after deploy):**
+
+1. AWS Console → Cognito → **`riffsync-staff-prod`** exists and is **not** **`riffsync-fan-prod`**
+2. App client **`riffsync-staff-web-prod`** lists **`https://riffsync.tv/admin/auth/callback`** (and localhost admin callback URLs)
+3. Groups **`admin`** and **`curator`** visible on the pool
+4. CloudFormation outputs **`StaffUserPoolId`**, **`StaffUserPoolClientId`**, **`StaffHostedUiBaseUrl`** readable from stack **`RiffSyncStaffAuth-prod`**
+
+**Deploy IAM:** extend the OIDC deploy role with **Cognito** permissions for **`RiffSyncStaffAuth-prod`** if **`cdk deploy`** fails on **`cognito-idp:*`**.
+
+**Out of scope here:** **`ApiCatalogStack`** staff JWT authorizer ([#64](https://github.com/StacksOnTheRacks/riffsync/issues/64)), SPA staff auth modules ([#65](https://github.com/StacksOnTheRacks/riffsync/issues/65)), **`deploy-prod.yml`** ([#66](https://github.com/StacksOnTheRacks/riffsync/issues/66)).
 
 ### SES inbound → SNS (receive mail — shared)
 
@@ -319,6 +359,7 @@ Full server IAM (Lambda, API Gateway, EventBridge, DynamoDB, Cognito, Secrets Ma
 - **`RiffSyncStatic-prod` —** **CloudFront** service-managed roles for the distribution (implicit in **`AWS::CloudFront::Distribution`**).
 - **`RiffSyncApi-prod` —** **HTTP API** (**catalog**, **rooms**, **lobby**) + **WebSocket API**; **JWT** (**HTTP** + **`aws-jwt-verify`** on **`$connect`**); DynamoDB (**catalog**, **rooms**, **connections**, **fan profiles**); **fan avatars** private **S3** + **CloudFront OAC**; **`execute-api:ManageConnections`** on **this stack’s WebSocket API** only; **TMDB** reconcile (**Secrets Manager**, **EventBridge**); **`cloudwatch:PutMetricData`** optional when emitting **EMF** in **`stdout`**.
 - **`RiffSyncFanAuth-prod` —** **Cognito User Pool** + **UserPoolDomain** + **UserPoolClient** (OAuth authorization code grant for the SPA). Pool **`EmailConfiguration`** sends verification / recovery mail through **Amazon SES** (**`DEVELOPER`** / **`SourceArn`** `identity/<domain>`); verify that identity **in the deploy Region** before go-live. **SES configuration set + SNS topic** for outbound reputation events (**outputs** **`SesSendingEventsTopicArn`**, **`SesSendingConfigurationSetName`**).
+- **`RiffSyncStaffAuth-prod` —** **Invite-only** staff **Cognito User Pool** + **Hosted UI** + SPA client (**`/admin/*`** OAuth URLs); **`admin`** / **`curator`** groups; reuses **`SesSendingConfigurationSetName`** from fan auth (depends on **`RiffSyncFanAuth-prod`**).
 - **`RiffSyncSesInbound` —** shared **SNS** topic + **SES** **`ReceiptRuleSet`** / **`ReceiptRule`** + **`AwsCustomResource`** (**`ses:SetActiveReceiptRuleSet`**) + optional Route 53 **MX** when hosted-zone context aligns with **`sesInboundMailDomain`**. Deploy role needs **`ses:*`** receipt-rule APIs for your organization policies.
 
 Older milestone copy: **M1** alone only created the static stack.

--- a/infra/cdk/bin/riffsync.ts
+++ b/infra/cdk/bin/riffsync.ts
@@ -3,6 +3,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import { ApiCatalogStack } from '../lib/api-catalog-stack';
 import { FanAuthStack } from '../lib/fan-auth-stack';
+import { StaffAuthStack } from '../lib/staff-auth-stack';
 import { SesInboundStack, sesInboundReceiptRulesActivated } from '../lib/ses-inbound-stack';
 import { StaticSiteStack } from '../lib/static-site-stack';
 import { MediaServerStack } from '../lib/media-server-stack';
@@ -91,6 +92,16 @@ const fanAuth = new FanAuthStack(app, 'RiffSyncFanAuth-prod', {
   },
 });
 
+const staffAuth = new StaffAuthStack(app, 'RiffSyncStaffAuth-prod', {
+  description: 'RiffSync staff Cognito (prod) — invite-only Hosted UI + admin/curator groups',
+  sesSendingConfigurationSetName: fanAuth.sesSendingConfigurationSetName,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+staffAuth.addDependency(fanAuth);
+
 /** Stack id stays **`RiffSyncTurn`** so the existing VPC + coturn resources remain in the same CFN stack. */
 const mediaServer = new MediaServerStack(app, 'RiffSyncTurn', {
   signalingHostedZone: sfuSignalingHostedZone,
@@ -115,6 +126,7 @@ const apiCatalog = new ApiCatalogStack(app, 'RiffSyncApi-prod', {
   },
 });
 apiCatalog.addDependency(fanAuth);
+apiCatalog.addDependency(staffAuth);
 apiCatalog.addDependency(mediaServer);
 
 new StaticSiteStack(app, 'RiffSyncStatic-prod', {

--- a/infra/cdk/lib/context-alternate-domains.ts
+++ b/infra/cdk/lib/context-alternate-domains.ts
@@ -22,3 +22,9 @@ export function oauthCallbacksForHost(hostname: string): string[] {
   const h = hostname.replace(/\.$/, '').toLowerCase();
   return [`https://${h}/`, `https://${h}/auth/callback`];
 }
+
+/** Staff admin SPA OAuth allowlist paths under `/admin/*`. */
+export function oauthAdminCallbacksForHost(hostname: string): string[] {
+  const h = hostname.replace(/\.$/, '').toLowerCase();
+  return [`https://${h}/admin/auth/callback`, `https://${h}/admin/login`];
+}

--- a/infra/cdk/lib/staff-auth-stack.ts
+++ b/infra/cdk/lib/staff-auth-stack.ts
@@ -1,0 +1,207 @@
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as cdk from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+
+import {
+  fanWebAlternateDomainNamesFromContext,
+  oauthAdminCallbacksForHost,
+} from './context-alternate-domains';
+
+export interface StaffAuthStackProps extends cdk.StackProps {
+  /**
+   * Shared SES configuration set (provisioned by {@link FanAuthStack} as **`riffsync-ses-send-prod`**).
+   */
+  readonly sesSendingConfigurationSetName: string;
+  /**
+   * Extra OAuth callback / sign-out URLs (comma-separated CDK context **`staffAuthOAuthExtras`**).
+   */
+  readonly extraOAuthUrls?: string[];
+  /**
+   * Override Cognito hosted domain prefix (must be unique per region). Default **`riffsync-staff-prod`**.
+   */
+  readonly cognitoDomainPrefix?: string;
+}
+
+function parseExtrasFromContext(scope: Construct): string[] {
+  const raw = scope.node.tryGetContext('staffAuthOAuthExtras');
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const DEFAULT_STAFF_SES_DOMAIN = 'riffsync.tv';
+
+/**
+ * Cognito invite / recovery email via Amazon SES — reuses the shared prod configuration set.
+ *
+ * Optional CDK context:
+ * - **`staffAuthSesVerifiedDomain`** — verified SES domain (default **`riffsync.tv`**).
+ * - **`staffAuthSesFromEmail`** — sender address on that domain (default **`noreply@<domain>`**).
+ * - **`staffAuthSesFromName`** — display name (default **`RiffSync`**).
+ * - **`staffAuthSesRegion`** — SES identity region when it differs from the stack region.
+ */
+function staffPoolSesEmail(
+  scope: Construct,
+  sesConfigurationSetName: string,
+): cognito.UserPoolEmail {
+  const domainRaw = scope.node.tryGetContext('staffAuthSesVerifiedDomain');
+  const sesVerifiedDomain =
+    typeof domainRaw === 'string' && domainRaw.trim() !== ''
+      ? domainRaw.trim().toLowerCase()
+      : DEFAULT_STAFF_SES_DOMAIN;
+
+  const fromEmailRaw = scope.node.tryGetContext('staffAuthSesFromEmail');
+  const fromEmail =
+    typeof fromEmailRaw === 'string' && fromEmailRaw.trim() !== ''
+      ? fromEmailRaw.trim().toLowerCase()
+      : `noreply@${sesVerifiedDomain}`;
+
+  const nameRaw = scope.node.tryGetContext('staffAuthSesFromName');
+  const fromName =
+    typeof nameRaw === 'string' && nameRaw.trim() !== '' ? nameRaw.trim() : 'RiffSync';
+
+  const sesRegionRaw = scope.node.tryGetContext('staffAuthSesRegion');
+  const sesRegion =
+    typeof sesRegionRaw === 'string' && sesRegionRaw.trim() !== ''
+      ? sesRegionRaw.trim()
+      : undefined;
+
+  return cognito.UserPoolEmail.withSES({
+    fromEmail,
+    fromName,
+    sesVerifiedDomain,
+    ...(sesRegion !== undefined ? { sesRegion } : {}),
+    configurationSetName: sesConfigurationSetName,
+  });
+}
+
+/**
+ * **Staff / operator** Cognito user pool — **invite-only** Hosted UI + PKCE SPA client.
+ *
+ * Aligns with **`.ai/integration/authorization.md`** (separate pool for **`/v1/admin/*`**).
+ */
+export class StaffAuthStack extends cdk.Stack {
+  public readonly staffUserPool: cognito.UserPool;
+  public readonly staffUserPoolClient: cognito.UserPoolClient;
+
+  constructor(scope: Construct, id: string, props: StaffAuthStackProps) {
+    super(scope, id, props);
+
+    const { cognitoDomainPrefix, sesSendingConfigurationSetName } = props;
+    const contextExtras = parseExtrasFromContext(this);
+    const extraOAuthUrls = [...(props.extraOAuthUrls ?? []), ...contextExtras];
+
+    cdk.Tags.of(this).add('Project', 'RiffSync');
+    cdk.Tags.of(this).add('Environment', 'prod');
+
+    this.staffUserPool = new cognito.UserPool(this, 'StaffUserPool', {
+      userPoolName: 'riffsync-staff-prod',
+      selfSignUpEnabled: false,
+      signInAliases: { email: true },
+      autoVerify: { email: true },
+      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
+      mfa: cognito.Mfa.OPTIONAL,
+      email: staffPoolSesEmail(this, sesSendingConfigurationSetName),
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      deletionProtection: true,
+    });
+
+    const localDevCallbackLogoutBase = [
+      'http://localhost:5173/admin/auth/callback',
+      'http://localhost:5173/admin/login',
+      'http://127.0.0.1:5173/admin/auth/callback',
+      'http://127.0.0.1:5173/admin/login',
+      'http://localhost:3000/admin/auth/callback',
+      'http://localhost:3000/admin/login',
+      'https://localhost:5173/admin/auth/callback',
+      'https://localhost:5173/admin/login',
+    ];
+    const prodCallbackLogoutBase = [
+      ...new Set([
+        ...oauthAdminCallbacksForHost('riffsync.tv'),
+        ...oauthAdminCallbacksForHost('www.riffsync.tv'),
+        ...fanWebAlternateDomainNamesFromContext(this).flatMap(oauthAdminCallbacksForHost),
+      ]),
+    ];
+
+    const callbackUrls = [
+      ...new Set([...prodCallbackLogoutBase, ...localDevCallbackLogoutBase, ...extraOAuthUrls]),
+    ];
+
+    const logoutUrls = callbackUrls;
+
+    const domainPrefixRaw =
+      typeof cognitoDomainPrefix === 'string' && cognitoDomainPrefix.trim() !== ''
+        ? cognitoDomainPrefix.trim().toLowerCase()
+        : (this.node.tryGetContext('staffAuthCognitoDomainPrefix') as string | undefined);
+    const domainPrefix =
+      typeof domainPrefixRaw === 'string' && domainPrefixRaw.trim() !== ''
+        ? domainPrefixRaw.trim().toLowerCase()
+        : 'riffsync-staff-prod';
+
+    this.staffUserPool.addDomain('StaffHostedUiDomain', {
+      cognitoDomain: { domainPrefix },
+    });
+
+    this.staffUserPoolClient = this.staffUserPool.addClient('StaffWebSpaClient', {
+      userPoolClientName: 'riffsync-staff-web-prod',
+      generateSecret: false,
+      authFlows: {
+        userSrp: true,
+        userPassword: true,
+        adminUserPassword: false,
+      },
+      oAuth: {
+        flows: { authorizationCodeGrant: true },
+        scopes: [
+          cognito.OAuthScope.OPENID,
+          cognito.OAuthScope.EMAIL,
+          cognito.OAuthScope.PROFILE,
+        ],
+        callbackUrls,
+        logoutUrls,
+      },
+      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
+    });
+
+    new cognito.CfnUserPoolGroup(this, 'AdminGroup', {
+      userPoolId: this.staffUserPool.userPoolId,
+      groupName: 'admin',
+      description: 'Full operator access for /v1/admin/*',
+    });
+
+    new cognito.CfnUserPoolGroup(this, 'CuratorGroup', {
+      userPoolId: this.staffUserPool.userPoolId,
+      groupName: 'curator',
+      description: 'Curated catalog / roster tools',
+    });
+
+    new cdk.CfnOutput(this, 'StaffUserPoolId', {
+      value: this.staffUserPool.userPoolId,
+      description: 'Staff Cognito pool id — JWT issuer for /v1/admin/* routes.',
+    });
+
+    new cdk.CfnOutput(this, 'StaffUserPoolArn', {
+      value: this.staffUserPool.userPoolArn,
+    });
+
+    new cdk.CfnOutput(this, 'StaffUserPoolClientId', {
+      value: this.staffUserPoolClient.userPoolClientId,
+      description: 'Staff SPA / Hosted UI OAuth app client (public).',
+    });
+
+    new cdk.CfnOutput(this, 'StaffHostedUiDomainPrefix', {
+      value: domainPrefix,
+      description: 'Staff Cognito Hosted UI domain prefix ({prefix}.auth.<region>.amazoncognito.com).',
+    });
+
+    new cdk.CfnOutput(this, 'StaffHostedUiBaseUrl', {
+      value: `https://${domainPrefix}.auth.${cdk.Stack.of(this).region}.amazoncognito.com`,
+      description: 'Staff Hosted UI base URL (append /oauth2/authorize with PKCE query params).',
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Add **`StaffAuthStack`** (`RiffSyncStaffAuth-prod`) with invite-only staff Cognito pool **`riffsync-staff-prod`**, Hosted UI domain, and public SPA client **`riffsync-staff-web-prod`**
- Reuse shared SES configuration set **`riffsync-ses-send-prod`** from **`FanAuthStack`** (no duplicate SES resources)
- Define **`admin`** and **`curator`** **`CfnUserPoolGroup`** resources; OAuth allowlist uses **`/admin/auth/callback`** and **`/admin/login`** paths
- Wire stack in **`bin/riffsync.ts`** with **`apiCatalog.addDependency(staffAuth)`**; document in **`infra/cdk/README.md`**

Closes #68

Part of #63

## Test plan

- [x] `npm run verify:push:cdk` (Vitest + `cdk synth`)
- [x] Synth includes **`RiffSyncStaffAuth-prod`** with **`riffsync-staff-prod`**, **`riffsync-staff-web-prod`**, **`StaffUserPoolId`**, **`AdminGroup`**, **`CuratorGroup`**
- [ ] Post-deploy: Cognito console smoke (pool, client callbacks, groups, CFN outputs)