### PR TITLE
[M13] Curator hints: API write + admin form (#90, #91)

### DIFF
--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -44,6 +44,9 @@ export interface StaffCatalogEpisodeWrite {
   youtubeVideoId?: string | null
   youtubeWatchUrl?: string | null
   carousel?: boolean
+  movieSearchTitle?: string | null
+  embedAllows?: boolean
+  curatorNotes?: string | null
 }
 
 export class StaffCatalogValidationError extends Error {

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   EMPTY_CATALOG_EPISODE_FORM_VALUES,
   mapValidationDetailsToFieldErrors,
+  normalizeNullableTextField,
   validateCatalogEpisodeForm,
 } from './validateCatalogEpisodeForm'
 
@@ -84,5 +85,30 @@ describe('validateCatalogEpisodeForm', () => {
       title: 'must not be empty',
       era: 'This value is not valid.',
     })
+  })
+
+  it('defaults embedAllows to true on empty create form', () => {
+    expect(EMPTY_CATALOG_EPISODE_FORM_VALUES.embedAllows).toBe(true)
+  })
+
+  it('rejects movieSearchTitle over max length', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, movieSearchTitle: 'x'.repeat(257) },
+      'create',
+    )
+    expect(result.fieldErrors.movieSearchTitle).toBeTruthy()
+  })
+
+  it('rejects curatorNotes over max length', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, curatorNotes: 'x'.repeat(4097) },
+      'create',
+    )
+    expect(result.fieldErrors.curatorNotes).toBeTruthy()
+  })
+
+  it('clears nullable hint fields when input is empty', () => {
+    expect(normalizeNullableTextField('   ')).toBeNull()
+    expect(normalizeNullableTextField('  Manos  ')).toBe('Manos')
   })
 })

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.ts
@@ -14,7 +14,13 @@ export type CatalogEpisodeFormValues = {
   youtubeVideoId: string
   youtubeWatchUrl: string
   carousel: boolean
+  movieSearchTitle: string
+  embedAllows: boolean
+  curatorNotes: string
 }
