### PR TITLE
[M13] Catalog episode delete API and admin UI (#83)

### DIFF
--- a/apps/web/src/admin/staffHasAdminGroup.ts
+++ b/apps/web/src/admin/staffHasAdminGroup.ts
@@ -1,0 +1,4 @@
+/** True when the operator session includes the Cognito `admin` group (delete and other admin-only APIs). */
+export function staffHasAdminGroup(groups: string[]): boolean {
+  return groups.includes('admin')
+}

--- a/apps/web/src/api/staffAdminCatalogApi.test.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createStaffCatalogEpisode,
+  deleteStaffCatalogEpisode,
   fetchStaffCatalogEpisode,
   fetchStaffCatalogList,
   patchStaffCatalogEpisode,
+  StaffCatalogEpisodeInUseError,
   StaffCatalogValidationError,
 } from './staffAdminCatalogApi'
 import {
@@ -134,5 +136,42 @@ describe('staffAdminCatalogApi', () => {
     await expect(
       patchStaffCatalogEpisode('staff-token', 'ep-1', { title: '' }),
     ).rejects.toBeInstanceOf(StaffCatalogValidationError)
+  })
+
+  it('deleteStaffCatalogEpisode sends DELETE and resolves on 204', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => '',
+    })
+
+    await deleteStaffCatalogEpisode('staff-token', 'ep-1')
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.test/v1/admin/catalog/episodes/ep-1')
+    expect(init.method).toBe('DELETE')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer staff-token',
+      Accept: 'application/json',
+    })
+  })
+
+  it('deleteStaffCatalogEpisode maps 409 catalog_episode_in_use', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        error: 'Conflict',
+        code: 'catalog_episode_in_use',
+        references: { rooms: 3, lists: 1 },
+      }),
+    })
+
+    await expect(deleteStaffCatalogEpisode('staff-token', 'ep-1')).rejects.toMatchObject({
+      references: { rooms: 3, lists: 1 },
+    })
+    await expect(deleteStaffCatalogEpisode('staff-token', 'ep-1')).rejects.toBeInstanceOf(
+      StaffCatalogEpisodeInUseError,
+    )
   })
 })

--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -77,6 +77,18 @@ export class StaffCatalogEpisodeNotFoundError extends Error {
   }
 }
 
