### PR TITLE
[M12] Catalog create and update API (#79)

### DIFF
--- a/apps/web/src/api/staffAdminCatalogApi.test.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  createStaffCatalogEpisode,
   fetchStaffCatalogEpisode,
   fetchStaffCatalogList,
+  patchStaffCatalogEpisode,
+  StaffCatalogValidationError,
 } from './staffAdminCatalogApi'
 import {
   StaffSessionForbiddenError,
@@ -75,5 +78,61 @@ describe('staffAdminCatalogApi', () => {
     await expect(fetchStaffCatalogEpisode('no-group', 'ep-1')).rejects.toBeInstanceOf(
       StaffSessionForbiddenError,
     )
+  })
+
+  it('createStaffCatalogEpisode POSTs writable body to episode path', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ entry: { id: 'new-ep' } }),
+    })
+
+    const body = {
+      experimentNumber: 1,
+      title: 'New',
+      era: 'other' as const,
+      youtubeVideoId: null,
+      youtubeWatchUrl: null,
+    }
+    await createStaffCatalogEpisode('staff-token', 'new-ep', body)
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/admin/catalog/episodes/new-ep')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer staff-token',
+      'Content-Type': 'application/json',
+    })
+    expect(JSON.parse(String(init.body))).toEqual(body)
+  })
+
+  it('patchStaffCatalogEpisode PATCHes partial body', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ entry: { id: 'ep-1', title: 'Updated' } }),
+    })
+
+    await patchStaffCatalogEpisode('staff-token', 'ep-1', { title: 'Updated' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/admin/catalog/episodes/ep-1')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(String(init.body))).toEqual({ title: 'Updated' })
+  })
+
+  it('maps 400 validation_error to StaffCatalogValidationError', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        code: 'validation_error',
+        details: [{ instancePath: '/title' }],
+      }),
+    })
+
+    await expect(
+      patchStaffCatalogEpisode('staff-token', 'ep-1', { title: '' }),
+    ).rejects.toBeInstanceOf(StaffCatalogValidationError)
   })
 })

--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -37,6 +37,108 @@ export interface StaffCatalogEpisodeResponse {
   entry: StaffCatalogEpisode
 }
 
