### PR TITLE
docs: resolve SFU multi-producer contracts for #102

### DIFF
--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -33,7 +33,7 @@
 
 ## Open implementation decisions
 
-- Ordering when host sets **`avDisabled`** concurrently with in-flight participant **`produce`** requests (Dynamo write vs SFU tear-down vs WebSocket broadcast).
+- **Kill-switch ordering (resolved #102 / #103):** durable **`avDisabled`** write → SFU **`/admin/teardown-producers`** → WebSocket fan-out → token mint denial. In-flight **`produce`** after teardown may fail at SFU or close shortly; clients unpublish on **`av_disabled`** (#104).
 - **`roomMode`** change to **`videoChat`** while **`broadcastCaptureActive`** is true: single **`PATCH`** vs two-step client sequence and which field write wins on **`409`** retry.
 - Whether WebSocket **`room_mode`** / **`av_disabled`** (exact **`type`** TBD) messages are emitted only after Dynamo commit or optimistically before ack.
 - SFU producer list freshness vs **RoomPresence** roster for layout (stale tile when producer exists but presence row expired).

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -80,13 +80,23 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 | Theater participant audio? | **Client-side mixing** — consumers attach multiple SFU audio consumers (host movie + participant mics); no server-side mixer in MVP. |
 | Video Chat vs host screen? | Clients **stop consuming** host screen producer in **`videoChat`** mode; host **fully stops** tab-capture on enter (resume requires **Share Source Tab** again). |
 
-## Open implementation decisions
+## `POST /v1/webrtc/sfu-token` response (#102)
+
+| Field | Contract |
+| --- | --- |
+| **`token`** | HMAC join JWT embedding **`SfuJoinClaims`** (see **`authorization.md`**). |
+| **`role`** | **`producer`** or **`consumer`**. |
+| **`producerClass`** | Present when **`role === producer`**: **`host_screen`** or **`participant_av`**. |
+| **`wsUrl`** | Public SFU signaling URL. |
+| **`expiresInSeconds`** | **900** today. |
+
+- **Cap enforcement:** **Both** Lambda (mint-time estimate + **`avDisabled`** gate) **and** SFU service **`SFU_MAX_*`** at **`produce`**.
+- **Token refresh:** Re-mint on SFU signaling reconnect or **~60s before `exp`** while tracks remain active (#104 implements client timer).
+
+## Open implementation decisions (#103 / WebSocket)
 
 - **`room_mode`** / **`av_disabled`** vs unified host action (e.g. **`room_av_control`**) and exact inbound JSON field names; align with **`docs/contracts.websocket.md`** when updated.
-- Whether host **`PATCH`** alone triggers **`PostToConnection`** fan-out or the SPA sends a follow-up WS action after successful **`PATCH`** (prefer **server fan-out after durable write**).
-- **`SfuJoinClaims`** field names and whether **`POST /v1/webrtc/sfu-token`** response includes **`producerClass`** alongside **`role`**.
-- SFU join token **refresh** while camera/mic tracks stay active (**900s** expiry): silent refresh interval vs re-mint on producer **`transport`** reconnect only.
-- Participant producer cap enforcement location: **`webrtc-sfu-token`** Lambda only vs SFU service **`SFU_MAX_*`** env caps vs both.
+- Whether host **`PATCH`** alone triggers **`PostToConnection`** fan-out or the SPA sends a follow-up WS action after successful **`PATCH`** (prefer **server fan-out after durable write** — #103).
 - **`room_mode`** fan-out payload: include full room snapshot subset vs **`roomMode`** + **`ts`** only.
 
 ## Open implementation details

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -71,13 +71,38 @@ Who may do what, and how identity is represented. Aligns with **`docs/architectu
 | AV kill switch enforcement? | **Server-enforced** — deny SFU participant producer tokens, tear down active participant producers, broadcast **`avDisabled`**; not client-cooperative-only. |
 | Host participant A/V while screen sharing? | **Allowed** — host may publish **participant A/V** alongside **host screen** (two video sources on the same SFU router). |
 
-## Open implementation decisions
+## SFU join token claims (`SfuJoinClaims`)
 
-- Exact **`SfuJoinClaims`** shape: e.g. **`producerClass`**: **`host_screen`** \| **`participant_av`** vs extending binary **`role`**; include **`sub`** / **`fanSub`** on participant producer tokens for audit and rate limits.
-- Whether one SFU join token covers **both** participant camera and mic producers per session or separate mint per track kind.
-- Host with concurrent **host screen** + **participant A/V**: single SFU WebSocket session with multiple producers vs separate sessions (Architect default: **one session per tab**).
-- **`webrtc-sfu-token`** **403** error body discriminator when **`avDisabled`**, missing **`fanSub`**, or publisher cap exceeded (client UX copy).
-- Per-**`sub`** rate limit for participant producer token minting (mirror Giphy/chat throttle patterns in IaC).
+| Field | When present | Contract |
+| --- | --- | --- |
+| **`env`** | Always | API environment slug (today **`prod`**). |
+| **`roomId`** | Always | Target watch room. |
+| **`sessionId`** | Always | Browser tab presence id (**`X-Session-Id`**). |
+| **`role`** | Always | **`producer`** or **`consumer`**. |
+| **`producerClass`** | **`role === producer`** | **`host_screen`** (tab capture) or **`participant_av`** (**`getUserMedia`**). |
+| **`fanSub`** | **`producerClass === participant_av`** | Cognito **`sub`** for audit and rate limits. |
+| **`iat`**, **`exp`** | Always | HMAC JWT lifetime (**900s** today). |
+
+- **One producer token per session** authorizes **multiple** mediasoup **`produce`** calls on the same SFU WebSocket (separate **`audio`** and **`video`** producers). No per-kind re-mint.
+- **Host concurrent producers:** **one SFU WebSocket per browser tab** may carry **`host_screen`** and **`participant_av`** producers together.
+
+## `POST /v1/webrtc/sfu-token` denial codes
+
+When status is **403** (or **429** for throttle), body includes stable **`code`** for client copy:
+
+| **`code`** | Meaning |
+| --- | --- |
+| **`av_disabled`** | Room **`avDisabled`** is true (participant producer only). |
+| **`fan_auth_required`** | Participant producer requested without verified fan JWT / **`fanSub`** on presence row. |
+| **`not_host`** | **`host_screen`** producer requested but **`JWT.sub !== room.hostSub`**. |
+| **`unknown_session`** | No active presence row for **`X-Session-Id`**. |
+| **`publisher_cap_exceeded`** | Per-room participant publisher estimate at cap. |
+| **`rate_limited`** | Per-**`fanSub`** mint throttle exceeded. |
+
+## Participant producer mint rate limit
+
+- **30** participant producer token mints per **`fanSub`** per rolling minute (Lambda guard + API Gateway route throttle).
+- Emit aggregate metric **`RiffSync/Media/sfu_token_denied`** with **`reason`** dimension; **no** **`fanSub`** in logs at INFO.
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -47,9 +47,15 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 | **ElastiCache** | Optional read-through cache for catalog/lobby. |
 | **EC2 (`RiffSyncTurn`)** | **mediasoup SFU** + **coturn** on shared VPC instances; **`POST /v1/webrtc/sfu-token`** mints HMAC join JWTs; browsers connect **`wss://`** for RTP. Multi-producer rooms replace single **`producersByKind`** slot model. |
 
-## Open implementation decisions
+## SFU admin teardown (kill switch)
 
-- SFU **admin teardown** surface for kill switch (internal HTTP on SFU EC2 vs mediasoup signaling message) — not a third-party boundary but affects how **`RiffSyncApi-prod`** Lambdas invoke **`RiffSyncTurn`**.
+| Topic | Contract |
+| --- | --- |
+| **Surface** | Internal HTTP on the SFU EC2 process: **`POST /admin/teardown-producers`**. |
+| **Auth** | Shared **`SFU_ADMIN_SECRET`** header; bind to loopback or VPC-only callers. |
+| **Body** | **`{ env, roomId, producerClass?: "participant_av" }`** — omit **`producerClass`** to tear down all **`participant_av`** producers in the room; **`host_screen`** is never torn down by kill switch. |
+| **Caller** | Room **`PATCH`** Lambda after durable **`avDisabled: true`** write (#101 / #102). Idempotent close-by-**`sessionId`** / **`producerId`**. |
+| **Failure** | Log + metric; room state remains **`avDisabled`**; token mint denial prevents re-publish. |
 
 ## Decisions (answered)
 

--- a/.ai/integration/messaging_async.md
+++ b/.ai/integration/messaging_async.md
@@ -31,11 +31,16 @@ Scheduled work, durable events, and side effects that are not synchronous reques
 | Reconcile on every catalog read? | **No**; scheduled/batch only. |
 | Room mode / AV kill switch ordering? | **Durable room write before fan-out** when persisted; best-effort delivery order across connections (same as playback **`PATCH`** + chat). |
 
-## Open implementation decisions
+## Kill-switch side-effect ordering (#102 / #103 split)
 
-- Kill-switch **SFU producer teardown** trigger: synchronous HTTP admin callback from room **`PATCH`** Lambda vs async invoke vs SFU polling room flags (prefer **explicit teardown hook** with idempotent close-by-**`sessionId`**).
-- Whether **`av_disabled`** WS fan-out is emitted by the **room PATCH handler** only, the **WS route handler** only, or both (avoid duplicate events).
-- Retry/backoff when **`PostToConnection`** fails mid-kill-switch fan-out (best-effort vs at-least-once to all tabs).
+| Step | Owner | Contract |
+| --- | --- | --- |
+| 1 | **#101 / room `PATCH` Lambda** | Conditional Dynamo write sets **`avDisabled: true`**. |
+| 2 | **#102** | Synchronous **`POST /admin/teardown-producers`** on SFU (participant class only). |
+| 3 | **#103** | **`PostToConnection`** **`av_disabled`** fan-out from **room `PATCH` handler only** (not duplicate WS inbound route). |
+| 4 | **#102** | Deny new **`participant_av`** producer tokens at **`webrtc-sfu-token`**. |
+
+- **`PostToConnection`** failures during kill-switch fan-out: **best-effort** + log/metric; late joiners read **`avDisabled`** from room snapshot.
 
 ## Primary code pointers (optional)
 

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -56,9 +56,14 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 | --- | --- |
 | **Third-party ToS** | YouTube embed + TMDB attribution + **Giphy** usage + Meta login rules documented for operators (**Giphy:** [`docs/operations/giphy.md`](../../docs/operations/giphy.md)). |
 
-## Open implementation decisions
+## SFU token mint abuse controls
 
-- **Abuse controls for token minting:** Whether **`POST /v1/webrtc/sfu-token`** needs per-session rate limits or stricter producer mint rules when multiple signed-in fans can publish (API Gateway / Lambda guard — no PII in logs).
+| Control | Contract |
+| --- | --- |
+| **Per-`fanSub` throttle** | Max **30** participant producer mints per rolling minute at **`webrtc-sfu-token`** Lambda (in-memory counter per execution environment + API Gateway route throttle). |
+| **Per-room cap** | Lambda rejects mint when estimated **`participant_av`** publishers would exceed **`SFU_MAX_PRODUCERS_PER_ROOM`**; SFU enforces hard cap at **`produce`**. |
+| **Logging** | Denials log **`code`** / **`reason`** only at INFO — **no** **`fanSub`** or JWT material. |
+| **Metrics** | **`RiffSync/Media/sfu_token_denied`** with **`reason`** dimension. |
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -70,11 +70,16 @@ Non-secret env knobs on the **`riffsync-sfu`** process (exact names in IaC):
 
 SPA build-time: **`VITE_PUBLIC_WS_URL`**, **`VITE_PUBLIC_API_BASE_URL`**, SFU WebSocket URL (or token-embedded **`wsUrl`**). Participant AV uses the **same** SFU signaling host as host screen share; no separate media endpoint.
 
-## Open implementation decisions
+## SFU producer cap env vars
 
-- New SFU env vars for max producers per room/session; defaults safe for target party scale (~8 concurrent AV publishers per room).
-- Whether SPA needs a new build-time flag for participant AV feature gate beyond existing **`VITE_WEBRTC_USE_MEDIASOU_SFU`**.
-- CDK wiring for **`SFU_PUBLIC_WS_URL`** unchanged; document that participant path shares host signaling URL.
+| Variable | Default | Contract |
+| --- | --- | --- |
+| **`SFU_MAX_PRODUCERS_PER_SESSION`** | **3** | Max mediasoup producers one signaling session may create (host screen + participant video + participant audio on one tab). |
+| **`SFU_MAX_PRODUCERS_PER_ROOM`** | **24** | Max producers per **`env:roomId`** router (~8 fans × 2 tracks + host screen + headroom). |
+| **`SFU_ADMIN_SECRET`** | (required prod) | Shared secret for **`POST /admin/teardown-producers`**; also on room **`PATCH`** Lambda env. |
+
+- **SPA feature gate:** No new build flag for participant AV beyond existing **`VITE_WEBRTC_USE_MEDIASOU_SFU`** (#104 gates UI on snapshot + JWT).
+- **`SFU_PUBLIC_WS_URL`:** Unchanged; participant and host share the same signaling **`wss://`** endpoint.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -43,16 +43,23 @@ Runtime topology: **AWS serverless MVP** (**`docs/architecture.server.md`**).
 | AV kill switch enforcement? | **Server-enforced:** deny participant producer SFU tokens, tear down active participant producers on SFU, broadcast authoritative **`avDisabled`** on room WebSocket. |
 | SFU producer registry? | **Per-producer registry** (not one producer per kind); **`tearDownSession`** removes **only that session's producers**, not a room-wide wipe. |
 
-## Open implementation decisions
+## SFU producer registry (mediasoup service)
 
-- Module layout: extend **`sfuRoomSession`** vs separate participant-AV helper; how **`RoomPage`** refs compose with existing **`sfuSessionRef`**.
-- Independent mic/cam toggles: one or two mediasoup producers per session; **`track.enabled`** vs **`producer.pause()`** when mic muted but camera on.
-- Map SFU **`newProducer`** / **`producerClosed`** events to per-participant UI streams (strip/grid) using **`sessionId`** in event payload.
-- Page Visibility / background tab: pause participant video producers or leave running; battery and bandwidth policy.
-- Producer registry schema in SFU **`rooms.ts`**; **`listProducerSummaries`** payload shape (**`sessionId`**, producer class, **`kind`**).
-- Room idle close (**`ROOM_IDLE_MS`**) when only participant producers remain (no host screen share).
-- Whether one fan with two tabs may hold two producer sessions; dedupe by **`sub`** or allow.
-- Per-room or per-session producer caps: env var names and default values safe for party scale.
+| Topic | Contract |
+| --- | --- |
+| **Registry shape** | Replace single **`producersByKind`** slot with **`producers: Map<producerId, { producer, sessionId, producerClass, kind }>`**. Upsert replaces the prior producer for the same **`(sessionId, producerClass, kind)`** tuple. |
+| **`listProducers` / events** | Summaries and **`newProducer`** / **`producerClosed`** fan-out include **`{ producerId, kind, sessionId, producerClass }`**. |
+| **Session teardown** | On SFU WebSocket close, remove **only** producers owned by that **`sessionId`** — never room-wide wipe. |
+| **Room idle** | **`ROOM_IDLE_MS`** schedules router close when the room has **zero** producers across all classes. |
+| **Two tabs per fan** | **Allow** — each tab **`sessionId`** may publish independently; per-room cap is the abuse guard (no **`fanSub`** dedupe MVP). |
+| **Caps (env)** | **`SFU_MAX_PRODUCERS_PER_SESSION`** default **3**; **`SFU_MAX_PRODUCERS_PER_ROOM`** default **24**. Enforced at **`produce`**; Lambda mirrors room-level estimate at mint. |
+
+## Client mapping (handoff to #104 / #105)
+
+- Map **`newProducer`** / **`producerClosed`** to strip/grid tiles by **`sessionId`** + **`producerClass`**.
+- Mic mute with camera on: prefer **`producer.pause()`** / **`resume()`** on the audio producer (#104).
+- Page Visibility: leave participant producers running for MVP (#104 may revisit battery policy).
+- Module layout (**`sfuRoomSession`** extension vs helper) is a #104 implementation choice; SFU contract above is normative.
 
 ## Primary code pointers (optional)
 


### PR DESCRIPTION
## Summary

- Resolves in-scope `## Open implementation decisions` from `/refine-issue` on parent issue #102.
- Defines `SfuJoinClaims` (`producerClass`, `fanSub`), multi-producer registry shape, kill-switch SFU admin teardown, token mint denial codes, and producer cap env vars.
- Splits remaining WebSocket fan-out open items to #103; client mapping handoff notes point to #104/#105.

## Test plan

- [ ] Review `.ai` diffs against GitHub issues #102, #110, #111, #112 for alignment
- [ ] Confirm no unresolved `#102` open bullets remain in touched contract files
- [ ] Merge before or alongside implementation PRs for #110–#112