### PR TITLE
feat(api): M13 catalog caching and generation (#84)

### DIFF
--- a/apps/web/src/catalog/catalogApi.test.ts
+++ b/apps/web/src/catalog/catalogApi.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchCatalogCarouselEntries,
+  fetchCatalogEntries,
+  fetchCatalogEpisodeById,
+  normalizeCatalogEtag,
+} from './catalogApi'
+
+const API_BASE = 'https://api.example.test'
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => API_BASE,
+}))
+
+describe('normalizeCatalogEtag', () => {
+  it('trims weak ETag values', () => {
+    expect(normalizeCatalogEtag('  W/"42-full"  ')).toBe('W/"42-full"')
+  })
+})
+
+function mockFetchResponse(init: {
+  status: number
+  headers?: Record<string, string>
+  body?: unknown
+}): Response {
+  const headerMap = new Map(
+    Object.entries(init.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]),
+  )
+  return {
+    status: init.status,
+    ok: init.status >= 200 && init.status < 300,
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+    },
+    json: async () => init.body,
+  } as Response
+}
+
+describe('catalogApi conditional GET', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetchCatalogEntries sends If-None-Match and handles 304', async () => {
+    fetchMock.mockResolvedValue(
+      mockFetchResponse({ status: 304, headers: { ETag: 'W/"2-full"' } }),
+    )
+
+    const result = await fetchCatalogEntries('W/"1-full"')
+
+    expect(result).toEqual({ kind: 'notModified' })
+    expect(fetchMock).toHaveBeenCalledWith(`${API_BASE}/v1/catalog`, {
+      headers: { Accept: 'application/json', 'If-None-Match': 'W/"1-full"' },
+    })
+  })
+
+  it('fetchCatalogEntries parses ETag and entries on 200', async () => {
+    fetchMock.mockResolvedValue(
+      mockFetchResponse({
+        status: 200,
+        headers: { ETag: 'W/"3-full"' },
+        body: {
+          entries: [
+            {
+              id: 'ep-1',
+              experimentNumber: 1,
+              title: 'T',
+              era: 'joel',
+              youtubeVideoId: null,
+              youtubeWatchUrl: null,
+              tagline: null,
+              posterImageUrl: null,
+              backdropImageUrl: null,
+              tmdbMovieId: null,
+              tmdbArtworkSyncedAt: null,
+            },
+          ],
+        },
+      }),
+    )
+
+    const result = await fetchCatalogEntries()
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.etag).toBe('W/"3-full"')
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0]?.id).toBe('ep-1')
+  })
+
+  it('fetchCatalogCarouselEntries requests carousel query param', async () => {
+    fetchMock.mockResolvedValue(
+      mockFetchResponse({
+        status: 200,
+        headers: { ETag: 'W/"4-carousel"' },
+        body: { entries: [] },
+      }),
+    )
+
+    await fetchCatalogCarouselEntries()
+
+    expect(fetchMock).toHaveBeenCalledWith(`${API_BASE}/v1/catalog?carousel=true`, {
+      headers: { Accept: 'application/json' },
+    })
+  })
+
+  it('fetchCatalogEpisodeById handles 304 and 200', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockFetchResponse({ status: 304, headers: { ETag: 'W/"5-episode-ep-1"' } }),
+    )
+    expect(await fetchCatalogEpisodeById('ep-1', 'W/"4-episode-ep-1"')).toEqual({
+      kind: 'notModified',
+    })
+
+    fetchMock.mockResolvedValueOnce(
+      mockFetchResponse({
+        status: 200,
+        headers: { ETag: 'W/"6-episode-ep-1"' },
+        body: { entry: { id: 'ep-1', experimentNumber: 1, title: 'T', era: 'mike' } },
+      }),
+    )
+    const ok = await fetchCatalogEpisodeById('ep-1')
+    expect(ok.kind).toBe('ok')
+    if (ok.kind !== 'ok') return
+    expect(ok.entry?.id).toBe('ep-1')
+    expect(ok.etag).toBe('W/"6-episode-ep-1"')
+  })
+})

--- a/apps/web/src/catalog/catalogApi.ts
+++ b/apps/web/src/catalog/catalogApi.ts
@@ -1,6 +1,17 @@
 import type { CatalogBundle, CatalogEpisode, CatalogEra, PlaybackExpectation } from './catalogTypes'
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 
+/** Default public catalog `Cache-Control` max-age when env does not override (see `docs/api.catalog.md`). */
+export const CATALOG_HTTP_MAX_AGE_MS = 60_000
+
+export type CatalogFetchResult<T> =
+  | { kind: 'notModified' }
+  | { kind: 'ok'; etag: string; data: T }
+
+export type CatalogEpisodeByIdResult =
+  | { kind: 'notModified' }
+  | { kind: 'ok'; etag: string; entry: CatalogEpisode | null }
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null
 }
@@ -27,6 +38,13 @@ function parseCarouselFlag(v: unknown): boolean {
   }
   if (typeof v === 'number' && Number.isFinite(v)) return v === 1
   return false