+export class StaffCatalogEpisodeInUseError extends Error {
+  readonly statusCode = 409
+  readonly code = 'catalog_episode_in_use'
+  readonly references: { rooms: number; lists: number }
+
+  constructor(references: { rooms: number; lists: number }) {
+    super('Episode is referenced by rooms or lists and cannot be deleted.')
+    this.name = 'StaffCatalogEpisodeInUseError'
+    this.references = references
+  }
+}
+
 function staffCatalogJsonHeaders(accessToken: string): HeadersInit {
   return {
     Authorization: `Bearer ${accessToken}`,
@@ -159,6 +171,60 @@ export async function patchStaffCatalogEpisode(
     await mapStaffCatalogWriteError(res)
   }
   return (await res.json()) as StaffCatalogEpisodeResponse
+}
+
+export async function deleteStaffCatalogEpisode(
+  accessToken: string,
+  id: string,
+): Promise<void> {
+  const base = getPublicApiBaseUrl()
+  if (!base) throw new Error('Configure VITE_PUBLIC_API_BASE_URL.')
+  const encodedId = encodeURIComponent(id)
+  const res = await fetch(`${base}/v1/admin/catalog/episodes/${encodedId}`, {
+    method: 'DELETE',
+    headers: staffCatalogAuthHeaders(accessToken),
+  })
+  if (res.status === 204) {
+    return
+  }
+  if (res.status === 401) {
+    throw new StaffSessionUnauthorizedError()
+  }
+  if (res.status === 403) {
+    let detail = 'Staff group required — contact an administrator'
+    try {
+      const parsed = (await res.json()) as { code?: string; error?: string }
+      if (parsed.code === 'staff_group_required' || parsed.error === 'Forbidden') {
+        detail = 'Staff group required — contact an administrator'
+      }
+    } catch {
+      /* use default copy */
+    }
+    throw new StaffSessionForbiddenError(detail)
+  }
+  if (res.status === 404) {
+    throw new StaffCatalogEpisodeNotFoundError()
+  }
+  if (res.status === 409) {
+    try {
+      const parsed = (await res.json()) as {
+        code?: string
+        references?: { rooms?: number; lists?: number }
+      }
+      if (parsed.code === 'catalog_episode_in_use') {
+        throw new StaffCatalogEpisodeInUseError({
+          rooms: parsed.references?.rooms ?? 0,
+          lists: parsed.references?.lists ?? 0,
+        })
+      }
+    } catch (err) {
+      if (err instanceof StaffCatalogEpisodeInUseError) {
+        throw err
+      }
+    }
+  }
+  const t = await res.text()
+  throw new Error(`Staff catalog delete failed (${res.status}): ${t}`)
 }
 
 function staffCatalogAuthHeaders(accessToken: string): HeadersInit {

--- a/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.test.ts
+++ b/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatCatalogEpisodeInUseMessage } from './formatCatalogEpisodeInUseMessage'
+
+describe('formatCatalogEpisodeInUseMessage', () => {
+  it('includes room and list counts when present', () => {
+    expect(formatCatalogEpisodeInUseMessage({ rooms: 3, lists: 1 })).toBe(
+      'Cannot delete — this episode is used by 3 room(s) and/or 1 list(s).',
+    )
+  })
+
+  it('omits zero reference counts', () => {
+    expect(formatCatalogEpisodeInUseMessage({ rooms: 2, lists: 0 })).toBe(
+      'Cannot delete — this episode is used by 2 room(s).',
+    )
+  })
+})

--- a/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.ts
+++ b/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.ts
@@ -1,0 +1,16 @@
+export function formatCatalogEpisodeInUseMessage(references: {
+  rooms: number
+  lists: number
+}): string {
+  const segments: string[] = []
+  if (references.rooms > 0) {
+    segments.push(`${references.rooms} room(s)`)
+  }
+  if (references.lists > 0) {
+    segments.push(`${references.lists} list(s)`)
+  }
+  if (segments.length === 0) {
+    return 'Cannot delete — this episode is used by rooms or lists.'
+  }
+  return `Cannot delete — this episode is used by ${segments.join(' and/or ')}.`
+}

--- a/apps/web/src/pages/admin/AdminCatalogDeleteControl.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogDeleteControl.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AdminCatalogDeleteControl } from './AdminCatalogDeleteControl'
+import {
+  StaffCatalogEpisodeInUseError,
+  StaffCatalogEpisodeNotFoundError,
+} from '../../api/staffAdminCatalogApi'
+
+const navigate = vi.fn()
+const deleteStaffCatalogEpisode = vi.fn()
+const onEpisodeNotFound = vi.fn()
+
+const useAdminSession = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  }
+})
+
+vi.mock('../../admin/useAdminSession', () => ({
+  useAdminSession: () => useAdminSession(),
+}))
+
+vi.mock('../../auth/staffHostedUiPkce', () => ({
+  refreshStaffTokensIfStale: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../auth/staffTokens', () => ({
+  getStaffAccessToken: () => 'staff-token',
+}))
+
+vi.mock('../../api/staffAdminCatalogApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/staffAdminCatalogApi')>()
+  return {
+    ...actual,
+    deleteStaffCatalogEpisode: (...args: unknown[]) => deleteStaffCatalogEpisode(...args),
+  }
+})
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('AdminCatalogDeleteControl', () => {
+  let container: HTMLDivElement
+  let root: Root | null = null
+
+  beforeEach(() => {
+    navigate.mockReset()
+    deleteStaffCatalogEpisode.mockReset()
+    onEpisodeNotFound.mockReset()
+    deleteStaffCatalogEpisode.mockResolvedValue(undefined)
+    useAdminSession.mockReturnValue({
+      session: { sub: 'op', email: 'op@test', groups: ['admin'] },
+      loading: false,
+      error: null,
+      reload: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    root?.unmount()
+    root = null
+    container?.remove()
+  })
+
+  function renderControl(groups: string[] = ['admin']) {
+    useAdminSession.mockReturnValue({
+      session: { sub: 'op', email: 'op@test', groups },
+      loading: false,
+      error: null,
+      reload: vi.fn(),
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root!.render(
+        <MemoryRouter>
+          <AdminCatalogDeleteControl episodeId="ep-1" onEpisodeNotFound={onEpisodeNotFound} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('hides delete control for curator-only session', () => {
+    renderControl(['curator'])
+    expect(container.textContent).not.toContain('Delete episode')
+  })
+
+  it('requires typing episode id before confirm proceeds', async () => {
+    renderControl()
+
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Delete episode'),
+    )!
+    await act(async () => {
+      openBtn.click()
+    })
+
+    const deleteBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim() === 'Delete',
+    ) as HTMLButtonElement
+    expect(deleteBtn.disabled).toBe(true)
+
+    const confirmInput = container.querySelector('.riffsync-admin-modal__field') as HTMLInputElement
+    await act(async () => {
+      setInputValue(confirmInput, 'ep-1')
+    })
+    expect(deleteBtn.disabled).toBe(false)
+
+    await act(async () => {
+      deleteBtn.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(deleteStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1')
+      expect(navigate).toHaveBeenCalledWith('/admin/catalog', { state: { deleted: true } })
+    })
+  })
+
+  it('shows 409 conflict copy with reference counts', async () => {
+    deleteStaffCatalogEpisode.mockRejectedValue(
+      new StaffCatalogEpisodeInUseError({ rooms: 2, lists: 1 }),
+    )
+    renderControl()
+
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Delete episode'),
+    )!
+    await act(async () => {
+      openBtn.click()
+    })
+
+    const confirmInput = container.querySelector('.riffsync-admin-modal__field') as HTMLInputElement
+    await act(async () => {
+      setInputValue(confirmInput, 'ep-1')
+    })
+
+    const deleteBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim() === 'Delete',
+    ) as HTMLButtonElement
+    await act(async () => {
+      deleteBtn.click()
+    })
+
+    await vi.waitFor(() => {
+      const alert = container.querySelector('[role="alert"]')
+      expect(alert?.textContent).toContain('2 room(s)')
+      expect(alert?.textContent).toContain('1 list(s)')
+    })
+  })
+
+  it('calls onEpisodeNotFound when delete returns 404', async () => {
+    deleteStaffCatalogEpisode.mockRejectedValue(new StaffCatalogEpisodeNotFoundError())
+    renderControl()
+
+    const openBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Delete episode'),
+    )!
+    await act(async () => {
+      openBtn.click()
+    })
+
+    const confirmInput = container.querySelector('.riffsync-admin-modal__field') as HTMLInputElement
+    await act(async () => {
+      setInputValue(confirmInput, 'ep-1')
+    })
+
+    const deleteBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.trim() === 'Delete',
+    ) as HTMLButtonElement
+    await act(async () => {
+      deleteBtn.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(onEpisodeNotFound).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
+import { getStaffAccessToken } from '../../auth/staffTokens'
+import { useAdminSession } from '../../admin/useAdminSession'
+import { staffHasAdminGroup } from '../../admin/staffHasAdminGroup'
+import {
+  deleteStaffCatalogEpisode,
+  StaffCatalogEpisodeInUseError,
+  StaffCatalogEpisodeNotFoundError,
+} from '../../api/staffAdminCatalogApi'
+import {
+  StaffSessionForbiddenError,
+  StaffSessionUnauthorizedError,
+} from '../../api/staffAdminSessionApi'
+import { formatCatalogEpisodeInUseMessage } from '../../catalog/formatCatalogEpisodeInUseMessage'
+
+export function AdminCatalogDeleteControl({
+  episodeId,
+  onEpisodeNotFound,
+}: {
+  episodeId: string
+  onEpisodeNotFound: () => void
+}) {
+  const navigate = useNavigate()
+  const { session } = useAdminSession()
+  const dialogTitleId = useId()
+  const confirmInputId = useId()
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [confirmId, setConfirmId] = useState('')
+  const [deleting, setDeleting] = useState(false)
+  const [dialogError, setDialogError] = useState<string | null>(null)
+
+  const closeDialog = useCallback(() => {
+    setDialogOpen(false)
+    setConfirmId('')
+    setDialogError(null)
+    setDeleting(false)
+  }, [])
+
+  const openDialog = () => {
+    setConfirmId('')
+    setDialogError(null)
+    setDialogOpen(true)
+  }
+
+  useEffect(() => {
+    if (!dialogOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !deleting) closeDialog()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [closeDialog, deleting, dialogOpen])
+
+  if (!session || !staffHasAdminGroup(session.groups)) {
+    return null
+  }
+
+  const confirmEnabled = confirmId === episodeId && !deleting
+
+  const onDelete = async () => {
+    if (!confirmEnabled) return
+    setDialogError(null)
+    setDeleting(true)
+    try {
+      await refreshStaffTokensIfStale()
+      const token = getStaffAccessToken()
+      if (!token) {
+        setDialogError('Operator sign-in required')
+        return
+      }
+      await deleteStaffCatalogEpisode(token, episodeId)
+      closeDialog()
+      navigate('/admin/catalog', { state: { deleted: true } })
+    } catch (e: unknown) {
+      if (e instanceof StaffCatalogEpisodeNotFoundError) {
+        closeDialog()
+        onEpisodeNotFound()
+        return
+      }
+      if (e instanceof StaffCatalogEpisodeInUseError) {
+        setDialogError(formatCatalogEpisodeInUseMessage(e.references))
+        return
+      }
+      if (e instanceof StaffSessionUnauthorizedError || e instanceof StaffSessionForbiddenError) {
+        setDialogError(e.message)
+        return
+      }
+      setDialogError('Could not delete episode. Try again.')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <section className="riffsync-admin-catalog-delete" aria-labelledby="admin-catalog-delete-heading">
+      <h2 id="admin-catalog-delete-heading" className="riffsync-admin-catalog-delete__heading">
+        Danger zone
+      </h2>
+      <p className="riffsync-admin-catalog-delete__lede">
+        Permanently remove this episode from the catalog. Deletion is blocked while rooms or lists
+        reference the episode.
+      </p>
+      <button type="button" className="btn btn-danger" onClick={openDialog} disabled={deleting}>
+        Delete episode
+      </button>
+
+      {dialogOpen ? (
+        <div
+          className="riffsync-admin-modal-overlay"
+          role="presentation"
+          onClick={() => {
+            if (!deleting) closeDialog()
+          }}
+        >
+          <div
+            className="riffsync-admin-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={dialogTitleId}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id={dialogTitleId} className="riffsync-admin-modal__heading">
+              Delete episode?
+            </h2>
+            <p className="riffsync-admin-modal__lede">
+              This action is permanent. You cannot delete while rooms or lists still reference this
+              episode.
+            </p>
+            <div className="riffsync-admin-modal__form">
+              <label className="riffsync-admin-modal__label" htmlFor={confirmInputId}>
+                Type <code>{episodeId}</code> to confirm
+              </label>
+              <input
+                id={confirmInputId}
+                className="riffsync-admin-modal__field"
+                type="text"
+                autoComplete="off"
+                value={confirmId}
+                onChange={(e) => setConfirmId(e.target.value)}
+                disabled={deleting}
+              />
+            </div>
+            {dialogError ? (
+              <p className="riffsync-admin-modal__err" role="alert">
+                {dialogError}
+              </p>
+            ) : null}
+            <div className="riffsync-admin-modal__actions">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={closeDialog}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => void onDelete()}
+                disabled={!confirmEnabled}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -36,6 +36,19 @@ vi.mock('../../api/staffAdminCatalogApi', async (importOriginal) => {
   }
 })
 
+vi.mock('../../admin/useAdminSession', () => ({
+  useAdminSession: () => ({
+    session: { sub: 'op', email: 'op@test', groups: ['admin'] },
+    loading: false,
+    error: null,
+    reload: vi.fn(),
+  }),
+}))
+
+vi.mock('./AdminCatalogDeleteControl', () => ({
+  AdminCatalogDeleteControl: () => null,
+}))
+
 function setInputValue(input: HTMLInputElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
   setter?.call(input, value)

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -22,6 +22,7 @@ import {
   type CatalogEpisodeFormMode,
   type CatalogEpisodeFormValues,
 } from '../../catalog/validateCatalogEpisodeForm'
+import { AdminCatalogDeleteControl } from './AdminCatalogDeleteControl'
 
 const CATALOG_ERAS: CatalogEra[] = ['joel', 'mike', 'jonah', 'emily', 'other']
 
@@ -87,6 +88,7 @@ export function AdminCatalogForm({
   const [values, setValues] = useState(initialValues)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [formError, setFormError] = useState<string | null>(null)
+  const [episodeNotFound, setEpisodeNotFound] = useState(false)
   const [saving, setSaving] = useState(false)
 
   const setField = useCallback(
@@ -182,6 +184,19 @@ export function AdminCatalogForm({
 
   const showReconcileSection = mode === 'edit' && (showTagline || reconcileFields.length > 0)
   const showCuratorHintsSection = mode === 'edit' && (hintFields.length > 0 || episode?.embedAllows === false)
+
+  if (episodeNotFound) {
+    return (
+      <div className="container riffsync-admin-page">
+        <div role="alert" className="riffsync-scaffold-note">
+          <p>Episode not found.</p>
+          <p>
+            <Link to="/admin/catalog">Back to catalog</Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="container riffsync-admin-page riffsync-admin-catalog-form-page">
@@ -426,6 +441,13 @@ export function AdminCatalogForm({
           </Link>
         </div>
       </form>
+
+      {mode === 'edit' && episode ? (
+        <AdminCatalogDeleteControl
+          episodeId={episode.id}
+          onEpisodeNotFound={() => setEpisodeNotFound(true)}
+        />
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/pages/admin/AdminCatalogListPage.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogListPage.tsx
@@ -38,6 +38,12 @@ export function AdminCatalogListPage() {
   const savedFromQuery = searchParams.get('saved') === '1'
   const [savedBannerVisible, setSavedBannerVisible] = useState(savedFromState || savedFromQuery)
 
+  const deletedFromState = (location.state as { deleted?: boolean } | null)?.deleted === true
+  const deletedFromQuery = searchParams.get('deleted') === '1'
+  const [deletedBannerVisible, setDeletedBannerVisible] = useState(
+    deletedFromState || deletedFromQuery,
+  )
+
   const dismissSavedBanner = useCallback(() => {
     setSavedBannerVisible(false)
     if (savedFromState) {
@@ -50,11 +56,37 @@ export function AdminCatalogListPage() {
     }
   }, [location.pathname, location.search, navigate, savedFromQuery, savedFromState, searchParams, setSearchParams])
 
+  const dismissDeletedBanner = useCallback(() => {
+    setDeletedBannerVisible(false)
+    if (deletedFromState) {
+      navigate(`${location.pathname}${location.search}`, { replace: true, state: {} })
+    }
+    if (deletedFromQuery) {
+      const next = new URLSearchParams(searchParams)
+      next.delete('deleted')
+      setSearchParams(next, { replace: true })
+    }
+  }, [
+    deletedFromQuery,
+    deletedFromState,
+    location.pathname,
+    location.search,
+    navigate,
+    searchParams,
+    setSearchParams,
+  ])
+
   useEffect(() => {
     if (!savedBannerVisible) return
     const timer = window.setTimeout(() => dismissSavedBanner(), SAVED_BANNER_TIMEOUT_MS)
     return () => window.clearTimeout(timer)
   }, [dismissSavedBanner, savedBannerVisible])
+
+  useEffect(() => {
+    if (!deletedBannerVisible) return
+    const timer = window.setTimeout(() => dismissDeletedBanner(), SAVED_BANNER_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [deletedBannerVisible, dismissDeletedBanner])
 
   useEffect(() => {
     let cancelled = false
@@ -137,6 +169,15 @@ export function AdminCatalogListPage() {
         <div role="status" className="riffsync-admin-catalog-saved-banner">
           <p>Episode saved</p>
           <button type="button" className="btn btn-secondary" onClick={dismissSavedBanner}>
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
+      {deletedBannerVisible ? (
+        <div role="status" className="riffsync-admin-catalog-saved-banner">
+          <p>Episode deleted.</p>
+          <button type="button" className="btn btn-secondary" onClick={dismissDeletedBanner}>
             Dismiss
           </button>
         </div>

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2415,6 +2415,129 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   text-decoration: none;
 }
 
+.riffsync-admin-catalog-delete {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgb(255 255 255 / 0.12);
+}
+
+.riffsync-admin-catalog-delete__heading {
+  font-family: var(--title-fonts);
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: #ff8a80;
+}
+
+.riffsync-admin-catalog-delete__lede {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.btn.btn-danger {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgb(229 57 53 / 0.65);
+  background: rgb(183 28 28 / 0.35);
+  color: #ffebee;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn.btn-danger:hover:not(:disabled),
+.btn.btn-danger:focus:not(:disabled) {
+  background: rgb(211 47 47 / 0.55);
+  border-color: rgb(239 83 80 / 0.85);
+}
+
+.btn.btn-danger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.riffsync-admin-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  background: rgb(0 0 0 / 0.72);
+}
+
+.riffsync-admin-modal {
+  width: min(100%, 28rem);
+  padding: 1.25rem 1.35rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgb(255 255 255 / 0.15);
+  background: var(--dark-color);
+  color: var(--white-color);
+  box-shadow: 0 12px 40px rgb(0 0 0 / 0.45);
+}
+
+.riffsync-admin-modal__heading {
+  font-family: var(--title-fonts);
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0 0 0.65rem;
+}
+
+.riffsync-admin-modal__lede {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-admin-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.85rem;
+}
+
+.riffsync-admin-modal__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.riffsync-admin-modal__field {
+  min-height: 2.75rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgb(255 255 255 / 0.2);
+  background: rgb(0 0 0 / 0.25);
+  color: var(--white-color);
+}
+
+.riffsync-admin-modal__err {
+  margin: 0 0 0.85rem;
+  font-size: 0.875rem;
+  color: #ff8a80;
+}
+
+.riffsync-admin-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.riffsync-admin-modal__actions .btn {
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.25rem;
+}
+
 @media (max-width: 767px) {
   .riffsync-admin-header {
     flex-direction: column;

--- a/infra/cdk/lambda/admin-catalog-delete-shared.ts
+++ b/infra/cdk/lambda/admin-catalog-delete-shared.ts
@@ -1,0 +1,51 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export type CatalogEpisodeReferences = {
+  rooms: number;
+  lists: number;
+};
+
+async function countScanMatches(
+  tableName: string,
+  filterExpression: string,
+  expressionAttributeValues: Record<string, unknown>,
+): Promise<number> {
+  const out = await client.send(
+    new ScanCommand({
+      TableName: tableName,
+      FilterExpression: filterExpression,
+      ExpressionAttributeValues: expressionAttributeValues,
+      Select: 'COUNT',
+    }),
+  );
+  return typeof out.Count === 'number' ? out.Count : 0;
+}
+
+export async function countCatalogEpisodeReferences(
+  episodeId: string,
+  roomsTableName: string,
+  listsTableName?: string,
+): Promise<CatalogEpisodeReferences> {
+  const rooms = await countScanMatches(roomsTableName, 'catalogEpisodeId = :id', { ':id': episodeId });
+  const lists =
+    listsTableName && listsTableName.length > 0
+      ? await countScanMatches(listsTableName, 'catalogEpisodeId = :id', { ':id': episodeId })
+      : 0;
+  return { rooms, lists };
+}
+
+export async function catalogEpisodeExists(
+  catalogTableName: string,
+  episodeId: string,
+): Promise<boolean> {
+  const out = await client.send(
+    new GetCommand({
+      TableName: catalogTableName,
+      Key: { id: episodeId },
+    }),
+  );
+  return out.Item !== undefined;
+}

--- a/infra/cdk/lambda/admin-catalog-delete.test.ts
+++ b/infra/cdk/lambda/admin-catalog-delete.test.ts
@@ -1,0 +1,202 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  recordAdminCatalogRoute: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  ScanCommand: vi.fn((input: unknown) => ({ input, kind: 'Scan' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+vi.mock('./riffsync-observability', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./riffsync-observability')>();
+  return {
+    ...actual,
+    recordAdminCatalogRoute: mocks.recordAdminCatalogRoute,
+    logRiffsyncDiagError: vi.fn(),
+  };
+});
+
+import { handler as deleteHandler } from './admin-catalog-delete';
+
+function deleteEvent(
+  path: string,
+  claims?: Record<string, unknown>,
+  pathParameters?: Record<string, string>,
+): APIGatewayProxyEventV2 {
+  const routeKey = 'DELETE /v1/admin/catalog/episodes/{id}';
+  return {
+    version: '2.0',
+    routeKey,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    body: undefined,
+    pathParameters,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'DELETE',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-delete-1',
+      routeKey,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: claims ? { jwt: { claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('admin-catalog-delete handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    process.env.ROOMS_TABLE_NAME = 'rooms-table';
+    delete process.env.STAFF_USER_POOL_ID;
+    delete process.env.LISTS_TABLE_NAME;
+  });
+
+  it('returns 204 when episode exists and no references', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: 'ep-1' } })
+      .mockResolvedValueOnce({ Count: 0 })
+      .mockResolvedValueOnce({});
+
+    const res = await deleteHandler(
+      deleteEvent(
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(204);
+    expect(res?.body).toBe('');
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogDelete',
+      'success',
+      expect.objectContaining({ action: 'delete', episodeId: 'ep-1', statusCode: 204 }),
+    );
+  });
+
+  it('returns 404 when episode missing', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+
+    const res = await deleteHandler(
+      deleteEvent(
+        '/v1/admin/catalog/episodes/missing',
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'missing' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(404);
+    expect(JSON.parse(res?.body ?? '')).toEqual({ error: 'Not found' });
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogDelete',
+      'not_found',
+      expect.any(Object),
+    );
+  });
+
+  it('returns 409 when room scan returns matches', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: 'ep-1' } })
+      .mockResolvedValueOnce({ Count: 2 });
+
+    const res = await deleteHandler(
+      deleteEvent(
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(409);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Conflict',
+      code: 'catalog_episode_in_use',
+      references: { rooms: 2, lists: 0 },
+    });
+    expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
+      'AdminCatalogDelete',
+      'conflict',
+      expect.any(Object),
+    );
+  });
+
+  it('returns 403 for curator-only JWT', async () => {
+    const res = await deleteHandler(
+      deleteEvent(
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['curator'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(403);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Forbidden',
+      code: 'staff_group_required',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authorizer claims omit sub', async () => {
+    const res = await deleteHandler(
+      deleteEvent('/v1/admin/catalog/episodes/ep-1', undefined, { id: 'ep-1' }),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(401);
+    expect(JSON.parse(res?.body ?? '')).toEqual({
+      error: 'Unauthorized',
+      code: 'unauthorized',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when staff groups omit admin/curator', async () => {
+    const res = await deleteHandler(
+      deleteEvent(
+        '/v1/admin/catalog/episodes/ep-1',
+        { sub: 'staff-1', 'cognito:groups': ['viewer'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(403);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/admin-catalog-delete.ts
+++ b/infra/cdk/lambda/admin-catalog-delete.ts
@@ -1,0 +1,116 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+import { requireAdminAccess, resolveStaffSub } from './admin-staff-access';
+import {
+  catalogEpisodeExists,
+  countCatalogEpisodeReferences,
+} from './admin-catalog-delete-shared';
+import { jsonResponse } from './giphy-search-shared';
+import {
+  adminCatalogDeleteOutcomeFromStatus,
+  logRiffsyncDiagError,
+  recordAdminCatalogRoute,
+  type AdminCatalogDeleteOutcome,
+} from './riffsync-observability';
+
+const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function emptyResponse(statusCode: 204) {
+  return { statusCode, body: '' };
+}
+
+function finishDelete(
+  event: APIGatewayProxyEventV2,
+  sub: string,
+  episodeId: string,
+  statusCode: number,
+  body?: Record<string, unknown>,
+) {
+  const outcome = adminCatalogDeleteOutcomeFromStatus(statusCode);
+  recordAdminCatalogRoute('AdminCatalogDelete', outcome, {
+    route: 'AdminCatalogDelete',
+    action: 'delete',
+    outcome,
+    sub,
+    episodeId,
+    requestId: event.requestContext.requestId,
+    statusCode,
+  });
+  if (statusCode === 204) {
+    return emptyResponse(204);
+  }
+  return jsonResponse(statusCode, body ?? { error: 'Internal server error' });
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const episodeId = event.pathParameters?.id ?? '';
+  const sub = resolveStaffSub(event) ?? 'unknown';
+
+  const denied = await requireAdminAccess(event);
+  if (denied) {
+    const statusCode = denied.statusCode ?? 403;
+    const outcome = adminCatalogDeleteOutcomeFromStatus(statusCode) as AdminCatalogDeleteOutcome;
+    recordAdminCatalogRoute('AdminCatalogDelete', outcome, {
+      route: 'AdminCatalogDelete',
+      action: 'delete',
+      outcome,
+      sub,
+      episodeId,
+      requestId: event.requestContext.requestId,
+      statusCode,
+    });
+    return denied;
+  }
+
+  const staffSub = resolveStaffSub(event);
+  if (!staffSub) {
+    return finishDelete(event, sub, episodeId, 401, {
+      error: 'Unauthorized',
+      code: 'unauthorized',
+    });
+  }
+
+  const catalogTableName = process.env.CATALOG_TABLE_NAME;
+  const roomsTableName = process.env.ROOMS_TABLE_NAME;
+  if (!catalogTableName || !roomsTableName) {
+    return finishDelete(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  if (!episodeId) {
+    return finishDelete(event, staffSub, episodeId, 404, { error: 'Not found' });
+  }
+
+  try {
+    const exists = await catalogEpisodeExists(catalogTableName, episodeId);
+    if (!exists) {
+      return finishDelete(event, staffSub, episodeId, 404, { error: 'Not found' });
+    }
+
+    const listsTableName = process.env.LISTS_TABLE_NAME?.trim();
+    const references = await countCatalogEpisodeReferences(
+      episodeId,
+      roomsTableName,
+      listsTableName,
+    );
+    if (references.rooms > 0 || references.lists > 0) {
+      return finishDelete(event, staffSub, episodeId, 409, {
+        error: 'Conflict',
+        code: 'catalog_episode_in_use',
+        references,
+      });
+    }
+
+    await client.send(
+      new DeleteCommand({
+        TableName: catalogTableName,
+        Key: { id: episodeId },
+      }),
+    );
+  } catch (err) {
+    logRiffsyncDiagError('admin_catalog_delete_failed', err);
+    return finishDelete(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  return finishDelete(event, staffSub, episodeId, 204);
+};

--- a/infra/cdk/lambda/admin-staff-access.ts
+++ b/infra/cdk/lambda/admin-staff-access.ts
@@ -75,3 +75,20 @@ export async function requireStaffAccess(
 
   return null;
 }
+
+/** Admin-only gate — **`curator`** receives **403** **`staff_group_required`**. */
+export async function requireAdminAccess(
+  event: APIGatewayProxyEventV2,
+): Promise<ReturnType<typeof jsonResponse> | null> {
+  const sub = resolveStaffSub(event);
+  if (!sub) {
+    return jsonResponse(401, { error: 'Unauthorized', code: 'unauthorized' });
+  }
+
+  const groups = await resolveStaffGroupsForRequest(event);
+  if (!groups.includes('admin')) {
+    return jsonResponse(403, { error: 'Forbidden', code: 'staff_group_required' });
+  }
+
+  return null;
+}

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -10,7 +10,8 @@ export type ApiRoute =
   | 'GiphySearch'
   | 'FanAvatarUpload'
   | 'AdminCatalogPost'
-  | 'AdminCatalogPatch';
+  | 'AdminCatalogPatch'
+  | 'AdminCatalogDelete';
 
 export type GiphySearchOutcome =
   | 'success'
@@ -44,11 +45,20 @@ export type AdminCatalogPatchOutcome =
   | 'not_found'
   | 'server_error';
 
+export type AdminCatalogDeleteOutcome =
+  | 'success'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'not_found'
+  | 'conflict'
+  | 'server_error';
+
 export type ApiOutcome =
   | GiphySearchOutcome
   | FanAvatarUploadOutcome
   | AdminCatalogPostOutcome
-  | AdminCatalogPatchOutcome;
+  | AdminCatalogPatchOutcome
+  | AdminCatalogDeleteOutcome;
 
 const REALTIME_METRIC_NAME = 'Requests';
 const API_METRIC_NAME = 'Requests';
@@ -215,9 +225,12 @@ export function recordApiRoute(
 }
 
 export type AdminCatalogAuditFields = {
-  route: 'AdminCatalogPost' | 'AdminCatalogPatch';
-  action: 'create' | 'update';
-  outcome: AdminCatalogPostOutcome | AdminCatalogPatchOutcome;
+  route: 'AdminCatalogPost' | 'AdminCatalogPatch' | 'AdminCatalogDelete';
+  action: 'create' | 'update' | 'delete';
+  outcome:
+    | AdminCatalogPostOutcome
+    | AdminCatalogPatchOutcome
+    | AdminCatalogDeleteOutcome;
   sub: string;
   episodeId: string;
   requestId: string;
@@ -244,8 +257,8 @@ export function logAdminCatalogAudit(fields: AdminCatalogAuditFields): void {
 }
 
 export function recordAdminCatalogRoute(
-  route: 'AdminCatalogPost' | 'AdminCatalogPatch',
-  outcome: AdminCatalogPostOutcome | AdminCatalogPatchOutcome,
+  route: 'AdminCatalogPost' | 'AdminCatalogPatch' | 'AdminCatalogDelete',
+  outcome: AdminCatalogPostOutcome | AdminCatalogPatchOutcome | AdminCatalogDeleteOutcome,
   audit: AdminCatalogAuditFields,
 ): void {
   emitApiEmf(route, outcome);
@@ -268,5 +281,14 @@ export function adminCatalogPatchOutcomeFromStatus(statusCode: number): AdminCat
   if (statusCode === 403) return 'forbidden';
   if (statusCode === 400) return 'validation_error';
   if (statusCode === 404) return 'not_found';
+  return 'server_error';
+}
+
+export function adminCatalogDeleteOutcomeFromStatus(statusCode: number): AdminCatalogDeleteOutcome {
+  if (statusCode === 204) return 'success';
+  if (statusCode === 401) return 'unauthorized';
+  if (statusCode === 403) return 'forbidden';
+  if (statusCode === 404) return 'not_found';
+  if (statusCode === 409) return 'conflict';
   return 'server_error';
 }

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -638,11 +638,34 @@ export class ApiCatalogStack extends cdk.Stack {
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
+    const adminCatalogDeleteFn = new lambdaNodejs.NodejsFunction(this, 'AdminCatalogDeleteFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/admin-catalog-delete.ts'),
+      handler: 'handler',
+      environment: {
+        CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        ROOMS_TABLE_NAME: this.roomsTable.tableName,
+        STAFF_USER_POOL_ID: staffUserPool.userPoolId,
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
     this.catalogTable.grantReadData(adminCatalogListFn);
     this.catalogTable.grantReadData(adminCatalogGetFn);
     this.catalogTable.grantReadWriteData(adminCatalogPostFn);
     this.catalogTable.grantReadWriteData(adminCatalogPatchFn);
-    for (const fn of [adminCatalogListFn, adminCatalogGetFn, adminCatalogPostFn, adminCatalogPatchFn]) {
+    this.catalogTable.grantReadWriteData(adminCatalogDeleteFn);
+    this.roomsTable.grantReadData(adminCatalogDeleteFn);
+    for (const fn of [
+      adminCatalogListFn,
+      adminCatalogGetFn,
+      adminCatalogPostFn,
+      adminCatalogPatchFn,
+      adminCatalogDeleteFn,
+    ]) {
       fn.addToRolePolicy(
         new iam.PolicyStatement({
           actions: ['cognito-idp:AdminListGroupsForUser'],
@@ -782,6 +805,7 @@ export class ApiCatalogStack extends cdk.Stack {
           apigwv2.CorsHttpMethod.POST,
           apigwv2.CorsHttpMethod.PATCH,
           apigwv2.CorsHttpMethod.PUT,
+          apigwv2.CorsHttpMethod.DELETE,
           apigwv2.CorsHttpMethod.OPTIONS,
         ],
         allowOrigins,
@@ -842,6 +866,10 @@ export class ApiCatalogStack extends cdk.Stack {
     const adminCatalogPatchIntegration = new integrations.HttpLambdaIntegration(
       'AdminCatalogPatchInt',
       adminCatalogPatchFn,
+    );
+    const adminCatalogDeleteIntegration = new integrations.HttpLambdaIntegration(
+      'AdminCatalogDeleteInt',
+      adminCatalogDeleteFn,
     );
 
     this.httpApi.addRoutes({
@@ -963,6 +991,13 @@ export class ApiCatalogStack extends cdk.Stack {
       authorizer: staffJwtAuthorizer,
     });
 
+    this.httpApi.addRoutes({
+      path: '/v1/admin/catalog/episodes/{id}',
+      methods: [apigwv2.HttpMethod.DELETE],
+      integration: adminCatalogDeleteIntegration,
+      authorizer: staffJwtAuthorizer,
+    });
+
     const httpStageL1 = this.httpApi.defaultStage?.node.defaultChild as apigwv2.CfnStage | undefined;
     if (httpStageL1) {
       httpStageL1.defaultRouteSettings = {
@@ -1019,7 +1054,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH).',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE).',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Adds **`DELETE /v1/admin/catalog/episodes/{id}`** behind the staff JWT authorizer with **admin-only** access (curators receive **403**).
- Blocks delete with **409 `catalog_episode_in_use`** when rooms (or list memberships when `LISTS_TABLE_NAME` is set) reference the episode.
- Extends **`AdminCatalogDelete`** EMF metrics and **`logAdminCatalogAudit`** with **`action: delete`**.
- Adds **`deleteStaffCatalogEpisode`** to the SPA API client.
- Adds **admin-only** delete on **`/admin/catalog/:id/edit`**: confirmation dialog (type episode id), **409** conflict copy, navigate to list with *Episode deleted.* status.

Closes #86
Closes #87

Part of #83 (M13 admin catalog management).

## Test plan

- [x] `npm run verify:push:cdk` (Vitest includes `admin-catalog-delete` cases; CDK synth registers DELETE route)
- [x] `npm run verify:push:web` (API client + `AdminCatalogDeleteControl` tests: admin vs curator, typed id confirm, 409, success navigation)
- [ ] Manual: admin deletes unreferenced episode; curator sees no delete control; referenced episode shows 409 with counts