### PR TITLE
[M11] Deploy pipeline wiring for staff auth

### DIFF
--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -35,6 +35,22 @@
 | --- | --- |
 | **SPA** | Vite/Next/CRA per frontend doc; **TypeScript**; build output to **S3 + CloudFront** (or host elsewhere) — wired from CDK or separate pipeline (document in stack README when added). |
 
+### Production SPA env (fan + staff)
+
+**`deploy-prod.yml`** reads CloudFormation outputs and passes them into **`apps/web`** **`npm run build`**:
+
+| CfnOutput stack | Output key | Vite env var | Transform |
+| --- | --- | --- | --- |
+| **`RiffSyncStatic-prod`** | **`FanWebSiteUrl`** | **`VITE_PUBLIC_ORIGIN`** | Use as-is |
+| **`RiffSyncApi-prod`** | **`HttpApiUrl`** | **`VITE_PUBLIC_API_BASE_URL`** | Use as-is |
+| **`RiffSyncApi-prod`** | **`WebSocketUrl`** | **`VITE_PUBLIC_WS_URL`** | Use as-is |
+| **`RiffSyncFanAuth-prod`** | **`FanHostedUiBaseUrl`** | **`VITE_COGNITO_HOSTED_UI_DOMAIN`** | Strip **`https://`** prefix |
+| **`RiffSyncFanAuth-prod`** | **`FanUserPoolClientId`** | **`VITE_COGNITO_CLIENT_ID`** | Use as-is |
+| **`RiffSyncStaffAuth-prod`** | **`StaffHostedUiBaseUrl`** | **`VITE_STAFF_COGNITO_HOSTED_UI_DOMAIN`** | Strip **`https://`** prefix |
+| **`RiffSyncStaffAuth-prod`** | **`StaffUserPoolClientId`** | **`VITE_STAFF_COGNITO_CLIENT_ID`** | Use as-is |
+
+One **`dist/`** artifact serves fan routes and **`/admin/*`** (single S3 sync + invalidation).
+
 ## Pull-request CI (recommended)
 
 - **`cdk synth`** with **`--context environment=prod`** (and optionally **`cdk diff`** against the prod account).