+export interface StaffCatalogEpisodeWrite {
+  experimentNumber?: number
+  title?: string
+  era?: StaffCatalogEpisode['era']
+  youtubeVideoId?: string | null
+  youtubeWatchUrl?: string | null
+  carousel?: boolean
+}
+
+export class StaffCatalogValidationError extends Error {
+  readonly statusCode = 400
+  readonly code = 'validation_error'
+  readonly details: Array<{ instancePath: string; message?: string }>
+
+  constructor(details: Array<{ instancePath: string; message?: string }>) {
+    super('Catalog validation failed')
+    this.name = 'StaffCatalogValidationError'
+    this.details = details
+  }
+}
+
+function staffCatalogJsonHeaders(accessToken: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  }
+}
+
+async function mapStaffCatalogWriteError(res: Response): Promise<never> {
+  if (res.status === 401) {
+    throw new StaffSessionUnauthorizedError()
+  }
+  if (res.status === 403) {
+    let detail = 'Staff group required — contact an administrator'
+    try {
+      const parsed = (await res.json()) as { code?: string; error?: string }
+      if (parsed.code === 'staff_group_required' || parsed.error === 'Forbidden') {
+        detail = 'Staff group required — contact an administrator'
+      }
+    } catch {
+      /* use default copy */
+    }
+    throw new StaffSessionForbiddenError(detail)
+  }
+  if (res.status === 400) {
+    try {
+      const parsed = (await res.json()) as {
+        code?: string
+        details?: Array<{ instancePath: string; message?: string }>
+      }
+      if (parsed.code === 'validation_error' && Array.isArray(parsed.details)) {
+        throw new StaffCatalogValidationError(parsed.details)
+      }
+    } catch (err) {
+      if (err instanceof StaffCatalogValidationError) {
+        throw err
+      }
+    }
+  }
+  const t = await res.text()
+  throw new Error(`Staff catalog write failed (${res.status}): ${t}`)
+}
+
+export async function createStaffCatalogEpisode(
+  accessToken: string,
+  id: string,
+  body: StaffCatalogEpisodeWrite,
+): Promise<StaffCatalogEpisodeResponse> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const encodedId = encodeURIComponent(id)
+  const res = await fetch(`${base}/v1/admin/catalog/episodes/${encodedId}`, {
+    method: 'POST',
+    headers: staffCatalogJsonHeaders(accessToken),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    await mapStaffCatalogWriteError(res)
+  }
+  return (await res.json()) as StaffCatalogEpisodeResponse
+}
+
+export async function patchStaffCatalogEpisode(
+  accessToken: string,
+  id: string,
+  body: StaffCatalogEpisodeWrite,
+): Promise<StaffCatalogEpisodeResponse> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const encodedId = encodeURIComponent(id)
+  const res = await fetch(`${base}/v1/admin/catalog/episodes/${encodedId}`, {
+    method: 'PATCH',
+    headers: staffCatalogJsonHeaders(accessToken),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    await mapStaffCatalogWriteError(res)
+  }
+  return (await res.json()) as StaffCatalogEpisodeResponse
+}
+
 function staffCatalogAuthHeaders(accessToken: string): HeadersInit {
   return {
     Authorization: `Bearer ${accessToken}`,

--- a/infra/cdk/lambda/admin-catalog-patch.ts
+++ b/infra/cdk/lambda/admin-catalog-patch.ts
@@ -1,0 +1,162 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { projectAdminEpisode } from './admin-catalog-shared';
+import { requireStaffAccess, resolveStaffSub } from './admin-staff-access';
+import {
+  validateCatalogEpisodePatch,
+  validationErrorResponse,
+  type ValidationDetail,
+} from './admin-catalog-validation';
+import { jsonResponse } from './giphy-search-shared';
+import {
+  adminCatalogPatchOutcomeFromStatus,
+  logRiffsyncDiagError,
+  recordAdminCatalogRoute,
+  type AdminCatalogPatchOutcome,
+} from './riffsync-observability';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function fieldPathsFromDetails(details: ValidationDetail[]): string[] {
+  return details.map((d) => d.instancePath).filter((p) => p.length > 0);
+}
+
+function finishPatch(
+  event: APIGatewayProxyEventV2,
+  sub: string,
+  episodeId: string,
+  statusCode: number,
+  body: Record<string, unknown>,
+  validationFieldPaths?: string[],
+) {
+  const outcome = adminCatalogPatchOutcomeFromStatus(statusCode);
+  recordAdminCatalogRoute('AdminCatalogPatch', outcome, {
+    route: 'AdminCatalogPatch',
+    action: 'update',
+    outcome,
+    sub,
+    episodeId,
+    requestId: event.requestContext.requestId,
+    statusCode,
+    validationFieldPaths,
+  });
+  return jsonResponse(statusCode, body);
+}
+
+function buildUpdateExpression(item: Record<string, unknown>): {
+  UpdateExpression: string;
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, unknown>;
+} {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {};
+  const sets: string[] = [];
+  for (const [key, value] of Object.entries(item)) {
+    if (key === 'id') continue;
+    const nameKey = `#${key}`;
+    const valueKey = `:${key}`;
+    names[nameKey] = key;
+    values[valueKey] = value;
+    sets.push(`${nameKey} = ${valueKey}`);
+  }
+  return {
+    UpdateExpression: `SET ${sets.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+  };
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const episodeId = event.pathParameters?.id ?? '';
+  const sub = resolveStaffSub(event) ?? 'unknown';
+
+  const denied = await requireStaffAccess(event);
+  if (denied) {
+    const statusCode = denied.statusCode ?? 403;
+    const outcome = adminCatalogPatchOutcomeFromStatus(statusCode) as AdminCatalogPatchOutcome;
+    recordAdminCatalogRoute('AdminCatalogPatch', outcome, {
+      route: 'AdminCatalogPatch',
+      action: 'update',
+      outcome,
+      sub,
+      episodeId,
+      requestId: event.requestContext.requestId,
+      statusCode,
+    });
+    return denied;
+  }
+
+  const staffSub = resolveStaffSub(event);
+  if (!staffSub) {
+    return finishPatch(event, sub, episodeId, 401, {
+      error: 'Unauthorized',
+      code: 'unauthorized',
+    });
+  }
+
+  const tableName = process.env.CATALOG_TABLE_NAME;
+  if (!tableName) {
+    return finishPatch(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  let parsedBody: Record<string, unknown>;
+  try {
+    parsedBody = event.body ? (JSON.parse(event.body) as Record<string, unknown>) : {};
+  } catch {
+    return finishPatch(
+      event,
+      staffSub,
+      episodeId,
+      400,
+      validationErrorResponse([{ instancePath: '/', message: 'Invalid JSON' }]),
+      ['/'],
+    );
+  }
+
+  let existing: Record<string, unknown>;
+  try {
+    const out = await client.send(
+      new GetCommand({
+        TableName: tableName,
+        Key: { id: episodeId },
+      }),
+    );
+    if (!out.Item) {
+      return finishPatch(event, staffSub, episodeId, 404, { error: 'Not found' });
+    }
+    existing = out.Item as Record<string, unknown>;
+  } catch (err) {
+    logRiffsyncDiagError('admin_catalog_patch_get_failed', err);
+    return finishPatch(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  const validated = validateCatalogEpisodePatch(episodeId, parsedBody, existing);
+  if (!validated.ok) {
+    return finishPatch(
+      event,
+      staffSub,
+      episodeId,
+      400,
+      validationErrorResponse(validated.details),
+      fieldPathsFromDetails(validated.details),
+    );
+  }
+
+  const update = buildUpdateExpression(validated.item);
+  try {
+    await client.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { id: episodeId },
+        ...update,
+      }),
+    );
+  } catch (err) {
+    logRiffsyncDiagError('admin_catalog_patch_update_failed', err);
+    return finishPatch(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  const entry = projectAdminEpisode(validated.item);
+  return finishPatch(event, staffSub, episodeId, 200, { entry });
+};

--- a/infra/cdk/lambda/admin-catalog-post.ts
+++ b/infra/cdk/lambda/admin-catalog-post.ts
@@ -1,0 +1,127 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { projectAdminEpisode } from './admin-catalog-shared';
+import { requireStaffAccess, resolveStaffSub } from './admin-staff-access';
+import {
+  validateCatalogEpisodePost,
+  validationErrorResponse,
+  type ValidationDetail,
+} from './admin-catalog-validation';
+import { jsonResponse } from './giphy-search-shared';
+import {
+  adminCatalogPostOutcomeFromStatus,
+  logRiffsyncDiagError,
+  recordAdminCatalogRoute,
+  type AdminCatalogPostOutcome,
+} from './riffsync-observability';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function fieldPathsFromDetails(details: ValidationDetail[]): string[] {
+  return details.map((d) => d.instancePath).filter((p) => p.length > 0);
+}
+
+function finishPost(
+  event: APIGatewayProxyEventV2,
+  sub: string,
+  episodeId: string,
+  statusCode: number,
+  body: Record<string, unknown>,
+  validationFieldPaths?: string[],
+) {
+  const outcome = adminCatalogPostOutcomeFromStatus(statusCode);
+  recordAdminCatalogRoute('AdminCatalogPost', outcome, {
+    route: 'AdminCatalogPost',
+    action: 'create',
+    outcome,
+    sub,
+    episodeId,
+    requestId: event.requestContext.requestId,
+    statusCode,
+    validationFieldPaths,
+  });
+  return jsonResponse(statusCode, body);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const episodeId = event.pathParameters?.id ?? '';
+  const sub = resolveStaffSub(event) ?? 'unknown';
+
+  const denied = await requireStaffAccess(event);
+  if (denied) {
+    const statusCode = denied.statusCode ?? 403;
+    const outcome = adminCatalogPostOutcomeFromStatus(statusCode) as AdminCatalogPostOutcome;
+    recordAdminCatalogRoute('AdminCatalogPost', outcome, {
+      route: 'AdminCatalogPost',
+      action: 'create',
+      outcome,
+      sub,
+      episodeId,
+      requestId: event.requestContext.requestId,
+      statusCode,
+    });
+    return denied;
+  }
+
+  const staffSub = resolveStaffSub(event);
+  if (!staffSub) {
+    return finishPost(event, sub, episodeId, 401, {
+      error: 'Unauthorized',
+      code: 'unauthorized',
+    });
+  }
+
+  const tableName = process.env.CATALOG_TABLE_NAME;
+  if (!tableName) {
+    return finishPost(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  let parsedBody: Record<string, unknown>;
+  try {
+    parsedBody = event.body ? (JSON.parse(event.body) as Record<string, unknown>) : {};
+  } catch {
+    return finishPost(
+      event,
+      staffSub,
+      episodeId,
+      400,
+      validationErrorResponse([{ instancePath: '/', message: 'Invalid JSON' }]),
+      ['/'],
+    );
+  }
+
+  const validated = validateCatalogEpisodePost(episodeId, parsedBody);
+  if (!validated.ok) {
+    return finishPost(
+      event,
+      staffSub,
+      episodeId,
+      400,
+      validationErrorResponse(validated.details),
+      fieldPathsFromDetails(validated.details),
+    );
+  }
+
+  try {
+    await client.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: validated.item,
+        ConditionExpression: 'attribute_not_exists(id)',
+      }),
+    );
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException) {
+      return finishPost(event, staffSub, episodeId, 409, {
+        error: 'Conflict',
+        code: 'catalog_episode_exists',
+      });
+    }
+    logRiffsyncDiagError('admin_catalog_post_dynamo_failed', err);
+    return finishPost(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  const entry = projectAdminEpisode(validated.item);
+  return finishPost(event, staffSub, episodeId, 201, { entry });
+};

--- a/infra/cdk/lambda/admin-catalog-validation.test.ts
+++ b/infra/cdk/lambda/admin-catalog-validation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADMIN_WRITABLE_KEYS,
+  READ_ONLY_WRITE_KEYS,
+  stripAndRejectReadOnly,
+  validateCatalogEpisodePatch,
+  validateCatalogEpisodePost,
+  validatePathEpisodeId,
+} from './admin-catalog-validation';
+
+const validPostBody = {
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  carousel: false,
+};
+
+describe('admin-catalog-validation', () => {
+  it('accepts valid POST payload and sets reconcile fields null', () => {
+    const result = validateCatalogEpisodePost('test-episode', validPostBody);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.item.id).toBe('test-episode');
+      expect(result.item.tagline).toBeNull();
+      expect(result.item.posterImageUrl).toBeNull();
+      expect(result.item.carousel).toBe(false);
+    }
+  });
+
+  it('defaults carousel to false on POST when omitted', () => {
+    const { carousel: _c, ...withoutCarousel } = validPostBody;
+    const result = validateCatalogEpisodePost('test-episode', withoutCarousel);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.item.carousel).toBe(false);
+    }
+  });
+
+  it('rejects read-only keys on write', () => {
+    const rejected = stripAndRejectReadOnly({ tagline: 'nope' });
+    expect(rejected?.ok).toBe(false);
+    if (rejected && !rejected.ok) {
+      expect(rejected.details.map((d) => d.instancePath)).toContain('/tagline');
+    }
+  });
+
+  it('rejects POST body with forbidden reconcile field', () => {
+    const result = validateCatalogEpisodePost('test-episode', {
+      ...validPostBody,
+      tagline: 'nope',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects invalid era on POST', () => {
+    const result = validateCatalogEpisodePost('test-episode', {
+      ...validPostBody,
+      era: 'invalid-era',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects invalid slug in path', () => {
+    const result = validatePathEpisodeId('Bad_Slug');
+    expect(result?.ok).toBe(false);
+  });
+
+  it('merges PATCH writable keys and preserves reconcile fields', () => {
+    const existing = {
+      id: 'test-episode',
+      experimentNumber: 101,
+      title: 'Old title',
+      era: 'mike',
+      youtubeVideoId: null,
+      youtubeWatchUrl: null,
+      tagline: 'keep-me',
+      posterImageUrl: 'https://example.test/poster.jpg',
+      backdropImageUrl: null,
+      tmdbMovieId: 42,
+      tmdbArtworkSyncedAt: '2024-01-01T00:00:00.000Z',
+      carousel: false,
+      movieSearchTitle: 'Manos',
+    };
+
+    const result = validateCatalogEpisodePatch('test-episode', { title: 'New title' }, existing);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.item.title).toBe('New title');
+      expect(result.item.tagline).toBe('keep-me');
+      expect(result.item.movieSearchTitle).toBe('Manos');
+    }
+  });
+
+  it('exports writable and read-only key lists', () => {
+    expect(ADMIN_WRITABLE_KEYS).toContain('title');
+    expect(READ_ONLY_WRITE_KEYS).toContain('tagline');
+    expect(READ_ONLY_WRITE_KEYS).toContain('movieSearchTitle');
+  });
+});

--- a/infra/cdk/lambda/admin-catalog-validation.ts
+++ b/infra/cdk/lambda/admin-catalog-validation.ts
@@ -1,0 +1,231 @@
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import catalogSchema from '../../../data/catalog/catalog.schema.json';
+
+export const ADMIN_WRITABLE_KEYS = [
+  'experimentNumber',
+  'title',
+  'era',
+  'youtubeVideoId',
+  'youtubeWatchUrl',
+  'carousel',
+] as const;
+
+export type AdminWritableKey = (typeof ADMIN_WRITABLE_KEYS)[number];
+
+export const READ_ONLY_WRITE_KEYS = [
+  'tagline',
+  'posterImageUrl',
+  'backdropImageUrl',
+  'tmdbMovieId',
+  'tmdbArtworkSyncedAt',
+  'movieSearchTitle',
+  'embedAllows',
+  'curatorNotes',
+  'tmdbNeedsReview',
+  'youtubeThumbnailUrl',
+  'tmdbOverview',
+  'tmdbPopularity',
+  'tmdbPosterPath',
+  'tmdbBackdropPath',
+] as const;
+
+const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+
+const episodeSchema = (catalogSchema as { $defs: { episode: object } }).$defs.episode;
+const validateEpisodeSchema = ajv.compile(episodeSchema);
+
+const EPISODE_SCHEMA_PROPERTY_KEYS = Object.keys(
+  (episodeSchema as { properties: Record<string, unknown> }).properties,
+);
+
+function pickSchemaEpisodeFields(item: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of EPISODE_SCHEMA_PROPERTY_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(item, key)) {
+      out[key] = item[key];
+    }
+  }
+  return out;
+}
+
+export type ValidationDetail = {
+  instancePath: string;
+  message?: string;
+};
+
+export type CatalogValidationResult =
+  | { ok: true; item: Record<string, unknown> }
+  | { ok: false; error: string; details: ValidationDetail[] };
+
+function ajvDetails(errors: typeof validateEpisodeSchema.errors): ValidationDetail[] {
+  if (!errors) return [];
+  return errors.map((err) => {
+    const path = err.instancePath || '';
+    const missing =
+      err.keyword === 'required' &&
+      err.params &&
+      typeof (err.params as { missingProperty?: string }).missingProperty === 'string'
+        ? `/${(err.params as { missingProperty: string }).missingProperty}`
+        : path;
+    return {
+      instancePath: missing.startsWith('/') ? missing : `/${missing}`.replace(/^\/\/+/, '/'),
+      message: err.message,
+    };
+  });
+}
+
+export function validatePathEpisodeId(id: string | undefined): CatalogValidationResult | null {
+  if (!id) {
+    return { ok: false, error: 'Missing path parameter id', details: [{ instancePath: '/id' }] };
+  }
+  if (!SLUG_PATTERN.test(id)) {
+    return {
+      ok: false,
+      error: 'Invalid episode id slug',
+      details: [{ instancePath: '/id', message: 'must match slug pattern' }],
+    };
+  }
+  return null;
+}
+
+export function stripAndRejectReadOnly(body: Record<string, unknown>): CatalogValidationResult | null {
+  const forbidden = Object.keys(body).filter((key) =>
+    (READ_ONLY_WRITE_KEYS as readonly string[]).includes(key),
+  );
+  if (forbidden.length > 0) {
+    return {
+      ok: false,
+      error: 'Read-only fields are not allowed on write',
+      details: forbidden.map((key) => ({ instancePath: `/${key}` })),
+    };
+  }
+  return null;
+}
+
+function parseWritableBody(body: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ADMIN_WRITABLE_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
+      out[key] = body[key];
+    }
+  }
+  return out;
+}
+
+function validateMergedEpisode(item: Record<string, unknown>): CatalogValidationResult | null {
+  if (!validateEpisodeSchema(item)) {
+    return {
+      ok: false,
+      error: 'Validation failed',
+      details: ajvDetails(validateEpisodeSchema.errors),
+    };
+  }
+  return null;
+}
+
+export function validateCatalogEpisodePost(
+  pathId: string,
+  body: Record<string, unknown>,
+): CatalogValidationResult {
+  const pathError = validatePathEpisodeId(pathId);
+  if (pathError) return pathError;
+
+  const readOnlyError = stripAndRejectReadOnly(body);
+  if (readOnlyError) return readOnlyError;
+
+  if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== pathId) {
+    return {
+      ok: false,
+      error: 'Path id and body id must match when body id is present',
+      details: [{ instancePath: '/id' }],
+    };
+  }
+
+  const writable = parseWritableBody(body);
+  const requiredKeys: AdminWritableKey[] = [
+    'experimentNumber',
+    'title',
+    'era',
+    'youtubeVideoId',
+    'youtubeWatchUrl',
+  ];
+  const missing = requiredKeys.filter((key) => !Object.prototype.hasOwnProperty.call(writable, key));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: 'Missing required fields',
+      details: missing.map((key) => ({ instancePath: `/${key}` })),
+    };
+  }
+
+  const carousel = Object.prototype.hasOwnProperty.call(writable, 'carousel')
+    ? writable.carousel
+    : false;
+
+  const item: Record<string, unknown> = {
+    id: pathId,
+    experimentNumber: writable.experimentNumber,
+    title: writable.title,
+    era: writable.era,
+    youtubeVideoId: writable.youtubeVideoId,
+    youtubeWatchUrl: writable.youtubeWatchUrl,
+    carousel,
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+  };
+
+  const schemaError = validateMergedEpisode(item);
+  if (schemaError) return schemaError;
+
+  return { ok: true, item };
+}
+
+export function validateCatalogEpisodePatch(
+  pathId: string,
+  body: Record<string, unknown>,
+  existing: Record<string, unknown>,
+): CatalogValidationResult {
+  const pathError = validatePathEpisodeId(pathId);
+  if (pathError) return pathError;
+
+  const readOnlyError = stripAndRejectReadOnly(body);
+  if (readOnlyError) return readOnlyError;
+
+  if (Object.prototype.hasOwnProperty.call(body, 'id') && body.id !== pathId) {
+    return {
+      ok: false,
+      error: 'Path id and body id must match when body id is present',
+      details: [{ instancePath: '/id' }],
+    };
+  }
+
+  const writable = parseWritableBody(body);
+  if (Object.keys(writable).length === 0) {
+    return {
+      ok: false,
+      error: 'No writable fields provided',
+      details: [{ instancePath: '/', message: 'at least one writable field required' }],
+    };
+  }
+
+  const merged: Record<string, unknown> = { ...existing, ...writable, id: pathId };
+  const schemaError = validateMergedEpisode(pickSchemaEpisodeFields(merged));
+  if (schemaError) return schemaError;
+
+  return { ok: true, item: merged };
+}
+
+export function validationErrorResponse(details: ValidationDetail[]) {
+  return {
+    error: 'Validation failed',
+    code: 'validation_error',
+    details,
+  };
+}

--- a/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
+++ b/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
@@ -1,0 +1,268 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  recordAdminCatalogRoute: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+  ConditionalCheckFailedException: class ConditionalCheckFailedException extends Error {
+    name = 'ConditionalCheckFailedException';
+  },
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+vi.mock('./riffsync-observability', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./riffsync-observability')>();
+  return {
+    ...actual,
+    recordAdminCatalogRoute: mocks.recordAdminCatalogRoute,
+    logRiffsyncDiagError: vi.fn(),
+  };
+});
+
+import { handler as postHandler } from './admin-catalog-post';
+import { handler as patchHandler } from './admin-catalog-patch';
+
+function staffEvent(
+  method: 'POST' | 'PATCH',
+  path: string,
+  body: Record<string, unknown>,
+  claims?: Record<string, unknown>,
+  pathParameters?: Record<string, string>,
+): APIGatewayProxyEventV2 {
+  const routeKey = `${method} /v1/admin/catalog/episodes/{id}`;
+  return {
+    version: '2.0',
+    routeKey,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    body: JSON.stringify(body),
+    pathParameters,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method,
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-post-1',
+      routeKey,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: claims ? { jwt: { claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+const writeBody = {
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  carousel: false,
+};
+
+const existingItem = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  tagline: 'keep',
+  posterImageUrl: null,
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: false,
+};
+
+describe('admin-catalog-post handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.STAFF_USER_POOL_ID;
+  });
+
+  it('creates row with null reconcile fields and returns 201', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-1',
+        writeBody,
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(201);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entry.id).toBe('ep-1');
+    expect(body.entry.tagline).toBeNull();
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogPost',
+      'success',
+      expect.objectContaining({ episodeId: 'ep-1', sub: 'staff-1', statusCode: 201 }),
+    );
+  });
+
+  it('returns 409 when id exists', async () => {
+    const { ConditionalCheckFailedException } = await import('@aws-sdk/client-dynamodb');
+    mocks.docSend.mockRejectedValueOnce(new ConditionalCheckFailedException({ message: 'exists', $metadata: {} }));
+
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-1',
+        writeBody,
+        { sub: 'staff-1', 'cognito:groups': ['curator'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(409);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Conflict',
+      code: 'catalog_episode_exists',
+    });
+  });
+
+  it('returns 400 when body includes read-only key', async () => {
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-1',
+        { ...writeBody, tagline: 'nope' },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(400);
+    expect(JSON.parse(res?.body ?? '').code).toBe('validation_error');
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogPost',
+      'validation_error',
+      expect.objectContaining({ validationFieldPaths: ['/tagline'] }),
+    );
+  });
+
+  it('returns 403 when staff groups omit admin/curator', async () => {
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-1',
+        writeBody,
+        { sub: 'staff-1', 'cognito:groups': ['viewer'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(403);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin-catalog-patch handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.STAFF_USER_POOL_ID;
+  });
+
+  it('updates allowed fields and preserves reconcile columns', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: existingItem })
+      .mockResolvedValueOnce({});
+
+    const res = await patchHandler(
+      staffEvent(
+        'PATCH',
+        '/v1/admin/catalog/episodes/ep-1',
+        { title: 'Updated title' },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(200);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entry.title).toBe('Updated title');
+    expect(body.entry.tagline).toBe('keep');
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogPatch',
+      'success',
+      expect.objectContaining({ action: 'update', episodeId: 'ep-1' }),
+    );
+  });
+
+  it('returns 404 for unknown id', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+
+    const res = await patchHandler(
+      staffEvent(
+        'PATCH',
+        '/v1/admin/catalog/episodes/missing',
+        { title: 'Updated title' },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'missing' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(404);
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogPatch',
+      'not_found',
+      expect.any(Object),
+    );
+  });
+
+  it('returns 403 when staff groups omit admin/curator', async () => {
+    const res = await patchHandler(
+      staffEvent(
+        'PATCH',
+        '/v1/admin/catalog/episodes/ep-1',
+        { title: 'Updated title' },
+        { sub: 'staff-1', 'cognito:groups': ['viewer'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+    expect(res?.statusCode).toBe(403);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/admin-staff-access.ts
+++ b/infra/cdk/lambda/admin-staff-access.ts
@@ -9,7 +9,7 @@ import {
 } from './admin-session-shared';
 import { jsonResponse } from './giphy-search-shared';
 
-function resolveSub(event: APIGatewayProxyEventV2): string | undefined {
+export function resolveStaffSub(event: APIGatewayProxyEventV2): string | undefined {
   const claims = getStaffJwtClaims(event);
   if (typeof claims?.sub === 'string' && claims.sub.length > 0) {
     return claims.sub;
@@ -40,7 +40,7 @@ async function resolveStaffGroupsForRequest(event: APIGatewayProxyEventV2): Prom
   if (username) {
     candidates.add(username);
   }
-  const sub = resolveSub(event);
+  const sub = resolveStaffSub(event);
   if (sub) {
     candidates.add(sub);
   }
@@ -63,7 +63,7 @@ async function resolveStaffGroupsForRequest(event: APIGatewayProxyEventV2): Prom
 export async function requireStaffAccess(
   event: APIGatewayProxyEventV2,
 ): Promise<ReturnType<typeof jsonResponse> | null> {
-  const sub = resolveSub(event);
+  const sub = resolveStaffSub(event);
   if (!sub) {
     return jsonResponse(401, { error: 'Unauthorized', code: 'unauthorized' });
   }

--- a/infra/cdk/lambda/riffsync-observability.test.ts
+++ b/infra/cdk/lambda/riffsync-observability.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   emitApiEmf,
   emitWsRealtimeEmf,
+  logAdminCatalogAudit,
   logApiAction,
   logRiffsyncDiagError,
   logWsAction,
+  recordAdminCatalogRoute,
   recordApiRoute,
   recordWsRealtimeRoute,
   riffsyncEnvironment,
@@ -176,5 +178,60 @@ describe('riffsync-observability', () => {
       errorType: 'Error',
       errorMessage: 'AccessDenied',
     });
+  });
+
+  it('emits AdminCatalogPost EMF without sub or episodeId dimensions', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'prod';
+    emitApiEmf('AdminCatalogPost', 'success');
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    const line = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed.Route).toBe('AdminCatalogPost');
+    expect(parsed.Outcome).toBe('success');
+    expect(parsed.sub).toBeUndefined();
+    expect(parsed.episodeId).toBeUndefined();
+  });
+
+  it('logs admin catalog audit with operator and episode metadata', () => {
+    logAdminCatalogAudit({
+      route: 'AdminCatalogPost',
+      action: 'create',
+      outcome: 'success',
+      sub: 'staff-sub-1',
+      episodeId: 'tw-smoke',
+      requestId: 'req-abc',
+      statusCode: 201,
+    });
+
+    expect(console.info).toHaveBeenCalledTimes(1);
+    const line = (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      riffsyncDiag: 'admin_catalog_audit',
+      route: 'AdminCatalogPost',
+      action: 'create',
+      sub: 'staff-sub-1',
+      episodeId: 'tw-smoke',
+      requestId: 'req-abc',
+      statusCode: 201,
+    });
+  });
+
+  it('recordAdminCatalogRoute emits EMF and audit together', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'prod';
+    recordAdminCatalogRoute('AdminCatalogPatch', 'validation_error', {
+      route: 'AdminCatalogPatch',
+      action: 'update',
+      outcome: 'validation_error',
+      sub: 'staff-sub-2',
+      episodeId: 'ep-1',
+      requestId: 'req-patch',
+      statusCode: 400,
+      validationFieldPaths: ['/title'],
+    });
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.info).toHaveBeenCalledTimes(2);
   });
 });

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -6,7 +6,11 @@ export type WsRealtimeOutcome =
   | 'auth_forbidden'
   | 'server_error';
 
-export type ApiRoute = 'GiphySearch' | 'FanAvatarUpload';
+export type ApiRoute =
+  | 'GiphySearch'
+  | 'FanAvatarUpload'
+  | 'AdminCatalogPost'
+  | 'AdminCatalogPatch';
 
 export type GiphySearchOutcome =
   | 'success'
@@ -24,7 +28,27 @@ export type FanAvatarUploadOutcome =
   | 'misconfigured'
   | 'server_error';
 
-export type ApiOutcome = GiphySearchOutcome | FanAvatarUploadOutcome;
+export type AdminCatalogPostOutcome =
+  | 'success'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'validation_error'
+  | 'conflict'
+  | 'server_error';
+
+export type AdminCatalogPatchOutcome =
+  | 'success'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'validation_error'
+  | 'not_found'
+  | 'server_error';
+
+export type ApiOutcome =
+  | GiphySearchOutcome
+  | FanAvatarUploadOutcome
+  | AdminCatalogPostOutcome
+  | AdminCatalogPatchOutcome;
 
 const REALTIME_METRIC_NAME = 'Requests';
 const API_METRIC_NAME = 'Requests';
@@ -188,4 +212,61 @@ export function recordApiRoute(
 ): void {
   emitApiEmf(route, outcome);
   logApiAction({ route, outcome, ...extras });
+}
+
+export type AdminCatalogAuditFields = {
+  route: 'AdminCatalogPost' | 'AdminCatalogPatch';
+  action: 'create' | 'update';
+  outcome: AdminCatalogPostOutcome | AdminCatalogPatchOutcome;
+  sub: string;
+  episodeId: string;
+  requestId: string;
+  statusCode: number;
+  validationFieldPaths?: string[];
+};
+
+/** Structured INFO audit log for admin catalog mutations (no request bodies). */
+export function logAdminCatalogAudit(fields: AdminCatalogAuditFields): void {
+  const payload: Record<string, unknown> = {
+    riffsyncDiag: 'admin_catalog_audit',
+    route: fields.route,
+    action: fields.action,
+    outcome: fields.outcome,
+    sub: fields.sub,
+    episodeId: fields.episodeId,
+    requestId: fields.requestId,
+    statusCode: fields.statusCode,
+  };
+  if (fields.validationFieldPaths !== undefined) {
+    payload.validationFieldPaths = fields.validationFieldPaths;
+  }
+  console.info(JSON.stringify(payload));
+}
+
+export function recordAdminCatalogRoute(
+  route: 'AdminCatalogPost' | 'AdminCatalogPatch',
+  outcome: AdminCatalogPostOutcome | AdminCatalogPatchOutcome,
+  audit: AdminCatalogAuditFields,
+): void {
+  emitApiEmf(route, outcome);
+  logApiAction({ route, outcome });
+  logAdminCatalogAudit(audit);
+}
+
+export function adminCatalogPostOutcomeFromStatus(statusCode: number): AdminCatalogPostOutcome {
+  if (statusCode === 201) return 'success';
+  if (statusCode === 401) return 'unauthorized';
+  if (statusCode === 403) return 'forbidden';
+  if (statusCode === 400) return 'validation_error';
+  if (statusCode === 409) return 'conflict';
+  return 'server_error';
+}
+
+export function adminCatalogPatchOutcomeFromStatus(statusCode: number): AdminCatalogPatchOutcome {
+  if (statusCode === 200) return 'success';
+  if (statusCode === 401) return 'unauthorized';
+  if (statusCode === 403) return 'forbidden';
+  if (statusCode === 400) return 'validation_error';
+  if (statusCode === 404) return 'not_found';
+  return 'server_error';
 }

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -610,9 +610,39 @@ export class ApiCatalogStack extends cdk.Stack {
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
+    const adminCatalogPostFn = new lambdaNodejs.NodejsFunction(this, 'AdminCatalogPostFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-catalog-post.ts'),
+      handler: 'handler',
+      environment: {
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        STAFF_USER_POOL_ID: staffUserPool.userPoolId,
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    const adminCatalogPatchFn = new lambdaNodejs.NodejsFunction(this, 'AdminCatalogPatchFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-catalog-patch.ts'),
+      handler: 'handler',
+      environment: {
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        STAFF_USER_POOL_ID: staffUserPool.userPoolId,
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
     this.catalogTable.grantReadData(adminCatalogListFn);
     this.catalogTable.grantReadData(adminCatalogGetFn);
-    for (const fn of [adminCatalogListFn, adminCatalogGetFn]) {
+    this.catalogTable.grantReadWriteData(adminCatalogPostFn);
+    this.catalogTable.grantReadWriteData(adminCatalogPatchFn);
+    for (const fn of [adminCatalogListFn, adminCatalogGetFn, adminCatalogPostFn, adminCatalogPatchFn]) {
       fn.addToRolePolicy(
         new iam.PolicyStatement({
           actions: ['cognito-idp:AdminListGroupsForUser'],
@@ -805,6 +835,14 @@ export class ApiCatalogStack extends cdk.Stack {
       'AdminCatalogGetInt',
       adminCatalogGetFn,
     );
+    const adminCatalogPostIntegration = new integrations.HttpLambdaIntegration(
+      'AdminCatalogPostInt',
+      adminCatalogPostFn,
+    );
+    const adminCatalogPatchIntegration = new integrations.HttpLambdaIntegration(
+      'AdminCatalogPatchInt',
+      adminCatalogPatchFn,
+    );
 
     this.httpApi.addRoutes({
       path: '/v1/catalog',
@@ -911,6 +949,20 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: staffJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/admin/catalog/episodes/{id}',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: adminCatalogPostIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/admin/catalog/episodes/{id}',
+      methods: [apigwv2.HttpMethod.PATCH],
+      integration: adminCatalogPatchIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -967,7 +1019,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH).',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Add `POST` and `PATCH /v1/admin/catalog/episodes/{id}` staff catalog write handlers with AJV validation against `catalog.schema.json`, Dynamo write-through, and staff group gating (`admin` or `curator`).
- Extend `riffsync-observability.ts` with `AdminCatalogPost` / `AdminCatalogPatch` EMF counters and structured audit logs (#82).
- Wire CDK routes and add SPA mutation helpers (`createStaffCatalogEpisode`, `patchStaffCatalogEpisode`) with 401/403/400 mapping.

Closes #79
Closes #82

## Test plan

- [x] `npm run test --prefix infra/cdk` (validation, write handlers, observability)
- [x] `npm run synth --prefix infra/cdk`
- [x] `npm test --prefix apps/web` (staffAdminCatalogApi mutation helpers)
- [ ] Manual curl against deployed API (create, patch, validation reject, duplicate 409, auth negatives)