### PR TITLE
[M11][#64] Staff JWT authorizer and GET /v1/admin/session

### DIFF
--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -154,6 +154,12 @@ Deployed with **`RiffSyncApi-prod`** (same CloudFormation stack as catalog). Dep
 | **`GET /v1/webrtc/ice`** | Anonymous | **`iceServers`** for WebRTC (STUN + time-limited TURN when **`turnHost`** context is set — see **Self-hosted TURN**). |
 | **`POST /v1/privacy-removal-request`** | Anonymous | JSON body **`contactEmail`**, **`message`** (10–8000 chars), optional honeypot **`website`** (must be empty). Sends mail via **SES** using **`riffsync/<env>/privacy-removal-routing`** (JSON **`notifyEmail`** + SES-verified **`fromEmail`**). Uses environment SES configuration set (**`SesSendingConfigurationSetName`**) so **bounce**/**complaint**/**delivery** events publish to **`SesSendingEventsTopicArn`**. Configure **SES** identities and replace secret placeholders before relying on the SPA form. |
 
+**HTTP — staff admin** (JWT = **staff pool access token**, audience = **`StaffUserPoolClientId`**)
+
+| Route | Auth | Behavior |
+| --- | --- | --- |
+| **`GET /v1/admin/session`** | **Staff JWT required** (`401` gateway for fan/wrong pool) | Reads authorizer claims; **`403`** **`staff_group_required`** unless **`cognito:groups`** includes **`admin`** or **`curator`**. **200** body: **`sub`**, **`email`**, **`groups`**. |
+
 **WebSocket**: outputs **`WebSocketUrl`** (**`wss://…/prod`**). Contracts: **`../../docs/contracts.websocket.md`**. **`execute-api:ManageConnections`** attaches only to this stack’s WebSocket API (**`…/*/*/@connections/*`**, parameterized by **`WebSocketApiId`**), not arbitrary `*` resources.
 
 **Housekeeping:** lobby staleness uses **read-time filtering** (**US-P0-08**) — optional EventBridge TTL/sweeper deferred.

--- a/infra/cdk/bin/riffsync.ts
+++ b/infra/cdk/bin/riffsync.ts
@@ -117,6 +117,8 @@ const apiCatalog = new ApiCatalogStack(app, 'RiffSyncApi-prod', {
   description: 'RiffSync HTTP API + Catalog + Rooms + WebSocket (prod) — DynamoDB + Lambda',
   fanUserPool: fanAuth.fanUserPool,
   fanUserPoolClient: fanAuth.fanUserPoolClient,
+  staffUserPool: staffAuth.staffUserPool,
+  staffUserPoolClient: staffAuth.staffUserPoolClient,
   sesSendingConfigurationSetName: fanAuth.sesSendingConfigurationSetName,
   turnSharedSecret: mediaServer.turnSharedSecret,
   sfuDefaultSignalingWsUrl: sfuDefaultSignalingWsUrlFromContext(app, sfuProdSignalingHostname),

--- a/infra/cdk/lambda/admin-session-get.test.ts
+++ b/infra/cdk/lambda/admin-session-get.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+
+import { handler } from './admin-session-get';
+import { hasStaffRole, parseCognitoGroups } from './admin-session-shared';
+
+function staffEvent(claims?: Record<string, unknown>): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'GET /v1/admin/session',
+    rawPath: '/v1/admin/session',
+    rawQueryString: '',
+    headers: {},
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'GET',
+        path: '/v1/admin/session',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req',
+      routeKey: 'GET /v1/admin/session',
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: claims ? { jwt: { claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('admin-session-shared', () => {
+  describe('parseCognitoGroups', () => {
+    it('parses array groups', () => {
+      expect(parseCognitoGroups({ 'cognito:groups': ['admin', 'other'] })).toEqual(['admin', 'other']);
+    });
+
+    it('parses single string group', () => {
+      expect(parseCognitoGroups({ 'cognito:groups': 'curator' })).toEqual(['curator']);
+    });
+
+    it('parses space-separated string groups', () => {
+      expect(parseCognitoGroups({ 'cognito:groups': 'admin curator' })).toEqual(['admin', 'curator']);
+    });
+
+    it('returns empty when groups absent', () => {
+      expect(parseCognitoGroups({})).toEqual([]);
+      expect(parseCognitoGroups(undefined)).toEqual([]);
+    });
+  });
+
+  describe('hasStaffRole', () => {
+    it('accepts admin or curator', () => {
+      expect(hasStaffRole(['admin'])).toBe(true);
+      expect(hasStaffRole(['curator'])).toBe(true);
+      expect(hasStaffRole(['viewer'])).toBe(false);
+      expect(hasStaffRole([])).toBe(false);
+    });
+  });
+});
+
+describe('admin-session-get handler', () => {
+  it('returns 200 for admin group', async () => {
+    const res = await handler(
+      staffEvent({ sub: 'staff-1', email: 'op@example.com', 'cognito:groups': ['admin'] }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(200);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      sub: 'staff-1',
+      email: 'op@example.com',
+      groups: ['admin'],
+    });
+  });
+
+  it('returns 200 for curator group only', async () => {
+    const res = await handler(
+      staffEvent({ sub: 'staff-2', 'cognito:groups': 'curator' }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(200);
+    expect(JSON.parse(res?.body ?? '')).toMatchObject({
+      sub: 'staff-2',
+      email: null,
+      groups: ['curator'],
+    });
+  });
+
+  it('returns 403 when sub present but groups missing staff role', async () => {
+    const res = await handler(
+      staffEvent({ sub: 'staff-3', 'cognito:groups': ['viewer'] }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(403);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Forbidden',
+      code: 'staff_group_required',
+    });
+  });
+
+  it('returns 401 when authorizer claims or sub absent', async () => {
+    const noAuthorizer = staffEvent();
+    (noAuthorizer.requestContext as { authorizer?: unknown }).authorizer = undefined;
+    const res1 = await handler(noAuthorizer, {} as never, () => undefined);
+    expect(res1?.statusCode).toBe(401);
+    expect(JSON.parse(res1?.body ?? '')).toEqual({ error: 'Unauthorized', code: 'unauthorized' });
+
+    const res2 = await handler(staffEvent({ 'cognito:groups': ['admin'] }), {} as never, () => undefined);
+    expect(res2?.statusCode).toBe(401);
+  });
+});

--- a/infra/cdk/lambda/admin-session-get.ts
+++ b/infra/cdk/lambda/admin-session-get.ts
@@ -1,0 +1,24 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import {
+  getStaffJwtClaims,
+  hasStaffRole,
+  parseCognitoGroups,
+} from './admin-session-shared';
+import { jsonResponse } from './giphy-search-shared';
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const claims = getStaffJwtClaims(event);
+  const sub = typeof claims?.sub === 'string' ? claims.sub : undefined;
+
+  if (!sub) {
+    return jsonResponse(401, { error: 'Unauthorized', code: 'unauthorized' });
+  }
+
+  const groups = parseCognitoGroups(claims);
+  if (!hasStaffRole(groups)) {
+    return jsonResponse(403, { error: 'Forbidden', code: 'staff_group_required' });
+  }
+
+  const email = typeof claims?.email === 'string' && claims.email.length > 0 ? claims.email : null;
+  return jsonResponse(200, { sub, email, groups });
+};

--- a/infra/cdk/lambda/admin-session-shared.ts
+++ b/infra/cdk/lambda/admin-session-shared.ts
@@ -1,0 +1,47 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+
+const STAFF_GROUPS = new Set(['admin', 'curator']);
+
+interface StaffJwtClaims {
+  sub?: string;
+  email?: string;
+  'cognito:groups'?: string | string[];
+}
+
+export type StaffSessionResponse = {
+  sub: string;
+  email: string | null;
+  groups: string[];
+};
+
+export function getStaffJwtClaims(
+  event: Parameters<APIGatewayProxyHandlerV2>[0],
+): StaffJwtClaims | undefined {
+  return (
+    event.requestContext as unknown as {
+      authorizer?: { jwt?: { claims?: StaffJwtClaims } };
+    }
+  ).authorizer?.jwt?.claims;
+}
+
+/** Normalize `cognito:groups` from API Gateway JWT authorizer context (string or array). */
+export function parseCognitoGroups(claims: StaffJwtClaims | undefined): string[] {
+  if (!claims) {
+    return [];
+  }
+  const raw = claims['cognito:groups'];
+  if (Array.isArray(raw)) {
+    return raw.filter((g): g is string => typeof g === 'string' && g.length > 0);
+  }
+  if (typeof raw === 'string' && raw.length > 0) {
+    if (raw.includes(' ')) {
+      return raw.split(/\s+/).filter(Boolean);
+    }
+    return [raw];
+  }
+  return [];
+}
+
+export function hasStaffRole(groups: readonly string[]): boolean {
+  return groups.some((g) => STAFF_GROUPS.has(g));
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -30,6 +30,9 @@ export interface ApiCatalogStackProps extends cdk.StackProps {
    */
   readonly fanUserPool: cognito.IUserPool;
   readonly fanUserPoolClient: cognito.IUserPoolClient;
+  /** Staff Cognito pool + SPA client for `/v1/admin/*` JWT validation (**M11**). */
+  readonly staffUserPool: cognito.IUserPool;
+  readonly staffUserPoolClient: cognito.IUserPoolClient;
   /** SES sending configuration set — Cognito + privacy-removal **`SendEmail`** emit events to SNS via this set. */
   readonly sesSendingConfigurationSetName: string;
   /**
@@ -157,6 +160,8 @@ export class ApiCatalogStack extends cdk.Stack {
       extraCorsOrigins = [],
       fanUserPool,
       fanUserPoolClient,
+      staffUserPool,
+      staffUserPoolClient,
       sesSendingConfigurationSetName,
       turnSharedSecret,
       sfuDefaultSignalingWsUrl,
@@ -352,6 +357,12 @@ export class ApiCatalogStack extends cdk.Stack {
     const fanJwtAuthorizer = new apigwv2Auth.HttpJwtAuthorizer('FanJwtAuthorizer', fanIssuer, {
       jwtAudience: [fanUserPoolClient.userPoolClientId],
       authorizerName: `riffsync-fan-${environment}`,
+    });
+
+    const staffIssuer = `https://cognito-idp.${this.region}.amazonaws.com/${staffUserPool.userPoolId}`;
+    const staffJwtAuthorizer = new apigwv2Auth.HttpJwtAuthorizer('StaffJwtAuthorizer', staffIssuer, {
+      jwtAudience: [staffUserPoolClient.userPoolClientId],
+      authorizerName: `riffsync-staff-${environment}`,
     });
 
     const jwtEnvShared = {
@@ -554,6 +565,18 @@ export class ApiCatalogStack extends cdk.Stack {
     this.giphyApiKeySecret.grantRead(giphySearchFn);
     giphyRateLimitTable.grantReadWriteData(giphySearchFn);
 
+    const adminSessionGetFn = new lambdaNodejs.NodejsFunction(this, 'AdminSessionGetFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(5),
+      memorySize: 128,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-session-get.ts'),
+      handler: 'handler',
+      environment: {
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+
     const fanAvatarPostFn = new lambdaNodejs.NodejsFunction(this, 'FanAvatarPostFn', {
       runtime: lambda.Runtime.NODEJS_24_X,
       timeout: cdk.Duration.seconds(29),
@@ -726,6 +749,10 @@ export class ApiCatalogStack extends cdk.Stack {
       'GiphySearchInt',
       giphySearchFn,
     );
+    const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
+      'AdminSessionGetInt',
+      adminSessionGetFn,
+    );
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -811,6 +838,13 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: fanJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/admin/session',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: adminSessionGetIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -867,7 +901,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Adds **`StaffJwtAuthorizer`** to **`RiffSyncApi-prod`** (staff pool issuer + SPA client audience).
- Wires **`StaffAuthStack`** pool/client props through **`bin/riffsync.ts`** into **`ApiCatalogStack`**.
- Ships **`GET /v1/admin/session`** via **`AdminSessionGetFn`**: claims-only handler returns **`sub`**, **`email`**, **`groups`** for **`admin`** / **`curator`**, **403** **`staff_group_required`** otherwise.
- Fan **`FanJwtAuthorizer`** bindings unchanged.

Closes #69
Part of #64

## Test plan

- [x] `npm run verify:push:cdk` (Vitest + `cdk synth`)
- [ ] Deployed: fan token on `/v1/admin/session` → **401** at gateway
- [ ] Deployed: staff token with `admin`/`curator` → **200**
- [ ] Deployed: staff token without required group → **403** `staff_group_required`
- [ ] Regression: fan routes still use fan authorizer