### PR TITLE
[M12] Admin shell and routing (#77)

### DIFF
--- a/apps/web/src/AppRoutes.admin.test.tsx
+++ b/apps/web/src/AppRoutes.admin.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AppRoutes } from './AppRoutes'
+
+vi.mock('./auth/StaffSessionKeepAlive', () => ({
+  StaffSessionKeepAlive: () => null,
+}))
+
+vi.mock('./auth/staffHostedUiPkce', () => ({
+  refreshStaffTokensIfStale: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('./auth/staffTokens', () => ({
+  getStaffAccessToken: () => 'staff-token',
+  clearStaffTokens: vi.fn(),
+}))
+
+vi.mock('./api/staffAdminSessionApi', () => ({
+  fetchStaffSession: vi.fn().mockResolvedValue({
+    sub: 'staff-1',
+    email: 'op@example.com',
+    groups: ['admin'],
+  }),
+  StaffSessionUnauthorizedError: class StaffSessionUnauthorizedError extends Error {},
+  StaffSessionForbiddenError: class StaffSessionForbiddenError extends Error {},
+}))
+
+describe('AppRoutes admin tree', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+  })
+
+  it('renders catalog placeholder inside admin shell without fan header', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root!.render(
+        <MemoryRouter initialEntries={['/admin/catalog']}>
+          <AppRoutes />
+        </MemoryRouter>,
+      )
+    })
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Catalog list UI ships')
+    })
+
+    expect(container.querySelector('.riffsync-admin-shell')).not.toBeNull()
+    expect(container.querySelector('#gen-header')).toBeNull()
+    expect(container.querySelector('#gen-footer')).toBeNull()
+  })
+})

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -12,7 +12,10 @@ import { DataRemovalRequestPage } from './pages/DataRemovalRequestPage'
 import { HowToHostWatchPartyPage } from './pages/HowToHostWatchPartyPage'
 import { StaffAuthCallbackPage } from './pages/admin/StaffAuthCallbackPage'
 import { AdminLoginPage } from './pages/admin/AdminLoginPage'