+
+const MOVIE_SEARCH_TITLE_MAX_LENGTH = 256
+const CURATOR_NOTES_MAX_LENGTH = 4096
 
 export type CatalogEpisodeFormValidation = {
   fieldErrors: Record<string, string>
@@ -29,6 +35,9 @@ export const EMPTY_CATALOG_EPISODE_FORM_VALUES: CatalogEpisodeFormValues = {
   youtubeVideoId: '',
   youtubeWatchUrl: '',
   carousel: false,
+  movieSearchTitle: '',
+  embedAllows: true,
+  curatorNotes: '',
 }
 
 function isValidHttpUrl(value: string): boolean {
@@ -96,6 +105,28 @@ export function normalizeYoutubeField(raw: string): string | null {
   return trimmed.length > 0 ? trimmed : null
 }
 
+export function normalizeNullableTextField(raw: string): string | null {
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function validateMovieSearchTitle(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  if (trimmed.length > MOVIE_SEARCH_TITLE_MAX_LENGTH) {
+    return `Movie search title must be ${MOVIE_SEARCH_TITLE_MAX_LENGTH} characters or fewer.`
+  }
+  return undefined
+}
+
+function validateCuratorNotes(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (trimmed.length > CURATOR_NOTES_MAX_LENGTH) {
+    return `Curator notes must be ${CURATOR_NOTES_MAX_LENGTH} characters or fewer.`
+  }
+  return undefined
+}
+
 export function validateCatalogEpisodeForm(
   values: CatalogEpisodeFormValues,
   mode: CatalogEpisodeFormMode,
@@ -121,6 +152,12 @@ export function validateCatalogEpisodeForm(
 
   const watchUrlError = validateYoutubeWatchUrl(values.youtubeWatchUrl)
   if (watchUrlError) fieldErrors.youtubeWatchUrl = watchUrlError
+
+  const movieSearchTitleError = validateMovieSearchTitle(values.movieSearchTitle)
+  if (movieSearchTitleError) fieldErrors.movieSearchTitle = movieSearchTitleError
+
+  const curatorNotesError = validateCuratorNotes(values.curatorNotes)
+  if (curatorNotesError) fieldErrors.curatorNotes = curatorNotesError
 
   if (Object.keys(fieldErrors).length > 0) {
     return {
@@ -156,6 +193,9 @@ export function catalogEpisodeToFormValues(
     youtubeVideoId: string | null
     youtubeWatchUrl: string | null
     carousel: boolean
+    movieSearchTitle?: string | null
+    embedAllows?: boolean | null
+    curatorNotes?: string | null
   },
 ): CatalogEpisodeFormValues {
   return {
@@ -166,5 +206,8 @@ export function catalogEpisodeToFormValues(
     youtubeVideoId: entry.youtubeVideoId ?? '',
     youtubeWatchUrl: entry.youtubeWatchUrl ?? '',
     carousel: entry.carousel,
+    movieSearchTitle: entry.movieSearchTitle ?? '',
+    embedAllows: entry.embedAllows !== false,
+    curatorNotes: entry.curatorNotes ?? '',
   }
 }

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -5,7 +5,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AdminCatalogForm } from './AdminCatalogForm'
-import { EMPTY_CATALOG_EPISODE_FORM_VALUES } from '../../catalog/validateCatalogEpisodeForm'
+import {
+  catalogEpisodeToFormValues,
+  EMPTY_CATALOG_EPISODE_FORM_VALUES,
+} from '../../catalog/validateCatalogEpisodeForm'
 import type { StaffCatalogEpisode } from '../../api/staffAdminCatalogApi'
 
 const navigate = vi.fn()
@@ -50,10 +53,21 @@ vi.mock('./AdminCatalogDeleteControl', () => ({
   AdminCatalogDeleteControl: () => null,
 }))
 
-function setInputValue(input: HTMLInputElement, value: string): void {
-  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+function setInputValue(
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+): void {
+  const prototype =
+    input instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set
   setter?.call(input, value)
   input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function uncheckCheckbox(checkbox: HTMLInputElement): void {
+  if (checkbox.checked) {
+    checkbox.click()
+  }
 }
 
 const baseEpisode: StaffCatalogEpisode = {
@@ -147,6 +161,9 @@ describe('AdminCatalogForm', () => {
           youtubeVideoId: null,
           youtubeWatchUrl: null,
           carousel: false,
+          movieSearchTitle: null,
+          embedAllows: true,
+          curatorNotes: null,
         }),
       )
     })
@@ -182,15 +199,7 @@ describe('AdminCatalogForm', () => {
     renderForm({
       mode: 'edit',
       initialEpisode: baseEpisode,
-      initialValues: {
-        id: baseEpisode.id,
-        experimentNumber: String(baseEpisode.experimentNumber),
-        title: baseEpisode.title,
-        era: baseEpisode.era,
-        youtubeVideoId: '',
-        youtubeWatchUrl: '',
-        carousel: baseEpisode.carousel,
-      },
+      initialValues: catalogEpisodeToFormValues(baseEpisode),
       breadcrumbLeaf: 'Edit',
       pageTitle: 'Edit episode',
     })
@@ -240,5 +249,89 @@ describe('AdminCatalogForm', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('too short')
     })
+  })
+
+  it('edit mode saves changed curator hints in PATCH body', async () => {
+    renderForm({
+      mode: 'edit',
+      initialEpisode: baseEpisode,
+      initialValues: catalogEpisodeToFormValues(baseEpisode),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    const movieSearchInput = container.querySelector(
+      '#catalog-form-movie-search-title',
+    ) as HTMLInputElement
+    const embedCheckbox = container.querySelector('#catalog-form-embed-allows') as HTMLInputElement
+    const notesInput = container.querySelector('#catalog-form-curator-notes') as HTMLTextAreaElement
+
+    await act(async () => {
+      setInputValue(movieSearchInput, 'The Crawling Eye')
+      uncheckCheckbox(embedCheckbox)
+      setInputValue(notesInput, 'Updated notes')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
+        movieSearchTitle: 'The Crawling Eye',
+        embedAllows: false,
+        curatorNotes: 'Updated notes',
+      })
+    })
+  })
+
+  it('shows embed-disabled note when embedAllows is unchecked', async () => {
+    renderForm({
+      mode: 'edit',
+      initialEpisode: { ...baseEpisode, embedAllows: true },
+      initialValues: catalogEpisodeToFormValues({ ...baseEpisode, embedAllows: true }),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    const embedCheckbox = container.querySelector('#catalog-form-embed-allows') as HTMLInputElement
+    await act(async () => {
+      uncheckCheckbox(embedCheckbox)
+    })
+
+    expect(container.textContent).toContain('In-app embed is disabled for this episode.')
+    expect(patchStaffCatalogEpisode).not.toHaveBeenCalled()
+  })
+
+  it('renders tmdbNeedsReview read-only and omits it from PATCH', async () => {
+    renderForm({
+      mode: 'edit',
+      initialEpisode: { ...baseEpisode, tmdbNeedsReview: true },
+      initialValues: catalogEpisodeToFormValues(baseEpisode),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    expect(container.textContent).toContain('TMDB needs review')
+    expect(container.textContent).toContain('Yes')
+
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    await act(async () => {
+      setInputValue(titleInput, 'Updated title')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
+        title: 'Updated title',
+      })
+    })
+    const patchBody = patchStaffCatalogEpisode.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(patchBody).not.toHaveProperty('tmdbNeedsReview')
   })
 })

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -18,6 +18,7 @@ import {
 import { formatCatalogEraLabel, type CatalogEra } from '../../catalog/catalogTypes'
 import {
   mapValidationDetailsToFieldErrors,
+  normalizeNullableTextField,
   normalizeYoutubeField,
   validateCatalogEpisodeForm,
   type CatalogEpisodeFormMode,
@@ -32,7 +33,7 @@ const RECONCILE_HELPER =
   'These fields are updated by the scheduled reconcile job. Edit title or YouTube details above; TMDB art and tagline refresh automatically when matched.'
 
 const CURATOR_HINTS_HELPER =
-  'Operator hints stored in Dynamo. Editing hints ships in a follow-on milestone; values shown here are read-only.'
+  'Operator hints stored in Dynamo. movieSearchTitle guides reconcile search; embedAllows controls fan in-app embed; notes are staff-only.'
 
 function formValuesToWriteBody(values: CatalogEpisodeFormValues): StaffCatalogEpisodeWrite {
   return {
@@ -42,6 +43,9 @@ function formValuesToWriteBody(values: CatalogEpisodeFormValues): StaffCatalogEp
     youtubeVideoId: normalizeYoutubeField(values.youtubeVideoId),
     youtubeWatchUrl: normalizeYoutubeField(values.youtubeWatchUrl),
     carousel: values.carousel,
+    movieSearchTitle: normalizeNullableTextField(values.movieSearchTitle),
+    embedAllows: values.embedAllows,
+    curatorNotes: normalizeNullableTextField(values.curatorNotes),
   }
 }
 
@@ -61,6 +65,16 @@ function buildPatchBody(
     body.youtubeWatchUrl = next.youtubeWatchUrl
   }
   if (next.carousel !== baseline.carousel) body.carousel = next.carousel
+  if (next.movieSearchTitle !== baseline.movieSearchTitle) {
+    body.movieSearchTitle = next.movieSearchTitle
+  }
+  const baselineEmbedAllows = baseline.embedAllows !== false
+  if (next.embedAllows !== baselineEmbedAllows) {
+    body.embedAllows = next.embedAllows
+  }
+  if (next.curatorNotes !== baseline.curatorNotes) {
+    body.curatorNotes = next.curatorNotes
+  }
   return body
 }
 
@@ -176,19 +190,9 @@ export function AdminCatalogForm({
       ).filter(([, v]) => v != null && String(v).trim() !== '')
     : []
 
-  const hintFields = episode
-    ? (
-        [
-          ['Movie search title', episode.movieSearchTitle],
-          ['Embed allows', episode.embedAllows != null ? (episode.embedAllows ? 'Yes' : 'No') : null],
-          ['Curator notes', episode.curatorNotes],
-          ['TMDB needs review', episode.tmdbNeedsReview != null ? (episode.tmdbNeedsReview ? 'Yes' : 'No') : null],
-        ] as const
-      ).filter(([, v]) => v != null && String(v).trim() !== '')
-    : []
-
   const showReconcileSection = mode === 'edit' && (showTagline || reconcileFields.length > 0)
-  const showCuratorHintsSection = mode === 'edit' && (hintFields.length > 0 || episode?.embedAllows === false)
+  const showTmdbNeedsReview =
+    mode === 'edit' && episode?.tmdbNeedsReview != null
 
   if (episodeNotFound) {
     return (
@@ -422,20 +426,96 @@ export function AdminCatalogForm({
           </fieldset>
         ) : null}
 
-        {showCuratorHintsSection ? (
-          <fieldset className="riffsync-admin-form-section riffsync-admin-form-section--readonly">
-            <legend>Curator hints (read-only)</legend>
-            <p className="riffsync-admin-form-section-helper">{CURATOR_HINTS_HELPER}</p>
-            {episode?.embedAllows === false ? (
-              <p className="riffsync-admin-form-embed-note" role="note">
-                In-app embed is disabled for this episode.
+        <fieldset className="riffsync-admin-form-section">
+          <legend>Curator hints</legend>
+          <p className="riffsync-admin-form-section-helper">{CURATOR_HINTS_HELPER}</p>
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-movie-search-title">Movie search title</label>
+            <input
+              id="catalog-form-movie-search-title"
+              name="movieSearchTitle"
+              type="text"
+              value={values.movieSearchTitle}
+              onChange={(e) => setField('movieSearchTitle', e.target.value)}
+              aria-invalid={fieldErrors.movieSearchTitle ? true : undefined}
+              aria-describedby={
+                fieldErrors.movieSearchTitle
+                  ? 'catalog-form-movie-search-title-error'
+                  : 'catalog-form-movie-search-title-helper'
+              }
+              disabled={saving}
+              placeholder="Leave empty to clear"
+            />
+            <p id="catalog-form-movie-search-title-helper" className="riffsync-admin-form-field-helper">
+              Override TMDB search title when reconcile has no movie id lock.
+            </p>
+            {fieldErrors.movieSearchTitle ? (
+              <p
+                id="catalog-form-movie-search-title-error"
+                className="riffsync-admin-form-field-error"
+                role="alert"
+              >
+                {fieldErrors.movieSearchTitle}
               </p>
             ) : null}
-            {hintFields.map(([label, value]) => (
-              <ReadOnlyField key={label} label={label} value={String(value)} />
-            ))}
-          </fieldset>
-        ) : null}
+          </div>
+
+          <div className="riffsync-admin-form-field riffsync-admin-form-field--checkbox">
+            <input
+              id="catalog-form-embed-allows"
+              name="embedAllows"
+              type="checkbox"
+              checked={values.embedAllows}
+              onChange={(e) => setField('embedAllows', e.target.checked)}
+              disabled={saving}
+            />
+            <label htmlFor="catalog-form-embed-allows">Allow in-app YouTube embed</label>
+          </div>
+          {!values.embedAllows ? (
+            <p className="riffsync-admin-form-embed-note" role="note">
+              In-app embed is disabled for this episode.
+            </p>
+          ) : null}
+
+          <div className="riffsync-admin-form-field">
+            <label htmlFor="catalog-form-curator-notes">Curator notes</label>
+            <textarea
+              id="catalog-form-curator-notes"
+              name="curatorNotes"
+              rows={4}
+              value={values.curatorNotes}
+              onChange={(e) => setField('curatorNotes', e.target.value)}
+              aria-invalid={fieldErrors.curatorNotes ? true : undefined}
+              aria-describedby={
+                fieldErrors.curatorNotes
+                  ? 'catalog-form-curator-notes-error'
+                  : 'catalog-form-curator-notes-helper'
+              }
+              disabled={saving}
+              placeholder="Leave empty to clear"
+            />
+            <p id="catalog-form-curator-notes-helper" className="riffsync-admin-form-field-helper">
+              Internal operator notes (staff-only, not shown on public catalog).
+            </p>
+            {fieldErrors.curatorNotes ? (
+              <p
+                id="catalog-form-curator-notes-error"
+                className="riffsync-admin-form-field-error"
+                role="alert"
+              >
+                {fieldErrors.curatorNotes}
+              </p>
+            ) : null}
+          </div>
+
+          {showTmdbNeedsReview && episode ? (
+            <ReadOnlyField
+              label="TMDB needs review"
+              value={episode.tmdbNeedsReview ? 'Yes' : 'No'}
+            />
+          ) : null}
+        </fieldset>
 
         <div className="riffsync-admin-catalog-form-actions">
           <button type="submit" className="btn btn-primary" disabled={saving}>

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2346,7 +2346,8 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 .riffsync-admin-form-field input[type='text'],
 .riffsync-admin-form-field input[type='number'],
 .riffsync-admin-form-field input[type='url'],
-.riffsync-admin-form-field select {
+.riffsync-admin-form-field select,
+.riffsync-admin-form-field textarea {
   min-height: 2.75rem;
   padding: 0.45rem 0.65rem;
   border-radius: 0.35rem;
@@ -2365,6 +2366,12 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   width: 1.25rem;
   height: 1.25rem;
   min-height: 1.25rem;
+}
+
+.riffsync-admin-form-field-helper {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--secondary-color);
 }
 
 .riffsync-admin-form-field-error {

--- a/data/catalog/catalog.schema.json
+++ b/data/catalog/catalog.schema.json
@@ -118,6 +118,20 @@
         "carousel": {
           "type": "boolean",
           "description": "When true, episode is eligible for home-page carousels; `GET /v1/catalog?carousel=true` returns only these rows (sorted by experimentNumber)."
+        },
+        "movieSearchTitle": {
+          "type": ["string", "null"],
+          "maxLength": 256,
+          "description": "Staff-only TMDB search hint; not exposed on public catalog reads."
+        },
+        "embedAllows": {
+          "type": "boolean",
+          "description": "When false, SPA should not offer in-app YouTube embed; exposed on public catalog when stored."
+        },
+        "curatorNotes": {
+          "type": ["string", "null"],
+          "maxLength": 4096,
+          "description": "Staff-only curator notes; not exposed on public catalog reads."
         }
       }
     }

--- a/docs/api.catalog.md
+++ b/docs/api.catalog.md
@@ -40,11 +40,13 @@ Returns a bundle aligned with **`data/catalog/episodes.json`**:
 
 Clients should treat optional / **`null`** enrichment fields as "not yet available."
 
-### Optional SPA hints (not in git schema)
+### Optional SPA hints (not in git seed)
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| **`embedAllows`** | `boolean` | When **`false`**, SPA should not offer in-app YouTube embed (see **`architecture.frontend.md`**). |
+| **`embedAllows`** | `boolean` | Operator-writable via admin catalog **POST**/**PATCH**; included on public **`CatalogEpisode`** when stored (especially **`false`**). When **`false`**, SPA should not offer in-app YouTube embed (see **`architecture.frontend.md`**). |
+| **`movieSearchTitle`** | `string \| null` | Staff-only TMDB search hint; admin API and staff reads only, not public projection. |
+| **`curatorNotes`** | `string \| null` | Staff-only curator notes; admin API and staff reads only, not public projection. |
 | **`playbackExpectation`** | `"premium"` \| `"ad_supported"` \| `"unknown"` | Honor-system advisory for **US-P0-07**; not verified server-side. |
 
 ## `GET /v1/catalog/{id}`

--- a/infra/cdk/lambda/admin-catalog-shared.test.ts
+++ b/infra/cdk/lambda/admin-catalog-shared.test.ts
@@ -24,6 +24,13 @@ describe('projectAdminEpisode', () => {
     expect(admin).toMatchObject(pub);
   });
 
+  it('public projection omits staff-only hints but keeps embedAllows when stored', () => {
+    const pub = projectEpisode({ ...baseItem, movieSearchTitle: 'Manos', embedAllows: false, curatorNotes: 'n' });
+    expect(pub.embedAllows).toBe(false);
+    expect(pub).not.toHaveProperty('movieSearchTitle');
+    expect(pub).not.toHaveProperty('curatorNotes');
+  });
+
   it('maps staff-only curator hints when present', () => {
     const admin = projectAdminEpisode({
       ...baseItem,

--- a/infra/cdk/lambda/admin-catalog-validation.test.ts
+++ b/infra/cdk/lambda/admin-catalog-validation.test.ts
@@ -1,101 +1,120 @@
 import { describe, expect, it } from 'vitest';
 import {
   ADMIN_WRITABLE_KEYS,
-  READ_ONLY_WRITE_KEYS,
-  stripAndRejectReadOnly,
   validateCatalogEpisodePatch,
   validateCatalogEpisodePost,
-  validatePathEpisodeId,
 } from './admin-catalog-validation';
 
-const validPostBody = {
+const requiredPostBody = {
   experimentNumber: 101,
   title: 'Test Episode',
   era: 'mike',
   youtubeVideoId: null,
   youtubeWatchUrl: null,
-  carousel: false,
 };
 
-describe('admin-catalog-validation', () => {
-  it('accepts valid POST payload and sets reconcile fields null', () => {
-    const result = validateCatalogEpisodePost('test-episode', validPostBody);
+const existingItem = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  tagline: null,
+  posterImageUrl: null,
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: false,
+  movieSearchTitle: 'Old title',
+  embedAllows: true,
+  curatorNotes: 'Old notes',
+};
+
+describe('ADMIN_WRITABLE_KEYS', () => {
+  it('includes curator hint fields', () => {
+    expect(ADMIN_WRITABLE_KEYS).toEqual(
+      expect.arrayContaining(['movieSearchTitle', 'embedAllows', 'curatorNotes']),
+    );
+  });
+});
+
+describe('validateCatalogEpisodePost', () => {
+  it('defaults hint fields when omitted', () => {
+    const result = validateCatalogEpisodePost('ep-1', requiredPostBody);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.item.id).toBe('test-episode');
-      expect(result.item.tagline).toBeNull();
-      expect(result.item.posterImageUrl).toBeNull();
-      expect(result.item.carousel).toBe(false);
-    }
+    if (!result.ok) return;
+    expect(result.item.embedAllows).toBe(true);
+    expect(result.item.movieSearchTitle).toBeNull();
+    expect(result.item.curatorNotes).toBeNull();
   });
 
-  it('defaults carousel to false on POST when omitted', () => {
-    const { carousel: _c, ...withoutCarousel } = validPostBody;
-    const result = validateCatalogEpisodePost('test-episode', withoutCarousel);
+  it('persists provided hint fields', () => {
+    const result = validateCatalogEpisodePost('ep-1', {
+      ...requiredPostBody,
+      movieSearchTitle: 'The Crawling Eye',
+      embedAllows: false,
+      curatorNotes: 'Test note',
+    });
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.item.carousel).toBe(false);
-    }
+    if (!result.ok) return;
+    expect(result.item.movieSearchTitle).toBe('The Crawling Eye');
+    expect(result.item.embedAllows).toBe(false);
+    expect(result.item.curatorNotes).toBe('Test note');
   });
 
-  it('rejects read-only keys on write', () => {
-    const rejected = stripAndRejectReadOnly({ tagline: 'nope' });
-    expect(rejected?.ok).toBe(false);
-    if (rejected && !rejected.ok) {
-      expect(rejected.details.map((d) => d.instancePath)).toContain('/tagline');
-    }
+  it('rejects tmdbNeedsReview on write', () => {
+    const result = validateCatalogEpisodePost('ep-1', {
+      ...requiredPostBody,
+      tmdbNeedsReview: true,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.details.some((d) => d.instancePath === '/tmdbNeedsReview')).toBe(true);
   });
 
-  it('rejects POST body with forbidden reconcile field', () => {
-    const result = validateCatalogEpisodePost('test-episode', {
-      ...validPostBody,
-      tagline: 'nope',
+  it('rejects movieSearchTitle over maxLength', () => {
+    const result = validateCatalogEpisodePost('ep-1', {
+      ...requiredPostBody,
+      movieSearchTitle: 'x'.repeat(257),
     });
     expect(result.ok).toBe(false);
   });
 
-  it('rejects invalid era on POST', () => {
-    const result = validateCatalogEpisodePost('test-episode', {
-      ...validPostBody,
-      era: 'invalid-era',
+  it('rejects curatorNotes over maxLength', () => {
+    const result = validateCatalogEpisodePost('ep-1', {
+      ...requiredPostBody,
+      curatorNotes: 'x'.repeat(4097),
     });
     expect(result.ok).toBe(false);
   });
+});
 
-  it('rejects invalid slug in path', () => {
-    const result = validatePathEpisodeId('Bad_Slug');
-    expect(result?.ok).toBe(false);
-  });
-
-  it('merges PATCH writable keys and preserves reconcile fields', () => {
-    const existing = {
-      id: 'test-episode',
-      experimentNumber: 101,
-      title: 'Old title',
-      era: 'mike',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: 'keep-me',
-      posterImageUrl: 'https://example.test/poster.jpg',
-      backdropImageUrl: null,
-      tmdbMovieId: 42,
-      tmdbArtworkSyncedAt: '2024-01-01T00:00:00.000Z',
-      carousel: false,
-      movieSearchTitle: 'Manos',
-    };
-
-    const result = validateCatalogEpisodePatch('test-episode', { title: 'New title' }, existing);
+describe('validateCatalogEpisodePatch', () => {
+  it('allows partial hint updates', () => {
+    const result = validateCatalogEpisodePatch(
+      'ep-1',
+      { embedAllows: false, curatorNotes: 'Updated' },
+      existingItem,
+    );
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.item.title).toBe('New title');
-      expect(result.item.tagline).toBe('keep-me');
-      expect(result.item.movieSearchTitle).toBe('Manos');
-    }
+    if (!result.ok) return;
+    expect(result.item.embedAllows).toBe(false);
+    expect(result.item.curatorNotes).toBe('Updated');
+    expect(result.item.movieSearchTitle).toBe('Old title');
   });
 
-  it('exports writable and read-only key lists', () => {
-    expect(ADMIN_WRITABLE_KEYS).toContain('title');
-    expect(READ_ONLY_WRITE_KEYS).toContain('tagline');
-    expect(READ_ONLY_WRITE_KEYS).toContain('movieSearchTitle');
+  it('clears nullable hint fields with null', () => {
+    const result = validateCatalogEpisodePatch('ep-1', { movieSearchTitle: null }, existingItem);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.item.movieSearchTitle).toBeNull();
+  });
+
+  it('rejects tmdbNeedsReview on write', () => {
+    const result = validateCatalogEpisodePatch('ep-1', { tmdbNeedsReview: false }, existingItem);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.details.some((d) => d.instancePath === '/tmdbNeedsReview')).toBe(true);
   });
 });

--- a/infra/cdk/lambda/admin-catalog-validation.ts
+++ b/infra/cdk/lambda/admin-catalog-validation.ts
@@ -9,6 +9,9 @@ export const ADMIN_WRITABLE_KEYS = [
   'youtubeVideoId',
   'youtubeWatchUrl',
   'carousel',
+  'movieSearchTitle',
+  'embedAllows',
+  'curatorNotes',
 ] as const;
 
 export type AdminWritableKey = (typeof ADMIN_WRITABLE_KEYS)[number];
@@ -19,9 +22,6 @@ export const READ_ONLY_WRITE_KEYS = [
   'backdropImageUrl',
   'tmdbMovieId',
   'tmdbArtworkSyncedAt',
-  'movieSearchTitle',
-  'embedAllows',
-  'curatorNotes',
   'tmdbNeedsReview',
   'youtubeThumbnailUrl',
   'tmdbOverview',
@@ -166,6 +166,16 @@ export function validateCatalogEpisodePost(
     ? writable.carousel
     : false;
 
+  const embedAllows = Object.prototype.hasOwnProperty.call(writable, 'embedAllows')
+    ? writable.embedAllows
+    : true;
+  const movieSearchTitle = Object.prototype.hasOwnProperty.call(writable, 'movieSearchTitle')
+    ? writable.movieSearchTitle
+    : null;
+  const curatorNotes = Object.prototype.hasOwnProperty.call(writable, 'curatorNotes')
+    ? writable.curatorNotes
+    : null;
+
   const item: Record<string, unknown> = {
     id: pathId,
     experimentNumber: writable.experimentNumber,
@@ -174,6 +184,9 @@ export function validateCatalogEpisodePost(
     youtubeVideoId: writable.youtubeVideoId,
     youtubeWatchUrl: writable.youtubeWatchUrl,
     carousel,
+    embedAllows,
+    movieSearchTitle,
+    curatorNotes,
     tagline: null,
     posterImageUrl: null,
     backdropImageUrl: null,

--- a/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
+++ b/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
@@ -125,6 +125,9 @@ describe('admin-catalog-post handler', () => {
     const body = JSON.parse(res?.body ?? '');
     expect(body.entry.id).toBe('ep-1');
     expect(body.entry.tagline).toBeNull();
+    expect(body.entry.embedAllows).toBe(true);
+    expect(body.entry.movieSearchTitle).toBeNull();
+    expect(body.entry.curatorNotes).toBeNull();
     expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
       'AdminCatalogPost',
       'success',
@@ -175,6 +178,35 @@ describe('admin-catalog-post handler', () => {
       'validation_error',
       expect.objectContaining({ validationFieldPaths: ['/tagline'] }),
     );
+  });
+
+  it('persists curator hints on create', async () => {
+    mocks.docSend.mockResolvedValueOnce({}).mockResolvedValueOnce({
+      Attributes: { catalogGeneration: 3 },
+    });
+
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-2',
+        {
+          ...writeBody,
+          movieSearchTitle: 'The Crawling Eye',
+          embedAllows: false,
+          curatorNotes: 'Test note',
+        },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-2' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(201);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entry.movieSearchTitle).toBe('The Crawling Eye');
+    expect(body.entry.embedAllows).toBe(false);
+    expect(body.entry.curatorNotes).toBe('Test note');
   });
 
   it('returns 403 when staff groups omit admin/curator', async () => {
@@ -228,6 +260,55 @@ describe('admin-catalog-patch handler', () => {
       'success',
       expect.objectContaining({ action: 'update', episodeId: 'ep-1' }),
     );
+  });
+
+  it('patches curator hints and returns updated entry', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: existingItem })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Attributes: { catalogGeneration: 6 } });
+
+    const res = await patchHandler(
+      staffEvent(
+        'PATCH',
+        '/v1/admin/catalog/episodes/ep-1',
+        {
+          movieSearchTitle: 'The Crawling Eye',
+          embedAllows: false,
+          curatorNotes: 'Test note',
+        },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(200);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entry.movieSearchTitle).toBe('The Crawling Eye');
+    expect(body.entry.embedAllows).toBe(false);
+    expect(body.entry.curatorNotes).toBe('Test note');
+  });
+
+  it('returns 400 when patch includes tmdbNeedsReview', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: existingItem });
+
+    const res = await patchHandler(
+      staffEvent(
+        'PATCH',
+        '/v1/admin/catalog/episodes/ep-1',
+        { tmdbNeedsReview: true },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-1' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(400);
+    expect(JSON.parse(res?.body ?? '').code).toBe('validation_error');
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
   });
 
   it('returns 404 for unknown id', async () => {

--- a/infra/cdk/lambda/catalog-public-handlers.test.ts
+++ b/infra/cdk/lambda/catalog-public-handlers.test.ts
@@ -185,4 +185,18 @@ describe('catalog-get handler cache headers', () => {
     expect(res?.headers?.ETag).toBe('W/"3-episode-101-the-crawling-eye"');
     expect(JSON.parse(res?.body ?? '').entry.id).toBe('101-the-crawling-eye');
   });
+
+  it('includes embedAllows on entry when stored', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 3 } })
+      .mockResolvedValueOnce({ Item: { ...sampleEpisode, embedAllows: false } });
+
+    const res = await getHandler(getEvent('101-the-crawling-eye'), {} as never, () => undefined);
+
+    expect(res?.statusCode).toBe(200);
+    const entry = JSON.parse(res?.body ?? '').entry;
+    expect(entry.embedAllows).toBe(false);
+    expect(entry).not.toHaveProperty('movieSearchTitle');
+    expect(entry).not.toHaveProperty('curatorNotes');
+  });
 });

--- a/infra/cdk/lambda/catalog-shared.test.ts
+++ b/infra/cdk/lambda/catalog-shared.test.ts
@@ -1,151 +1,45 @@
 import { describe, expect, it } from 'vitest';
-import { projectEpisode, sortEpisodes } from './catalog-shared';
+import { projectEpisode } from './catalog-shared';
+
+const baseItem = {
+  id: 'ep-1',
+  experimentNumber: 101,
+  title: 'Test Episode',
+  era: 'mike',
+  youtubeVideoId: null,
+  youtubeWatchUrl: null,
+  tagline: null,
+  posterImageUrl: null,
+  backdropImageUrl: null,
+  tmdbMovieId: null,
+  tmdbArtworkSyncedAt: null,
+  carousel: false,
+};
 
 describe('projectEpisode', () => {
-  it('maps a minimal seed-shaped row', () => {
-    const row = {
-      id: '101-the-crawling-eye',
-      experimentNumber: 101,
-      title: 'The Crawling Eye',
-      era: 'joel',
-      youtubeVideoId: 'lJgQrjYaLbQ',
-      youtubeWatchUrl: 'https://www.youtube.com/watch?v=lJgQrjYaLbQ',
-      tagline: null,
-      posterImageUrl: null,
-      backdropImageUrl: null,
-      tmdbMovieId: null,
-      tmdbArtworkSyncedAt: null,
-    };
-    const ep = projectEpisode(row);
-    expect(ep.id).toBe('101-the-crawling-eye');
-    expect(ep.experimentNumber).toBe(101);
-    expect(ep.tagline).toBeNull();
-    expect(ep.tmdbOverview).toBeUndefined();
-    expect(ep.carousel).toBe(false);
+  it('omits embedAllows when not stored on the row', () => {
+    const entry = projectEpisode(baseItem);
+    expect(entry).not.toHaveProperty('embedAllows');
   });
 
-  it('sets carousel from the stored attribute', () => {
-    const on = projectEpisode({
-      id: 'x',
-      experimentNumber: 1,
-      title: 'T',
-      era: 'joel',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: null,
-      posterImageUrl: null,
-      backdropImageUrl: null,
-      tmdbMovieId: null,
-      tmdbArtworkSyncedAt: null,
-      carousel: true,
-    });
-    expect(on.carousel).toBe(true);
-    const off = projectEpisode({
-      id: 'y',
-      experimentNumber: 2,
-      title: 'U',
-      era: 'joel',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: null,
-      posterImageUrl: null,
-      backdropImageUrl: null,
-      tmdbMovieId: null,
-      tmdbArtworkSyncedAt: null,
-      carousel: false,
-    });
-    expect(off.carousel).toBe(false);
+  it('includes embedAllows false when stored', () => {
+    const entry = projectEpisode({ ...baseItem, embedAllows: false });
+    expect(entry.embedAllows).toBe(false);
   });
 
-  it('accepts string/number carousel flags from Dynamo or legacy clients', () => {
-    expect(
-      projectEpisode({
-        id: 'a',
-        experimentNumber: 1,
-        title: 'T',
-        era: 'joel',
-        youtubeVideoId: null,
-        youtubeWatchUrl: null,
-        tagline: null,
-        posterImageUrl: null,
-        backdropImageUrl: null,
-        tmdbMovieId: null,
-        tmdbArtworkSyncedAt: null,
-        carousel: 'true',
-      }).carousel,
-    ).toBe(true);
-    expect(
-      projectEpisode({
-        id: 'b',
-        experimentNumber: 2,
-        title: 'U',
-        era: 'joel',
-        youtubeVideoId: null,
-        youtubeWatchUrl: null,
-        tagline: null,
-        posterImageUrl: null,
-        backdropImageUrl: null,
-        tmdbMovieId: null,
-        tmdbArtworkSyncedAt: null,
-        carousel: 1,
-      }).carousel,
-    ).toBe(true);
+  it('includes embedAllows true when stored', () => {
+    const entry = projectEpisode({ ...baseItem, embedAllows: true });
+    expect(entry.embedAllows).toBe(true);
   });
 
-  it('preserves optional TMDB copy fields when present', () => {
-    const row = {
-      id: 'x',
-      experimentNumber: 1,
-      title: 'T',
-      era: 'mike',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: 'Hi',
-      posterImageUrl: 'https://example.com/p.jpg',
-      backdropImageUrl: null,
-      tmdbMovieId: 99,
-      tmdbArtworkSyncedAt: '2026-05-01T00:00:00.000Z',
-      tmdbOverview: 'Overview text',
-      tmdbPopularity: 12.5,
-      tmdbPosterPath: '/p.jpg',
-      tmdbBackdropPath: '/b.jpg',
-    };
-    const ep = projectEpisode(row);
-    expect(ep.tmdbOverview).toBe('Overview text');
-    expect(ep.tmdbPopularity).toBe(12.5);
-    expect(ep.tmdbPosterPath).toBe('/p.jpg');
-  });
-});
-
-describe('sortEpisodes', () => {
-  it('orders by experimentNumber ascending', () => {
-    const a = projectEpisode({
-      id: 'b',
-      experimentNumber: 2,
-      title: 'B',
-      era: 'joel',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: null,
-      posterImageUrl: null,
-      backdropImageUrl: null,
-      tmdbMovieId: null,
-      tmdbArtworkSyncedAt: null,
+  it('does not expose staff-only curator hints', () => {
+    const entry = projectEpisode({
+      ...baseItem,
+      movieSearchTitle: 'Manos',
+      curatorNotes: 'secret',
+      embedAllows: false,
     });
-    const b = projectEpisode({
-      id: 'a',
-      experimentNumber: 1,
-      title: 'A',
-      era: 'joel',
-      youtubeVideoId: null,
-      youtubeWatchUrl: null,
-      tagline: null,
-      posterImageUrl: null,
-      backdropImageUrl: null,
-      tmdbMovieId: null,
-      tmdbArtworkSyncedAt: null,
-    });
-    const sorted = sortEpisodes([a, b]).map((e) => e.id);
-    expect(sorted).toEqual(['a', 'b']);
+    expect(entry).not.toHaveProperty('movieSearchTitle');
+    expect(entry).not.toHaveProperty('curatorNotes');
   });
 });

--- a/infra/cdk/lambda/catalog-shared.ts
+++ b/infra/cdk/lambda/catalog-shared.ts
@@ -17,6 +17,8 @@ export interface CatalogEpisode {
   readonly tmdbArtworkSyncedAt: string | null;
   /** When true, row is included in **`GET /v1/catalog?carousel=true`**. */
   readonly carousel: boolean;
+  /** When false, SPA should not offer in-app YouTube embed; omitted when not stored on the row. */
+  readonly embedAllows?: boolean;
   readonly tmdbOverview?: string | null;
   readonly tmdbPopularity?: number | null;
   readonly tmdbPosterPath?: string | null;
@@ -62,6 +64,11 @@ export function projectEpisode(item: Record<string, unknown>): CatalogEpisode {
   const optionalNumberField = (v: unknown): number | undefined =>
     v === null || v === undefined ? undefined : Number(v);
 
+  const embedAllows =
+    Object.prototype.hasOwnProperty.call(item, 'embedAllows') && typeof item.embedAllows === 'boolean'
+      ? item.embedAllows
+      : undefined;
+
   return {
     id,
     experimentNumber,
@@ -75,6 +82,7 @@ export function projectEpisode(item: Record<string, unknown>): CatalogEpisode {
     tmdbMovieId: optionalNumber(item.tmdbMovieId),
     tmdbArtworkSyncedAt: optionalString(item.tmdbArtworkSyncedAt),
     carousel: parseCarouselFlag(item.carousel),
+    ...(embedAllows !== undefined ? { embedAllows } : {}),
     tmdbOverview: optionalStringField(item.tmdbOverview),
     tmdbPopularity: optionalNumberField(item.tmdbPopularity),
     tmdbPosterPath: optionalStringField(item.tmdbPosterPath),


### PR DESCRIPTION
## Summary

Implements M13 curator hints on the shared branch `feature/issue-85`:

- **#90 (API):** Widen catalog schema; allow `movieSearchTitle`, `embedAllows`, and `curatorNotes` on admin POST/PATCH; public projection keeps `embedAllows` only; Vitest + `docs/api.catalog.md`
- **#91 (web):** Editable Curator hints in `AdminCatalogForm` with client validation, create/PATCH wiring, `embedAllows: false` inline note, read-only `tmdbNeedsReview`, and Vitest coverage

Closes #90.
Closes #91.

Parent epic: #85

## Test plan

- [x] `npm run verify:push:cdk` (API / CDK)
- [x] `npm run verify:push:web` (form validation + AdminCatalogForm Vitest; `apps/web` build)
- [ ] Manual: edit episode hints in admin UI against deployed API; confirm fan catalog / solo watch respects `embedAllows: false`