### PR TITLE
[M12] Staff catalog read API (#78)

### DIFF
--- a/apps/web/src/api/staffAdminCatalogApi.test.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchStaffCatalogEpisode,
+  fetchStaffCatalogList,
+} from './staffAdminCatalogApi'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from './staffAdminSessionApi'
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.example.test',
+}))
+
+describe('staffAdminCatalogApi', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetchStaffCatalogList hits list URL with bearer auth', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: 1, entries: [] }),
+    })
+
+    const result = await fetchStaffCatalogList('staff-token')
+
+    expect(result.version).toBe(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/admin/catalog')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer staff-token',
+      Accept: 'application/json',
+    })
+  })
+
+  it('fetchStaffCatalogEpisode encodes episode id in path', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ entry: { id: 'ep/special' } }),
+    })
+
+    await fetchStaffCatalogEpisode('staff-token', 'ep/special')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/admin/catalog/episodes/ep%2Fspecial')
+  })
+
+  it('maps 401 to StaffSessionUnauthorizedError', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => '',
+    })
+
+    await expect(fetchStaffCatalogList('bad')).rejects.toBeInstanceOf(StaffSessionUnauthorizedError)
+  })
+
+  it('maps 403 to StaffSessionForbiddenError', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Forbidden', code: 'staff_group_required' }),
+    })
+
+    await expect(fetchStaffCatalogEpisode('no-group', 'ep-1')).rejects.toBeInstanceOf(
+      StaffSessionForbiddenError,
+    )
+  })
+})

--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -1,0 +1,95 @@
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from './staffAdminSessionApi'
+
+export interface StaffCatalogEpisode {
+  id: string
+  experimentNumber: number
+  title: string
+  era: 'joel' | 'mike' | 'jonah' | 'emily' | 'other'
+  youtubeVideoId: string | null
+  youtubeWatchUrl: string | null
+  tagline: string | null
+  posterImageUrl: string | null
+  backdropImageUrl: string | null
+  tmdbMovieId: number | null
+  tmdbArtworkSyncedAt: string | null
+  carousel: boolean
+  tmdbOverview?: string | null
+  tmdbPopularity?: number | null
+  tmdbPosterPath?: string | null
+  tmdbBackdropPath?: string | null
+  movieSearchTitle: string | null
+  embedAllows: boolean | null
+  curatorNotes: string | null
+  tmdbNeedsReview?: boolean | null
+  youtubeThumbnailUrl: string | null
+}
+
+export interface StaffCatalogListResponse {
+  version: number
+  entries: StaffCatalogEpisode[]
+}
+
+export interface StaffCatalogEpisodeResponse {
+  entry: StaffCatalogEpisode
+}
+
+function staffCatalogAuthHeaders(accessToken: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+  }
+}
+
+async function mapStaffCatalogError(res: Response): Promise<never> {
+  if (res.status === 401) {
+    throw new StaffSessionUnauthorizedError()
+  }
+  if (res.status === 403) {
+    let detail = 'Staff group required — contact an administrator'
+    try {
+      const parsed = (await res.json()) as { code?: string; error?: string }
+      if (parsed.code === 'staff_group_required' || parsed.error === 'Forbidden') {
+        detail = 'Staff group required — contact an administrator'
+      }
+    } catch {
+      /* use default copy */
+    }
+    throw new StaffSessionForbiddenError(detail)
+  }
+  const t = await res.text()
+  throw new Error(`Staff catalog read failed (${res.status}): ${t}`)
+}
+
+export async function fetchStaffCatalogList(
+  accessToken: string,
+): Promise<StaffCatalogListResponse> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const res = await fetch(`${base}/v1/admin/catalog`, {
+    headers: staffCatalogAuthHeaders(accessToken),
+  })
+  if (!res.ok) {
+    await mapStaffCatalogError(res)
+  }
+  return (await res.json()) as StaffCatalogListResponse
+}
+
+export async function fetchStaffCatalogEpisode(
+  accessToken: string,
+  id: string,
+): Promise<StaffCatalogEpisodeResponse> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const encodedId = encodeURIComponent(id)
+  const res = await fetch(`${base}/v1/admin/catalog/episodes/${encodedId}`, {
+    headers: staffCatalogAuthHeaders(accessToken),
+  })
+  if (!res.ok) {
+    await mapStaffCatalogError(res)
+  }
+  return (await res.json()) as StaffCatalogEpisodeResponse
+}