+}
+
+/** Trim and preserve weak ETag form for `If-None-Match` round-trips. */
+export function normalizeCatalogEtag(header: string | null | undefined): string | undefined {
+  if (header == null) return undefined
+  const trimmed = header.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 export function normalizeEpisode(raw: unknown): CatalogEpisode {
@@ -79,25 +97,49 @@ async function loadDevSeedBundle(): Promise<CatalogBundle> {
   return mod.default as CatalogBundle
 }
 
-export async function fetchCatalogEntries(): Promise<CatalogEpisode[]> {
+async function catalogJsonGet(
+  url: string,
+  etag?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (etag) {
+    headers['If-None-Match'] = etag
+  }
+  return fetch(url, { headers })
+}
+
+function parseListBody(body: unknown): CatalogEpisode[] {
+  if (!isRecord(body) || !Array.isArray(body.entries)) {
+    throw new Error('Catalog response missing entries array')
+  }
+  return body.entries.map(normalizeEpisode)
+}
+
+export async function fetchCatalogEntries(etag?: string): Promise<CatalogFetchResult<CatalogEpisode[]>> {
   const base = getPublicApiBaseUrl()
   if (base) {
-    const res = await fetch(`${base}/v1/catalog`, {
-      headers: { Accept: 'application/json' },
-    })
+    const res = await catalogJsonGet(`${base}/v1/catalog`, etag)
+    if (res.status === 304) {
+      return { kind: 'notModified' }
+    }
     if (!res.ok) {
       throw new Error(`Catalog request failed (${res.status})`)
     }
-    const body = (await res.json()) as { entries?: unknown[] }
-    if (!Array.isArray(body.entries)) {
-      throw new Error('Catalog response missing entries array')
+    const responseEtag = normalizeCatalogEtag(res.headers.get('ETag'))
+    if (!responseEtag) {
+      throw new Error('Catalog response missing ETag')
     }
-    return body.entries.map(normalizeEpisode)
+    const body = (await res.json()) as unknown
+    return { kind: 'ok', etag: responseEtag, data: parseListBody(body) }
   }
 
   if (import.meta.env.DEV) {
     const bundle = await loadDevSeedBundle()
-    return bundle.entries.map(normalizeEpisode)
+    return {
+      kind: 'ok',
+      etag: 'dev-seed-full',
+      data: bundle.entries.map(normalizeEpisode),
+    }
   }
 
   throw new Error(
@@ -105,29 +147,35 @@ export async function fetchCatalogEntries(): Promise<CatalogEpisode[]> {
   )
 }
 
-export async function fetchCatalogCarouselEntries(): Promise<CatalogEpisode[]> {
+export async function fetchCatalogCarouselEntries(
+  etag?: string,
+): Promise<CatalogFetchResult<CatalogEpisode[]>> {
   const base = getPublicApiBaseUrl()
   if (base) {
     const url = new URL(`${base}/v1/catalog`)
     url.searchParams.set('carousel', 'true')
-    const res = await fetch(url.toString(), {
-      headers: { Accept: 'application/json' },
-    })
+    const res = await catalogJsonGet(url.toString(), etag)
+    if (res.status === 304) {
+      return { kind: 'notModified' }
+    }
     if (!res.ok) {
       throw new Error(`Catalog carousel request failed (${res.status})`)
     }
-    const body = (await res.json()) as { entries?: unknown[] }
-    if (!Array.isArray(body.entries)) {
-      throw new Error('Catalog carousel response missing entries array')
+    const responseEtag = normalizeCatalogEtag(res.headers.get('ETag'))
+    if (!responseEtag) {
+      throw new Error('Catalog carousel response missing ETag')
     }
-    return body.entries.map(normalizeEpisode)
+    const body = (await res.json()) as unknown
+    return { kind: 'ok', etag: responseEtag, data: parseListBody(body) }
   }
 
   if (import.meta.env.DEV) {
     const bundle = await loadDevSeedBundle()
-    return bundle.entries
-      .map(normalizeEpisode)
-      .filter((e) => e.carousel === true)
+    return {
+      kind: 'ok',
+      etag: 'dev-seed-carousel',
+      data: bundle.entries.map(normalizeEpisode).filter((e) => e.carousel === true),
+    }
   }
 
   throw new Error(
@@ -135,23 +183,38 @@ export async function fetchCatalogCarouselEntries(): Promise<CatalogEpisode[]> {
   )
 }
 
-export async function fetchCatalogEpisodeById(id: string): Promise<CatalogEpisode | null> {
+export async function fetchCatalogEpisodeById(
+  id: string,
+  etag?: string,
+): Promise<CatalogEpisodeByIdResult> {
   const base = getPublicApiBaseUrl()
   if (base) {
-    const res = await fetch(`${base}/v1/catalog/${encodeURIComponent(id)}`, {
-      headers: { Accept: 'application/json' },
-    })
-    if (res.status === 404) return null
+    const res = await catalogJsonGet(`${base}/v1/catalog/${encodeURIComponent(id)}`, etag)
+    if (res.status === 304) {
+      return { kind: 'notModified' }
+    }
+    if (res.status === 404) {
+      const responseEtag = normalizeCatalogEtag(res.headers.get('ETag')) ?? ''
+      return { kind: 'ok', etag: responseEtag, entry: null }
+    }
     if (!res.ok) {
       throw new Error(`Catalog item request failed (${res.status})`)
+    }
+    const responseEtag = normalizeCatalogEtag(res.headers.get('ETag'))
+    if (!responseEtag) {
+      throw new Error('Catalog item response missing ETag')
     }
     const body = (await res.json()) as { entry?: unknown }
     if (!body.entry) {
       throw new Error('Catalog item response missing entry')
     }
-    return normalizeEpisode(body.entry)
+    return { kind: 'ok', etag: responseEtag, entry: normalizeEpisode(body.entry) }
   }
 
-  const entries = await fetchCatalogEntries()
-  return entries.find((e) => e.id === id) ?? null
+  const list = await fetchCatalogEntries()
+  if (list.kind === 'notModified') {
+    throw new Error('Catalog episode lookup requires a prior list cache in dev without API')
+  }
+  const entry = list.data.find((e) => e.id === id) ?? null
+  return { kind: 'ok', etag: 'dev-seed-episode', entry }
 }

--- a/apps/web/src/catalog/catalogQueries.ts
+++ b/apps/web/src/catalog/catalogQueries.ts
@@ -35,10 +35,11 @@ function setStoredEtag(queryKey: readonly unknown[], etag: string): void {
 }
 
 function resolveNotModified<T>(
-  ctx: QueryFunctionContext<readonly unknown[], unknown>,
+  client: QueryClient,
+  queryKey: readonly unknown[],
   label: string,
 ): T {
-  const cached = ctx.client.getQueryData<T>(ctx.queryKey)
+  const cached = client.getQueryData<T>(queryKey)
   if (cached === undefined) {
     throw new Error(`${label}: 304 Not Modified without cached data`)
   }
@@ -52,7 +53,7 @@ async function runCatalogListQuery(
   const etag = getStoredEtag(ctx.queryKey)
   const result = await fetcher(etag)
   if (result.kind === 'notModified') {
-    return resolveNotModified(ctx, 'Catalog list')
+    return resolveNotModified(ctx.client, ctx.queryKey, 'Catalog list')
   }
   setStoredEtag(ctx.queryKey, result.etag)
   return result.data
@@ -68,7 +69,7 @@ async function runCatalogEpisodeQuery(
   const etag = getStoredEtag(ctx.queryKey)
   const result: CatalogEpisodeByIdResult = await fetchCatalogEpisodeById(id, etag)
   if (result.kind === 'notModified') {
-    return resolveNotModified(ctx, 'Catalog episode')
+    return resolveNotModified(ctx.client, ctx.queryKey, 'Catalog episode')
   }
   if (result.etag) {
     setStoredEtag(ctx.queryKey, result.etag)

--- a/apps/web/src/catalog/catalogQueries.ts
+++ b/apps/web/src/catalog/catalogQueries.ts
@@ -1,0 +1,106 @@
+import {
+  useQuery,
+  type QueryClient,
+  type QueryFunctionContext,
+} from '@tanstack/react-query'
+import {
+  fetchCatalogCarouselEntries,
+  fetchCatalogEntries,
+  fetchCatalogEpisodeById,
+  CATALOG_HTTP_MAX_AGE_MS,
+  type CatalogFetchResult,
+  type CatalogEpisodeByIdResult,
+} from './catalogApi'
+import type { CatalogEpisode } from './catalogTypes'
+
+export const catalogListFullQueryKey = ['catalog', 'list', 'full'] as const
+export const catalogListCarouselQueryKey = ['catalog', 'list', 'carousel'] as const
+
+export function catalogEpisodeQueryKey(id: string) {
+  return ['catalog', 'episode', id] as const
+}
+
+const etagByQueryKey = new Map<string, string>()
+
+function queryKeyStorageKey(queryKey: readonly unknown[]): string {
+  return JSON.stringify(queryKey)
+}
+
+function getStoredEtag(queryKey: readonly unknown[]): string | undefined {
+  return etagByQueryKey.get(queryKeyStorageKey(queryKey))
+}
+
+function setStoredEtag(queryKey: readonly unknown[], etag: string): void {
+  etagByQueryKey.set(queryKeyStorageKey(queryKey), etag)
+}
+
+function resolveNotModified<T>(
+  ctx: QueryFunctionContext<readonly unknown[], unknown>,
+  label: string,
+): T {
+  const cached = ctx.client.getQueryData<T>(ctx.queryKey)
+  if (cached === undefined) {
+    throw new Error(`${label}: 304 Not Modified without cached data`)
+  }
+  return cached
+}
+
+async function runCatalogListQuery(
+  ctx: QueryFunctionContext<readonly ['catalog', 'list', string]>,
+  fetcher: (etag?: string) => Promise<CatalogFetchResult<CatalogEpisode[]>>,
+): Promise<CatalogEpisode[]> {
+  const etag = getStoredEtag(ctx.queryKey)
+  const result = await fetcher(etag)
+  if (result.kind === 'notModified') {
+    return resolveNotModified(ctx, 'Catalog list')
+  }
+  setStoredEtag(ctx.queryKey, result.etag)
+  return result.data
+}
+
+async function runCatalogEpisodeQuery(
+  ctx: QueryFunctionContext<ReturnType<typeof catalogEpisodeQueryKey>>,
+): Promise<CatalogEpisode | null> {
+  const id = ctx.queryKey[2]
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('Catalog episode query requires an id')
+  }
+  const etag = getStoredEtag(ctx.queryKey)
+  const result: CatalogEpisodeByIdResult = await fetchCatalogEpisodeById(id, etag)
+  if (result.kind === 'notModified') {
+    return resolveNotModified(ctx, 'Catalog episode')
+  }
+  if (result.etag) {
+    setStoredEtag(ctx.queryKey, result.etag)
+  }
+  return result.entry
+}
+
+export function invalidatePublicCatalogQueries(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: ['catalog'] })
+}
+
+export function useCatalogListQuery() {
+  return useQuery({
+    queryKey: catalogListFullQueryKey,
+    queryFn: (ctx) => runCatalogListQuery(ctx, fetchCatalogEntries),
+    staleTime: CATALOG_HTTP_MAX_AGE_MS,
+  })
+}
+
+export function useCatalogCarouselQuery() {
+  return useQuery({
+    queryKey: catalogListCarouselQueryKey,
+    queryFn: (ctx) => runCatalogListQuery(ctx, fetchCatalogCarouselEntries),
+    staleTime: CATALOG_HTTP_MAX_AGE_MS,
+  })
+}
+
+export function useCatalogEpisodeQuery(id: string | undefined) {
+  return useQuery({
+    queryKey: catalogEpisodeQueryKey(id ?? ''),
+    queryFn: runCatalogEpisodeQuery,
+    staleTime: CATALOG_HTTP_MAX_AGE_MS,
+    enabled: typeof id === 'string' && id.length > 0,
+  })
+}

--- a/apps/web/src/catalog/useCatalogQuery.ts
+++ b/apps/web/src/catalog/useCatalogQuery.ts
@@ -1,34 +1,13 @@
-import { useQuery } from '@tanstack/react-query'
-import {
-  fetchCatalogCarouselEntries,
-  fetchCatalogEntries,
-  fetchCatalogEpisodeById,
-} from './catalogApi'
+/** @deprecated Import from `./catalogQueries` instead. */
+export {
+  catalogListCarouselQueryKey,
+  catalogListFullQueryKey,
+  catalogEpisodeQueryKey,
+  invalidatePublicCatalogQueries,
+  useCatalogCarouselQuery,
+  useCatalogEpisodeQuery,
+  useCatalogListQuery,
+} from './catalogQueries'
 
-export const catalogEntriesQueryKey = ['catalog', 'entries'] as const
-export const catalogCarouselQueryKey = [...catalogEntriesQueryKey, 'carousel'] as const
-
-export function useCatalogEntriesQuery() {
-  return useQuery({
-    queryKey: catalogEntriesQueryKey,
-    queryFn: fetchCatalogEntries,
-    staleTime: 1000 * 60 * 5,
-  })
-}
-
-export function useCatalogCarouselQuery() {
-  return useQuery({
-    queryKey: catalogCarouselQueryKey,
-    queryFn: fetchCatalogCarouselEntries,
-    staleTime: 1000 * 60 * 5,
-  })
-}
-
-export function useCatalogEpisodeQuery(id: string | undefined) {
-  return useQuery({
-    queryKey: ['catalog', 'entry', id],
-    queryFn: () => fetchCatalogEpisodeById(id!),
-    staleTime: 1000 * 60 * 5,
-    enabled: typeof id === 'string' && id.length > 0,
-  })
-}
+/** @deprecated Use `useCatalogListQuery`. */
+export { useCatalogListQuery as useCatalogEntriesQuery } from './catalogQueries'

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom'
-import { useCatalogEntriesQuery } from '../catalog/useCatalogQuery'
+import { useCatalogListQuery } from '../catalog/catalogQueries'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
 import { catalogCardImageUrl, catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
 import { PlaybackExpectationBadge } from '../components/watch/PlaybackExpectationBadge'
@@ -47,7 +47,7 @@ function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
 
 export function CatalogPage() {
   const navigate = useNavigate()
-  const { data, isPending, isError, error } = useCatalogEntriesQuery()
+  const { data, isPending, isError, error } = useCatalogListQuery()
 
   useResumePendingPartyRoom(data, navigate)
 

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom'
-import { useCatalogCarouselQuery, useCatalogEntriesQuery } from '../catalog/useCatalogQuery'
+import { useCatalogCarouselQuery, useCatalogListQuery } from '../catalog/catalogQueries'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
 import {
   buildHeroSlides,
@@ -20,7 +20,7 @@ import { HomeSpotlightBanner } from './home/HomeSpotlightBanner'
  */
 export function HomePage() {
   const navigate = useNavigate()
-  const { data, isPending, isError, error } = useCatalogEntriesQuery()
+  const { data, isPending, isError, error } = useCatalogListQuery()
   const carouselQ = useCatalogCarouselQuery()
 
   useResumePendingPartyRoom(data, navigate)

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -7,8 +7,7 @@ import {
   uploadFanProfileAvatar,
 } from '../api/fanProfileApi'
 import { fetchRoom, patchRoom } from '../api/roomsApi'
-import { fetchCatalogEpisodeById } from '../catalog/catalogApi'
-import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { useCatalogEpisodeQuery } from '../catalog/catalogQueries'
 import { cognitoSub } from '../auth/jwtDecode'
 import { getFanAccessToken } from '../auth/fanTokens'
 import { startFanHostedUiSignIn } from '../auth/fanHostedUiPkce'
@@ -150,7 +149,11 @@ export function RoomPage() {
 
   const [room, setRoom] = useState<RoomSnapshot | null | undefined>(undefined)
   const [roomErr, setRoomErr] = useState<string | null>(null)
-  const [catalogEp, setCatalogEp] = useState<CatalogEpisode | null>(null)
+  const catalogEpisodeIdForQuery =
+    room && room !== undefined && room !== null && room.roomId === roomId
+      ? room.catalogEpisodeId
+      : undefined
+  const { data: catalogEp } = useCatalogEpisodeQuery(catalogEpisodeIdForQuery)
   const [chat, setChat] = useState<ChatLine[]>([])
   const [chatReactions, setChatReactions] = useState<ReactionsByMessage>({})
   const [chatDraft, setChatDraft] = useState('')
@@ -482,13 +485,6 @@ export function RoomPage() {
     }, 5000)
     return () => window.clearInterval(t)
   }, [roomId, room, loadRoom])
-
-  useEffect(() => {
-    if (!room?.catalogEpisodeId) return
-    void fetchCatalogEpisodeById(room.catalogEpisodeId)
-      .then(setCatalogEp)
-      .catch(() => setCatalogEp(null))
-  }, [room?.catalogEpisodeId])
 
   useEffect(() => {
     const prev = document.title

--- a/apps/web/src/pages/SoloWatchPage.tsx
+++ b/apps/web/src/pages/SoloWatchPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { SoloYouTubePlayer } from '../components/watch/SoloYouTubePlayer'
-import { useCatalogEpisodeQuery } from '../catalog/useCatalogQuery'
+import { useCatalogEpisodeQuery } from '../catalog/catalogQueries'
 import { formatCatalogEraLabel } from '../catalog/catalogTypes'
 import { SITE_DOCUMENT_TITLE, trimTabTitleSegment } from '../config/documentTitle'
 

--- a/apps/web/src/pages/admin/AdminCatalogDeleteControl.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogDeleteControl.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AdminCatalogDeleteControl } from './AdminCatalogDeleteControl'
@@ -52,8 +53,10 @@ function setInputValue(input: HTMLInputElement, value: string): void {
 describe('AdminCatalogDeleteControl', () => {
   let container: HTMLDivElement
   let root: Root | null = null
+  let queryClient: QueryClient
 
   beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     navigate.mockReset()
     deleteStaffCatalogEpisode.mockReset()
     onEpisodeNotFound.mockReset()
@@ -84,9 +87,11 @@ describe('AdminCatalogDeleteControl', () => {
     root = createRoot(container)
     act(() => {
       root!.render(
-        <MemoryRouter>
-          <AdminCatalogDeleteControl episodeId="ep-1" onEpisodeNotFound={onEpisodeNotFound} />
-        </MemoryRouter>,
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <AdminCatalogDeleteControl episodeId="ep-1" onEpisodeNotFound={onEpisodeNotFound} />
+          </MemoryRouter>
+        </QueryClientProvider>,
       )
     })
   }

--- a/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
 import { getStaffAccessToken } from '../../auth/staffTokens'
@@ -13,6 +14,7 @@ import {
   StaffSessionForbiddenError,
   StaffSessionUnauthorizedError,
 } from '../../api/staffAdminSessionApi'
+import { invalidatePublicCatalogQueries } from '../../catalog/catalogQueries'
 import { formatCatalogEpisodeInUseMessage } from '../../catalog/formatCatalogEpisodeInUseMessage'
 
 export function AdminCatalogDeleteControl({
@@ -23,6 +25,7 @@ export function AdminCatalogDeleteControl({
   onEpisodeNotFound: () => void
 }) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { session } = useAdminSession()
   const dialogTitleId = useId()
   const confirmInputId = useId()
@@ -72,6 +75,7 @@ export function AdminCatalogDeleteControl({
         return
       }
       await deleteStaffCatalogEpisode(token, episodeId)
+      await invalidatePublicCatalogQueries(queryClient)
       closeDialog()
       navigate('/admin/catalog', { state: { deleted: true } })
     } catch (e: unknown) {

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AdminCatalogForm } from './AdminCatalogForm'
@@ -77,6 +78,7 @@ const baseEpisode: StaffCatalogEpisode = {
 describe('AdminCatalogForm', () => {
   let container: HTMLDivElement
   let root: Root | null = null
+  let queryClient: QueryClient
 
   beforeEach(() => {
     navigate.mockReset()
@@ -84,6 +86,7 @@ describe('AdminCatalogForm', () => {
     patchStaffCatalogEpisode.mockReset()
     createStaffCatalogEpisode.mockResolvedValue({ entry: { id: 'new-ep' } })
     patchStaffCatalogEpisode.mockResolvedValue({ entry: baseEpisode })
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   })
 
   afterEach(() => {
@@ -106,9 +109,11 @@ describe('AdminCatalogForm', () => {
     }
     act(() => {
       root!.render(
-        <MemoryRouter>
-          <AdminCatalogForm {...defaults} {...props} />
-        </MemoryRouter>,
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <AdminCatalogForm {...defaults} {...props} />
+          </MemoryRouter>
+        </QueryClientProvider>,
       )
     })
   }
@@ -147,6 +152,30 @@ describe('AdminCatalogForm', () => {
     })
 
     expect(navigate).toHaveBeenCalledWith('/admin/catalog', { state: { saved: true } })
+  })
+
+  it('invalidates public catalog queries after successful create', async () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    renderForm({ mode: 'create' })
+
+    const idInput = container.querySelector('#catalog-form-id') as HTMLInputElement
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    const experimentInput = container.querySelector('#catalog-form-experiment') as HTMLInputElement
+
+    await act(async () => {
+      setInputValue(idInput, 'new-ep')
+      setInputValue(experimentInput, '99')
+      setInputValue(titleInput, 'New title')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['catalog'] })
+    })
   })
 
   it('edit mode keeps id out of PATCH and sends only changed fields', async () => {

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, type FormEvent } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import { refreshStaffTokensIfStale } from '../../auth/staffHostedUiPkce'
 import { getStaffAccessToken } from '../../auth/staffTokens'
@@ -22,6 +23,7 @@ import {
   type CatalogEpisodeFormMode,
   type CatalogEpisodeFormValues,
 } from '../../catalog/validateCatalogEpisodeForm'
+import { invalidatePublicCatalogQueries } from '../../catalog/catalogQueries'
 import { AdminCatalogDeleteControl } from './AdminCatalogDeleteControl'
 
 const CATALOG_ERAS: CatalogEra[] = ['joel', 'mike', 'jonah', 'emily', 'other']
@@ -85,6 +87,7 @@ export function AdminCatalogForm({
   pageTitle: string
 }) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [values, setValues] = useState(initialValues)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [formError, setFormError] = useState<string | null>(null)
@@ -130,12 +133,14 @@ export function AdminCatalogForm({
       } else if (initialEpisode) {
         const patchBody = buildPatchBody(initialEpisode, values)
         if (Object.keys(patchBody).length === 0) {
+          await invalidatePublicCatalogQueries(queryClient)
           navigate('/admin/catalog', { state: { saved: true } })
           return
         }
         await patchStaffCatalogEpisode(token, initialEpisode.id, patchBody)
       }
 
+      await invalidatePublicCatalogQueries(queryClient)
       navigate('/admin/catalog', { state: { saved: true } })
     } catch (e: unknown) {
       if (e instanceof StaffCatalogValidationError) {

--- a/docs/api.catalog.md
+++ b/docs/api.catalog.md
@@ -38,7 +38,7 @@ Returns a bundle aligned with **`data/catalog/episodes.json`**:
 | **`tmdbPosterPath`** | `string \| optional` | Raw TMDB path; **`posterImageUrl`** is the resolved CDN URL when set. |
 | **`tmdbBackdropPath`** | `string \| optional` | |
 
-Clients should treat optional / **`null`** enrichment fields as “not yet available.”
+Clients should treat optional / **`null`** enrichment fields as "not yet available."
 
 ### Optional SPA hints (not in git schema)
 
@@ -55,7 +55,32 @@ Clients should treat optional / **`null`** enrichment fields as “not yet avail
 
 **`404`** when the **`id`** is unknown.
 
+## HTTP caching (M13)
+
+Public catalog reads use a monotonic **`catalogGeneration`** counter stored on the Catalog table meta row (**`id: "_meta"`**). Admin catalog create, patch, and delete bump the counter after a successful Dynamo write so clients and intermediaries can revalidate without scanning for **`max(updatedAt)`**.
+
+### Response headers
+
+| Header | Rule |
+| --- | --- |
+| **`ETag`** | Weak validator: **`W/"{generation}-{variant}"`**. Variants: **`full`** (list), **`carousel`** (**`?carousel=true`**), **`episode-{id}`** (single entry). |
+| **`Cache-Control`** | **`public, max-age=<seconds>`** — default **60**; Lambda env **`CATALOG_HTTP_MAX_AGE_SECONDS`** (integer, clamped **0–86400**). |
+
+### Conditional requests
+
+Send **`If-None-Match`** with the **`ETag`** from a prior response (weak prefix optional). When the generation and variant match, the API returns **`304 Not Modified`** with an empty body and the same cache headers. List **`304`** avoids a full table **`Scan`**.
+
+After an admin catalog mutation, generation increments; repeat **`GET`** with the old **`If-None-Match`** returns **`200`** and a new **`ETag`**.
+
+### Meta row
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| **`catalogGeneration`** | non-negative integer | Starts at **`1`** on first bump; defaults to **`1`** when the row is absent (pre-M13 tables). |
+
+Reconcile/TMDB batch writers should call the same bump helper when they mutate catalog rows (not wired in the initial M13 slice).
+
 ## Infrastructure
 
-- **Table:** **`RiffSyncApi-prod`** stack output **`CatalogTableName`** — PK **`id`** (string). No sort key; list route uses **`Scan`** (see **`infra/cdk/README.md`**).
+- **Table:** **`RiffSyncApi-prod`** stack output **`CatalogTableName`** — PK **`id`** (string). No sort key; list route uses **`Scan`** (see **`infra/cdk/README.md`**). Reserved meta PK **`_meta`** holds **`catalogGeneration`**.
 - **Seed:** **`infra/cdk`** → **`npm run seed:catalog -- <CatalogTableName>`** after deploy (validates against **`catalog.schema.json`**).

--- a/infra/cdk/lambda/admin-catalog-delete.test.ts
+++ b/infra/cdk/lambda/admin-catalog-delete.test.ts
@@ -17,6 +17,7 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
   GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
   ScanCommand: vi.fn((input: unknown) => ({ input, kind: 'Scan' })),
   DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
 }));
 
 vi.mock('./riffsync-observability', async (importOriginal) => {
@@ -80,7 +81,8 @@ describe('admin-catalog-delete handler', () => {
     mocks.docSend
       .mockResolvedValueOnce({ Item: { id: 'ep-1' } })
       .mockResolvedValueOnce({ Count: 0 })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Attributes: { catalogGeneration: 3 } });
 
     const res = await deleteHandler(
       deleteEvent(

--- a/infra/cdk/lambda/admin-catalog-delete.ts
+++ b/infra/cdk/lambda/admin-catalog-delete.ts
@@ -6,6 +6,7 @@ import {
   catalogEpisodeExists,
   countCatalogEpisodeReferences,
 } from './admin-catalog-delete-shared';
+import { bumpCatalogGeneration } from './catalog-meta';
 import { jsonResponse } from './giphy-search-shared';
 import {
   adminCatalogDeleteOutcomeFromStatus,
@@ -107,6 +108,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         Key: { id: episodeId },
       }),
     );
+
+    await bumpCatalogGeneration(client, catalogTableName);
   } catch (err) {
     logRiffsyncDiagError('admin_catalog_delete_failed', err);
     return finishDelete(event, staffSub, episodeId, 500, { error: 'Internal server error' });

--- a/infra/cdk/lambda/admin-catalog-patch.ts
+++ b/infra/cdk/lambda/admin-catalog-patch.ts
@@ -8,6 +8,7 @@ import {
   validationErrorResponse,
   type ValidationDetail,
 } from './admin-catalog-validation';
+import { bumpCatalogGeneration } from './catalog-meta';
 import { jsonResponse } from './giphy-search-shared';
 import {
   adminCatalogPatchOutcomeFromStatus,
@@ -154,6 +155,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     );
   } catch (err) {
     logRiffsyncDiagError('admin_catalog_patch_update_failed', err);
+    return finishPatch(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  try {
+    await bumpCatalogGeneration(client, tableName);
+  } catch (err) {
+    logRiffsyncDiagError('admin_catalog_patch_bump_generation_failed', err);
     return finishPatch(event, staffSub, episodeId, 500, { error: 'Internal server error' });
   }
 

--- a/infra/cdk/lambda/admin-catalog-post.ts
+++ b/infra/cdk/lambda/admin-catalog-post.ts
@@ -8,6 +8,7 @@ import {
   validationErrorResponse,
   type ValidationDetail,
 } from './admin-catalog-validation';
+import { bumpCatalogGeneration } from './catalog-meta';
 import { jsonResponse } from './giphy-search-shared';
 import {
   adminCatalogPostOutcomeFromStatus,
@@ -119,6 +120,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       });
     }
     logRiffsyncDiagError('admin_catalog_post_dynamo_failed', err);
+    return finishPost(event, staffSub, episodeId, 500, { error: 'Internal server error' });
+  }
+
+  try {
+    await bumpCatalogGeneration(client, tableName);
+  } catch (err) {
+    logRiffsyncDiagError('admin_catalog_post_bump_generation_failed', err);
     return finishPost(event, staffSub, episodeId, 500, { error: 'Internal server error' });
   }
 

--- a/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
+++ b/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
@@ -105,7 +105,9 @@ describe('admin-catalog-post handler', () => {
   });
 
   it('creates row with null reconcile fields and returns 201', async () => {
-    mocks.docSend.mockResolvedValueOnce({});
+    mocks.docSend.mockResolvedValueOnce({}).mockResolvedValueOnce({
+      Attributes: { catalogGeneration: 2 },
+    });
 
     const res = await postHandler(
       staffEvent(
@@ -202,7 +204,8 @@ describe('admin-catalog-patch handler', () => {
   it('updates allowed fields and preserves reconcile columns', async () => {
     mocks.docSend
       .mockResolvedValueOnce({ Item: existingItem })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Attributes: { catalogGeneration: 5 } });
 
     const res = await patchHandler(
       staffEvent(

--- a/infra/cdk/lambda/catalog-cache-headers.test.ts
+++ b/infra/cdk/lambda/catalog-cache-headers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildCatalogCacheControl,
+  buildCatalogETag,
+  catalogCacheHeaders,
+  etagMatches,
+  parseCatalogHttpMaxAgeSeconds,
+} from './catalog-cache-headers';
+
+describe('parseCatalogHttpMaxAgeSeconds', () => {
+  it('defaults to 60 when unset or invalid', () => {
+    expect(parseCatalogHttpMaxAgeSeconds(undefined)).toBe(60);
+    expect(parseCatalogHttpMaxAgeSeconds('')).toBe(60);
+    expect(parseCatalogHttpMaxAgeSeconds('nope')).toBe(60);
+  });
+
+  it('clamps configured values to 0 through 86400', () => {
+    expect(parseCatalogHttpMaxAgeSeconds('0')).toBe(0);
+    expect(parseCatalogHttpMaxAgeSeconds('120')).toBe(120);
+    expect(parseCatalogHttpMaxAgeSeconds('999999')).toBe(86400);
+    expect(parseCatalogHttpMaxAgeSeconds('-5')).toBe(0);
+  });
+});
+
+describe('catalog cache ETag helpers', () => {
+  it('builds weak validators per variant', () => {
+    expect(buildCatalogETag(3, 'full')).toBe('W/"3-full"');
+    expect(buildCatalogETag(3, 'carousel')).toBe('W/"3-carousel"');
+    expect(buildCatalogETag(5, 'episode-ep-1')).toBe('W/"5-episode-ep-1"');
+  });
+
+  it('builds Cache-Control from max-age', () => {
+    expect(buildCatalogCacheControl(60)).toBe('public, max-age=60');
+  });
+
+  it('matches If-None-Match with or without weak prefix', () => {
+    const etag = buildCatalogETag(2, 'full');
+    expect(etagMatches(etag, etag)).toBe(true);
+    expect(etagMatches('"2-full"', etag)).toBe(true);
+    expect(etagMatches('W/"2-full"', etag)).toBe(true);
+    expect(etagMatches('W/"3-full"', etag)).toBe(false);
+    expect(etagMatches('*', etag)).toBe(true);
+  });
+
+  it('returns combined cache headers', () => {
+    expect(catalogCacheHeaders(4, 'carousel', 30)).toEqual({
+      ETag: 'W/"4-carousel"',
+      'Cache-Control': 'public, max-age=30',
+    });
+  });
+});

--- a/infra/cdk/lambda/catalog-cache-headers.ts
+++ b/infra/cdk/lambda/catalog-cache-headers.ts
@@ -1,0 +1,74 @@
+export type CatalogCacheVariant = 'full' | 'carousel' | `episode-${string}`;
+
+const DEFAULT_MAX_AGE_SECONDS = 60;
+
+export function parseCatalogHttpMaxAgeSeconds(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') {
+    return DEFAULT_MAX_AGE_SECONDS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_MAX_AGE_SECONDS;
+  }
+  return Math.min(86400, Math.max(0, parsed));
+}
+
+export function buildCatalogETag(generation: number, variant: CatalogCacheVariant): string {
+  return `W/"${generation}-${variant}"`;
+}
+
+export function buildCatalogCacheControl(maxAgeSeconds: number): string {
+  return `public, max-age=${maxAgeSeconds}`;
+}
+
+export function catalogCacheHeaders(
+  generation: number,
+  variant: CatalogCacheVariant,
+  maxAgeSeconds: number,
+): Record<string, string> {
+  return {
+    ETag: buildCatalogETag(generation, variant),
+    'Cache-Control': buildCatalogCacheControl(maxAgeSeconds),
+  };
+}
+
+function normalizeEtagValue(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith('W/') ? trimmed.slice(2).trim() : trimmed;
+}
+
+/** Compare client `If-None-Match` to the computed weak ETag (strips optional `W/` prefix). */
+export function etagMatches(ifNoneMatch: string | undefined, etag: string): boolean {
+  if (!ifNoneMatch) {
+    return false;
+  }
+  const normalized = ifNoneMatch.trim();
+  if (!normalized) {
+    return false;
+  }
+  const target = normalizeEtagValue(etag);
+  for (const part of normalized.split(',')) {
+    const candidate = part.trim();
+    if (!candidate) {
+      continue;
+    }
+    if (candidate === '*') {
+      return true;
+    }
+    if (candidate === etag || normalizeEtagValue(candidate) === target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function notModifiedResponse(cacheHeaders: Record<string, string>) {
+  return {
+    statusCode: 304 as const,
+    headers: {
+      ...cacheHeaders,
+      'content-type': 'application/json; charset=utf-8',
+    },
+    body: '',
+  };
+}

--- a/infra/cdk/lambda/catalog-get.ts
+++ b/infra/cdk/lambda/catalog-get.ts
@@ -1,6 +1,13 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  catalogCacheHeaders,
+  etagMatches,
+  notModifiedResponse,
+  parseCatalogHttpMaxAgeSeconds,
+} from './catalog-cache-headers';
+import { CATALOG_META_ID, getCatalogGeneration } from './catalog-meta';
 import { projectEpisode } from './catalog-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -14,6 +21,20 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const id = event.pathParameters?.id;
   if (!id) {
     return { statusCode: 400, body: JSON.stringify({ error: 'Missing path parameter id' }) };
+  }
+  if (id === CATALOG_META_ID) {
+    return { statusCode: 404, body: JSON.stringify({ error: 'Not found' }) };
+  }
+
+  const maxAgeSeconds = parseCatalogHttpMaxAgeSeconds(process.env.CATALOG_HTTP_MAX_AGE_SECONDS);
+  const generation = await getCatalogGeneration(client, tableName);
+  const variant = `episode-${id}` as const;
+  const cacheHeaders = catalogCacheHeaders(generation, variant, maxAgeSeconds);
+  const ifNoneMatch =
+    event.headers?.['if-none-match'] ?? event.headers?.['If-None-Match'];
+
+  if (etagMatches(ifNoneMatch, cacheHeaders.ETag)) {
+    return notModifiedResponse(cacheHeaders);
   }
 
   const out = await client.send(
@@ -30,7 +51,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const entry = projectEpisode(out.Item as Record<string, unknown>);
   return {
     statusCode: 200,
-    headers: { 'content-type': 'application/json; charset=utf-8' },
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...cacheHeaders,
+    },
     body: JSON.stringify({ entry }),
   };
 };

--- a/infra/cdk/lambda/catalog-list.ts
+++ b/infra/cdk/lambda/catalog-list.ts
@@ -1,6 +1,13 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  catalogCacheHeaders,
+  etagMatches,
+  notModifiedResponse,
+  parseCatalogHttpMaxAgeSeconds,
+} from './catalog-cache-headers';
+import { CATALOG_META_ID, getCatalogGeneration } from './catalog-meta';
 import { projectEpisode, sortEpisodes } from './catalog-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -13,6 +20,17 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
   const carouselParam = event.queryStringParameters?.carousel;
   const carouselOnly = carouselParam === 'true' || carouselParam === '1';
+  const variant = carouselOnly ? 'carousel' : 'full';
+  const maxAgeSeconds = parseCatalogHttpMaxAgeSeconds(process.env.CATALOG_HTTP_MAX_AGE_SECONDS);
+
+  const generation = await getCatalogGeneration(client, tableName);
+  const cacheHeaders = catalogCacheHeaders(generation, variant, maxAgeSeconds);
+  const ifNoneMatch =
+    event.headers?.['if-none-match'] ?? event.headers?.['If-None-Match'];
+
+  if (etagMatches(ifNoneMatch, cacheHeaders.ETag)) {
+    return notModifiedResponse(cacheHeaders);
+  }
 
   const entries: ReturnType<typeof projectEpisode>[] = [];
   let startKey: Record<string, unknown> | undefined;
@@ -25,7 +43,11 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       }),
     );
     for (const raw of out.Items ?? []) {
-      entries.push(projectEpisode(raw as Record<string, unknown>));
+      const item = raw as Record<string, unknown>;
+      if (item.id === CATALOG_META_ID) {
+        continue;
+      }
+      entries.push(projectEpisode(item));
     }
     startKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
   } while (startKey);
@@ -36,7 +58,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   }
   return {
     statusCode: 200,
-    headers: { 'content-type': 'application/json; charset=utf-8' },
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...cacheHeaders,
+    },
     body: JSON.stringify({
       version: 1,
       entries: sorted,

--- a/infra/cdk/lambda/catalog-meta.test.ts
+++ b/infra/cdk/lambda/catalog-meta.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+import { bumpCatalogGeneration, CATALOG_META_ID, getCatalogGeneration } from './catalog-meta';
+
+describe('catalog-meta', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getCatalogGeneration returns 1 when meta row is absent', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+    const gen = await getCatalogGeneration({ send: mocks.docSend } as never, 'catalog-table');
+    expect(gen).toBe(1);
+    expect(mocks.docSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Key: { id: CATALOG_META_ID },
+        }),
+      }),
+    );
+  });
+
+  it('getCatalogGeneration reads stored counter', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: { id: CATALOG_META_ID, catalogGeneration: 7 } });
+    await expect(getCatalogGeneration({ send: mocks.docSend } as never, 'catalog-table')).resolves.toBe(
+      7,
+    );
+  });
+
+  it('bumpCatalogGeneration increments via ADD and returns new value', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Attributes: { catalogGeneration: 2 },
+    });
+    const gen = await bumpCatalogGeneration({ send: mocks.docSend } as never, 'catalog-table');
+    expect(gen).toBe(2);
+    expect(mocks.docSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Key: { id: CATALOG_META_ID },
+          UpdateExpression: 'ADD catalogGeneration :one',
+        }),
+      }),
+    );
+  });
+
+  it('bumpCatalogGeneration throws when response lacks generation', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Attributes: {} });
+    await expect(
+      bumpCatalogGeneration({ send: mocks.docSend } as never, 'catalog-table'),
+    ).rejects.toThrow(/missing catalogGeneration/);
+  });
+});

--- a/infra/cdk/lambda/catalog-meta.ts
+++ b/infra/cdk/lambda/catalog-meta.ts
@@ -1,0 +1,49 @@
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+
+export const CATALOG_META_ID = '_meta';
+
+/**
+ * Read the monotonic catalog generation counter from the `_meta` row.
+ * Returns `1` when the row is absent (tables seeded before M13).
+ */
+export async function getCatalogGeneration(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+): Promise<number> {
+  const out = await docClient.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { id: CATALOG_META_ID },
+    }),
+  );
+  const gen = out.Item?.catalogGeneration;
+  if (typeof gen === 'number' && Number.isFinite(gen) && gen >= 1) {
+    return Math.floor(gen);
+  }
+  return 1;
+}
+
+/**
+ * Increment `catalogGeneration` on the `_meta` row (creates the row on first bump).
+ * TODO: invoke from reconcile/TMDB writers when those jobs mutate catalog rows.
+ */
+export async function bumpCatalogGeneration(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+): Promise<number> {
+  const out = await docClient.send(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: { id: CATALOG_META_ID },
+      UpdateExpression: 'ADD catalogGeneration :one',
+      ExpressionAttributeValues: { ':one': 1 },
+      ReturnValues: 'UPDATED_NEW',
+    }),
+  );
+  const gen = out.Attributes?.catalogGeneration;
+  if (typeof gen === 'number' && Number.isFinite(gen) && gen >= 1) {
+    return Math.floor(gen);
+  }
+  throw new Error('bumpCatalogGeneration: missing catalogGeneration in UpdateItem response');
+}

