### PR TITLE
[M12] Catalog list and search UI (#80)

### DIFF
--- a/apps/web/src/AppRoutes.admin.test.tsx
+++ b/apps/web/src/AppRoutes.admin.test.tsx
@@ -28,6 +28,34 @@ vi.mock('./api/staffAdminSessionApi', () => ({
   StaffSessionForbiddenError: class StaffSessionForbiddenError extends Error {},
 }))
 
+vi.mock('./api/staffAdminCatalogApi', () => ({
+  fetchStaffCatalogList: vi.fn().mockResolvedValue({
+    version: 1,
+    entries: [
+      {
+        id: 'ep-route-test',
+        experimentNumber: 42,
+        title: 'Route Test Episode',
+        era: 'joel',
+        youtubeVideoId: null,
+        youtubeWatchUrl: null,
+        tagline: null,
+        posterImageUrl: null,
+        backdropImageUrl: null,
+        tmdbMovieId: null,
+        tmdbArtworkSyncedAt: null,
+        carousel: false,
+        movieSearchTitle: null,
+        embedAllows: true,
+        curatorNotes: null,
+        youtubeThumbnailUrl: null,
+      },
+    ],
+  }),
+  StaffSessionUnauthorizedError: class StaffSessionUnauthorizedError extends Error {},
+  StaffSessionForbiddenError: class StaffSessionForbiddenError extends Error {},
+}))
+
 describe('AppRoutes admin tree', () => {
   let container: HTMLDivElement
   let root: Root | null = null
@@ -38,7 +66,7 @@ describe('AppRoutes admin tree', () => {
     container?.remove()
   })
 
-  it('renders catalog placeholder inside admin shell without fan header', async () => {
+  it('renders catalog list inside admin shell without fan header', async () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -52,8 +80,10 @@ describe('AppRoutes admin tree', () => {
     })
 
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('Catalog list UI ships')
+      expect(container.textContent).toContain('Route Test Episode')
     })
+
+    expect(container.querySelector('.riffsync-admin-catalog-table')).not.toBeNull()
 
     expect(container.querySelector('.riffsync-admin-shell')).not.toBeNull()
     expect(container.querySelector('#gen-header')).toBeNull()

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -12,6 +12,7 @@ import { DataRemovalRequestPage } from './pages/DataRemovalRequestPage'
 import { HowToHostWatchPartyPage } from './pages/HowToHostWatchPartyPage'
 import { StaffAuthCallbackPage } from './pages/admin/StaffAuthCallbackPage'
 import { AdminLoginPage } from './pages/admin/AdminLoginPage'
+import { AdminCatalogListPage } from './pages/admin/AdminCatalogListPage'
 import { AdminCatalogRoutePlaceholder } from './pages/admin/AdminCatalogRoutePlaceholder'
 import { AdminHomePage } from './pages/admin/AdminHomePage'
 import { StaffAdminGate } from './pages/admin/StaffAdminGate'
@@ -28,7 +29,7 @@ export function AppRoutes() {
           <Route index element={<AdminHomePage />} />
           <Route path="catalog/new" element={<AdminCatalogRoutePlaceholder variant="new" />} />
           <Route path="catalog/:id/edit" element={<AdminCatalogRoutePlaceholder variant="edit" />} />
-          <Route path="catalog" element={<AdminCatalogRoutePlaceholder variant="list" />} />
+          <Route path="catalog" element={<AdminCatalogListPage />} />
         </Route>
       </Route>
       <Route element={<SiteLayout />}>

--- a/apps/web/src/catalog/filterStaffCatalogEntries.test.ts
+++ b/apps/web/src/catalog/filterStaffCatalogEntries.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { filterStaffCatalogEntries } from './filterStaffCatalogEntries'
+import type { StaffCatalogEpisode } from './staffCatalogTypes'
+
+function episode(overrides: Partial<StaffCatalogEpisode> & Pick<StaffCatalogEpisode, 'id'>): StaffCatalogEpisode {
+  return {
+    experimentNumber: 100,
+    title: 'Default',
+    era: 'joel',
+    youtubeVideoId: null,
+    youtubeWatchUrl: null,
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    movieSearchTitle: null,
+    embedAllows: true,
+    curatorNotes: null,
+    youtubeThumbnailUrl: null,
+    ...overrides,
+  }
+}
+
+const sampleEntries: StaffCatalogEpisode[] = [
+  episode({ id: 'ep-a', experimentNumber: 200, title: 'Pod People', era: 'joel' }),
+  episode({ id: 'ep-b', experimentNumber: 101, title: 'Cave Dwellers', era: 'mike' }),
+  episode({ id: 'special-ep', experimentNumber: 310, title: 'Giant Spider', era: 'jonah' }),
+]
+
+describe('filterStaffCatalogEntries', () => {
+  it('returns all entries sorted by experimentNumber when filters are empty', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: '', era: 'all' })
+    expect(result.map((e) => e.id)).toEqual(['ep-b', 'ep-a', 'special-ep'])
+  })
+
+  it('filters by case-insensitive id substring', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: 'SPECIAL', era: 'all' })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('special-ep')
+  })
+
+  it('filters by title substring', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: 'cave', era: 'all' })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.title).toBe('Cave Dwellers')
+  })
+
+  it('filters by experiment number substring', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: '101', era: 'all' })
+    expect(result.map((e) => e.id)).toEqual(['ep-b'])
+  })
+
+  it('filters by era when not All', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: '', era: 'mike' })
+    expect(result.map((e) => e.id)).toEqual(['ep-b'])
+  })
+
+  it('combines query and era filters', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: 'ep', era: 'joel' })
+    expect(result.map((e) => e.id)).toEqual(['ep-a'])
+  })
+
+  it('returns empty when query matches no rows', () => {
+    const result = filterStaffCatalogEntries(sampleEntries, { query: 'zzzz-no-match', era: 'all' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('re-sorts filtered rows by experimentNumber ascending', () => {
+    const shuffled = [sampleEntries[2]!, sampleEntries[0]!, sampleEntries[1]!]
+    const result = filterStaffCatalogEntries(shuffled, { query: '', era: 'all' })
+    expect(result.map((e) => e.experimentNumber)).toEqual([101, 200, 310])
+  })
+})

--- a/apps/web/src/catalog/filterStaffCatalogEntries.ts
+++ b/apps/web/src/catalog/filterStaffCatalogEntries.ts
@@ -1,0 +1,36 @@
+import type { CatalogEra } from './catalogTypes'
+import type { StaffCatalogEpisode } from './staffCatalogTypes'
+
+export type StaffCatalogFilterEra = CatalogEra | 'all'
+
+export interface StaffCatalogFilterOptions {
+  query: string
+  era: StaffCatalogFilterEra
+}
+
+export function filterStaffCatalogEntries(
+  entries: StaffCatalogEpisode[],
+  { query, era }: StaffCatalogFilterOptions,
+): StaffCatalogEpisode[] {
+  const trimmed = query.trim()
+  const qLower = trimmed.toLowerCase()
+
+  let filtered = entries
+
+  if (era !== 'all') {
+    filtered = filtered.filter((entry) => entry.era === era)
+  }
+
+  if (trimmed) {
+    filtered = filtered.filter((entry) => {
+      const experimentStr = String(entry.experimentNumber)
+      return (
+        entry.id.toLowerCase().includes(qLower) ||
+        entry.title.toLowerCase().includes(qLower) ||
+        experimentStr.includes(trimmed)
+      )
+    })
+  }
+
+  return [...filtered].sort((a, b) => a.experimentNumber - b.experimentNumber)
+}

--- a/apps/web/src/catalog/staffCatalogTypes.ts
+++ b/apps/web/src/catalog/staffCatalogTypes.ts
@@ -1,0 +1,1 @@
+export type { StaffCatalogEpisode, StaffCatalogListResponse } from '../api/staffAdminCatalogApi'

--- a/apps/web/src/pages/admin/AdminCatalogListPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogListPage.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AdminCatalogListPage } from './AdminCatalogListPage'
+import type { StaffCatalogEpisode } from '../../api/staffAdminCatalogApi'
+
+const fetchStaffCatalogList = vi.fn()
+const refreshStaffTokensIfStale = vi.fn()
+const getStaffAccessToken = vi.fn()
+
+vi.mock('../../auth/staffHostedUiPkce', () => ({
+  refreshStaffTokensIfStale: () => refreshStaffTokensIfStale(),
+}))
+
+vi.mock('../../auth/staffTokens', () => ({
+  getStaffAccessToken: () => getStaffAccessToken(),
+}))
+
+vi.mock('../../api/staffAdminCatalogApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/staffAdminCatalogApi')>()
+  return {
+    ...actual,
+    fetchStaffCatalogList: (...args: unknown[]) => fetchStaffCatalogList(...args),
+  }
+})
+
+const baseEpisode: StaffCatalogEpisode = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Pod People',
+  era: 'joel',
+  youtubeVideoId: 'abc',
+  youtubeWatchUrl: null,
+  tagline: null,
+  posterImageUrl: 'https://cdn.test/poster.jpg',
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: true,
+  movieSearchTitle: null,
+  embedAllows: true,
+  curatorNotes: null,
+  youtubeThumbnailUrl: null,
+}
+
+describe('AdminCatalogListPage', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  beforeEach(() => {
+    refreshStaffTokensIfStale.mockResolvedValue(undefined)
+    getStaffAccessToken.mockReturnValue('staff-token')
+    fetchStaffCatalogList.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+  })
+
+  function renderPage(initialEntry = '/admin/catalog') {
+    act(() => {
+      root!.render(
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <AdminCatalogListPage />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('renders table columns and edit links from staff catalog API', async () => {
+    fetchStaffCatalogList.mockResolvedValue({
+      version: 1,
+      entries: [
+        baseEpisode,
+        {
+          ...baseEpisode,
+          id: 'no-yt',
+          experimentNumber: 202,
+          title: 'No Tube',
+          youtubeVideoId: null,
+          posterImageUrl: null,
+          youtubeThumbnailUrl: 'https://cdn.test/yt-thumb.jpg',
+        },
+      ],
+    })
+
+    renderPage()
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Pod People')
+    })
+
+    expect(fetchStaffCatalogList).toHaveBeenCalledWith('staff-token')
+    expect(container.querySelector('.riffsync-admin-catalog-table')).not.toBeNull()
+    expect(container.querySelector('th')?.textContent).toBe('id')
+    const editLink = container.querySelector('a.riffsync-admin-catalog-edit-link') as HTMLAnchorElement
+    expect(editLink?.getAttribute('href')).toBe('/admin/catalog/ep-1/edit')
+    expect(container.textContent).toContain('No Tube')
+    expect(container.textContent).toContain('Yes')
+  })
+
+  it('shows empty catalog copy when API returns no entries', async () => {
+    fetchStaffCatalogList.mockResolvedValue({ version: 1, entries: [] })
+    renderPage()
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('No episodes in catalog yet.')
+    })
+  })
+
+  it('shows post-save banner from location state', async () => {
+    fetchStaffCatalogList.mockResolvedValue({ version: 1, entries: [baseEpisode] })
+
+    act(() => {
+      root!.render(
+        <MemoryRouter
+          initialEntries={[{ pathname: '/admin/catalog', state: { saved: true } }]}
+        >
+          <AdminCatalogListPage />
+        </MemoryRouter>,
+      )
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[role="status"]')?.textContent).toContain('Episode saved')
+    })
+  })
+})