-import { AdminHomePage, StaffAdminGate } from './pages/admin/AdminHomePage'
+import { AdminCatalogRoutePlaceholder } from './pages/admin/AdminCatalogRoutePlaceholder'
+import { AdminHomePage } from './pages/admin/AdminHomePage'
+import { StaffAdminGate } from './pages/admin/StaffAdminGate'
+import { AdminLayout } from './layouts/AdminLayout'
 
 export function AppRoutes() {
   return (
@@ -21,8 +24,12 @@ export function AppRoutes() {
       <Route path="/admin/auth/callback" element={<StaffAuthCallbackPage />} />
       <Route path="/admin/login" element={<AdminLoginPage />} />
       <Route path="/admin" element={<StaffAdminGate />}>
-        <Route index element={<AdminHomePage />} />
-        <Route path="*" element={<Navigate to="/admin" replace />} />
+        <Route element={<AdminLayout />}>
+          <Route index element={<AdminHomePage />} />
+          <Route path="catalog/new" element={<AdminCatalogRoutePlaceholder variant="new" />} />
+          <Route path="catalog/:id/edit" element={<AdminCatalogRoutePlaceholder variant="edit" />} />
+          <Route path="catalog" element={<AdminCatalogRoutePlaceholder variant="list" />} />
+        </Route>
       </Route>
       <Route element={<SiteLayout />}>
         <Route path="/" element={<HomePage />} />

--- a/apps/web/src/admin/AdminSessionContext.tsx
+++ b/apps/web/src/admin/AdminSessionContext.tsx
@@ -1,0 +1,97 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useNavigate } from 'react-router-dom'
+import { refreshStaffTokensIfStale } from '../auth/staffHostedUiPkce'
+import { getStaffAccessToken } from '../auth/staffTokens'
+import {
+  fetchStaffSession,
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+  type StaffSessionPayload,
+} from '../api/staffAdminSessionApi'
+
+export interface AdminSessionState {
+  session: StaffSessionPayload | null
+  loading: boolean
+  error: string | null
+  reload: () => void
+}
+
+const AdminSessionContext = createContext<AdminSessionState | null>(null)
+
+export function AdminSessionProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate()
+  const [session, setSession] = useState<StaffSessionPayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [reloadToken, setReloadToken] = useState(0)
+
+  const reload = useCallback(() => {
+    setReloadToken((n) => n + 1)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        await refreshStaffTokensIfStale()
+        const token = getStaffAccessToken()
+        if (!token) {
+          if (!cancelled) navigate('/admin/login', { replace: true })
+          return
+        }
+        const payload = await fetchStaffSession(token)
+        if (!cancelled) setSession(payload)
+      } catch (e: unknown) {
+        if (cancelled) return
+        setSession(null)
+        if (e instanceof StaffSessionUnauthorizedError || e instanceof StaffSessionForbiddenError) {
+          setError(e.message)
+        } else {
+          setError(e instanceof Error ? e.message : 'Could not load operator session')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [navigate, reloadToken])
+
+  const value = useMemo(
+    () => ({ session, loading, error, reload }),
+    [session, loading, error, reload],
+  )
+
+  return <AdminSessionContext.Provider value={value}>{children}</AdminSessionContext.Provider>
+}
+
+export function useAdminSession(): AdminSessionState {
+  const ctx = useContext(AdminSessionContext)
+  if (!ctx) {
+    throw new Error('useAdminSession must be used within AdminSessionProvider')
+  }
+  return ctx
+}
+
+/** Visible label for Cognito groups in the session strip (abbreviated when long). */
+export function abbreviateStaffGroups(groups: string[]): string {
+  if (groups.length === 0) return '(none)'
+  if (groups.length <= 2) return groups.join(', ')
+  const shown = groups.slice(0, 2).join(', ')
+  const rest = groups.length - 2
+  return `${shown} (+${rest})`
+}

--- a/apps/web/src/admin/AdminSessionProvider.tsx
+++ b/apps/web/src/admin/AdminSessionProvider.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { refreshStaffTokensIfStale } from '../auth/staffHostedUiPkce'
 import { getStaffAccessToken } from '../auth/staffTokens'
@@ -16,15 +8,7 @@ import {
   StaffSessionUnauthorizedError,
   type StaffSessionPayload,
 } from '../api/staffAdminSessionApi'
-
-export interface AdminSessionState {
-  session: StaffSessionPayload | null
-  loading: boolean
-  error: string | null
-  reload: () => void
-}
-
-const AdminSessionContext = createContext<AdminSessionState | null>(null)
+import { AdminSessionContext } from './adminSessionState'
 
 export function AdminSessionProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
@@ -77,21 +61,4 @@ export function AdminSessionProvider({ children }: { children: ReactNode }) {
   )
 
   return <AdminSessionContext.Provider value={value}>{children}</AdminSessionContext.Provider>
-}
-
-export function useAdminSession(): AdminSessionState {
-  const ctx = useContext(AdminSessionContext)
-  if (!ctx) {
-    throw new Error('useAdminSession must be used within AdminSessionProvider')
-  }
-  return ctx
-}
-
-/** Visible label for Cognito groups in the session strip (abbreviated when long). */
-export function abbreviateStaffGroups(groups: string[]): string {
-  if (groups.length === 0) return '(none)'
-  if (groups.length <= 2) return groups.join(', ')
-  const shown = groups.slice(0, 2).join(', ')
-  const rest = groups.length - 2
-  return `${shown} (+${rest})`
 }

--- a/apps/web/src/admin/abbreviateStaffGroups.test.ts
+++ b/apps/web/src/admin/abbreviateStaffGroups.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { abbreviateStaffGroups } from './AdminSessionContext'
+import { abbreviateStaffGroups } from './abbreviateStaffGroups'
 
 describe('abbreviateStaffGroups', () => {
   it('returns (none) for empty groups', () => {

--- a/apps/web/src/admin/abbreviateStaffGroups.test.ts
+++ b/apps/web/src/admin/abbreviateStaffGroups.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { abbreviateStaffGroups } from './AdminSessionContext'
+
+describe('abbreviateStaffGroups', () => {
+  it('returns (none) for empty groups', () => {
+    expect(abbreviateStaffGroups([])).toBe('(none)')
+  })
+
+  it('joins up to two groups without abbreviation', () => {
+    expect(abbreviateStaffGroups(['admin'])).toBe('admin')
+    expect(abbreviateStaffGroups(['admin', 'curator'])).toBe('admin, curator')
+  })
+
+  it('abbreviates when more than two groups', () => {
+    expect(abbreviateStaffGroups(['admin', 'curator', 'editor'])).toBe('admin, curator (+1)')
+  })
+})

--- a/apps/web/src/admin/abbreviateStaffGroups.ts
+++ b/apps/web/src/admin/abbreviateStaffGroups.ts
@@ -1,0 +1,8 @@
+/** Visible label for Cognito groups in the session strip (abbreviated when long). */
+export function abbreviateStaffGroups(groups: string[]): string {
+  if (groups.length === 0) return '(none)'
+  if (groups.length <= 2) return groups.join(', ')
+  const shown = groups.slice(0, 2).join(', ')
+  const rest = groups.length - 2
+  return `${shown} (+${rest})`
+}

--- a/apps/web/src/admin/adminSessionState.ts
+++ b/apps/web/src/admin/adminSessionState.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+import type { StaffSessionPayload } from '../api/staffAdminSessionApi'
+
+export interface AdminSessionState {
+  session: StaffSessionPayload | null
+  loading: boolean
+  error: string | null
+  reload: () => void
+}
+
+export const AdminSessionContext = createContext<AdminSessionState | null>(null)

--- a/apps/web/src/admin/useAdminSession.ts
+++ b/apps/web/src/admin/useAdminSession.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AdminSessionContext, type AdminSessionState } from './adminSessionState'
+
+export function useAdminSession(): AdminSessionState {
+  const ctx = useContext(AdminSessionContext)
+  if (!ctx) {
+    throw new Error('useAdminSession must be used within AdminSessionProvider')
+  }
+  return ctx
+}

--- a/apps/web/src/layouts/AdminLayout.test.tsx
+++ b/apps/web/src/layouts/AdminLayout.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminSessionState } from '../admin/AdminSessionContext'
+import { AdminLayout } from './AdminLayout'
+
+const clearStaffTokens = vi.fn()
+const navigate = vi.fn()
+const useAdminSession = vi.fn()
+
+vi.mock('../auth/staffTokens', () => ({
+  clearStaffTokens: () => clearStaffTokens(),
+}))
+
+vi.mock('../admin/AdminSessionContext', () => ({
+  useAdminSession: () => useAdminSession(),
+  abbreviateStaffGroups: (groups: string[]) =>
+    groups.length === 0 ? '(none)' : groups.length <= 2 ? groups.join(', ') : `${groups.slice(0, 2).join(', ')} (+${groups.length - 2})`,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  }
+})
+
+function mockSessionState(overrides: Partial<AdminSessionState> = {}): AdminSessionState {
+  return {
+    session: {
+      sub: 'staff-sub',
+      email: 'op@example.com',
+      groups: ['admin', 'curator'],
+    },
+    loading: false,
+    error: null,
+    reload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderAdminLayout(path = '/admin'): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  useAdminSession.mockReturnValue(mockSessionState())
+  act(() => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/admin" element={<AdminLayout />}>
+            <Route index element={<p>Child</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+  })
+  return { container, root }
+}
+
+describe('AdminLayout', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    clearStaffTokens.mockClear()
+    navigate.mockClear()
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+    container = null
+  })
+
+  it('renders operator nav links and session strip', () => {
+    const rendered = renderAdminLayout('/admin')
+    root = rendered.root
+    container = rendered.container
+
+    const home = container.querySelector('a[href="/admin"]')
+    const catalog = container.querySelector('a[href="/admin/catalog"]')
+    expect(home?.textContent).toBe('Home')
+    expect(catalog?.textContent).toBe('Catalog')
+    expect(container.textContent).toContain('op@example.com')
+    expect(container.textContent).toContain('admin, curator')
+    expect(container.querySelector('#gen-header')).toBeNull()
+    expect(container.querySelector('#gen-footer')).toBeNull()
+  })
+
+  it('Sign out clears staff tokens and navigates to login', () => {
+    const rendered = renderAdminLayout('/admin')
+    root = rendered.root
+    container = rendered.container
+
+    const signOut = container.querySelector('.riffsync-admin-sign-out') as HTMLButtonElement
+    act(() => {
+      signOut.click()
+    })
+
+    expect(clearStaffTokens).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('/admin/login', { replace: true })
+  })
+})

--- a/apps/web/src/layouts/AdminLayout.test.tsx
+++ b/apps/web/src/layouts/AdminLayout.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AdminSessionState } from '../admin/AdminSessionContext'
+import type { AdminSessionState } from '../admin/adminSessionState'
 import { AdminLayout } from './AdminLayout'
 
 const clearStaffTokens = vi.fn()
@@ -14,10 +14,8 @@ vi.mock('../auth/staffTokens', () => ({
   clearStaffTokens: () => clearStaffTokens(),
 }))
 
-vi.mock('../admin/AdminSessionContext', () => ({
+vi.mock('../admin/useAdminSession', () => ({
   useAdminSession: () => useAdminSession(),
-  abbreviateStaffGroups: (groups: string[]) =>
-    groups.length === 0 ? '(none)' : groups.length <= 2 ? groups.join(', ') : `${groups.slice(0, 2).join(', ')} (+${groups.length - 2})`,
 }))
 
 vi.mock('react-router-dom', async (importOriginal) => {

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
-import { abbreviateStaffGroups, useAdminSession } from '../admin/AdminSessionContext'
+import { abbreviateStaffGroups } from '../admin/abbreviateStaffGroups'
+import { useAdminSession } from '../admin/useAdminSession'
 import { clearStaffTokens } from '../auth/staffTokens'
 
 function adminNavClassName({ isActive }: { isActive: boolean }): string {

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -1,0 +1,65 @@
+import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { abbreviateStaffGroups, useAdminSession } from '../admin/AdminSessionContext'
+import { clearStaffTokens } from '../auth/staffTokens'
+
+function adminNavClassName({ isActive }: { isActive: boolean }): string {
+  return `riffsync-admin-nav-link${isActive ? ' riffsync-admin-nav-link--active' : ''}`
+}
+
+export function AdminLayout() {
+  const navigate = useNavigate()
+  const { session, loading, error } = useAdminSession()
+
+  const onSignOut = () => {
+    clearStaffTokens()
+    navigate('/admin/login', { replace: true })
+  }
+
+  const identityLabel = session ? (session.email ?? session.sub) : null
+  const groupsLabel = session ? abbreviateStaffGroups(session.groups) : null
+
+  return (
+    <div className="riffsync-admin-shell">
+      <header className="riffsync-admin-header">
+        <div className="riffsync-admin-header__brand">
+          <span className="riffsync-admin-wordmark">RiffSync Admin</span>
+        </div>
+        <nav className="riffsync-admin-nav" aria-label="Operator">
+          <NavLink to="/admin" end className={adminNavClassName}>
+            Home
+          </NavLink>
+          <NavLink to="/admin/catalog" className={adminNavClassName}>
+            Catalog
+          </NavLink>
+        </nav>
+        <div className="riffsync-admin-session-strip" aria-live="polite">
+          {loading ? (
+            <span className="riffsync-admin-session-strip__meta">Loading session…</span>
+          ) : error ? (
+            <div role="alert" className="riffsync-admin-session-strip__alert">
+              <p>{error}</p>
+              <p>
+                <a href="/admin/login">Try operator sign-in again</a>
+              </p>
+            </div>
+          ) : session ? (
+            <>
+              <span className="riffsync-admin-session-strip__identity" title={session.sub}>
+                {identityLabel}
+              </span>
+              <span className="riffsync-admin-session-strip__groups" title={session.groups.join(', ')}>
+                {groupsLabel}
+              </span>
+              <button type="button" className="btn btn-secondary riffsync-admin-sign-out" onClick={onSignOut}>
+                Sign out
+              </button>
+            </>
+          ) : null}
+        </div>
+      </header>
+      <main className="riffsync-admin-main" id="riffsync-admin-main">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/AdminCatalogRoutePlaceholder.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogRoutePlaceholder.tsx
@@ -1,0 +1,67 @@
+import { Link, useParams } from 'react-router-dom'
+
+export type AdminCatalogPlaceholderVariant = 'list' | 'new' | 'edit'
+
+export function AdminCatalogRoutePlaceholder({
+  variant = 'list',
+}: {
+  variant?: AdminCatalogPlaceholderVariant
+}) {
+  const { id } = useParams<{ id: string }>()
+
+  const showBreadcrumb = variant === 'new' || variant === 'edit'
+  const crumbLeaf = variant === 'new' ? 'New episode' : 'Edit'
+
+  return (
+    <div className="container riffsync-admin-page">
+      {showBreadcrumb ? (
+        <nav className="riffsync-admin-breadcrumb" aria-label="Breadcrumb">
+          <ol>
+            <li>
+              <Link to="/admin">Admin</Link>
+            </li>
+            <li>
+              <Link to="/admin/catalog">Catalog</Link>
+            </li>
+            <li aria-current="page">{crumbLeaf}</li>
+          </ol>
+        </nav>
+      ) : null}
+
+      {variant === 'list' ? (
+        <>
+          <h1>Catalog</h1>
+          <p className="riffsync-admin-placeholder-note">
+            Catalog list UI ships in{' '}
+            <a href="https://github.com/StacksOnTheRacks/riffsync/issues/80">issue #80</a>.
+          </p>
+        </>
+      ) : null}
+
+      {variant === 'new' ? (
+        <>
+          <h1>New episode</h1>
+          <p className="riffsync-admin-placeholder-note">
+            Create/edit form UI ships in{' '}
+            <a href="https://github.com/StacksOnTheRacks/riffsync/issues/81">issue #81</a>.
+          </p>
+        </>
+      ) : null}
+
+      {variant === 'edit' ? (
+        <>
+          <h1>Edit episode</h1>
+          {id ? (
+            <p className="riffsync-admin-placeholder-id">
+              Episode id: <code>{id}</code>
+            </p>
+          ) : null}
+          <p className="riffsync-admin-placeholder-note">
+            Create/edit form UI ships in{' '}
+            <a href="https://github.com/StacksOnTheRacks/riffsync/issues/81">issue #81</a>.
+          </p>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/AdminHomePage.tsx
+++ b/apps/web/src/pages/admin/AdminHomePage.tsx
@@ -1,120 +1,42 @@
-import { useEffect, useState } from 'react'
-import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom'
-import { StaffSessionKeepAlive } from '../../auth/StaffSessionKeepAlive'
-import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
-import { clearStaffTokens, getStaffAccessToken } from '../../auth/staffTokens'
-import {
-  fetchStaffSession,
-  StaffSessionForbiddenError,
-  StaffSessionUnauthorizedError,
-  type StaffSessionPayload,
-} from '../../api/staffAdminSessionApi'
-
-export function StaffAdminGate() {
-  const location = useLocation()
-  const token = getStaffAccessToken()
-
-  if (!token) {
-    const returnTo = `${location.pathname}${location.search}`
-    return (
-      <Navigate
-        to={`/admin/login?returnTo=${encodeURIComponent(returnTo)}`}
-        replace
-        state={{ from: location }}
-      />
-    )
-  }
-
-  return (
-    <>
-      <StaffSessionKeepAlive />
-      <Outlet />
-    </>
-  )
-}
+import { Link } from 'react-router-dom'
+import { useAdminSession } from '../../admin/AdminSessionContext'
 
 export function AdminHomePage() {
-  const navigate = useNavigate()
-  const [session, setSession] = useState<StaffSessionPayload | null>(null)
-  const [err, setErr] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    let cancelled = false
-
-    const load = async () => {
-      setLoading(true)
-      setErr(null)
-      try {
-        await refreshStaffTokensIfStale()
-        const token = getStaffAccessToken()
-        if (!token) {
-          if (!cancelled) navigate('/admin/login', { replace: true })
-          return
-        }
-        const payload = await fetchStaffSession(token)
-        if (!cancelled) setSession(payload)
-      } catch (e: unknown) {
-        if (cancelled) return
-        if (e instanceof StaffSessionUnauthorizedError || e instanceof StaffSessionForbiddenError) {
-          setErr(e.message)
-        } else {
-          setErr(e instanceof Error ? e.message : 'Could not load operator session')
-        }
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-
-    void load()
-    return () => {
-      cancelled = true
-    }
-  }, [navigate])
-
-  const onSignOut = () => {
-    clearStaffTokens()
-    navigate('/admin/login', { replace: true })
-  }
+  const { loading, error, reload } = useAdminSession()
 
   if (loading) {
     return (
-      <div className="container">
+      <div className="container riffsync-admin-page">
         <p>Loading operator session…</p>
       </div>
     )
   }
 
   return (
-    <div className="container">
-      <h1>Admin</h1>
-      {err ? (
+    <div className="container riffsync-admin-page">
+      <h1>Admin home</h1>
+      {error ? (
         <div role="alert" className="riffsync-scaffold-note">
-          <p>{err}</p>
+          <p>{error}</p>
           <p>
             <a href="/admin/login">Try operator sign-in again</a>
           </p>
+          <p>
+            <button type="button" className="btn btn-secondary" onClick={() => reload()}>
+              Retry session
+            </button>
+          </p>
         </div>
-      ) : session ? (
+      ) : (
         <>
-          <p>Signed in as operator.</p>
-          <dl className="riffsync-admin-session">
-            <dt>Email</dt>
-            <dd>{session.email ?? session.sub}</dd>
-            <dt>Subject</dt>
-            <dd>
-              <code>{session.sub}</code>
-            </dd>
-            <dt>Groups</dt>
-            <dd>{session.groups.length > 0 ? session.groups.join(', ') : '(none)'}</dd>
-          </dl>
+          <p>Operator tools for catalog and curation. Use Catalog to manage episodes when list UI ships.</p>
+          <p>
+            <Link to="/admin/catalog" className="btn btn-primary">
+              Open catalog
+            </Link>
+          </p>
         </>
-      ) : null}
-      <p>
-        <button type="button" className="btn btn-secondary" onClick={onSignOut}>
-          Sign out
-        </button>
-      </p>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/admin/AdminHomePage.tsx
+++ b/apps/web/src/pages/admin/AdminHomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { useAdminSession } from '../../admin/AdminSessionContext'
+import { useAdminSession } from '../../admin/useAdminSession'
 
 export function AdminHomePage() {
   const { loading, error, reload } = useAdminSession()

--- a/apps/web/src/pages/admin/StaffAdminGate.tsx
+++ b/apps/web/src/pages/admin/StaffAdminGate.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
-import { AdminSessionProvider } from '../../admin/AdminSessionContext'
+import { AdminSessionProvider } from '../../admin/AdminSessionProvider'
 import { StaffSessionKeepAlive } from '../../auth/StaffSessionKeepAlive'
 import { getStaffAccessToken } from '../../auth/staffTokens'
 

--- a/apps/web/src/pages/admin/StaffAdminGate.tsx
+++ b/apps/web/src/pages/admin/StaffAdminGate.tsx
@@ -1,0 +1,29 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { AdminSessionProvider } from '../../admin/AdminSessionContext'
+import { StaffSessionKeepAlive } from '../../auth/StaffSessionKeepAlive'
+import { getStaffAccessToken } from '../../auth/staffTokens'
+
+export function StaffAdminGate() {
+  const location = useLocation()
+  const token = getStaffAccessToken()
+
+  if (!token) {
+    const returnTo = `${location.pathname}${location.search}`
+    return (
+      <Navigate
+        to={`/admin/login?returnTo=${encodeURIComponent(returnTo)}`}
+        replace
+        state={{ from: location }}
+      />
+    )
+  }
+
+  return (
+    <>
+      <StaffSessionKeepAlive />
+      <AdminSessionProvider>
+        <Outlet />
+      </AdminSessionProvider>
+    </>
+  )
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2003,3 +2003,162 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
     animation: none;
   }
 }
+
+/* Operator admin shell (no fan SiteHeader / SiteFooter) */
+.riffsync-admin-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--dark-color);
+  color: var(--white-color);
+}
+
+.riffsync-admin-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.25rem;
+  padding: 1rem 1.25rem;
+  background: var(--black-color);
+  border-bottom: 1px solid rgb(255 255 255 / 0.12);
+}
+
+.riffsync-admin-wordmark {
+  font-family: var(--title-fonts);
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--white-color);
+}
+
+.riffsync-admin-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.riffsync-admin-nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.35rem 0.85rem;
+  border-radius: 6px;
+  font-family: var(--title-fonts);
+  font-weight: 600;
+  color: var(--secondary-color);
+  text-decoration: none;
+}
+
+.riffsync-admin-nav-link:hover,
+.riffsync-admin-nav-link:focus {
+  color: var(--white-color);
+  background: rgb(255 255 255 / 0.08);
+  text-decoration: none;
+}
+
+.riffsync-admin-nav-link--active {
+  color: var(--white-color);
+  background: rgb(229 9 22 / 0.2);
+}
+
+.riffsync-admin-session-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  margin-left: auto;
+  font-size: 0.875rem;
+}
+
+.riffsync-admin-session-strip__identity {
+  font-weight: 600;
+  color: var(--white-color);
+}
+
+.riffsync-admin-session-strip__groups {
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-session-strip__alert {
+  margin: 0;
+}
+
+.riffsync-admin-session-strip__alert p {
+  margin: 0 0 0.25rem;
+}
+
+.riffsync-admin-sign-out {
+  min-height: 44px;
+}
+
+.riffsync-admin-main {
+  flex: 1;
+  padding: 2rem 0 3rem;
+}
+
+.riffsync-admin-page h1 {
+  font-family: var(--title-fonts);
+  font-size: 1.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.riffsync-admin-breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-breadcrumb a {
+  color: var(--secondary-color);
+  text-decoration: none;
+}
+
+.riffsync-admin-breadcrumb a:hover,
+.riffsync-admin-breadcrumb a:focus {
+  color: var(--primary-color);
+}
+
+.riffsync-admin-breadcrumb li:not(:last-child)::after {
+  content: '/';
+  margin-left: 0.5rem;
+  color: rgb(255 255 255 / 0.35);
+}
+
+.riffsync-admin-breadcrumb li[aria-current='page'] {
+  color: var(--white-color);
+}
+
+.riffsync-admin-placeholder-note {
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-placeholder-id code {
+  font-size: 0.875rem;
+}
+
+@media (max-width: 767px) {
+  .riffsync-admin-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .riffsync-admin-nav {
+    order: 2;
+    width: 100%;
+  }
+
+  .riffsync-admin-session-strip {
+    order: 3;
+    margin-left: 0;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the operator admin shell for **#77**: `AdminLayout` with themed chrome (no fan `SiteLayout`), shared `AdminSessionProvider` under `StaffAdminGate`, operator nav (Home / Catalog), session strip with sign-out, and catalog route placeholders for #80 / #81.

## Changes

- `AdminLayout` + `riffsync-admin-*` styles (dark palette, mobile stacking at 767px)
- `AdminSessionProvider` loads `GET /v1/admin/session` once per admin visit
- Routes: `/admin`, `/admin/catalog`, `/admin/catalog/new`, `/admin/catalog/:id/edit`
- Removed admin catch-all redirect that swallowed catalog paths
- Vitest: layout nav/sign-out, route harness without fan header

## Test plan

- [x] `npm run verify:push:web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual: sign in at `/admin/login`, confirm admin shell, nav, placeholders, sign-out
- [ ] Manual: unauthenticated `/admin/catalog` redirects with `returnTo`
- [ ] After deploy: deep link `/admin/catalog/new` loads SPA

Closes #77