--- a/infra/cdk/lambda/admin-catalog-get.ts
+++ b/infra/cdk/lambda/admin-catalog-get.ts
@@ -1,0 +1,39 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { projectAdminEpisode } from './admin-catalog-shared';
+import { requireStaffAccess } from './admin-staff-access';
+import { jsonResponse } from './giphy-search-shared';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const denied = await requireStaffAccess(event);
+  if (denied) {
+    return denied;
+  }
+
+  const tableName = process.env.CATALOG_TABLE_NAME;
+  if (!tableName) {
+    return jsonResponse(500, { error: 'Missing CATALOG_TABLE_NAME' });
+  }
+
+  const id = event.pathParameters?.id;
+  if (!id) {
+    return jsonResponse(400, { error: 'Missing path parameter id' });
+  }
+
+  const out = await client.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { id },
+    }),
+  );
+
+  if (!out.Item) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const entry = projectAdminEpisode(out.Item as Record<string, unknown>);
+  return jsonResponse(200, { entry });
+};

--- a/infra/cdk/lambda/admin-catalog-handlers.test.ts
+++ b/infra/cdk/lambda/admin-catalog-handlers.test.ts
@@ -1,0 +1,177 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  ScanCommand: vi.fn((input: unknown) => ({ input, kind: 'Scan' })),
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+}));
+
+import { handler as listHandler } from './admin-catalog-list';
+import { handler as getHandler } from './admin-catalog-get';
+
+function staffEvent(
+  routeKey: string,
+  path: string,
+  claims?: Record<string, unknown>,
+  pathParameters?: Record<string, string>,
+): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    pathParameters,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'GET',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req',
+      routeKey,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: claims ? { jwt: { claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+const catalogItem = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: 'abc123',
+  carousel: false,
+  movieSearchTitle: 'Manos',
+  embedAllows: false,
+  curatorNotes: 'notes',
+};
+
+describe('admin-catalog-list handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.STAFF_USER_POOL_ID;
+  });
+
+  it('returns sorted entries with curator hints', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Items: [catalogItem, { ...catalogItem, id: 'ep-2', experimentNumber: 50 }],
+    });
+
+    const res = await listHandler(
+      staffEvent('GET /v1/admin/catalog', '/v1/admin/catalog', {
+        sub: 'staff-1',
+        'cognito:groups': ['admin'],
+      }),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(200);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.version).toBe(1);
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].id).toBe('ep-2');
+    expect(body.entries[1].movieSearchTitle).toBe('Manos');
+    expect(body.entries[1].embedAllows).toBe(false);
+    expect(body.entries[1].curatorNotes).toBe('notes');
+  });
+
+  it('returns 403 when staff groups omit admin/curator', async () => {
+    const res = await listHandler(
+      staffEvent('GET /v1/admin/catalog', '/v1/admin/catalog', {
+        sub: 'staff-1',
+        'cognito:groups': ['viewer'],
+      }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(403);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Forbidden',
+      code: 'staff_group_required',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin-catalog-get handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.STAFF_USER_POOL_ID;
+  });
+
+  it('returns entry for known id', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: catalogItem });
+
+    const res = await getHandler(
+      staffEvent(
+        'GET /v1/admin/catalog/episodes/{id}',
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['curator'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(200);
+    expect(JSON.parse(res?.body ?? '').entry.id).toBe('ep-1');
+  });
+
+  it('returns 404 for unknown id', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+
+    const res = await getHandler(
+      staffEvent(
+        'GET /v1/admin/catalog/episodes/{id}',
+        '/v1/admin/catalog/episodes/missing',
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'missing' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(404);
+    expect(JSON.parse(res?.body ?? '')).toEqual({ error: 'Not found' });
+  });
+
+  it('returns 403 when staff groups omit admin/curator', async () => {
+    const res = await getHandler(
+      staffEvent(
+        'GET /v1/admin/catalog/episodes/{id}',
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['viewer'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(403);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/admin-catalog-list.ts
+++ b/infra/cdk/lambda/admin-catalog-list.ts
@@ -1,0 +1,42 @@
+import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { projectAdminEpisode, sortEpisodes } from './admin-catalog-shared';
+import { requireStaffAccess } from './admin-staff-access';
+import { jsonResponse } from './giphy-search-shared';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const denied = await requireStaffAccess(event);
+  if (denied) {
+    return denied;
+  }
+
+  const tableName = process.env.CATALOG_TABLE_NAME;
+  if (!tableName) {
+    return jsonResponse(500, { error: 'Missing CATALOG_TABLE_NAME' });
+  }
+
+  const entries: ReturnType<typeof projectAdminEpisode>[] = [];
+  let startKey: Record<string, unknown> | undefined;
+
+  do {
+    const out = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ...(startKey ? { ExclusiveStartKey: startKey } : {}),
+      }),
+    );
+    for (const raw of out.Items ?? []) {
+      entries.push(projectAdminEpisode(raw as Record<string, unknown>));
+    }
+    startKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (startKey);
+
+  const sorted = sortEpisodes(entries);
+  return jsonResponse(200, {
+    version: 1,
+    entries: sorted,
+  });
+};

--- a/infra/cdk/lambda/admin-catalog-shared.test.ts
+++ b/infra/cdk/lambda/admin-catalog-shared.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { projectAdminEpisode, sortEpisodes } from './admin-catalog-shared';
+import { projectEpisode } from './catalog-shared';
+
+const baseItem = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: 'abc123',
+  youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc123',
+  tagline: 'A tagline',
+  posterImageUrl: null,
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: true,
+};
+
+describe('projectAdminEpisode', () => {
+  it('preserves public projectEpisode fields', () => {
+    const admin = projectAdminEpisode(baseItem);
+    const pub = projectEpisode(baseItem);
+    expect(admin).toMatchObject(pub);
+  });
+
+  it('maps staff-only curator hints when present', () => {
+    const admin = projectAdminEpisode({
+      ...baseItem,
+      movieSearchTitle: 'Manos',
+      embedAllows: false,
+      curatorNotes: 'Check TMDB match',
+      tmdbNeedsReview: true,
+      youtubeThumbnailUrl: 'https://img.youtube.com/vi/abc123/hqdefault.jpg',
+    });
+    expect(admin.movieSearchTitle).toBe('Manos');
+    expect(admin.embedAllows).toBe(false);
+    expect(admin.curatorNotes).toBe('Check TMDB match');
+    expect(admin.tmdbNeedsReview).toBe(true);
+    expect(admin.youtubeThumbnailUrl).toBe('https://img.youtube.com/vi/abc123/hqdefault.jpg');
+  });
+
+  it('surfaces null for absent staff-only fields', () => {
+    const admin = projectAdminEpisode(baseItem);
+    expect(admin.movieSearchTitle).toBeNull();
+    expect(admin.embedAllows).toBeNull();
+    expect(admin.curatorNotes).toBeNull();
+    expect(admin.youtubeThumbnailUrl).toBeNull();
+    expect(admin.tmdbNeedsReview).toBeUndefined();
+  });
+});
+
+describe('sortEpisodes (admin re-export)', () => {
+  it('sorts AdminEpisode rows by experimentNumber', () => {
+    const a = projectAdminEpisode({ ...baseItem, id: 'b', experimentNumber: 200 });
+    const b = projectAdminEpisode({ ...baseItem, id: 'a', experimentNumber: 100 });
+    expect(sortEpisodes([a, b]).map((e) => e.id)).toEqual(['a', 'b']);
+  });
+});

--- a/infra/cdk/lambda/admin-catalog-shared.ts
+++ b/infra/cdk/lambda/admin-catalog-shared.ts
@@ -1,0 +1,49 @@
+import {
+  type CatalogEpisode,
+  projectEpisode,
+  sortEpisodes,
+} from './catalog-shared';
+
+/** Staff-only catalog row returned by **`GET /v1/admin/catalog`** handlers. */
+export interface AdminEpisode extends CatalogEpisode {
+  readonly movieSearchTitle: string | null;
+  readonly embedAllows: boolean | null;
+  readonly curatorNotes: string | null;
+  readonly tmdbNeedsReview?: boolean | null;
+  readonly youtubeThumbnailUrl: string | null;
+}
+
+function optionalString(v: unknown): string | null {
+  return v === null || v === undefined ? null : String(v);
+}
+
+function optionalBoolean(v: unknown): boolean | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase();
+    if (s === 'true' || s === '1' || s === 'yes') return true;
+    if (s === 'false' || s === '0' || s === 'no') return false;
+  }
+  if (typeof v === 'number' && Number.isFinite(v)) return v === 1;
+  return null;
+}
+
+function optionalBooleanField(v: unknown): boolean | undefined {
+  if (v === null || v === undefined) return undefined;
+  return optionalBoolean(v) ?? undefined;
+}
+
+export function projectAdminEpisode(item: Record<string, unknown>): AdminEpisode {
+  const base = projectEpisode(item);
+  return {
+    ...base,
+    movieSearchTitle: optionalString(item.movieSearchTitle),
+    embedAllows: optionalBoolean(item.embedAllows),
+    curatorNotes: optionalString(item.curatorNotes),
+    tmdbNeedsReview: optionalBooleanField(item.tmdbNeedsReview),
+    youtubeThumbnailUrl: optionalString(item.youtubeThumbnailUrl),
+  };
+}
+
+export { sortEpisodes };

--- a/infra/cdk/lambda/admin-staff-access.ts
+++ b/infra/cdk/lambda/admin-staff-access.ts
@@ -1,0 +1,77 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { listStaffGroupsViaCognito } from './admin-session-cognito';
+import {
+  decodeJwtPayload,
+  getStaffJwtClaims,
+  hasStaffRole,
+  resolveStaffGroups,
+  resolveStaffUsername,
+} from './admin-session-shared';
+import { jsonResponse } from './giphy-search-shared';
+
+function resolveSub(event: APIGatewayProxyEventV2): string | undefined {
+  const claims = getStaffJwtClaims(event);
+  if (typeof claims?.sub === 'string' && claims.sub.length > 0) {
+    return claims.sub;
+  }
+  const auth = event.headers?.authorization ?? event.headers?.Authorization;
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+    const sub = decodeJwtPayload(auth.slice('Bearer '.length).trim())?.sub;
+    if (typeof sub === 'string' && sub.length > 0) {
+      return sub;
+    }
+  }
+  return undefined;
+}
+
+async function resolveStaffGroupsForRequest(event: APIGatewayProxyEventV2): Promise<string[]> {
+  const fromToken = resolveStaffGroups(event);
+  if (hasStaffRole(fromToken)) {
+    return fromToken;
+  }
+
+  const userPoolId = process.env.STAFF_USER_POOL_ID?.trim();
+  if (!userPoolId) {
+    return fromToken;
+  }
+
+  const candidates = new Set<string>();
+  const username = resolveStaffUsername(event);
+  if (username) {
+    candidates.add(username);
+  }
+  const sub = resolveSub(event);
+  if (sub) {
+    candidates.add(sub);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const fromCognito = await listStaffGroupsViaCognito(userPoolId, candidate);
+      if (fromCognito.length > 0) {
+        return fromCognito;
+      }
+    } catch {
+      /* try next candidate */
+    }
+  }
+
+  return fromToken;
+}
+
+/** Returns a JSON error response when staff access is denied; **`null`** when the caller may proceed. */
+export async function requireStaffAccess(
+  event: APIGatewayProxyEventV2,
+): Promise<ReturnType<typeof jsonResponse> | null> {
+  const sub = resolveSub(event);
+  if (!sub) {
+    return jsonResponse(401, { error: 'Unauthorized', code: 'unauthorized' });
+  }
+
+  const groups = await resolveStaffGroupsForRequest(event);
+  if (!hasStaffRole(groups)) {
+    return jsonResponse(403, { error: 'Forbidden', code: 'staff_group_required' });
+  }
+
+  return null;
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -584,6 +584,43 @@ export class ApiCatalogStack extends cdk.Stack {
       }),
     );
 