--- a/.ai/operations/deployment_environments.md
+++ b/.ai/operations/deployment_environments.md
@@ -16,6 +16,20 @@ RiffSync **hosted** footprint is **production only** in AWS (plus **local** deve
 
 **Not automatic by default:** production does not continuous deploy on every push unless product policy changes—keeps costs and surprise releases down (**`.ai/operations/build_packaging.md`**).
 
+## Production deploy phases (`deploy-prod.yml`)
+
+Manual **Deploy CDK (production)** runs these jobs in order (parallel where noted):
+
+| Phase | Workflow job | CDK / publish targets |
+| --- | --- | --- |
+| **1a** | **`cdk-media`** | **`RiffSyncTurn`** (TURN + SFU + VPC) |
+| **1b** | **`cdk-platform`** (parallel with 1a) | **`RiffSyncFanAuth-prod`**, **`RiffSyncStaffAuth-prod`**, **`RiffSyncStatic-prod`**, **`RiffSyncSesInbound`** |
+| **2** | **`cdk-api`** (after 1a + 1b) | **`RiffSyncApi-prod`** (`--exclusively`) |
+| **3** | **`cdk-oauth-cors`** (after 2) | **`RiffSyncFanAuth-prod`**, **`RiffSyncStaffAuth-prod`**, **`RiffSyncApi-prod`** (`--exclusively`) with **`fanAuthOAuthExtras`**, **`staffAuthOAuthExtras`**, **`catalogCorsOrigins`** from **`FanWebSiteUrl`** |
+| **4** | **`fan-spa`** (after 3) | Vite build with fan + staff Cognito outputs; **`aws s3 sync`** + CloudFront invalidation |
+
+**Media-only** changes use **`deploy-turn.yml`** without the full sequence above.
+
 ## Removed: hosted staging
 
 The former **staging** stacks (`RiffSyncFanAuth-staging`, `RiffSyncApi-staging`, `RiffSyncStatic-staging`) are **not** defined in CDK anymore. Operators should delete those stacks via **CloudFormation** after migrating any needed data and confirming DNS/clients no longer point at staging. See **`infra/cdk/README.md`** (Decommissioning hosted staging).

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,7 +2,7 @@ name: Deploy CDK (production)
 
 # Policy: **`main` → production** (manual). See `.ai/operations/deployment_environments.md`.
 #
-# - **Media** (**`RiffSyncTurn`**: TURN + SFU + VPC) and **platform** (fan auth, static, SES) run in parallel.
+# - **Media** (**`RiffSyncTurn`**: TURN + SFU + VPC) and **platform** (fan + staff auth, static, SES) run in parallel.
 # - **API** (`--exclusively`) runs after both (**`RiffSyncApi-prod`** imports turn secret from **`RiffSyncTurn`**).
 # OAuth/CORS uses **`--exclusively`** so CDK does not redeploy **`RiffSyncTurn`** while updating Cognito + API.
 on:
@@ -65,7 +65,7 @@ jobs:
           npx cdk deploy RiffSyncTurn "${CDK_CTX[@]}" --require-approval never
 
   cdk-platform:
-    name: CDK prod – Fan auth, static site, SES inbound
+    name: CDK prod – Fan + staff auth, static site, SES inbound
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,12 +78,12 @@ jobs:
           aws_role_arn: ${{ vars.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws_region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
-      - name: Deploy RiffSyncFanAuth-prod, RiffSyncStatic-prod, RiffSyncSesInbound
+      - name: Deploy RiffSyncFanAuth-prod, RiffSyncStaffAuth-prod, RiffSyncStatic-prod, RiffSyncSesInbound
         working-directory: infra/cdk
         run: |
           set -euo pipefail
           mapfile -t CDK_CTX < <(bash scripts/cdk-prod-context-args.sh)
-          npx cdk deploy RiffSyncFanAuth-prod RiffSyncStatic-prod RiffSyncSesInbound "${CDK_CTX[@]}" --require-approval never
+          npx cdk deploy RiffSyncFanAuth-prod RiffSyncStaffAuth-prod RiffSyncStatic-prod RiffSyncSesInbound "${CDK_CTX[@]}" --require-approval never
 
   cdk-api:
     name: CDK prod – API (exclusive; deps already deployed)
@@ -134,9 +134,10 @@ jobs:
             --query "Stacks[0].Outputs[?OutputKey=='FanWebSiteUrl'].OutputValue" --output text)"
           echo "Adding ${SITE_URL} to HTTP API CORS and Cognito SPA callbacks"
           # --exclusively: Api depends on RiffSyncTurn; without this CDK would redeploy media (TURN+SFU).
-          npx cdk deploy RiffSyncFanAuth-prod RiffSyncApi-prod --exclusively \
+          npx cdk deploy RiffSyncFanAuth-prod RiffSyncStaffAuth-prod RiffSyncApi-prod --exclusively \
             "${CDK_CTX[@]}" \
             --context "fanAuthOAuthExtras=${SITE_URL}/,${SITE_URL}/auth/callback" \
+            --context "staffAuthOAuthExtras=${SITE_URL}/admin/auth/callback,${SITE_URL}/admin/login" \
             --context "catalogCorsOrigins=${SITE_URL}" \
             --require-approval never
 
@@ -172,6 +173,7 @@ jobs:
           STACK_NAME: RiffSyncStatic-prod
           API_STACK_NAME: RiffSyncApi-prod
           FAN_AUTH_STACK_NAME: RiffSyncFanAuth-prod
+          STAFF_AUTH_STACK_NAME: RiffSyncStaffAuth-prod
         run: |
           set -euo pipefail
           SITE_URL="$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
@@ -185,6 +187,11 @@ jobs:
           COGNITO_DOMAIN="${COGNITO_BASE#https://}"
           COGNITO_CLIENT="$(aws cloudformation describe-stacks --stack-name "$FAN_AUTH_STACK_NAME" \
             --query "Stacks[0].Outputs[?OutputKey=='FanUserPoolClientId'].OutputValue" --output text)"
+          STAFF_COGNITO_BASE="$(aws cloudformation describe-stacks --stack-name "$STAFF_AUTH_STACK_NAME" \
+            --query "Stacks[0].Outputs[?OutputKey=='StaffHostedUiBaseUrl'].OutputValue" --output text)"
+          STAFF_COGNITO_DOMAIN="${STAFF_COGNITO_BASE#https://}"
+          STAFF_COGNITO_CLIENT="$(aws cloudformation describe-stacks --stack-name "$STAFF_AUTH_STACK_NAME" \
+            --query "Stacks[0].Outputs[?OutputKey=='StaffUserPoolClientId'].OutputValue" --output text)"
           echo "Production public site URL: ${SITE_URL}"
           echo "Production HTTP API base: ${API_BASE}"
           cd "${GITHUB_WORKSPACE}/apps/web"
@@ -198,6 +205,8 @@ jobs:
             VITE_PUBLIC_WS_URL="${WS_URL}" \
             VITE_COGNITO_HOSTED_UI_DOMAIN="${COGNITO_DOMAIN}" \
             VITE_COGNITO_CLIENT_ID="${COGNITO_CLIENT}" \
+            VITE_STAFF_COGNITO_HOSTED_UI_DOMAIN="${STAFF_COGNITO_DOMAIN}" \
+            VITE_STAFF_COGNITO_CLIENT_ID="${STAFF_COGNITO_CLIENT}" \
             npm run build
           BUCKET="$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
             --query "Stacks[0].Outputs[?OutputKey=='BucketName'].OutputValue" --output text)"

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -191,7 +191,7 @@ One account, **one CloudFormation stack** **`RiffSyncTurn`** ([`lib/media-server
 
 **Ordering in [`bin/riffsync.ts`](bin/riffsync.ts):** **`RiffSyncApi-prod`** **depends on** **`RiffSyncTurn`** (turn secret + deploy ordering).
 
-**Deploy:** **[`deploy-prod.yml`](../../.github/workflows/deploy-prod.yml)** runs **media** (`RiffSyncTurn`) and **platform** in **parallel**, then **API** (`--exclusively`). **OAuth/CORS** also uses **`--exclusively`** so CDK does not redeploy **`RiffSyncTurn`** while updating Cognito + API. For **media-only** changes, **[`deploy-turn.yml`](../../.github/workflows/deploy-turn.yml)** runs **`cdk deploy RiffSyncTurn`** (updates **both** EC2 roles; there is no separate SFU stack).
+**Deploy:** **[`deploy-prod.yml`](../../.github/workflows/deploy-prod.yml)** runs **media** (`RiffSyncTurn`) and **platform** (**`RiffSyncFanAuth-prod`**, **`RiffSyncStaffAuth-prod`**, static, SES) in **parallel**, then **API** (`--exclusively`). **OAuth/CORS** deploys fan + staff Cognito and API with **`fanAuthOAuthExtras`**, **`staffAuthOAuthExtras`**, and **`catalogCorsOrigins`** from **`FanWebSiteUrl`**; it uses **`--exclusively`** so CDK does not redeploy **`RiffSyncTurn`**. The **fan-spa** job bakes **`VITE_STAFF_*`** from **`RiffSyncStaffAuth-prod`** outputs (see **`.ai/operations/build_packaging.md`**). For **media-only** changes, **[`deploy-turn.yml`](../../.github/workflows/deploy-turn.yml)** runs **`cdk deploy RiffSyncTurn`** (updates **both** EC2 roles; there is no separate SFU stack).
 
 **Migrating from the old `RiffSyncSfu` stack:** CDK no longer defines that stack. If it still exists in AWS: after **`cdk deploy RiffSyncTurn`** succeeds and the **new** SFU in **`RiffSyncTurn`** is healthy (and **`wss://`** / DNS if used), delete the old stack (**`aws cloudformation delete-stack --stack-name RiffSyncSfu`**). If **`UPDATE`/`CREATE` fails** on the signaling **`A`** record because the name is still owned by **`RiffSyncSfu`**, delete **`RiffSyncSfu`** first (expect brief SFU gap), then deploy **`RiffSyncTurn`**.
 
@@ -302,7 +302,7 @@ Hosted stack **`RiffSyncStaffAuth-prod`** provisions an **invite-only** operator
 
 **Deploy IAM:** extend the OIDC deploy role with **Cognito** permissions for **`RiffSyncStaffAuth-prod`** if **`cdk deploy`** fails on **`cognito-idp:*`**.
 
-**Out of scope here:** **`ApiCatalogStack`** staff JWT authorizer ([#64](https://github.com/StacksOnTheRacks/riffsync/issues/64)), SPA staff auth modules ([#65](https://github.com/StacksOnTheRacks/riffsync/issues/65)), **`deploy-prod.yml`** ([#66](https://github.com/StacksOnTheRacks/riffsync/issues/66)).
+**Pipeline wiring:** **`deploy-prod.yml`** deploys this stack in the **platform** wave and refreshes **`staffAuthOAuthExtras`** in the **OAuth/CORS** job; SPA publish reads **`StaffHostedUiBaseUrl`** and **`StaffUserPoolClientId`** into **`VITE_STAFF_*`** (see **Deploy** and **Fan SPA publish** below).
 
 ### SES inbound → SNS (receive mail — shared)
 
@@ -402,6 +402,8 @@ After **`cdk deploy`**, **`deploy-prod.yml`** reads **CloudFormation outputs** f
 | **`DistributionDomainName`** | **CloudFront** hostname; **`FanWebSiteUrl`** is preferred when a custom domain is configured. |
 | **`HttpApiUrl`** ( **`RiffSyncApi-prod`** ) | **`VITE_PUBLIC_API_BASE_URL`** — catalog + rooms REST |
 | **`WebSocketUrl`** ( **`RiffSyncApi-prod`** ) | Build-time **`VITE_PUBLIC_WS_URL`** (**`wss://…`**) once SPA subscribes to realtime (**`contracts.websocket`**). |
+| **`StaffHostedUiBaseUrl`** ( **`RiffSyncStaffAuth-prod`** ) | **`VITE_STAFF_COGNITO_HOSTED_UI_DOMAIN`** — strip **`https://`** from output |
+| **`StaffUserPoolClientId`** ( **`RiffSyncStaffAuth-prod`** ) | **`VITE_STAFF_COGNITO_CLIENT_ID`** |
 
 **IAM for the GitHub OIDC deploy role** must allow, in addition to CDK/CloudFormation permissions:
 


### PR DESCRIPTION
## Summary

- Deploy **`RiffSyncStaffAuth-prod`** in the **`cdk-platform`** wave alongside fan auth, static, and SES.
- Refresh fan + staff Cognito OAuth callbacks and API CORS from **`FanWebSiteUrl`** in **`cdk-oauth-cors`** (`staffAuthOAuthExtras` for `/admin/*`).
- Read staff CloudFormation outputs into **`VITE_STAFF_COGNITO_*`** during SPA publish (single S3 sync + invalidation).
- Align **`.ai/operations/deployment_environments.md`**, **`build_packaging.md`**, and **`infra/cdk/README.md`** with the workflow.

Closes #66

## Test plan

- [x] `npm run verify:push` (CDK tests + synth, web tests, SFU build)
- [ ] CI green on this PR (`infra-cdk`, `web-app`)
- [ ] Post-merge: manual **Deploy CDK (production)** smoke per issue #66 (staff stack outputs, Cognito callbacks, `/admin/login`)