--- a/apps/web/src/pages/admin/AdminCatalogListPage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogListPage.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
+import { getStaffAccessToken } from '../../auth/staffTokens'
+import {
+  fetchStaffCatalogList,
+  type StaffCatalogEpisode,
+} from '../../api/staffAdminCatalogApi'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from '../../api/staffAdminSessionApi'
+import {
+  filterStaffCatalogEntries,
+  type StaffCatalogFilterEra,
+} from '../../catalog/filterStaffCatalogEntries'
+import { formatCatalogEraLabel, type CatalogEra } from '../../catalog/catalogTypes'
+
+const CATALOG_ERAS: CatalogEra[] = ['joel', 'mike', 'jonah', 'emily', 'other']
+const SAVED_BANNER_TIMEOUT_MS = 5000
+
+function posterThumbUrl(entry: StaffCatalogEpisode): string | null {
+  return entry.posterImageUrl ?? entry.youtubeThumbnailUrl ?? null
+}
+
+export function AdminCatalogListPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const [entries, setEntries] = useState<StaffCatalogEpisode[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [era, setEra] = useState<StaffCatalogFilterEra>('all')
+
+  const savedFromState = (location.state as { saved?: boolean } | null)?.saved === true
+  const savedFromQuery = searchParams.get('saved') === '1'
+  const [savedBannerVisible, setSavedBannerVisible] = useState(savedFromState || savedFromQuery)
+
+  const dismissSavedBanner = useCallback(() => {
+    setSavedBannerVisible(false)
+    if (savedFromState) {
+      navigate(`${location.pathname}${location.search}`, { replace: true, state: {} })
+    }
+    if (savedFromQuery) {
+      const next = new URLSearchParams(searchParams)
+      next.delete('saved')
+      setSearchParams(next, { replace: true })
+    }
+  }, [location.pathname, location.search, navigate, savedFromQuery, savedFromState, searchParams, setSearchParams])
+
+  useEffect(() => {
+    if (!savedBannerVisible) return
+    const timer = window.setTimeout(() => dismissSavedBanner(), SAVED_BANNER_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [dismissSavedBanner, savedBannerVisible])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        await refreshStaffTokensIfStale()
+        const token = getStaffAccessToken()
+        if (!token) {
+          if (!cancelled) setError('Operator sign-in required')
+          return
+        }
+        const response = await fetchStaffCatalogList(token)
+        if (!cancelled) setEntries(response.entries)
+      } catch (e: unknown) {
+        if (cancelled) return
+        if (e instanceof StaffSessionUnauthorizedError || e instanceof StaffSessionForbiddenError) {
+          setError(e.message)
+        } else {
+          setError(e instanceof Error ? e.message : 'Could not load catalog')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const filteredEntries = useMemo(
+    () => filterStaffCatalogEntries(entries, { query, era }),
+    [entries, query, era],
+  )
+
+  const isEmptyCatalog = !loading && !error && entries.length === 0
+  const isFilterNoMatch = !loading && !error && entries.length > 0 && filteredEntries.length === 0
+
+  return (
+    <div className="container riffsync-admin-page riffsync-admin-catalog-page">
+      <header className="riffsync-admin-catalog-header">
+        <h1>Catalog</h1>
+        <div className="riffsync-admin-catalog-toolbar">
+          <label className="riffsync-admin-catalog-search">
+            <span className="sr-only">Search catalog</span>
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by id, title, or #"
+              disabled={loading || Boolean(error)}
+            />
+          </label>
+          <label className="riffsync-admin-catalog-era">
+            <span className="sr-only">Filter by era</span>
+            <select
+              value={era}
+              onChange={(e) => setEra(e.target.value as StaffCatalogFilterEra)}
+              disabled={loading || Boolean(error)}
+            >
+              <option value="all">All eras</option>
+              {CATALOG_ERAS.map((value) => (
+                <option key={value} value={value}>
+                  {formatCatalogEraLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Link to="/admin/catalog/new" className="btn btn-primary riffsync-admin-catalog-add">
+            Add episode
+          </Link>
+        </div>
+      </header>
+
+      {savedBannerVisible ? (
+        <div role="status" className="riffsync-admin-catalog-saved-banner">
+          <p>Episode saved</p>
+          <button type="button" className="btn btn-secondary" onClick={dismissSavedBanner}>
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div role="alert" className="riffsync-scaffold-note">
+          <p>{error}</p>
+          <p>
+            <a href="/admin/login">Try operator sign-in again</a>
+          </p>
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p className="riffsync-admin-catalog-loading">Loading catalog…</p>
+      ) : null}
+
+      {!loading && !error && isEmptyCatalog ? (
+        <div className="riffsync-admin-catalog-empty">
+          <p>No episodes in catalog yet.</p>
+          <p>
+            <Link to="/admin/catalog/new" className="btn btn-primary riffsync-admin-catalog-add">
+              Add episode
+            </Link>
+          </p>
+        </div>
+      ) : null}
+
+      {!loading && !error && isFilterNoMatch ? (
+        <div className="riffsync-admin-catalog-no-match">
+          <p>No episodes match your search.</p>
+          <p className="riffsync-admin-catalog-no-match-hint">
+            Clear the search field or set era to All eras to see all episodes.
+          </p>
+        </div>
+      ) : null}
+
+      {!loading && !error && filteredEntries.length > 0 ? (
+        <div className="riffsync-admin-catalog-table-wrap">
+          <table className="riffsync-admin-catalog-table">
+            <thead>
+              <tr>
+                <th scope="col">id</th>
+                <th scope="col">#</th>
+                <th scope="col">Poster</th>
+                <th scope="col">title</th>
+                <th scope="col">era</th>
+                <th scope="col">carousel</th>
+                <th scope="col">YouTube</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredEntries.map((entry) => {
+                const thumb = posterThumbUrl(entry)
+                return (
+                  <tr key={entry.id} className={entry.embedAllows === false ? 'riffsync-admin-catalog-row--embed-blocked' : undefined}>
+                    <td>
+                      <code className="riffsync-admin-catalog-id">{entry.id}</code>
+                      {entry.embedAllows === false ? (
+                        <span className="riffsync-admin-catalog-embed-hint" title="Embed not allowed">
+                          Embed blocked
+                        </span>
+                      ) : null}
+                    </td>
+                    <td>{entry.experimentNumber}</td>
+                    <td className="riffsync-admin-catalog-poster-cell">
+                      {thumb ? (
+                        <img
+                          src={thumb}
+                          alt=""
+                          width={48}
+                          height={48}
+                          className="riffsync-admin-catalog-poster-thumb"
+                        />
+                      ) : (
+                        <span aria-hidden="true">—</span>
+                      )}
+                    </td>
+                    <td>{entry.title}</td>
+                    <td>{formatCatalogEraLabel(entry.era)}</td>
+                    <td>{entry.carousel ? 'Yes' : 'No'}</td>
+                    <td>{entry.youtubeVideoId ? 'Yes' : 'No'}</td>
+                    <td>
+                      <Link
+                        to={`/admin/catalog/${encodeURIComponent(entry.id)}/edit`}
+                        className="riffsync-admin-catalog-edit-link"
+                      >
+                        Edit
+                      </Link>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2145,6 +2145,138 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   font-size: 0.875rem;
 }
 
+.riffsync-admin-catalog-page {
+  max-width: 100%;
+}
+
+.riffsync-admin-catalog-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.riffsync-admin-catalog-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
+}
+
+.riffsync-admin-catalog-search input,
+.riffsync-admin-catalog-era select {
+  min-height: 2.75rem;
+  min-width: 12rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgb(255 255 255 / 0.2);
+  background: rgb(0 0 0 / 0.25);
+  color: var(--white-color);
+}
+
+.riffsync-admin-catalog-add {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+}
+
+.riffsync-admin-catalog-saved-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.35rem;
+  background: rgb(46 125 50 / 0.25);
+  border: 1px solid rgb(129 199 132 / 0.45);
+}
+
+.riffsync-admin-catalog-loading {
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-catalog-empty,
+.riffsync-admin-catalog-no-match {
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-catalog-no-match-hint {
+  font-size: 0.875rem;
+  margin-top: 0.35rem;
+}
+
+.riffsync-admin-catalog-table-wrap {
+  overflow-x: auto;
+  margin-top: 0.5rem;
+}
+
+.riffsync-admin-catalog-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.riffsync-admin-catalog-table th,
+.riffsync-admin-catalog-table td {
+  padding: 0.45rem 0.65rem;
+  text-align: left;
+  border-bottom: 1px solid rgb(255 255 255 / 0.12);
+  vertical-align: middle;
+}
+
+.riffsync-admin-catalog-table th {
+  font-weight: 600;
+  color: var(--secondary-color);
+  white-space: nowrap;
+}
+
+.riffsync-admin-catalog-id {
+  font-size: 0.8125rem;
+}
+
+.riffsync-admin-catalog-embed-hint {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-catalog-poster-cell {
+  width: 3.5rem;
+}
+
+.riffsync-admin-catalog-poster-thumb {
+  display: block;
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 0.2rem;
+  background: rgb(0 0 0 / 0.35);
+}
+
+.riffsync-admin-catalog-edit-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  padding: 0.35rem 0.75rem;
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.riffsync-admin-catalog-edit-link:hover,
+.riffsync-admin-catalog-edit-link:focus {
+  text-decoration: underline;
+}
+
 @media (max-width: 767px) {
   .riffsync-admin-header {
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Replaces the `/admin/catalog` placeholder with `AdminCatalogListPage`: dense operator table, client-side search and era filter, post-save banner, and links to create/edit routes.
- Adds `filterStaffCatalogEntries` helper with Vitest coverage; admin table styles in `riffsync-app.css`.
- Wires the list route in `AppRoutes` and updates admin route tests.

Closes #80

## Test plan

- [x] `npm run verify:push:web` (Vitest + `apps/web` build)
- [ ] Manual: sign in at `/admin/login`, open Catalog, verify search/era filters, Add episode / Edit links, post-save banner via `state.saved` or `?saved=1`
- [ ] Manual: confirm rows without YouTube still appear; 401 shows login link