### PR TITLE
feat(room-patch): WebSocket fan-out wiring for room admin PATCH (#103)

### DIFF
--- a/infra/cdk/lambda/room-patch-fanout.test.ts
+++ b/infra/cdk/lambda/room-patch-fanout.test.ts
@@ -14,6 +14,7 @@ vi.mock('./ws-shared', () => ({
 }));
 
 import {
+  buildAvDisabledFanoutEnvelope,
   buildRoomModeFanoutEnvelope,
   fanOutRoomPatchEnvelope,
   readHostSessionIdFromHeaders,
@@ -30,6 +31,23 @@ describe('buildRoomModeFanoutEnvelope', () => {
     ).toEqual({
       type: 'room_mode',
       roomMode: 'videoChat',
+      ts: 1_717_700_000_000,
+      version: 42,
+    });
+  });
+});
+
+describe('buildAvDisabledFanoutEnvelope', () => {
+  it('builds contract-shaped av_disabled payload', () => {
+    expect(
+      buildAvDisabledFanoutEnvelope({
+        avDisabled: true,
+        ts: 1_717_700_000_000,
+        version: 42,
+      }),
+    ).toEqual({
+      type: 'av_disabled',
+      avDisabled: true,
       ts: 1_717_700_000_000,
       version: 42,
     });

--- a/infra/cdk/lambda/room-patch-fanout.test.ts
+++ b/infra/cdk/lambda/room-patch-fanout.test.ts
@@ -1,0 +1,107 @@
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wsMocks = vi.hoisted(() => ({
+  queryConnectionsForRoom: vi.fn(),
+  postToConnections: vi.fn(),
+  wsManagementClient: vi.fn(),
+}));
+
+vi.mock('./ws-shared', () => ({
+  queryConnectionsForRoom: wsMocks.queryConnectionsForRoom,
+  postToConnections: wsMocks.postToConnections,
+  wsManagementClient: wsMocks.wsManagementClient,
+}));
+
+import { fanOutRoomPatchEnvelope, readHostSessionIdFromHeaders } from './room-patch-fanout';
+
+describe('readHostSessionIdFromHeaders', () => {
+  it('reads x-session-id case-insensitively', () => {
+    expect(readHostSessionIdFromHeaders({ 'x-session-id': '  sess-1  ' })).toBe('sess-1');
+    expect(readHostSessionIdFromHeaders({ 'X-Session-Id': 'sess-2' })).toBe('sess-2');
+  });
+
+  it('returns undefined when header missing or blank', () => {
+    expect(readHostSessionIdFromHeaders({})).toBeUndefined();
+    expect(readHostSessionIdFromHeaders({ 'x-session-id': '   ' })).toBeUndefined();
+    expect(readHostSessionIdFromHeaders(undefined)).toBeUndefined();
+  });
+});
+
+describe('fanOutRoomPatchEnvelope', () => {
+  const doc = {} as DynamoDBDocumentClient;
+  const mgmtClient = { kind: 'mgmt' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONNECTIONS_TABLE_NAME = 'connections-table';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence-table';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    wsMocks.queryConnectionsForRoom.mockResolvedValue(['conn-a', 'conn-b']);
+    wsMocks.wsManagementClient.mockReturnValue(mgmtClient);
+    wsMocks.postToConnections.mockResolvedValue(undefined);
+  });
+
+  it('queries room connections and posts encoded envelope with host sessionId', async () => {
+    await fanOutRoomPatchEnvelope({
+      doc,
+      roomId: 'room-1',
+      hostSessionId: 'host-sess',
+      envelope: { type: 'av_disabled', avDisabled: true, ts: 1_700_000_000_000 },
+    });
+
+    expect(wsMocks.queryConnectionsForRoom).toHaveBeenCalledWith(doc, 'presence-table', 'room-1');
+    expect(wsMocks.wsManagementClient).toHaveBeenCalledOnce();
+    expect(wsMocks.postToConnections).toHaveBeenCalledOnce();
+
+    const postArgs = wsMocks.postToConnections.mock.calls[0] as [
+      unknown,
+      DynamoDBDocumentClient,
+      string,
+      string[],
+      Uint8Array,
+      string | undefined,
+      string,
+    ];
+    expect(postArgs[0]).toBe(mgmtClient);
+    expect(postArgs[1]).toBe(doc);
+    expect(postArgs[2]).toBe('connections-table');
+    expect(postArgs[3]).toEqual(['conn-a', 'conn-b']);
+    expect(postArgs[5]).toBeUndefined();
+    expect(postArgs[6]).toBe('presence-table');
+
+    const decoded = JSON.parse(new TextDecoder().decode(postArgs[4])) as Record<string, unknown>;
+    expect(decoded).toMatchObject({
+      type: 'av_disabled',
+      roomId: 'room-1',
+      sessionId: 'host-sess',
+      avDisabled: true,
+      ts: 1_700_000_000_000,
+    });
+  });
+
+  it('omits sessionId when host session header was not provided', async () => {
+    await fanOutRoomPatchEnvelope({
+      doc,
+      roomId: 'room-2',
+      envelope: { type: 'room_mode', roomMode: 'videoChat', ts: 42 },
+    });
+
+    const postArgs = wsMocks.postToConnections.mock.calls[0] as [unknown, unknown, unknown, unknown, Uint8Array];
+    const decoded = JSON.parse(new TextDecoder().decode(postArgs[4])) as Record<string, unknown>;
+    expect(decoded.sessionId).toBeUndefined();
+    expect(decoded.roomId).toBe('room-2');
+  });
+
+  it('throws when fan-out table env is missing', async () => {
+    delete process.env.CONNECTIONS_TABLE_NAME;
+
+    await expect(
+      fanOutRoomPatchEnvelope({
+        doc,
+        roomId: 'room-1',
+        envelope: { type: 'av_disabled', avDisabled: true },
+      }),
+    ).rejects.toThrow('Missing fan-out table env');
+  });
+});

--- a/infra/cdk/lambda/room-patch-fanout.test.ts
+++ b/infra/cdk/lambda/room-patch-fanout.test.ts
@@ -13,7 +13,28 @@ vi.mock('./ws-shared', () => ({
   wsManagementClient: wsMocks.wsManagementClient,
 }));
 
-import { fanOutRoomPatchEnvelope, readHostSessionIdFromHeaders } from './room-patch-fanout';
+import {
+  buildRoomModeFanoutEnvelope,
+  fanOutRoomPatchEnvelope,
+  readHostSessionIdFromHeaders,
+} from './room-patch-fanout';
+
+describe('buildRoomModeFanoutEnvelope', () => {
+  it('builds contract-shaped room_mode payload', () => {
+    expect(
+      buildRoomModeFanoutEnvelope({
+        roomMode: 'videoChat',
+        ts: 1_717_700_000_000,
+        version: 42,
+      }),
+    ).toEqual({
+      type: 'room_mode',
+      roomMode: 'videoChat',
+      ts: 1_717_700_000_000,
+      version: 42,
+    });
+  });
+});
 
 describe('readHostSessionIdFromHeaders', () => {
   it('reads x-session-id case-insensitively', () => {

--- a/infra/cdk/lambda/room-patch-fanout.ts
+++ b/infra/cdk/lambda/room-patch-fanout.ts
@@ -1,0 +1,45 @@
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { TextEncoder } from 'node:util';
+import { postToConnections, queryConnectionsForRoom, wsManagementClient } from './ws-shared';
+
+const encoder = new TextEncoder();
+
+export function readHostSessionIdFromHeaders(
+  headers: Record<string, string | undefined> | undefined,
+): string | undefined {
+  const raw = headers?.['x-session-id'] ?? headers?.['X-Session-Id'];
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  return trimmed || undefined;
+}
+
+export type RoomPatchFanoutEnvelope = Record<string, unknown> & {
+  roomId: string;
+  sessionId?: string;
+};
+
+/** Fan-out a room admin PATCH envelope to all WebSocket connections in the room. */
+export async function fanOutRoomPatchEnvelope(params: {
+  doc: DynamoDBDocumentClient;
+  roomId: string;
+  envelope: RoomPatchFanoutEnvelope;
+  hostSessionId?: string;
+}): Promise<void> {
+  const connectionsTable = process.env.CONNECTIONS_TABLE_NAME;
+  const roomPresenceTable = process.env.ROOM_PRESENCE_TABLE_NAME;
+  if (!connectionsTable || !roomPresenceTable) {
+    throw new Error('Missing fan-out table env');
+  }
+
+  const { doc, roomId, envelope, hostSessionId } = params;
+  const payload: RoomPatchFanoutEnvelope = {
+    ...envelope,
+    roomId,
+    ...(hostSessionId ? { sessionId: hostSessionId } : {}),
+  };
+
+  const connectionIds = await queryConnectionsForRoom(doc, roomPresenceTable, roomId);
+  const mgmt = wsManagementClient();
+  const buf = encoder.encode(JSON.stringify(payload));
+
+  await postToConnections(mgmt, doc, connectionsTable, connectionIds, buf, undefined, roomPresenceTable);
+}

--- a/infra/cdk/lambda/room-patch-fanout.ts
+++ b/infra/cdk/lambda/room-patch-fanout.ts
@@ -25,6 +25,13 @@ export type RoomModeFanoutEnvelope = {
   version: number;
 };
 
+export type AvDisabledFanoutEnvelope = {
+  type: 'av_disabled';
+  avDisabled: boolean;
+  ts: number;
+  version: number;
+};
+
 /** Build the outbound `room_mode` WebSocket payload after a successful roomMode PATCH. */
 export function buildRoomModeFanoutEnvelope(params: {
   roomMode: RoomMode;
@@ -34,6 +41,20 @@ export function buildRoomModeFanoutEnvelope(params: {
   return {
     type: 'room_mode',
     roomMode: params.roomMode,
+    ts: params.ts,
+    version: params.version,
+  };
+}
+
+/** Build the outbound `av_disabled` WebSocket payload after a successful avDisabled PATCH. */
+export function buildAvDisabledFanoutEnvelope(params: {
+  avDisabled: boolean;
+  ts: number;
+  version: number;
+}): AvDisabledFanoutEnvelope {
+  return {
+    type: 'av_disabled',
+    avDisabled: params.avDisabled,
     ts: params.ts,
     version: params.version,
   };

--- a/infra/cdk/lambda/room-patch-fanout.ts
+++ b/infra/cdk/lambda/room-patch-fanout.ts
@@ -1,5 +1,6 @@
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { TextEncoder } from 'node:util';
+import type { RoomMode } from './room-shared';
 import { postToConnections, queryConnectionsForRoom, wsManagementClient } from './ws-shared';
 
 const encoder = new TextEncoder();
@@ -16,6 +17,27 @@ export type RoomPatchFanoutEnvelope = Record<string, unknown> & {
   roomId: string;
   sessionId?: string;
 };
+
+export type RoomModeFanoutEnvelope = {
+  type: 'room_mode';
+  roomMode: RoomMode;
+  ts: number;
+  version: number;
+};
+
+/** Build the outbound `room_mode` WebSocket payload after a successful roomMode PATCH. */
+export function buildRoomModeFanoutEnvelope(params: {
+  roomMode: RoomMode;
+  ts: number;
+  version: number;
+}): RoomModeFanoutEnvelope {
+  return {
+    type: 'room_mode',
+    roomMode: params.roomMode,
+    ts: params.ts,
+    version: params.version,
+  };
+}
 
 /** Fan-out a room admin PATCH envelope to all WebSocket connections in the room. */
 export async function fanOutRoomPatchEnvelope(params: {

--- a/infra/cdk/lambda/room-patch.test.ts
+++ b/infra/cdk/lambda/room-patch.test.ts
@@ -28,6 +28,18 @@ vi.mock('./sfu-admin-teardown', () => ({
   requestSfuProducerTeardown: teardownMocks.requestSfuProducerTeardown,
 }));
 
+const fanoutMocks = vi.hoisted(() => ({
+  fanOutRoomPatchEnvelope: vi.fn(),
+}));
+
+vi.mock('./room-patch-fanout', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./room-patch-fanout')>();
+  return {
+    ...actual,
+    fanOutRoomPatchEnvelope: fanoutMocks.fanOutRoomPatchEnvelope,
+  };
+});
+
 import { handler } from './room-patch';
 
 const hostSub = 'host-sub-1';
@@ -50,6 +62,7 @@ function patchEvent(
   body: Record<string, unknown>,
   sub = hostSub,
   roomId = 'room-1',
+  headers: Record<string, string> = {},
 ): APIGatewayProxyEventV2 {
   const routeKey = 'PATCH /v1/rooms/{roomId}';
   return {
@@ -58,7 +71,7 @@ function patchEvent(
     rawPath: `/v1/rooms/${roomId}`,
     rawQueryString: '',
     pathParameters: { roomId },
-    headers: {},
+    headers,
     body: JSON.stringify(body),
     requestContext: {
       accountId: '123',
@@ -90,13 +103,30 @@ describe('room-patch handler', () => {
     process.env.CATALOG_TABLE_NAME = 'catalog-table';
     process.env.RIFFSYNC_API_ENV = 'prod';
     teardownMocks.requestSfuProducerTeardown.mockResolvedValue({ ok: true, closedCount: 0 });
+    fanoutMocks.fanOutRoomPatchEnvelope.mockResolvedValue(undefined);
   });
 
   it('updates roomMode and avDisabled with version increment', async () => {
     mocks.docSend.mockResolvedValueOnce({ Item: baseRoom }).mockResolvedValueOnce({});
 
     const res = await handler(
-      patchEvent({ roomMode: 'videoChat', avDisabled: true }),
+      patchEvent({ roomMode: 'videoChat', avDisabled: true }, hostSub, 'room-1', {
+        'x-session-id': 'host-sess-1',
+      }),
+    );
+
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledOnce();
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        hostSessionId: 'host-sess-1',
+        envelope: {
+          type: 'room_mode',
+          roomMode: 'videoChat',
+          ts: expect.any(Number) as number,
+          version: 3,
+        },
+      }),
     );
 
     expect(teardownMocks.requestSfuProducerTeardown).toHaveBeenCalledWith({
@@ -190,6 +220,27 @@ describe('room-patch handler', () => {
       error: 'Conflict — stale version',
       version: 2,
     });
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('does not fan out room_mode when roomMode is unchanged', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: baseRoom }).mockResolvedValueOnce({});
+
+    const res = await handler(patchEvent({ roomMode: 'theater' }));
+
+    expect(res.statusCode).toBe(200);
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('does not fan out room_mode on 409 conflict', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: baseRoom })
+      .mockRejectedValueOnce({ name: 'ConditionalCheckFailedException' });
+
+    const res = await handler(patchEvent({ roomMode: 'videoChat' }));
+
+    expect(res.statusCode).toBe(409);
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).not.toHaveBeenCalled();
   });
 
   it('does not call SFU teardown when avDisabled is false', async () => {

--- a/infra/cdk/lambda/room-patch.test.ts
+++ b/infra/cdk/lambda/room-patch.test.ts
@@ -115,14 +115,28 @@ describe('room-patch handler', () => {
       }),
     );
 
-    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledOnce();
-    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledWith(
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledTimes(2);
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         roomId: 'room-1',
         hostSessionId: 'host-sess-1',
         envelope: {
           type: 'room_mode',
           roomMode: 'videoChat',
+          ts: expect.any(Number) as number,
+          version: 3,
+        },
+      }),
+    );
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        roomId: 'room-1',
+        hostSessionId: 'host-sess-1',
+        envelope: {
+          type: 'av_disabled',
+          avDisabled: true,
           ts: expect.any(Number) as number,
           version: 3,
         },
@@ -221,6 +235,7 @@ describe('room-patch handler', () => {
       version: 2,
     });
     expect(fanoutMocks.fanOutRoomPatchEnvelope).not.toHaveBeenCalled();
+    expect(teardownMocks.requestSfuProducerTeardown).not.toHaveBeenCalled();
   });
 
   it('does not fan out room_mode when roomMode is unchanged', async () => {
@@ -244,12 +259,65 @@ describe('room-patch handler', () => {
   });
 
   it('does not call SFU teardown when avDisabled is false', async () => {
+    const disabledRoom = { ...baseRoom, avDisabled: true };
+    mocks.docSend.mockResolvedValueOnce({ Item: disabledRoom }).mockResolvedValueOnce({});
+
+    const res = await handler(
+      patchEvent({ avDisabled: false }, hostSub, 'room-1', { 'x-session-id': 'host-sess-1' }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(teardownMocks.requestSfuProducerTeardown).not.toHaveBeenCalled();
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledOnce();
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        hostSessionId: 'host-sess-1',
+        envelope: {
+          type: 'av_disabled',
+          avDisabled: false,
+          ts: expect.any(Number) as number,
+          version: 3,
+        },
+      }),
+    );
+  });
+
+  it('does not fan out av_disabled when avDisabled is unchanged', async () => {
     mocks.docSend.mockResolvedValueOnce({ Item: baseRoom }).mockResolvedValueOnce({});
 
     const res = await handler(patchEvent({ avDisabled: false }));
 
     expect(res.statusCode).toBe(200);
-    expect(teardownMocks.requestSfuProducerTeardown).not.toHaveBeenCalled();
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).not.toHaveBeenCalled();
+  });
+
+  it('fans out av_disabled after Dynamo write and SFU teardown when disabling', async () => {
+    const callOrder: string[] = [];
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string }) => {
+      if (cmd.kind === 'Get') return { Item: baseRoom };
+      if (cmd.kind === 'Update') {
+        callOrder.push('dynamo');
+        return {};
+      }
+      return {};
+    });
+    teardownMocks.requestSfuProducerTeardown.mockImplementation(async () => {
+      callOrder.push('teardown');
+      return { ok: true, closedCount: 2 };
+    });
+    fanoutMocks.fanOutRoomPatchEnvelope.mockImplementation(
+      async (params: { envelope: { type: string } }) => {
+        if (params.envelope.type === 'av_disabled') callOrder.push('fanout');
+      },
+    );
+
+    const res = await handler(
+      patchEvent({ avDisabled: true }, hostSub, 'room-1', { 'x-session-id': 'host-sess-1' }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(callOrder).toEqual(['dynamo', 'teardown', 'fanout']);
   });
 
   it('still returns 200 when SFU teardown fails after avDisabled write', async () => {
@@ -260,11 +328,19 @@ describe('room-patch handler', () => {
       detail: 'timeout',
     });
 
-    const res = await handler(patchEvent({ avDisabled: true }));
+    const res = await handler(
+      patchEvent({ avDisabled: true }, hostSub, 'room-1', { 'x-session-id': 'host-sess-1' }),
+    );
 
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
     expect(body.avDisabled).toBe(true);
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledOnce();
+    expect(fanoutMocks.fanOutRoomPatchEnvelope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envelope: expect.objectContaining({ type: 'av_disabled', avDisabled: true }),
+      }),
+    );
   });
 
   it('atomically patches roomMode and clears broadcastCaptureActive', async () => {

--- a/infra/cdk/lambda/room-patch.ts
+++ b/infra/cdk/lambda/room-patch.ts
@@ -22,6 +22,8 @@ import {
 } from './room-shared';
 import { requestSfuProducerTeardown } from './sfu-admin-teardown';
 
+export { fanOutRoomPatchEnvelope, readHostSessionIdFromHeaders } from './room-patch-fanout';
+
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 interface JwtClaims {

--- a/infra/cdk/lambda/room-patch.ts
+++ b/infra/cdk/lambda/room-patch.ts
@@ -21,8 +21,17 @@ import {
   type RoomMode,
 } from './room-shared';
 import { requestSfuProducerTeardown } from './sfu-admin-teardown';
+import {
+  buildRoomModeFanoutEnvelope,
+  fanOutRoomPatchEnvelope,
+  readHostSessionIdFromHeaders,
+} from './room-patch-fanout';
 
-export { fanOutRoomPatchEnvelope, readHostSessionIdFromHeaders } from './room-patch-fanout';
+export {
+  buildRoomModeFanoutEnvelope,
+  fanOutRoomPatchEnvelope,
+  readHostSessionIdFromHeaders,
+} from './room-patch-fanout';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -143,8 +152,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     }
   }
 
+  const previousRoomMode = readRoomMode(room);
+
   let roomModePatch: RoomMode | undefined;
-  let responseRoomMode = readRoomMode(room);
+  let responseRoomMode = previousRoomMode;
   if (Object.prototype.hasOwnProperty.call(body, 'roomMode')) {
     const rm = parseRoomMode(body.roomMode);
     if (!rm) {
@@ -320,13 +331,27 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     }
   }
 
+  const nextVersion = version + 1;
+  if (roomModePatch !== undefined && roomModePatch !== previousRoomMode) {
+    await fanOutRoomPatchEnvelope({
+      doc: client,
+      roomId,
+      hostSessionId: readHostSessionIdFromHeaders(event.headers),
+      envelope: buildRoomModeFanoutEnvelope({
+        roomMode: roomModePatch,
+        ts: now,
+        version: nextVersion,
+      }),
+    });
+  }
+
   return {
     statusCode: 200,
     headers: { 'content-type': 'application/json; charset=utf-8' },
     body: JSON.stringify({
       ok: true,
       roomId,
-      version: version + 1,
+      version: nextVersion,
       catalogEpisodeId,
       youtubeVideoId,
       visibility,

--- a/infra/cdk/lambda/room-patch.ts
+++ b/infra/cdk/lambda/room-patch.ts
@@ -22,12 +22,14 @@ import {
 } from './room-shared';
 import { requestSfuProducerTeardown } from './sfu-admin-teardown';
 import {
+  buildAvDisabledFanoutEnvelope,
   buildRoomModeFanoutEnvelope,
   fanOutRoomPatchEnvelope,
   readHostSessionIdFromHeaders,
 } from './room-patch-fanout';
 
 export {
+  buildAvDisabledFanoutEnvelope,
   buildRoomModeFanoutEnvelope,
   fanOutRoomPatchEnvelope,
   readHostSessionIdFromHeaders,
@@ -168,8 +170,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     responseRoomMode = rm;
   }
 
+  const previousAvDisabled = readAvDisabled(room);
+
   let avDisabledPatch: boolean | undefined;
-  let responseAvDisabled = readAvDisabled(room);
+  let responseAvDisabled = previousAvDisabled;
   if (Object.prototype.hasOwnProperty.call(body, 'avDisabled')) {
     if (typeof body.avDisabled !== 'boolean') {
       return {
@@ -332,13 +336,28 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   }
 
   const nextVersion = version + 1;
+  const hostSessionId = readHostSessionIdFromHeaders(event.headers);
+
   if (roomModePatch !== undefined && roomModePatch !== previousRoomMode) {
     await fanOutRoomPatchEnvelope({
       doc: client,
       roomId,
-      hostSessionId: readHostSessionIdFromHeaders(event.headers),
+      hostSessionId,
       envelope: buildRoomModeFanoutEnvelope({
         roomMode: roomModePatch,
+        ts: now,
+        version: nextVersion,
+      }),
+    });
+  }
+
+  if (avDisabledPatch !== undefined && avDisabledPatch !== previousAvDisabled) {
+    await fanOutRoomPatchEnvelope({
+      doc: client,
+      roomId,
+      hostSessionId,
+      envelope: buildAvDisabledFanoutEnvelope({
+        avDisabled: avDisabledPatch,
         ts: now,
         version: nextVersion,
       }),

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -809,6 +809,13 @@ export class ApiCatalogStack extends cdk.Stack {
     this.fanProfilesTable.grantReadData(wsRouteFn);
     this.webSocketApi.grantManageConnections(wsRouteFn);
 
+    roomPatchFn.addEnvironment('WS_MANAGEMENT_API_ENDPOINT', wsMgmtEndpoint);
+    roomPatchFn.addEnvironment('CONNECTIONS_TABLE_NAME', this.connectionsTable.tableName);
+    roomPatchFn.addEnvironment('ROOM_PRESENCE_TABLE_NAME', this.roomPresenceTable.tableName);
+    this.connectionsTable.grantReadData(roomPatchFn);
+    this.roomPresenceTable.grantReadData(roomPatchFn);
+    this.webSocketApi.grantManageConnections(roomPatchFn);
+
     // WebSocketLambdaIntegration can leave InvokeFunction scoped to only one route (IAM showed SourceArn ending in *ping).
     // chat/signaling/$default then fail invoke auth; API Gateway returns Internal server error on the WebSocket frame.
     wsRouteFn.addPermission('WsRouteFnAllowExecuteApiWebSocket', {


### PR DESCRIPTION
## Summary

- Wire `RoomPatchFn` with WebSocket management endpoint, connections/presence table env vars, Dynamo read grants, and `execute-api:ManageConnections` IAM (closes #114).
- Add `room-patch-fanout.ts` reusing `queryConnectionsForRoom`, `postToConnections`, and `wsManagementClient` from `ws-shared.ts`, with optional host `X-Session-Id` passthrough for fan-out envelopes.
- Fan out `room_mode` WebSocket envelopes after successful `roomMode` PATCH when the mode actually changes; skip fan-out on 409 conflicts and unchanged mode (closes #115).
- Fan out `av_disabled` after successful `avDisabled` PATCH with kill-switch ordering: Dynamo write, SFU participant teardown when disabling, then WebSocket fan-out; re-enable fans out without teardown; SFU failure does not block fan-out (closes #116).

## Test plan

- [x] `npm ci --prefix infra/cdk && npm run test --prefix infra/cdk` (214 tests pass)
- [x] `npm run synth --prefix infra/cdk` confirms `RoomPatchFn` env vars and IAM
- [ ] Deployed smoke: host PATCH `roomMode` change fans out `room_mode` to connected clients
- [ ] Deployed smoke: host PATCH `avDisabled` tears down SFU producers and fans out `av_disabled`

Part of #103 (M14 room mode / AV kill switch).