--- a/infra/cdk/lambda/catalog-public-handlers.test.ts
+++ b/infra/cdk/lambda/catalog-public-handlers.test.ts
@@ -1,0 +1,188 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  ScanCommand: vi.fn((input: unknown) => ({ input, kind: 'Scan' })),
+}));
+
+import { handler as getHandler } from './catalog-get';
+import { handler as listHandler } from './catalog-list';
+
+const sampleEpisode = {
+  id: '101-the-crawling-eye',
+  experimentNumber: 101,
+  title: 'The Crawling Eye',
+  era: 'joel',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  tagline: null,
+  posterImageUrl: null,
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: false,
+};
+
+function listEvent(
+  queryStringParameters?: Record<string, string>,
+  headers?: Record<string, string>,
+): APIGatewayProxyEventV2 {
+  const routeKey = 'GET /v1/catalog';
+  return {
+    version: '2.0',
+    routeKey,
+    rawPath: '/v1/catalog',
+    rawQueryString: '',
+    queryStringParameters,
+    headers,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'GET',
+        path: '/v1/catalog',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-list-1',
+      routeKey,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+function getEvent(
+  id: string,
+  headers?: Record<string, string>,
+): APIGatewayProxyEventV2 {
+  const routeKey = 'GET /v1/catalog/{id}';
+  return {
+    version: '2.0',
+    routeKey,
+    rawPath: `/v1/catalog/${id}`,
+    rawQueryString: '',
+    pathParameters: { id },
+    headers,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'GET',
+        path: `/v1/catalog/${id}`,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-get-1',
+      routeKey,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('catalog-list handler cache headers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.CATALOG_HTTP_MAX_AGE_SECONDS;
+  });
+
+  it('returns 304 when If-None-Match matches generation ETag without scanning', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 4 } });
+
+    const res = await listHandler(
+      listEvent(undefined, { 'if-none-match': 'W/"4-full"' }),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(304);
+    expect(res?.body).toBe('');
+    expect(res?.headers?.ETag).toBe('W/"4-full"');
+    expect(res?.headers?.['Cache-Control']).toBe('public, max-age=60');
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 200 with ETag and body when generation differs', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 2 } })
+      .mockResolvedValueOnce({ Items: [sampleEpisode] });
+
+    const res = await listHandler(listEvent(), {} as never, () => undefined);
+
+    expect(res?.statusCode).toBe(200);
+    expect(res?.headers?.ETag).toBe('W/"2-full"');
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].id).toBe('101-the-crawling-eye');
+  });
+
+  it('uses carousel variant in ETag when carousel query is set', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 1 } });
+
+    const res = await listHandler(
+      listEvent({ carousel: 'true' }, { 'if-none-match': 'W/"1-carousel"' }),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(304);
+    expect(res?.headers?.ETag).toBe('W/"1-carousel"');
+  });
+});
+
+describe('catalog-get handler cache headers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CATALOG_TABLE_NAME = 'catalog-table';
+    delete process.env.CATALOG_HTTP_MAX_AGE_SECONDS;
+  });
+
+  it('returns 304 when If-None-Match matches episode variant ETag', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 9 } });
+
+    const res = await getHandler(
+      getEvent('101-the-crawling-eye', { 'If-None-Match': 'W/"9-episode-101-the-crawling-eye"' }),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(304);
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 200 with entry and per-episode ETag when not modified check fails', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 3 } })
+      .mockResolvedValueOnce({ Item: sampleEpisode });
+
+    const res = await getHandler(getEvent('101-the-crawling-eye'), {} as never, () => undefined);
+
+    expect(res?.statusCode).toBe(200);
+    expect(res?.headers?.ETag).toBe('W/"3-episode-101-the-crawling-eye"');
+    expect(JSON.parse(res?.body ?? '').entry.id).toBe('101-the-crawling-eye');
+  });
+});

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -290,6 +290,7 @@ export class ApiCatalogStack extends cdk.Stack {
       handler: 'handler',
       environment: {
         CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        CATALOG_HTTP_MAX_AGE_SECONDS: '60',
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
@@ -303,6 +304,7 @@ export class ApiCatalogStack extends cdk.Stack {
       handler: 'handler',
       environment: {
         CATALOG_TABLE_NAME: this.catalogTable.tableName,
+        CATALOG_HTTP_MAX_AGE_SECONDS: '60',
         NODE_OPTIONS: '--enable-source-maps',
       },
     });


### PR DESCRIPTION
## Summary

- Add `catalogGeneration` meta row (`_meta`) with bump helper for admin catalog mutations
- Public `GET /v1/catalog` and `GET /v1/catalog/{id}` return weak `ETag` + `Cache-Control` and honor `If-None-Match` (304 avoids list Scan when unchanged)
- Wire generation bumps into admin create/patch/delete handlers (500 on bump failure)
- SPA: conditional catalog fetch (`If-None-Match`), TanStack Query keys under `['catalog', ...]`, and invalidation after admin create/edit/delete (#89)
- Document caching behavior in `docs/api.catalog.md`

## Issues

- Parent: #84
- API ETag / generation: #88
- SPA client cache + invalidation: #89

## Test plan

- [x] `npm run verify:push:cdk`
- [x] `npm run verify:push:web` (Vitest + `tsc -b` + Vite build)
- [ ] Manual: capture ETag on first GET, confirm 304 with `If-None-Match`, confirm fan catalog/home/room refresh after admin save without hard reload