### PR TITLE
[M12] Catalog create/edit form UI (#81)

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -12,8 +12,9 @@ import { DataRemovalRequestPage } from './pages/DataRemovalRequestPage'
 import { HowToHostWatchPartyPage } from './pages/HowToHostWatchPartyPage'
 import { StaffAuthCallbackPage } from './pages/admin/StaffAuthCallbackPage'
 import { AdminLoginPage } from './pages/admin/AdminLoginPage'
+import { AdminCatalogCreatePage } from './pages/admin/AdminCatalogCreatePage'
+import { AdminCatalogEditPage } from './pages/admin/AdminCatalogEditPage'
 import { AdminCatalogListPage } from './pages/admin/AdminCatalogListPage'
-import { AdminCatalogRoutePlaceholder } from './pages/admin/AdminCatalogRoutePlaceholder'
 import { AdminHomePage } from './pages/admin/AdminHomePage'
 import { StaffAdminGate } from './pages/admin/StaffAdminGate'
 import { AdminLayout } from './layouts/AdminLayout'
@@ -27,8 +28,8 @@ export function AppRoutes() {
       <Route path="/admin" element={<StaffAdminGate />}>
         <Route element={<AdminLayout />}>
           <Route index element={<AdminHomePage />} />
-          <Route path="catalog/new" element={<AdminCatalogRoutePlaceholder variant="new" />} />
-          <Route path="catalog/:id/edit" element={<AdminCatalogRoutePlaceholder variant="edit" />} />
+          <Route path="catalog/new" element={<AdminCatalogCreatePage />} />
+          <Route path="catalog/:id/edit" element={<AdminCatalogEditPage />} />
           <Route path="catalog" element={<AdminCatalogListPage />} />
         </Route>
       </Route>

--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -58,6 +58,25 @@ export class StaffCatalogValidationError extends Error {
   }
 }
 
+export class StaffCatalogEpisodeConflictError extends Error {
+  readonly statusCode = 409
+  readonly code = 'catalog_episode_exists'
+
+  constructor() {
+    super('An episode with this id already exists.')
+    this.name = 'StaffCatalogEpisodeConflictError'
+  }
+}
+
+export class StaffCatalogEpisodeNotFoundError extends Error {
+  readonly statusCode = 404
+
+  constructor() {
+    super('Episode not found.')
+    this.name = 'StaffCatalogEpisodeNotFoundError'
+  }
+}
+
 function staffCatalogJsonHeaders(accessToken: string): HeadersInit {
   return {
     Authorization: `Bearer ${accessToken}`,
@@ -81,6 +100,9 @@ async function mapStaffCatalogWriteError(res: Response): Promise<never> {
       /* use default copy */
     }
     throw new StaffSessionForbiddenError(detail)
+  }
+  if (res.status === 409) {
+    throw new StaffCatalogEpisodeConflictError()
   }
   if (res.status === 400) {
     try {
@@ -161,6 +183,9 @@ async function mapStaffCatalogError(res: Response): Promise<never> {
       /* use default copy */
     }
     throw new StaffSessionForbiddenError(detail)
+  }
+  if (res.status === 404) {
+    throw new StaffCatalogEpisodeNotFoundError()
   }
   const t = await res.text()
   throw new Error(`Staff catalog read failed (${res.status}): ${t}`)

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EMPTY_CATALOG_EPISODE_FORM_VALUES,
+  mapValidationDetailsToFieldErrors,
+  validateCatalogEpisodeForm,
+} from './validateCatalogEpisodeForm'
+
+const validCreate = {
+  ...EMPTY_CATALOG_EPISODE_FORM_VALUES,
+  id: '421-crow-magnum',
+  experimentNumber: '421',
+  title: 'Crow Magnum',
+  era: 'mike' as const,
+  youtubeVideoId: 'dQw4w9WgXcQ',
+  youtubeWatchUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+}
+
+describe('validateCatalogEpisodeForm', () => {
+  it('accepts a valid create payload', () => {
+    const result = validateCatalogEpisodeForm(validCreate, 'create')
+    expect(result.fieldErrors).toEqual({})
+    expect(result.formError).toBeUndefined()
+  })
+
+  it('rejects invalid slug on create', () => {
+    const result = validateCatalogEpisodeForm({ ...validCreate, id: 'Bad_Slug' }, 'create')
+    expect(result.fieldErrors.id).toBeTruthy()
+  })
+
+  it('rejects negative experiment number', () => {
+    const result = validateCatalogEpisodeForm({ ...validCreate, experimentNumber: '-1' }, 'create')
+    expect(result.fieldErrors.experimentNumber).toBeTruthy()
+  })
+
+  it('rejects empty title on create', () => {
+    const result = validateCatalogEpisodeForm({ ...validCreate, title: '   ' }, 'create')
+    expect(result.fieldErrors.title).toBeTruthy()
+  })
+
+  it('rejects invalid era', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, era: 'invalid' as typeof validCreate.era },
+      'create',
+    )
+    expect(result.fieldErrors.era).toBeTruthy()
+  })
+
+  it('rejects youtube video id with wrong length', () => {
+    const result = validateCatalogEpisodeForm({ ...validCreate, youtubeVideoId: 'short' }, 'create')
+    expect(result.fieldErrors.youtubeVideoId).toBeTruthy()
+  })
+
+  it('allows null youtube fields when empty strings', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, youtubeVideoId: '', youtubeWatchUrl: '' },
+      'create',
+    )
+    expect(result.fieldErrors).toEqual({})
+  })
+
+  it('rejects invalid watch URL', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, youtubeWatchUrl: 'not-a-url' },
+      'create',
+    )
+    expect(result.fieldErrors.youtubeWatchUrl).toBeTruthy()
+  })
+
+  it('does not validate id on edit', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, id: 'invalid slug!!!' },
+      'edit',
+    )
+    expect(result.fieldErrors.id).toBeUndefined()
+  })
+
+  it('maps server validation details to field keys', () => {
+    expect(
+      mapValidationDetailsToFieldErrors([
+        { instancePath: '/title', message: 'must not be empty' },
+        { instancePath: '/era' },
+      ]),
+    ).toEqual({
+      title: 'must not be empty',
+      era: 'This value is not valid.',
+    })
+  })
+})

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.ts
@@ -1,0 +1,170 @@
+import type { CatalogEra } from './catalogTypes'
+
+const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/
+const CATALOG_ERAS: readonly CatalogEra[] = ['joel', 'mike', 'jonah', 'emily', 'other']
+
+export type CatalogEpisodeFormMode = 'create' | 'edit'
+
+export type CatalogEpisodeFormValues = {
+  id: string
+  experimentNumber: string
+  title: string
+  era: CatalogEra
+  youtubeVideoId: string
+  youtubeWatchUrl: string
+  carousel: boolean
+}
+
+export type CatalogEpisodeFormValidation = {
+  fieldErrors: Record<string, string>
+  formError?: string
+}
+
+export const EMPTY_CATALOG_EPISODE_FORM_VALUES: CatalogEpisodeFormValues = {
+  id: '',
+  experimentNumber: '',
+  title: '',
+  era: 'other',
+  youtubeVideoId: '',
+  youtubeWatchUrl: '',
+  carousel: false,
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function validateSlug(id: string): string | undefined {
+  const trimmed = id.trim()
+  if (!trimmed) return 'Episode id is required.'
+  if (!SLUG_PATTERN.test(trimmed)) {
+    return 'Use lowercase letters, numbers, and hyphens (no leading or trailing hyphen).'
+  }
+  return undefined
+}
+
+function validateExperimentNumber(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return 'Experiment number is required.'
+  if (!/^\d+$/.test(trimmed)) return 'Enter a whole number (0 or greater).'
+  const n = Number.parseInt(trimmed, 10)
+  if (!Number.isInteger(n) || n < 0) return 'Enter a whole number (0 or greater).'
+  return undefined
+}
+
+function validateTitle(title: string, mode: CatalogEpisodeFormMode): string | undefined {
+  const trimmed = title.trim()
+  if (!trimmed) {
+    return mode === 'create' ? 'Title is required.' : 'Title cannot be empty.'
+  }
+  return undefined
+}
+
+function validateEra(era: string): string | undefined {
+  if (!(CATALOG_ERAS as readonly string[]).includes(era)) {
+    return 'Choose a valid era.'
+  }
+  return undefined
+}
+
+function validateYoutubeVideoId(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  if (!YOUTUBE_VIDEO_ID_PATTERN.test(trimmed)) {
+    return 'Enter an 11-character YouTube video id or leave empty.'
+  }
+  return undefined
+}
+
+function validateYoutubeWatchUrl(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  if (!isValidHttpUrl(trimmed)) {
+    return 'Enter a valid http or https URL or leave empty.'
+  }
+  return undefined
+}
+
+export function normalizeYoutubeField(raw: string): string | null {
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function validateCatalogEpisodeForm(
+  values: CatalogEpisodeFormValues,
+  mode: CatalogEpisodeFormMode,
+): CatalogEpisodeFormValidation {
+  const fieldErrors: Record<string, string> = {}
+
+  if (mode === 'create') {
+    const idError = validateSlug(values.id)
+    if (idError) fieldErrors.id = idError
+  }
+
+  const experimentError = validateExperimentNumber(values.experimentNumber)
+  if (experimentError) fieldErrors.experimentNumber = experimentError
+
+  const titleError = validateTitle(values.title, mode)
+  if (titleError) fieldErrors.title = titleError
+
+  const eraError = validateEra(values.era)
+  if (eraError) fieldErrors.era = eraError
+
+  const videoIdError = validateYoutubeVideoId(values.youtubeVideoId)
+  if (videoIdError) fieldErrors.youtubeVideoId = videoIdError
+
+  const watchUrlError = validateYoutubeWatchUrl(values.youtubeWatchUrl)
+  if (watchUrlError) fieldErrors.youtubeWatchUrl = watchUrlError
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      fieldErrors,
+      formError: 'Fix the highlighted fields before saving.',
+    }
+  }
+
+  return { fieldErrors }
+}
+
+export function mapValidationDetailsToFieldErrors(
+  details: Array<{ instancePath: string; message?: string }>,
+): Record<string, string> {
+  const fieldErrors: Record<string, string> = {}
+  for (const detail of details) {
+    const key = detail.instancePath.replace(/^\//, '') || 'form'
+    if (!fieldErrors[key]) {
+      fieldErrors[key] =
+        detail.message ??
+        (key === 'id' ? 'Episode id is invalid.' : 'This value is not valid.')
+    }
+  }
+  return fieldErrors
+}
+
+export function catalogEpisodeToFormValues(
+  entry: {
+    id: string
+    experimentNumber: number
+    title: string
+    era: CatalogEra
+    youtubeVideoId: string | null
+    youtubeWatchUrl: string | null
+    carousel: boolean
+  },
+): CatalogEpisodeFormValues {
+  return {
+    id: entry.id,
+    experimentNumber: String(entry.experimentNumber),
+    title: entry.title,
+    era: entry.era,
+    youtubeVideoId: entry.youtubeVideoId ?? '',
+    youtubeWatchUrl: entry.youtubeWatchUrl ?? '',
+    carousel: entry.carousel,
+  }
+}

--- a/apps/web/src/pages/admin/AdminCatalogCreatePage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogCreatePage.tsx
@@ -1,7 +1,5 @@
-import {
-  AdminCatalogForm,
-  EMPTY_CATALOG_EPISODE_FORM_VALUES,
-} from './AdminCatalogForm'
+import { EMPTY_CATALOG_EPISODE_FORM_VALUES } from '../../catalog/validateCatalogEpisodeForm'
+import { AdminCatalogForm } from './AdminCatalogForm'
 
 export function AdminCatalogCreatePage() {
   return (

--- a/apps/web/src/pages/admin/AdminCatalogCreatePage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogCreatePage.tsx
@@ -1,0 +1,16 @@
+import {
+  AdminCatalogForm,
+  EMPTY_CATALOG_EPISODE_FORM_VALUES,
+} from './AdminCatalogForm'
+
+export function AdminCatalogCreatePage() {
+  return (
+    <AdminCatalogForm
+      mode="create"
+      initialEpisode={null}
+      initialValues={EMPTY_CATALOG_EPISODE_FORM_VALUES}
+      breadcrumbLeaf="New episode"
+      pageTitle="New episode"
+    />
+  )
+}

--- a/apps/web/src/pages/admin/AdminCatalogEditPage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogEditPage.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
+import { getStaffAccessToken } from '../../auth/staffTokens'
+import {
+  fetchStaffCatalogEpisode,
+  StaffCatalogEpisodeNotFoundError,
+  type StaffCatalogEpisode,
+} from '../../api/staffAdminCatalogApi'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from '../../api/staffAdminSessionApi'
+import { catalogEpisodeToFormValues } from '../../catalog/validateCatalogEpisodeForm'
+import { AdminCatalogForm } from './AdminCatalogForm'
+
+export function AdminCatalogEditPage() {
+  const { id: routeId } = useParams<{ id: string }>()
+  const episodeId = routeId ? decodeURIComponent(routeId) : ''
+
+  const [episode, setEpisode] = useState<StaffCatalogEpisode | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!episodeId) {
+      setError('Missing episode id in URL.')
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        await refreshStaffTokensIfStale()
+        const token = getStaffAccessToken()
+        if (!token) {
+          if (!cancelled) setError('Operator sign-in required')
+          return
+        }
+        const response = await fetchStaffCatalogEpisode(token, episodeId)
+        if (!cancelled) setEpisode(response.entry)
+      } catch (e: unknown) {
+        if (cancelled) return
+        if (e instanceof StaffCatalogEpisodeNotFoundError) {
+          setError('Episode not found.')
+        } else if (
+          e instanceof StaffSessionUnauthorizedError ||
+          e instanceof StaffSessionForbiddenError
+        ) {
+          setError(e.message)
+        } else {
+          setError(e instanceof Error ? e.message : 'Could not load episode')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [episodeId])
+
+  if (loading) {
+    return (
+      <div className="container riffsync-admin-page">
+        <p className="riffsync-admin-catalog-form-loading">Loading episode…</p>
+      </div>
+    )
+  }
+
+  if (error || !episode) {
+    const showLogin =
+      error === 'Operator sign-in required' ||
+      (error?.includes('Staff group') ?? false) ||
+      (error?.toLowerCase().includes('unauthorized') ?? false)
+
+    return (
+      <div className="container riffsync-admin-page">
+        <div role="alert" className="riffsync-scaffold-note">
+          <p>{error ?? 'Episode not found.'}</p>
+          {showLogin ? (
+            <p>
+              <a href="/admin/login">Try operator sign-in again</a>
+            </p>
+          ) : (
+            <p>
+              <Link to="/admin/catalog">Back to catalog</Link>
+            </p>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <AdminCatalogForm
+      mode="edit"
+      initialEpisode={episode}
+      initialValues={catalogEpisodeToFormValues(episode)}
+      breadcrumbLeaf="Edit"
+      pageTitle="Edit episode"
+    />
+  )
+}

--- a/apps/web/src/pages/admin/AdminCatalogEditPage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogEditPage.tsx
@@ -14,21 +14,25 @@ import {
 import { catalogEpisodeToFormValues } from '../../catalog/validateCatalogEpisodeForm'
 import { AdminCatalogForm } from './AdminCatalogForm'
 
-export function AdminCatalogEditPage() {
-  const { id: routeId } = useParams<{ id: string }>()
-  const episodeId = routeId ? decodeURIComponent(routeId) : ''
+function AdminCatalogEditMissingId() {
+  return (
+    <div className="container riffsync-admin-page">
+      <div role="alert" className="riffsync-scaffold-note">
+        <p>Missing episode id in URL.</p>
+        <p>
+          <Link to="/admin/catalog">Back to catalog</Link>
+        </p>
+      </div>
+    </div>
+  )
+}
 
+function AdminCatalogEditPageLoaded({ episodeId }: { episodeId: string }) {
   const [episode, setEpisode] = useState<StaffCatalogEpisode | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!episodeId) {
-      setError('Missing episode id in URL.')
-      setLoading(false)
-      return
-    }
-
     let cancelled = false
 
     const load = async () => {
@@ -107,4 +111,15 @@ export function AdminCatalogEditPage() {
       pageTitle="Edit episode"
     />
   )
+}
+
+export function AdminCatalogEditPage() {
+  const { id: routeId } = useParams<{ id: string }>()
+  const episodeId = routeId ? decodeURIComponent(routeId) : ''
+
+  if (!episodeId) {
+    return <AdminCatalogEditMissingId />
+  }
+
+  return <AdminCatalogEditPageLoaded episodeId={episodeId} />
 }

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AdminCatalogForm } from './AdminCatalogForm'
+import { EMPTY_CATALOG_EPISODE_FORM_VALUES } from '../../catalog/validateCatalogEpisodeForm'
+import type { StaffCatalogEpisode } from '../../api/staffAdminCatalogApi'
+
+const navigate = vi.fn()
+const createStaffCatalogEpisode = vi.fn()
+const patchStaffCatalogEpisode = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  }
+})
+
+vi.mock('../../auth/staffHostedUiPkce', () => ({
+  refreshStaffTokensIfStale: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../auth/staffTokens', () => ({
+  getStaffAccessToken: () => 'staff-token',
+}))
+
+vi.mock('../../api/staffAdminCatalogApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/staffAdminCatalogApi')>()
+  return {
+    ...actual,
+    createStaffCatalogEpisode: (...args: unknown[]) => createStaffCatalogEpisode(...args),
+    patchStaffCatalogEpisode: (...args: unknown[]) => patchStaffCatalogEpisode(...args),
+  }
+})
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+const baseEpisode: StaffCatalogEpisode = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Original',
+  era: 'joel',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  tagline: 'A tagline',
+  posterImageUrl: 'https://example.test/poster.jpg',
+  backdropImageUrl: null,
+  tmdbMovieId: 42,
+  tmdbArtworkSyncedAt: '2024-01-01T00:00:00.000Z',
+  carousel: false,
+  movieSearchTitle: 'Manos',
+  embedAllows: true,
+  curatorNotes: 'Notes',
+  youtubeThumbnailUrl: null,
+}
+
+describe('AdminCatalogForm', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  beforeEach(() => {
+    navigate.mockReset()
+    createStaffCatalogEpisode.mockReset()
+    patchStaffCatalogEpisode.mockReset()
+    createStaffCatalogEpisode.mockResolvedValue({ entry: { id: 'new-ep' } })
+    patchStaffCatalogEpisode.mockResolvedValue({ entry: baseEpisode })
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+  })
+
+  function renderForm(
+    props: Partial<Parameters<typeof AdminCatalogForm>[0]> & { mode: 'create' | 'edit' },
+  ) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const defaults = {
+      initialEpisode: null as StaffCatalogEpisode | null,
+      initialValues: EMPTY_CATALOG_EPISODE_FORM_VALUES,
+      breadcrumbLeaf: 'New episode',
+      pageTitle: 'New episode',
+    }
+    act(() => {
+      root!.render(
+        <MemoryRouter>
+          <AdminCatalogForm {...defaults} {...props} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('renders create fields and calls createStaffCatalogEpisode on save', async () => {
+    renderForm({ mode: 'create' })
+
+    const idInput = container.querySelector('#catalog-form-id') as HTMLInputElement
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    const experimentInput = container.querySelector('#catalog-form-experiment') as HTMLInputElement
+
+    await act(async () => {
+      setInputValue(idInput, 'new-ep')
+      setInputValue(experimentInput, '99')
+      setInputValue(titleInput, 'New title')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(createStaffCatalogEpisode).toHaveBeenCalledWith(
+        'staff-token',
+        'new-ep',
+        expect.objectContaining({
+          experimentNumber: 99,
+          title: 'New title',
+          era: 'other',
+          youtubeVideoId: null,
+          youtubeWatchUrl: null,
+          carousel: false,
+        }),
+      )
+    })
+
+    expect(navigate).toHaveBeenCalledWith('/admin/catalog', { state: { saved: true } })
+  })
+
+  it('edit mode keeps id out of PATCH and sends only changed fields', async () => {
+    renderForm({
+      mode: 'edit',
+      initialEpisode: baseEpisode,
+      initialValues: {
+        id: baseEpisode.id,
+        experimentNumber: String(baseEpisode.experimentNumber),
+        title: baseEpisode.title,
+        era: baseEpisode.era,
+        youtubeVideoId: '',
+        youtubeWatchUrl: '',
+        carousel: baseEpisode.carousel,
+      },
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    expect(container.querySelector('#catalog-form-id')).toBeNull()
+
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    await act(async () => {
+      setInputValue(titleInput, 'Updated title')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
+        title: 'Updated title',
+      })
+    })
+  })
+
+  it('maps server validation errors to inline field messages', async () => {
+    const { StaffCatalogValidationError } = await import('../../api/staffAdminCatalogApi')
+    createStaffCatalogEpisode.mockRejectedValue(
+      new StaffCatalogValidationError([{ instancePath: '/title', message: 'too short' }]),
+    )
+
+    renderForm({ mode: 'create' })
+
+    const idInput = container.querySelector('#catalog-form-id') as HTMLInputElement
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    const experimentInput = container.querySelector('#catalog-form-experiment') as HTMLInputElement
+
+    await act(async () => {
+      setInputValue(idInput, 'new-ep')
+      setInputValue(experimentInput, '1')
+      setInputValue(titleInput, 'Ok title')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('too short')
+    })
+  })
+})

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -429,5 +429,3 @@ export function AdminCatalogForm({
     </div>
   )
 }
-
-export { catalogEpisodeToFormValues, EMPTY_CATALOG_EPISODE_FORM_VALUES } from '../../catalog/validateCatalogEpisodeForm'

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -1,0 +1,433 @@
+import { useCallback, useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
+import { getStaffAccessToken } from '../../auth/staffTokens'
+import {
+  createStaffCatalogEpisode,
+  patchStaffCatalogEpisode,
+  StaffCatalogEpisodeConflictError,
+  StaffCatalogValidationError,
+  type StaffCatalogEpisode,
+  type StaffCatalogEpisodeWrite,
+} from '../../api/staffAdminCatalogApi'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from '../../api/staffAdminSessionApi'
+import { formatCatalogEraLabel, type CatalogEra } from '../../catalog/catalogTypes'
+import {
+  mapValidationDetailsToFieldErrors,
+  normalizeYoutubeField,
+  validateCatalogEpisodeForm,
+  type CatalogEpisodeFormMode,
+  type CatalogEpisodeFormValues,
+} from '../../catalog/validateCatalogEpisodeForm'
+
+const CATALOG_ERAS: CatalogEra[] = ['joel', 'mike', 'jonah', 'emily', 'other']
+
+const RECONCILE_HELPER =
+  'These fields are updated by the scheduled reconcile job. Edit title or YouTube details above; TMDB art and tagline refresh automatically when matched.'
+
+const CURATOR_HINTS_HELPER =
+  'Operator hints stored in Dynamo. Editing hints ships in a follow-on milestone; values shown here are read-only.'
+
+function formValuesToWriteBody(values: CatalogEpisodeFormValues): StaffCatalogEpisodeWrite {
+  return {
+    experimentNumber: Number.parseInt(values.experimentNumber.trim(), 10),
+    title: values.title.trim(),
+    era: values.era,
+    youtubeVideoId: normalizeYoutubeField(values.youtubeVideoId),
+    youtubeWatchUrl: normalizeYoutubeField(values.youtubeWatchUrl),
+    carousel: values.carousel,
+  }
+}
+
+function buildPatchBody(
+  baseline: StaffCatalogEpisode,
+  values: CatalogEpisodeFormValues,
+): StaffCatalogEpisodeWrite {
+  const next = formValuesToWriteBody(values)
+  const body: StaffCatalogEpisodeWrite = {}
+  if (next.experimentNumber !== baseline.experimentNumber) {
+    body.experimentNumber = next.experimentNumber
+  }
+  if (next.title !== baseline.title) body.title = next.title
+  if (next.era !== baseline.era) body.era = next.era
+  if (next.youtubeVideoId !== baseline.youtubeVideoId) body.youtubeVideoId = next.youtubeVideoId
+  if (next.youtubeWatchUrl !== baseline.youtubeWatchUrl) {
+    body.youtubeWatchUrl = next.youtubeWatchUrl
+  }
+  if (next.carousel !== baseline.carousel) body.carousel = next.carousel
+  return body
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="riffsync-admin-form-readonly-field">
+      <span className="riffsync-admin-form-readonly-field__label">{label}</span>
+      <span className="riffsync-admin-form-readonly-field__value">{value}</span>
+    </div>
+  )
+}
+
+export function AdminCatalogForm({
+  mode,
+  initialEpisode,
+  initialValues,
+  breadcrumbLeaf,
+  pageTitle,
+}: {
+  mode: CatalogEpisodeFormMode
+  initialEpisode: StaffCatalogEpisode | null
+  initialValues: CatalogEpisodeFormValues
+  breadcrumbLeaf: string
+  pageTitle: string
+}) {
+  const navigate = useNavigate()
+  const [values, setValues] = useState(initialValues)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [formError, setFormError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const setField = useCallback(
+    <K extends keyof CatalogEpisodeFormValues>(key: K, value: CatalogEpisodeFormValues[K]) => {
+      setValues((prev) => ({ ...prev, [key]: value }))
+      setFieldErrors((prev) => {
+        if (!prev[key]) return prev
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    },
+    [],
+  )
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    setFormError(null)
+
+    const validation = validateCatalogEpisodeForm(values, mode)
+    if (validation.formError || Object.keys(validation.fieldErrors).length > 0) {
+      setFieldErrors(validation.fieldErrors)
+      setFormError(validation.formError ?? null)
+      return
+    }
+
+    setSaving(true)
+    try {
+      await refreshStaffTokensIfStale()
+      const token = getStaffAccessToken()
+      if (!token) {
+        setFormError('Operator sign-in required')
+        return
+      }
+
+      if (mode === 'create') {
+        const id = values.id.trim()
+        await createStaffCatalogEpisode(token, id, formValuesToWriteBody(values))
+      } else if (initialEpisode) {
+        const patchBody = buildPatchBody(initialEpisode, values)
+        if (Object.keys(patchBody).length === 0) {
+          navigate('/admin/catalog', { state: { saved: true } })
+          return
+        }
+        await patchStaffCatalogEpisode(token, initialEpisode.id, patchBody)
+      }
+
+      navigate('/admin/catalog', { state: { saved: true } })
+    } catch (e: unknown) {
+      if (e instanceof StaffCatalogValidationError) {
+        setFieldErrors(mapValidationDetailsToFieldErrors(e.details))
+        setFormError('Fix the highlighted fields before saving.')
+        return
+      }
+      if (e instanceof StaffCatalogEpisodeConflictError) {
+        setFieldErrors({ id: e.message })
+        return
+      }
+      if (e instanceof StaffSessionUnauthorizedError || e instanceof StaffSessionForbiddenError) {
+        setFormError(e.message)
+        return
+      }
+      setFormError(e instanceof Error ? e.message : 'Could not save episode')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const episode = initialEpisode
+  const showTagline = Boolean(episode?.tagline?.trim())
+  const reconcileFields = episode
+    ? (
+        [
+          ['Poster image URL', episode.posterImageUrl],
+          ['Backdrop image URL', episode.backdropImageUrl],
+          ['TMDB movie id', episode.tmdbMovieId != null ? String(episode.tmdbMovieId) : null],
+          ['TMDB artwork synced at', episode.tmdbArtworkSyncedAt],
+          ['YouTube thumbnail URL', episode.youtubeThumbnailUrl],
+        ] as const
+      ).filter(([, v]) => v != null && String(v).trim() !== '')
+    : []
+
+  const hintFields = episode
+    ? (
+        [
+          ['Movie search title', episode.movieSearchTitle],
+          ['Embed allows', episode.embedAllows != null ? (episode.embedAllows ? 'Yes' : 'No') : null],
+          ['Curator notes', episode.curatorNotes],
+          ['TMDB needs review', episode.tmdbNeedsReview != null ? (episode.tmdbNeedsReview ? 'Yes' : 'No') : null],
+        ] as const
+      ).filter(([, v]) => v != null && String(v).trim() !== '')
+    : []
+
+  const showReconcileSection = mode === 'edit' && (showTagline || reconcileFields.length > 0)
+  const showCuratorHintsSection = mode === 'edit' && (hintFields.length > 0 || episode?.embedAllows === false)
+
+  return (
+    <div className="container riffsync-admin-page riffsync-admin-catalog-form-page">
+      <nav className="riffsync-admin-breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li>
+            <Link to="/admin">Admin</Link>
+          </li>
+          <li>
+            <Link to="/admin/catalog">Catalog</Link>
+          </li>
+          <li aria-current="page">{breadcrumbLeaf}</li>
+        </ol>
+      </nav>
+
+      <header className="riffsync-admin-catalog-form-header">
+        <h1>{pageTitle}</h1>
+        {mode === 'edit' && episode ? (
+          <p className="riffsync-admin-catalog-form-episode-id">
+            Episode id: <code>{episode.id}</code>
+          </p>
+        ) : null}
+      </header>
+
+      {formError ? (
+        <div role="alert" className="riffsync-scaffold-note riffsync-admin-catalog-form-alert">
+          <p>{formError}</p>
+          {formError === 'Operator sign-in required' ||
+          formError.includes('Staff group') ||
+          formError.toLowerCase().includes('unauthorized') ? (
+            <p>
+              <a href="/admin/login">Try operator sign-in again</a>
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <form className="riffsync-admin-catalog-form" onSubmit={onSubmit} noValidate>
+        <fieldset className="riffsync-admin-form-section">
+          <legend>Episode identity</legend>
+          {mode === 'create' ? (
+            <div className="riffsync-admin-form-field">
+              <label htmlFor="catalog-form-id">Episode id</label>
+              <input
+                id="catalog-form-id"
+                name="id"
+                type="text"
+                required
+                autoComplete="off"
+                value={values.id}
+                onChange={(e) => setField('id', e.target.value)}
+                aria-invalid={fieldErrors.id ? true : undefined}
+                aria-describedby={fieldErrors.id ? 'catalog-form-id-error' : undefined}
+                disabled={saving}
+              />
+              {fieldErrors.id ? (
+                <p id="catalog-form-id-error" className="riffsync-admin-form-field-error" role="alert">
+                  {fieldErrors.id}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-experiment">Experiment #</label>
+            <input
+              id="catalog-form-experiment"
+              name="experimentNumber"
+              type="number"
+              min={0}
+              step={1}
+              required
+              value={values.experimentNumber}
+              onChange={(e) => setField('experimentNumber', e.target.value)}
+              aria-invalid={fieldErrors.experimentNumber ? true : undefined}
+              aria-describedby={
+                fieldErrors.experimentNumber ? 'catalog-form-experiment-error' : undefined
+              }
+              disabled={saving}
+            />
+            {fieldErrors.experimentNumber ? (
+              <p
+                id="catalog-form-experiment-error"
+                className="riffsync-admin-form-field-error"
+                role="alert"
+              >
+                {fieldErrors.experimentNumber}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-title">Title</label>
+            <input
+              id="catalog-form-title"
+              name="title"
+              type="text"
+              required
+              value={values.title}
+              onChange={(e) => setField('title', e.target.value)}
+              aria-invalid={fieldErrors.title ? true : undefined}
+              aria-describedby={fieldErrors.title ? 'catalog-form-title-error' : undefined}
+              disabled={saving}
+            />
+            {fieldErrors.title ? (
+              <p id="catalog-form-title-error" className="riffsync-admin-form-field-error" role="alert">
+                {fieldErrors.title}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-era">Era</label>
+            <select
+              id="catalog-form-era"
+              name="era"
+              required
+              value={values.era}
+              onChange={(e) => setField('era', e.target.value as CatalogEra)}
+              aria-invalid={fieldErrors.era ? true : undefined}
+              aria-describedby={fieldErrors.era ? 'catalog-form-era-error' : undefined}
+              disabled={saving}
+            >
+              {CATALOG_ERAS.map((era) => (
+                <option key={era} value={era}>
+                  {formatCatalogEraLabel(era)}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.era ? (
+              <p id="catalog-form-era-error" className="riffsync-admin-form-field-error" role="alert">
+                {fieldErrors.era}
+              </p>
+            ) : null}
+          </div>
+        </fieldset>
+
+        <fieldset className="riffsync-admin-form-section">
+          <legend>YouTube</legend>
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-youtube-id">YouTube video id</label>
+            <input
+              id="catalog-form-youtube-id"
+              name="youtubeVideoId"
+              type="text"
+              value={values.youtubeVideoId}
+              onChange={(e) => setField('youtubeVideoId', e.target.value)}
+              aria-invalid={fieldErrors.youtubeVideoId ? true : undefined}
+              aria-describedby={
+                fieldErrors.youtubeVideoId ? 'catalog-form-youtube-id-error' : undefined
+              }
+              disabled={saving}
+              placeholder="Leave empty if unknown"
+            />
+            {fieldErrors.youtubeVideoId ? (
+              <p
+                id="catalog-form-youtube-id-error"
+                className="riffsync-admin-form-field-error"
+                role="alert"
+              >
+                {fieldErrors.youtubeVideoId}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-youtube-url">YouTube watch URL</label>
+            <input
+              id="catalog-form-youtube-url"
+              name="youtubeWatchUrl"
+              type="url"
+              value={values.youtubeWatchUrl}
+              onChange={(e) => setField('youtubeWatchUrl', e.target.value)}
+              aria-invalid={fieldErrors.youtubeWatchUrl ? true : undefined}
+              aria-describedby={
+                fieldErrors.youtubeWatchUrl ? 'catalog-form-youtube-url-error' : undefined
+              }
+              disabled={saving}
+              placeholder="https://www.youtube.com/watch?v=…"
+            />
+            {fieldErrors.youtubeWatchUrl ? (
+              <p
+                id="catalog-form-youtube-url-error"
+                className="riffsync-admin-form-field-error"
+                role="alert"
+              >
+                {fieldErrors.youtubeWatchUrl}
+              </p>
+            ) : null}
+          </div>
+        </fieldset>
+
+        <fieldset className="riffsync-admin-form-section">
+          <legend>Featured on home carousel</legend>
+          <div className="riffsync-admin-form-field riffsync-admin-form-field--checkbox">
+            <input
+              id="catalog-form-carousel"
+              name="carousel"
+              type="checkbox"
+              checked={values.carousel}
+              onChange={(e) => setField('carousel', e.target.checked)}
+              disabled={saving}
+            />
+            <label htmlFor="catalog-form-carousel">Show on home carousel</label>
+          </div>
+        </fieldset>
+
+        {showReconcileSection ? (
+          <fieldset className="riffsync-admin-form-section riffsync-admin-form-section--readonly">
+            <legend>Reconcile (read-only)</legend>
+            <p className="riffsync-admin-form-section-helper">{RECONCILE_HELPER}</p>
+            {showTagline && episode?.tagline ? (
+              <ReadOnlyField label="Tagline" value={episode.tagline} />
+            ) : null}
+            {reconcileFields.map(([label, value]) => (
+              <ReadOnlyField key={label} label={label} value={String(value)} />
+            ))}
+          </fieldset>
+        ) : null}
+
+        {showCuratorHintsSection ? (
+          <fieldset className="riffsync-admin-form-section riffsync-admin-form-section--readonly">
+            <legend>Curator hints (read-only)</legend>
+            <p className="riffsync-admin-form-section-helper">{CURATOR_HINTS_HELPER}</p>
+            {episode?.embedAllows === false ? (
+              <p className="riffsync-admin-form-embed-note" role="note">
+                In-app embed is disabled for this episode.
+              </p>
+            ) : null}
+            {hintFields.map(([label, value]) => (
+              <ReadOnlyField key={label} label={label} value={String(value)} />
+            ))}
+          </fieldset>
+        ) : null}
+
+        <div className="riffsync-admin-catalog-form-actions">
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? 'Saving…' : 'Save episode'}
+          </button>
+          <Link to="/admin/catalog" className="btn btn-secondary riffsync-admin-catalog-form-cancel">
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export { catalogEpisodeToFormValues, EMPTY_CATALOG_EPISODE_FORM_VALUES } from '../../catalog/validateCatalogEpisodeForm'

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2277,6 +2277,144 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   text-decoration: underline;
 }
 
+.riffsync-admin-catalog-form-page {
+  max-width: 42rem;
+}
+
+.riffsync-admin-catalog-form-header {
+  margin-bottom: 1.25rem;
+}
+
+.riffsync-admin-catalog-form-episode-id {
+  margin-top: 0.35rem;
+  color: var(--secondary-color);
+  font-size: 0.875rem;
+}
+
+.riffsync-admin-catalog-form-loading {
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-catalog-form-alert {
+  margin-bottom: 1rem;
+}
+
+.riffsync-admin-catalog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.riffsync-admin-form-section {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 0.35rem;
+}
+
+.riffsync-admin-form-section legend {
+  font-weight: 600;
+  padding: 0 0.25rem;
+}
+
+.riffsync-admin-form-section-helper {
+  margin: 0 0 0.85rem;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-form-section--readonly {
+  background: rgb(0 0 0 / 0.15);
+}
+
+.riffsync-admin-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.riffsync-admin-form-field:last-child {
+  margin-bottom: 0;
+}
+
+.riffsync-admin-form-field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.riffsync-admin-form-field input[type='text'],
+.riffsync-admin-form-field input[type='number'],
+.riffsync-admin-form-field input[type='url'],
+.riffsync-admin-form-field select {
+  min-height: 2.75rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgb(255 255 255 / 0.2);
+  background: rgb(0 0 0 / 0.25);
+  color: var(--white-color);
+}
+
+.riffsync-admin-form-field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.riffsync-admin-form-field--checkbox input {
+  width: 1.25rem;
+  height: 1.25rem;
+  min-height: 1.25rem;
+}
+
+.riffsync-admin-form-field-error {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #ff8a80;
+}
+
+.riffsync-admin-form-readonly-field {
+  display: grid;
+  gap: 0.2rem;
+  margin-bottom: 0.65rem;
+  font-size: 0.875rem;
+}
+
+.riffsync-admin-form-readonly-field__label {
+  color: var(--secondary-color);
+  font-weight: 600;
+}
+
+.riffsync-admin-form-readonly-field__value {
+  color: var(--white-color);
+  word-break: break-word;
+}
+
+.riffsync-admin-form-embed-note {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-catalog-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+}
+
+.riffsync-admin-catalog-form-actions .btn {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.25rem;
+}
+
+.riffsync-admin-catalog-form-cancel {
+  text-decoration: none;
+}
+
 @media (max-width: 767px) {
   .riffsync-admin-header {
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Replace `/admin/catalog/new` and `/admin/catalog/:id/edit` placeholders with a shared `AdminCatalogForm` (grouped fields, read-only reconcile and curator-hint sections).
- Add client-side `validateCatalogEpisodeForm` aligned with catalog schema rules; wire create/edit pages to staff catalog POST/PATCH/GET APIs.
- On successful save, navigate to `/admin/catalog` with `state: { saved: true }` for the list confirmation banner (#80).

Closes #81

## Test plan

- [x] `npm run verify:push:web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual: create episode at `/admin/catalog/new`, edit from list, verify read-only reconcile/hints and cancel path