+    const adminCatalogListFn = new lambdaNodejs.NodejsFunction(this, 'AdminCatalogListFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(29),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-catalog-list.ts'),
+      handler: 'handler',
+      environment: {
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        STAFF_USER_POOL_ID: staffUserPool.userPoolId,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    const adminCatalogGetFn = new lambdaNodejs.NodejsFunction(this, 'AdminCatalogGetFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-catalog-get.ts'),
+      handler: 'handler',
+      environment: {
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        STAFF_USER_POOL_ID: staffUserPool.userPoolId,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.catalogTable.grantReadData(adminCatalogListFn);
+    this.catalogTable.grantReadData(adminCatalogGetFn);
+    for (const fn of [adminCatalogListFn, adminCatalogGetFn]) {
+      fn.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ['cognito-idp:AdminListGroupsForUser'],
+          resources: [staffUserPool.userPoolArn],
+        }),
+      );
+    }
+
     const fanAvatarPostFn = new lambdaNodejs.NodejsFunction(this, 'FanAvatarPostFn', {
       runtime: lambda.Runtime.NODEJS_24_X,
       timeout: cdk.Duration.seconds(29),
@@ -760,6 +797,14 @@ export class ApiCatalogStack extends cdk.Stack {
       'AdminSessionGetInt',
       adminSessionGetFn,
     );
+    const adminCatalogListIntegration = new integrations.HttpLambdaIntegration(
+      'AdminCatalogListInt',
+      adminCatalogListFn,
+    );
+    const adminCatalogGetIntegration = new integrations.HttpLambdaIntegration(
+      'AdminCatalogGetInt',
+      adminCatalogGetFn,
+    );
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -852,6 +897,20 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: staffJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/admin/catalog',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: adminCatalogListIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/admin/catalog/episodes/{id}',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: adminCatalogGetIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -908,7 +967,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Add read-only staff catalog HTTP handlers: `GET /v1/admin/catalog` and `GET /v1/admin/catalog/episodes/{id}` behind the existing staff JWT authorizer with `admin`/`curator` group enforcement.
- Introduce `AdminEpisode` projection (public `CatalogEpisode` fields plus curator hints) and wire CDK Lambdas with Dynamo read + Cognito group fallback.
- Add `staffAdminCatalogApi.ts` SPA client with Bearer auth and 401/403 error mapping for upcoming catalog editor UI (#80, #81).

## Test plan

- [x] `npm run verify:push:cdk` (Vitest + CDK synth)
- [x] `npm run verify:push:web` (includes `staffAdminCatalogApi` tests)
- [ ] Manual curl against deployed API with staff token (list + detail), fan token 401, missing group 403

Closes #78