### PR TITLE
[M14] Participant AV runtime lifecycle (#104)

### DIFF
--- a/apps/web/src/api/webrtcSfuApi.ts
+++ b/apps/web/src/api/webrtcSfuApi.ts
@@ -10,6 +10,7 @@ export async function fetchSfuJoinToken(options: {
   roomId: string
   sessionId: string
   accessToken: string | null
+  producerClass?: 'host_screen' | 'participant_av'
 }): Promise<SfuTokenResponse> {
   const base = requireApiBase(options.apiBaseUrl)
   const headers: Record<string, string> = {
@@ -19,10 +20,16 @@ export async function fetchSfuJoinToken(options: {
   if (options.accessToken) {
     headers.Authorization = `Bearer ${options.accessToken}`
   }
+  const body: { roomId: string; producerClass?: 'host_screen' | 'participant_av' } = {
+    roomId: options.roomId,
+  }
+  if (options.producerClass) {
+    body.producerClass = options.producerClass
+  }
   const res = await fetch(`${base.replace(/\/$/, '')}/v1/webrtc/sfu-token`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ roomId: options.roomId }),
+    body: JSON.stringify(body),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -48,6 +48,7 @@ import {
   type ParticipantAvController,
   type ParticipantAvPublishGate,
 } from '../room/sfu/participantAvSession'
+import { createTheaterAudioMix } from '../room/audio/theaterAudioMix'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatComposeMediaPicker } from '../room/ChatComposeMediaPicker'
@@ -214,6 +215,7 @@ export function RoomPage() {
   const acceptedOfferShareGenerationRef = useRef(0)
   const lastDedupOfferGenerationRef = useRef(0)
   const sfuSessionRef = useRef<{ close: () => void } | null>(null)
+  const theaterAudioMixRef = useRef<ReturnType<typeof createTheaterAudioMix> | null>(null)
   const captureStreamRef = useRef<MediaStream | null>(null)
   const [sfuTokenIntentTick, setSfuTokenIntentTick] = useState(0)
   const isPublisherRef = useRef(false)
@@ -242,10 +244,12 @@ export function RoomPage() {
   } = useChatLogStickToBottom(chat.length, roomChatTabActive)
   const isPublisher = Boolean(room && fanToken && cognitoSub(fanToken) === room.hostSub)
   const avDisabled = room?.avDisabled ?? true
+  const roomMode = room?.roomMode ?? 'theater'
 
   /** Prefer the room document id so WebSocket presence matches server fan-out even if the route param differed. */
   const canonicalRoomId = useMemo(() => room?.roomId ?? roomId, [room?.roomId, roomId])
   const sfuEnabled = isMediasoupSfuEnabled()
+  const theaterMixEnabled = sfuEnabled && roomMode === 'theater'
   const meshUnsupportedProdBuild = import.meta.env.PROD && isMeshWatchPartyMediaEnabled()
 
   useEffect(() => {
@@ -635,6 +639,10 @@ export function RoomPage() {
         setGuestRemote(null)
         return
       }
+      if (t === 'av_disabled' && typeof data.avDisabled === 'boolean') {
+        setRoom((prev) => (prev ? { ...prev, avDisabled: data.avDisabled as boolean } : prev))
+        return
+      }
       if (t !== 'signaling' || sfuEnabled) return
 
       const fromSessionId = typeof data.fromSessionId === 'string' ? data.fromSessionId : ''
@@ -883,6 +891,31 @@ export function RoomPage() {
   }, [captureStream, getIceServers, isPublisher, wsStatus, sfuEnabled])
 
   useEffect(() => {
+    if (!theaterMixEnabled) {
+      theaterAudioMixRef.current?.dispose()
+      theaterAudioMixRef.current = null
+      return
+    }
+    const mix = createTheaterAudioMix()
+    theaterAudioMixRef.current = mix
+    return () => {
+      mix.dispose()
+      theaterAudioMixRef.current = null
+    }
+  }, [theaterMixEnabled])
+
+  useEffect(() => {
+    theaterAudioMixRef.current?.setAvDisabled(avDisabled)
+  }, [avDisabled])
+
+  useEffect(() => {
+    if (!theaterMixEnabled) return
+    theaterAudioMixRef.current?.setHostVideoElement(
+      isPublisher ? hostCaptureVideoRef.current : videoRef.current,
+    )
+  }, [theaterMixEnabled, isPublisher, captureStream, guestRemote])
+
+  useEffect(() => {
     if (!sfuEnabled || wsStatus !== 'open' || !room) return
     const api = getPublicApiBaseUrl()
     if (!api || !canonicalRoomId) return
@@ -896,6 +929,10 @@ export function RoomPage() {
       getHostScreenStream: () => captureStreamRef.current,
       participantAv: participantAvController,
       onRemoteStream: setGuestRemote,
+      onConsumerTrack: (event) => {
+        theaterAudioMixRef.current?.onConsumerEvent(event)
+        void theaterAudioMixRef.current?.resumeIfSuspended()
+      },
       assignSession: (s) => {
         sfuSessionRef.current = s
       },
@@ -937,29 +974,39 @@ export function RoomPage() {
       v.srcObject = null
       return
     }
-    v.srcObject = guestRemote
+    const playbackStream = theaterMixEnabled
+      ? new MediaStream(guestRemote.getVideoTracks())
+      : guestRemote
+    v.srcObject = playbackStream
     let cancelled = false
     void (async () => {
-      v.muted = false
+      v.muted = theaterMixEnabled
       try {
         await v.play()
         if (!cancelled) setGuestPlayHint(false)
+        if (theaterMixEnabled) {
+          await theaterAudioMixRef.current?.resumeIfSuspended()
+        }
         return
       } catch {
         /* autoplay policy often blocks unmuted remote playback */
       }
-      try {
-        v.muted = true
-        await v.play()
-        if (!cancelled) setGuestPlayHint(false)
-      } catch {
-        if (!cancelled) setGuestPlayHint(true)
+      if (!theaterMixEnabled) {
+        try {
+          v.muted = true
+          await v.play()
+          if (!cancelled) setGuestPlayHint(false)
+        } catch {
+          if (!cancelled) setGuestPlayHint(true)
+        }
+      } else if (!cancelled) {
+        setGuestPlayHint(true)
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [guestRemote, isPublisher])
+  }, [guestRemote, isPublisher, theaterMixEnabled])
 
   useEffect(() => {
     const v = hostCaptureVideoRef.current
@@ -969,8 +1016,20 @@ export function RoomPage() {
       return
     }
     v.srcObject = captureStream
-    void v.play().catch(() => setHostCapturePlayHint(true))
-  }, [captureStream, isPublisher])
+    v.muted = theaterMixEnabled
+    void (async () => {
+      try {
+        await v.play()
+        setHostCapturePlayHint(false)
+        if (theaterMixEnabled) {
+          theaterAudioMixRef.current?.setHostVideoElement(v)
+          await theaterAudioMixRef.current?.resumeIfSuspended()
+        }
+      } catch {
+        setHostCapturePlayHint(true)
+      }
+    })()
+  }, [captureStream, isPublisher, theaterMixEnabled])
 
   const stopCapture = () => {
     setHostCapturePlayHint(false)
@@ -1236,21 +1295,28 @@ export function RoomPage() {
   const playGuestVideo = async () => {
     const v = videoRef.current
     if (!v) return
-    v.muted = false
+    if (!theaterMixEnabled) {
+      v.muted = false
+    }
     try {
       await v.play()
       setGuestPlayHint(false)
+      await theaterAudioMixRef.current?.resumeIfSuspended()
       return
     } catch {
       /* continue */
     }
-    try {
-      v.muted = true
-      await v.play()
-      setGuestPlayHint(false)
-    } catch {
-      setGuestPlayHint(true)
+    if (!theaterMixEnabled) {
+      try {
+        v.muted = true
+        await v.play()
+        setGuestPlayHint(false)
+      } catch {
+        setGuestPlayHint(true)
+      }
+      return
     }
+    setGuestPlayHint(true)
   }
 
   const playHostCapturePreview = async () => {
@@ -1259,6 +1325,10 @@ export function RoomPage() {
     try {
       await v.play()
       setHostCapturePlayHint(false)
+      if (theaterMixEnabled) {
+        theaterAudioMixRef.current?.setHostVideoElement(v)
+        await theaterAudioMixRef.current?.resumeIfSuspended()
+      }
     } catch {
       setHostCapturePlayHint(true)
     }

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router-dom'
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
-import type { RoomSnapshot } from '../api/roomsApi'
+import type { RoomMode, RoomSnapshot } from '../api/roomsApi'
 import {
   fetchFanProfile,
   patchFanProfileDisplayName,
@@ -49,6 +49,12 @@ import {
   type ParticipantAvPublishGate,
 } from '../room/sfu/participantAvSession'
 import { createTheaterAudioMix } from '../room/audio/theaterAudioMix'
+import {
+  enteredVideoChatMode,
+  parseInboundRoomMode,
+  stopMediaStreamTracks,
+} from '../room/roomMediaLifecycle'
+import type { SfuUnifiedSessionHandle } from '../room/sfu/mediasoupSharing'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatComposeMediaPicker } from '../room/ChatComposeMediaPicker'
@@ -214,7 +220,9 @@ export function RoomPage() {
   const hostNegotiationMilestoneMsByGuestRef = useRef(new Map<string, number>())
   const acceptedOfferShareGenerationRef = useRef(0)
   const lastDedupOfferGenerationRef = useRef(0)
-  const sfuSessionRef = useRef<{ close: () => void } | null>(null)
+  const sfuSessionRef = useRef<SfuUnifiedSessionHandle | null>(null)
+  const prevRoomModeRef = useRef<RoomMode>('theater')
+  const prevAvDisabledRef = useRef<boolean | null>(null)
   const theaterAudioMixRef = useRef<ReturnType<typeof createTheaterAudioMix> | null>(null)
   const captureStreamRef = useRef<MediaStream | null>(null)
   const [sfuTokenIntentTick, setSfuTokenIntentTick] = useState(0)
@@ -639,6 +647,19 @@ export function RoomPage() {
         setGuestRemote(null)
         return
       }
+      if (t === 'room_mode') {
+        const nextMode = parseInboundRoomMode(data.roomMode)
+        if (!nextMode) return
+        setRoom((prev) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            roomMode: nextMode,
+            ...(nextMode === 'videoChat' ? { broadcastCaptureActive: false } : {}),
+          }
+        })
+        return
+      }
       if (t === 'av_disabled' && typeof data.avDisabled === 'boolean') {
         setRoom((prev) => (prev ? { ...prev, avDisabled: data.avDisabled as boolean } : prev))
         return
@@ -908,6 +929,61 @@ export function RoomPage() {
     theaterAudioMixRef.current?.setAvDisabled(avDisabled)
   }, [avDisabled])
 
+  const stopHostCaptureForModeTransition = useCallback(() => {
+    setHostCapturePlayHint(false)
+    sfuSessionRef.current?.unpublishProducerClass('host_screen')
+    setCaptureStream((prev) => {
+      stopMediaStreamTracks(prev)
+      return null
+    })
+    for (const pc of peerByGuestRef.current.values()) {
+      pc.close()
+    }
+    peerByGuestRef.current.clear()
+    pendingReadyGuestsRef.current.clear()
+    hostPendingGuestIceRef.current.clear()
+    hostLastOfferGenByGuestRef.current.clear()
+    hostNegotiationMilestoneMsByGuestRef.current.clear()
+  }, [])
+
+  useEffect(() => {
+    const previousMode = prevRoomModeRef.current
+    prevRoomModeRef.current = roomMode
+    if (!enteredVideoChatMode(previousMode, roomMode)) return
+
+    if (!isPublisher) {
+      if (sfuEnabled) {
+        sfuSessionRef.current?.detachConsumerClass('host_screen')
+      } else {
+        queueMicrotask(() => {
+          guestPcRef.current?.close()
+          guestPcRef.current = null
+          guestPendingIceRef.current = []
+          acceptedOfferShareGenerationRef.current = 0
+          lastDedupOfferGenerationRef.current = 0
+          setGuestRemote(null)
+        })
+      }
+      return
+    }
+
+    if (captureStreamRef.current) {
+      stopHostCaptureForModeTransition()
+      queueMicrotask(() => {
+        setRoom((prev) => (prev ? { ...prev, broadcastCaptureActive: false } : prev))
+      })
+    }
+  }, [roomMode, isPublisher, sfuEnabled, stopHostCaptureForModeTransition])
+
+  useEffect(() => {
+    const previous = prevAvDisabledRef.current
+    prevAvDisabledRef.current = avDisabled
+    if (previous === null || !avDisabled || previous === avDisabled) return
+
+    participantAvController.teardownPublishing()
+    sfuSessionRef.current?.detachConsumerClass('participant_av')
+  }, [avDisabled, participantAvController])
+
   useEffect(() => {
     if (!theaterMixEnabled) return
     theaterAudioMixRef.current?.setHostVideoElement(
@@ -941,7 +1017,13 @@ export function RoomPage() {
       onMediaError: (_code, msg) => setSfuRoomErr(msg),
       onConnecting: () => setSfuRoomErr(null),
     })
-    return cancel
+    return () => {
+      participantAvController.teardownPublishing()
+      stopMediaStreamTracks(captureStreamRef.current)
+      captureStreamRef.current = null
+      sfuSessionRef.current?.unpublishProducerClass('host_screen')
+      cancel()
+    }
   }, [
     sfuEnabled,
     wsStatus,
@@ -1042,10 +1124,9 @@ export function RoomPage() {
     shareGenerationRef.current = 0
     hostLastOfferGenByGuestRef.current.clear()
     hostNegotiationMilestoneMsByGuestRef.current.clear()
-    sfuSessionRef.current?.close()
-    sfuSessionRef.current = null
+    sfuSessionRef.current?.unpublishProducerClass('host_screen')
     setCaptureStream((prev) => {
-      if (prev) prev.getTracks().forEach((t) => t.stop())
+      stopMediaStreamTracks(prev)
       return null
     })
     for (const pc of peerByGuestRef.current.values()) {

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -43,6 +43,11 @@ import {
 } from '../room/webrtcDebug'
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 import { isMediasoupSfuEnabled, isMeshWatchPartyMediaEnabled } from '../config/mediasoupSfuFeature'
+import {
+  createBoundParticipantAvController,
+  type ParticipantAvController,
+  type ParticipantAvPublishGate,
+} from '../room/sfu/participantAvSession'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatComposeMediaPicker } from '../room/ChatComposeMediaPicker'
@@ -209,6 +214,8 @@ export function RoomPage() {
   const acceptedOfferShareGenerationRef = useRef(0)
   const lastDedupOfferGenerationRef = useRef(0)
   const sfuSessionRef = useRef<{ close: () => void } | null>(null)
+  const captureStreamRef = useRef<MediaStream | null>(null)
+  const [sfuTokenIntentTick, setSfuTokenIntentTick] = useState(0)
   const isPublisherRef = useRef(false)
   const prevRoomSidebarTabRef = useRef<'chat' | 'people' | 'room' | 'profile'>('chat')
   const chatInputRef = useRef<HTMLInputElement>(null)
@@ -234,6 +241,7 @@ export function RoomPage() {
     jumpToLatest,
   } = useChatLogStickToBottom(chat.length, roomChatTabActive)
   const isPublisher = Boolean(room && fanToken && cognitoSub(fanToken) === room.hostSub)
+  const avDisabled = room?.avDisabled ?? true
 
   /** Prefer the room document id so WebSocket presence matches server fan-out even if the route param differed. */
   const canonicalRoomId = useMemo(() => room?.roomId ?? roomId, [room?.roomId, roomId])
@@ -700,6 +708,39 @@ export function RoomPage() {
     onMessage: onWsMessage,
   })
 
+  const participantAvGate = useMemo<ParticipantAvPublishGate>(
+    () => ({
+      wsOpen: false,
+      fanToken: null,
+      avDisabled: true,
+    }),
+    [],
+  )
+  const participantAvController = useMemo<ParticipantAvController>(
+    () => createBoundParticipantAvController(() => participantAvGate),
+    [participantAvGate],
+  )
+
+  useEffect(() => {
+    /* Mutable gate snapshot for stable participant AV controller (#117). */
+    Object.assign(participantAvGate, {
+      wsOpen: wsStatus === 'open',
+      fanToken,
+      avDisabled,
+      onNeedsProducerTokenChange: () => {
+        setSfuTokenIntentTick((n) => n + 1)
+      },
+    })
+    participantAvController.refreshPublishGate()
+    if (wsStatus !== 'open') {
+      participantAvController.resetOnReconnect()
+    }
+  }, [wsStatus, fanToken, avDisabled, participantAvController, participantAvGate])
+
+  useEffect(() => {
+    captureStreamRef.current = captureStream
+  }, [captureStream])
+
   /** Warm ICE early so negotiation is faster and /v1/webrtc/ice appears in Network as soon as the room is live. */
   useEffect(() => {
     if (!roomId || !room || wsStatus !== 'open') return
@@ -842,40 +883,18 @@ export function RoomPage() {
   }, [captureStream, getIceServers, isPublisher, wsStatus, sfuEnabled])
 
   useEffect(() => {
-    if (!sfuEnabled || !isPublisher || !captureStream || wsStatus !== 'open') return
+    if (!sfuEnabled || wsStatus !== 'open' || !room) return
     const api = getPublicApiBaseUrl()
     if (!api || !canonicalRoomId) return
 
     const { cancel } = startSfuRoomSession({
-      role: 'producer',
       apiBaseUrl: api,
       roomId: canonicalRoomId,
       sessionId,
       accessToken: fanToken,
-      captureStream,
       getIceServers,
-      assignSession: (s) => {
-        sfuSessionRef.current = s
-      },
-      onMissingWsUrl: () => setSfuRoomErr(SFU_RELAY_URL_MISSING_MSG),
-      onTokenError: (msg) => setSfuRoomErr(msg),
-      onMediaError: (_code, msg) => setSfuRoomErr(msg),
-      onConnecting: () => setSfuRoomErr(null),
-    })
-    return cancel
-  }, [sfuEnabled, isPublisher, captureStream, wsStatus, canonicalRoomId, sessionId, fanToken, getIceServers])
-
-  useEffect(() => {
-    if (!sfuEnabled || isPublisher || wsStatus !== 'open') return
-    const api = getPublicApiBaseUrl()
-    if (!api || !canonicalRoomId) return
-
-    const { cancel } = startSfuRoomSession({
-      role: 'consumer',
-      apiBaseUrl: api,
-      roomId: canonicalRoomId,
-      sessionId,
-      getIceServers,
+      getHostScreenStream: () => captureStreamRef.current,
+      participantAv: participantAvController,
       onRemoteStream: setGuestRemote,
       assignSession: (s) => {
         sfuSessionRef.current = s
@@ -886,7 +905,19 @@ export function RoomPage() {
       onConnecting: () => setSfuRoomErr(null),
     })
     return cancel
-  }, [sfuEnabled, isPublisher, wsStatus, canonicalRoomId, sessionId, getIceServers])
+  }, [
+    sfuEnabled,
+    wsStatus,
+    room,
+    avDisabled,
+    canonicalRoomId,
+    sessionId,
+    fanToken,
+    getIceServers,
+    captureStream,
+    sfuTokenIntentTick,
+    participantAvController,
+  ])
 
   useEffect(() => {
     if (isPublisher) return

--- a/apps/web/src/room/audio/theaterAudioMix.test.ts
+++ b/apps/web/src/room/audio/theaterAudioMix.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createTheaterAudioMix,
+  shouldRouteConsumerAudio,
+  THEATER_AUDIO_GAIN,
+} from './theaterAudioMix'
+
+vi.stubGlobal(
+  'MediaStream',
+  function MockMediaStream(this: { tracks: MediaStreamTrack[] }, tracks: MediaStreamTrack[]) {
+    this.tracks = tracks
+  },
+)
+
+function makeTrack(id: string): MediaStreamTrack {
+  return { id } as MediaStreamTrack
+}
+
+function makeMockAudioContext() {
+  const destination = {}
+  const gainNodes: Array<{
+    gain: { value: number }
+    connect: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+  }> = []
+  const streamSources: Array<{ connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }> =
+    []
+  const elementSources: Array<{ connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }> =
+    []
+
+  const ctx = {
+    state: 'suspended' as AudioContextState,
+    destination,
+    createGain: () => {
+      const node = {
+        gain: { value: 0 },
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      }
+      gainNodes.push(node)
+      return node as unknown as GainNode
+    },
+    createMediaStreamSource: () => {
+      const node = { connect: vi.fn(), disconnect: vi.fn() }
+      streamSources.push(node)
+      return node as unknown as MediaStreamAudioSourceNode
+    },
+    createMediaElementSource: () => {
+      const node = { connect: vi.fn(), disconnect: vi.fn() }
+      elementSources.push(node)
+      return node as unknown as MediaElementAudioSourceNode
+    },
+    resume: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+  }
+
+  return { ctx: ctx as unknown as AudioContext, gainNodes, streamSources, elementSources }
+}
+
+describe('shouldRouteConsumerAudio', () => {
+  it('accepts host_screen and participant_av', () => {
+    expect(shouldRouteConsumerAudio('host_screen')).toBe(true)
+    expect(shouldRouteConsumerAudio('participant_av')).toBe(true)
+  })
+
+  it('rejects unknown producer classes', () => {
+    expect(shouldRouteConsumerAudio(undefined)).toBe(false)
+  })
+})
+
+describe('createTheaterAudioMix', () => {
+  it('attaches host_screen and participant_av audio at equal gain', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'audio',
+      track: makeTrack('host-audio'),
+    })
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: makeTrack('fan-audio'),
+    })
+
+    expect(gainNodes).toHaveLength(2)
+    expect(gainNodes[0]?.gain.value).toBe(THEATER_AUDIO_GAIN)
+    expect(gainNodes[1]?.gain.value).toBe(THEATER_AUDIO_GAIN)
+    mix.dispose()
+  })
+
+  it('detaches participant audio on producerClosed', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: makeTrack('fan-audio'),
+    })
+    expect(gainNodes).toHaveLength(1)
+
+    mix.onConsumerEvent({ action: 'detach', producerId: 'fan-1' })
+    expect(gainNodes[0]?.disconnect).toHaveBeenCalled()
+    mix.dispose()
+  })
+
+  it('mutes participant audio when avDisabled is true', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.setAvDisabled(true)
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: makeTrack('fan-audio'),
+    })
+
+    expect(gainNodes[0]?.gain.value).toBe(0)
+
+    mix.setAvDisabled(false)
+    expect(gainNodes[0]?.gain.value).toBe(THEATER_AUDIO_GAIN)
+    mix.dispose()
+  })
+
+  it('keeps host_screen audio active when avDisabled is true', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.setAvDisabled(true)
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'audio',
+      track: makeTrack('host-audio'),
+    })
+
+    expect(gainNodes[0]?.gain.value).toBe(THEATER_AUDIO_GAIN)
+    mix.dispose()
+  })
+
+  it('ignores video consumer attach events', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'video',
+      track: makeTrack('host-video'),
+    })
+
+    expect(gainNodes).toHaveLength(0)
+    mix.dispose()
+  })
+
+  it('falls back to host video element when no host_screen consumer exists', () => {
+    const { ctx, elementSources } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+    const video = {} as HTMLVideoElement
+
+    mix.setHostVideoElement(video)
+
+    expect(elementSources).toHaveLength(1)
+    mix.dispose()
+  })
+
+  it('prefers host_screen consumer audio over video element source', () => {
+    const { ctx, elementSources, streamSources } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+    const video = {} as HTMLVideoElement
+
+    mix.setHostVideoElement(video)
+    expect(elementSources).toHaveLength(1)
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'audio',
+      track: makeTrack('host-audio'),
+    })
+
+    expect(streamSources).toHaveLength(1)
+    expect(elementSources[0]?.disconnect).toHaveBeenCalled()
+    mix.dispose()
+  })
+
+  it('resumes a suspended AudioContext', async () => {
+    const { ctx } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: makeTrack('fan-audio'),
+    })
+
+    await mix.resumeIfSuspended()
+    expect(ctx.resume).toHaveBeenCalled()
+    mix.dispose()
+    expect(ctx.close).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/room/audio/theaterAudioMix.ts
+++ b/apps/web/src/room/audio/theaterAudioMix.ts
@@ -1,0 +1,226 @@
+import type { SfuProducerClass } from '../sfu/mediasoupSharing'
+
+export const THEATER_AUDIO_GAIN = 1.0
+
+export type TheaterAudioConsumerEvent =
+  | {
+      action: 'attach'
+      producerId: string
+      producerClass: SfuProducerClass | undefined
+      kind: 'audio' | 'video'
+      track: MediaStreamTrack
+    }
+  | { action: 'detach'; producerId: string }
+
+type AudioNodeBundle = {
+  source: AudioNode
+  gain: GainNode
+}
+
+export type TheaterAudioMix = {
+  dispose: () => void
+  setAvDisabled: (disabled: boolean) => void
+  setHostVideoElement: (element: HTMLVideoElement | null) => void
+  onConsumerEvent: (event: TheaterAudioConsumerEvent) => void
+  resumeIfSuspended: () => Promise<void>
+}
+
+export type CreateTheaterAudioMixOptions = {
+  createContext?: () => AudioContext
+}
+
+function isAudioAttachEvent(
+  event: TheaterAudioConsumerEvent,
+): event is Extract<TheaterAudioConsumerEvent, { action: 'attach' }> {
+  return event.action === 'attach' && event.kind === 'audio'
+}
+
+export function shouldRouteConsumerAudio(
+  producerClass: SfuProducerClass | undefined,
+): producerClass is SfuProducerClass {
+  return producerClass === 'host_screen' || producerClass === 'participant_av'
+}
+
+export function createTheaterAudioMix(options: CreateTheaterAudioMixOptions = {}): TheaterAudioMix {
+  const createContext = options.createContext ?? (() => new AudioContext())
+  let ctx: AudioContext | null = null
+  let avDisabled = false
+  let hostVideoEl: HTMLVideoElement | null = null
+  let hostElementSource: MediaElementAudioSourceNode | null = null
+  let hostElementGain: GainNode | null = null
+  const hostScreenConsumers = new Map<string, AudioNodeBundle>()
+  const participantConsumers = new Map<string, AudioNodeBundle>()
+
+  const ensureContext = (): AudioContext => {
+    if (!ctx) {
+      ctx = createContext()
+    }
+    return ctx
+  }
+
+  const connectGain = (gain: GainNode) => {
+    const audioCtx = ensureContext()
+    gain.gain.value = THEATER_AUDIO_GAIN
+    gain.connect(audioCtx.destination)
+  }
+
+  const setParticipantGainsActive = (active: boolean) => {
+    for (const bundle of participantConsumers.values()) {
+      bundle.gain.gain.value = active ? THEATER_AUDIO_GAIN : 0
+    }
+  }
+
+  const clearHostElementSource = () => {
+    if (hostElementGain) {
+      try {
+        hostElementGain.disconnect()
+      } catch {
+        /* ignore */
+      }
+      hostElementGain = null
+    }
+    if (hostElementSource) {
+      try {
+        hostElementSource.disconnect()
+      } catch {
+        /* ignore */
+      }
+      hostElementSource = null
+    }
+  }
+
+  const clearHostScreenConsumers = () => {
+    for (const [producerId, bundle] of hostScreenConsumers) {
+      try {
+        bundle.gain.disconnect()
+        bundle.source.disconnect()
+      } catch {
+        /* ignore */
+      }
+      hostScreenConsumers.delete(producerId)
+    }
+  }
+
+  const clearParticipantConsumers = () => {
+    for (const [producerId, bundle] of participantConsumers) {
+      try {
+        bundle.gain.disconnect()
+        bundle.source.disconnect()
+      } catch {
+        /* ignore */
+      }
+      participantConsumers.delete(producerId)
+    }
+  }
+
+  const syncHostElementSource = () => {
+    clearHostElementSource()
+    if (!hostVideoEl || hostScreenConsumers.size > 0) return
+    const audioCtx = ensureContext()
+    hostElementSource = audioCtx.createMediaElementSource(hostVideoEl)
+    hostElementGain = audioCtx.createGain()
+    hostElementSource.connect(hostElementGain)
+    connectGain(hostElementGain)
+  }
+
+  const attachConsumerAudio = (
+    map: Map<string, AudioNodeBundle>,
+    producerId: string,
+    track: MediaStreamTrack,
+  ) => {
+    const existing = map.get(producerId)
+    if (existing) {
+      try {
+        existing.gain.disconnect()
+        existing.source.disconnect()
+      } catch {
+        /* ignore */
+      }
+      map.delete(producerId)
+    }
+    const audioCtx = ensureContext()
+    const stream = new MediaStream([track])
+    const source = audioCtx.createMediaStreamSource(stream)
+    const gain = audioCtx.createGain()
+    source.connect(gain)
+    connectGain(gain)
+    if (map === participantConsumers && avDisabled) {
+      gain.gain.value = 0
+    }
+    map.set(producerId, { source, gain })
+  }
+
+  const detachProducer = (producerId: string) => {
+    const hostBundle = hostScreenConsumers.get(producerId)
+    if (hostBundle) {
+      try {
+        hostBundle.gain.disconnect()
+        hostBundle.source.disconnect()
+      } catch {
+        /* ignore */
+      }
+      hostScreenConsumers.delete(producerId)
+      if (hostScreenConsumers.size === 0) {
+        syncHostElementSource()
+      }
+      return
+    }
+    const participantBundle = participantConsumers.get(producerId)
+    if (!participantBundle) return
+    try {
+      participantBundle.gain.disconnect()
+      participantBundle.source.disconnect()
+    } catch {
+      /* ignore */
+    }
+    participantConsumers.delete(producerId)
+  }
+
+  return {
+    dispose: () => {
+      clearHostElementSource()
+      clearHostScreenConsumers()
+      clearParticipantConsumers()
+      if (ctx) {
+        try {
+          void ctx.close()
+        } catch {
+          /* ignore */
+        }
+        ctx = null
+      }
+      hostVideoEl = null
+    },
+    setAvDisabled: (disabled) => {
+      avDisabled = disabled
+      setParticipantGainsActive(!disabled)
+    },
+    setHostVideoElement: (element) => {
+      hostVideoEl = element
+      syncHostElementSource()
+    },
+    onConsumerEvent: (event) => {
+      if (event.action === 'detach') {
+        detachProducer(event.producerId)
+        return
+      }
+      if (!isAudioAttachEvent(event)) return
+      if (!shouldRouteConsumerAudio(event.producerClass)) return
+      if (event.producerClass === 'host_screen') {
+        clearHostElementSource()
+        attachConsumerAudio(hostScreenConsumers, event.producerId, event.track)
+        return
+      }
+      attachConsumerAudio(participantConsumers, event.producerId, event.track)
+    },
+    resumeIfSuspended: async () => {
+      const audioCtx = ctx
+      if (!audioCtx || audioCtx.state !== 'suspended') return
+      try {
+        await audioCtx.resume()
+      } catch {
+        /* ignore autoplay policy */
+      }
+    },
+  }
+}

--- a/apps/web/src/room/roomMediaLifecycle.test.ts
+++ b/apps/web/src/room/roomMediaLifecycle.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  enteredVideoChatMode,
+  parseInboundRoomMode,
+  stopMediaStreamTracks,
+} from './roomMediaLifecycle'
+
+describe('parseInboundRoomMode', () => {
+  it('accepts theater and videoChat', () => {
+    expect(parseInboundRoomMode('theater')).toBe('theater')
+    expect(parseInboundRoomMode('videoChat')).toBe('videoChat')
+  })
+
+  it('rejects unknown values', () => {
+    expect(parseInboundRoomMode('cinema')).toBeNull()
+    expect(parseInboundRoomMode(null)).toBeNull()
+  })
+})
+
+describe('enteredVideoChatMode', () => {
+  it('is true only on theater to videoChat transition', () => {
+    expect(enteredVideoChatMode('theater', 'videoChat')).toBe(true)
+    expect(enteredVideoChatMode('videoChat', 'videoChat')).toBe(false)
+    expect(enteredVideoChatMode('videoChat', 'theater')).toBe(false)
+  })
+})
+
+describe('stopMediaStreamTracks', () => {
+  it('stops every track on the stream', () => {
+    const stops: string[] = []
+    const stream = {
+      getTracks: () => [
+        { stop: () => stops.push('video') },
+        { stop: () => stops.push('audio') },
+      ],
+    } as unknown as MediaStream
+    stopMediaStreamTracks(stream)
+    expect(stops).toEqual(['video', 'audio'])
+  })
+})

--- a/apps/web/src/room/roomMediaLifecycle.ts
+++ b/apps/web/src/room/roomMediaLifecycle.ts
@@ -1,0 +1,22 @@
+import type { RoomMode } from '../api/roomsApi'
+
+export function parseInboundRoomMode(raw: unknown): RoomMode | null {
+  if (raw === 'theater' || raw === 'videoChat') return raw
+  return null
+}
+
+/** True when authoritative room mode transitions into Video Chat. */
+export function enteredVideoChatMode(previous: RoomMode, next: RoomMode): boolean {
+  return previous !== 'videoChat' && next === 'videoChat'
+}
+
+export function stopMediaStreamTracks(stream: MediaStream | null | undefined): void {
+  if (!stream) return
+  for (const track of stream.getTracks()) {
+    try {
+      track.stop()
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -221,25 +221,136 @@ function watchTransportUntilUnhealthy(
   }
 }
 
-export async function connectSfuProducer(options: {
+export type SfuProducerClass = 'host_screen' | 'participant_av'
+
+type ProducerSummary = {
+  producerId: string
+  kind: string
+  sessionId?: string
+  producerClass?: SfuProducerClass
+}
+
+type LiveProducer = {
+  producer: mediasoupClient.types.Producer
+  producerClass: SfuProducerClass
+  kind: 'audio' | 'video'
+}
+
+export type SfuUnifiedSessionHandle = {
+  close: (reason?: SfuSessionEndReason) => void
+  sessionEnded: Promise<SfuSessionEndReason>
+  ready: Promise<void>
+  publishStream: (stream: MediaStream, producerClass: SfuProducerClass) => Promise<void>
+  unpublishProducerClass: (producerClass: SfuProducerClass) => void
+  pauseProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
+  resumeProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
+}
+
+function parseProducerClass(value: unknown): SfuProducerClass | null {
+  if (value === 'host_screen' || value === 'participant_av') return value
+  return null
+}
+
+export async function connectSfuUnifiedSession(options: {
   wsBaseUrl: string
   token: string
-  captureStream: MediaStream
+  tokenRole: 'producer' | 'consumer'
   getIceServers: () => Promise<RTCIceServer[]>
+  onRemoteStream: (stream: MediaStream | null) => void
+  ownSessionId?: string
   onMediaError?: (code: SfuMediaErrorCode, message: string) => void
-}): Promise<{ close: (reason?: SfuSessionEndReason) => void; sessionEnded: Promise<SfuSessionEndReason> }> {
-  const { wsBaseUrl, token, captureStream, getIceServers, onMediaError } = options
+}): Promise<SfuUnifiedSessionHandle> {
+  const { wsBaseUrl, token, tokenRole, getIceServers, onRemoteStream, ownSessionId, onMediaError } =
+    options
   const signaling = new SfuSignaling(signalingWsUrl(wsBaseUrl, token))
   let userClosed = false
   let settled = false
   let resolveEnd!: (r: SfuSessionEndReason) => void
+  let resolveReady!: () => void
+  let rejectReady!: (e: Error) => void
   const sessionEnded = new Promise<SfuSessionEndReason>((resolve) => {
     resolveEnd = resolve
+  })
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve
+    rejectReady = reject
   })
   const finish = (r: SfuSessionEndReason) => {
     if (settled) return
     settled = true
     resolveEnd(userClosed ? 'user_close' : r)
+  }
+
+  let sendTransport: mediasoupClient.types.Transport | null = null
+  let recvTransport: mediasoupClient.types.Transport | null = null
+  let recvTransportId = ''
+  const liveProducers: LiveProducer[] = []
+  const mediasoupConsumers: mediasoupClient.types.Consumer[] = []
+  const attachedProducerIds = new Set<string>()
+  const remoteStream = new MediaStream()
+  const unwatchFns: Array<() => void> = []
+
+  const emitRemote = () => {
+    onRemoteStream(remoteStream.getTracks().length > 0 ? remoteStream : null)
+  }
+
+  const unpublishProducerClass = (producerClass: SfuProducerClass) => {
+    const keep: LiveProducer[] = []
+    for (const lp of liveProducers) {
+      if (lp.producerClass === producerClass) {
+        try {
+          lp.producer.close()
+        } catch {
+          /* ignore */
+        }
+      } else {
+        keep.push(lp)
+      }
+    }
+    liveProducers.length = 0
+    for (const lp of keep) liveProducers.push(lp)
+  }
+
+  const findLiveProducer = (
+    producerClass: SfuProducerClass,
+    kind: 'audio' | 'video',
+  ): LiveProducer | undefined =>
+    liveProducers.find((lp) => lp.producerClass === producerClass && lp.kind === kind)
+
+  const pauseProducerKind = (producerClass: SfuProducerClass, kind: 'audio' | 'video') => {
+    const lp = findLiveProducer(producerClass, kind)
+    if (!lp) return
+    try {
+      if (!lp.producer.paused) lp.producer.pause()
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const resumeProducerKind = (producerClass: SfuProducerClass, kind: 'audio' | 'video') => {
+    const lp = findLiveProducer(producerClass, kind)
+    if (!lp) return
+    try {
+      if (lp.producer.paused) lp.producer.resume()
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const publishStream = async (stream: MediaStream, producerClass: SfuProducerClass) => {
+    if (!sendTransport) {
+      throw new Error('SFU send transport not ready')
+    }
+    unpublishProducerClass(producerClass)
+    for (const track of stream.getTracks()) {
+      const kind = track.kind === 'audio' || track.kind === 'video' ? track.kind : null
+      if (!kind) continue
+      const producer = await sendTransport.produce({
+        track,
+        appData: { producerClass },
+      })
+      liveProducers.push({ producer, producerClass, kind })
+    }
   }
 
   void (async () => {
@@ -248,6 +359,7 @@ export async function connectSfuProducer(options: {
     } catch {
       onMediaError?.('signaling_failed', 'Could not connect to video relay (signaling).')
       finish('signaling_close')
+      rejectReady(new Error('signaling_failed'))
       return
     }
 
@@ -259,6 +371,7 @@ export async function connectSfuProducer(options: {
       if (!isRecord(capsRes.routerRtpCapabilities)) {
         onMediaError?.('bad_capabilities', 'Video relay misconfigured (router capabilities).')
         finish('signaling_close')
+        rejectReady(new Error('bad_capabilities'))
         return
       }
       routerRtpCapabilities = capsRes.routerRtpCapabilities as Record<string, unknown>
@@ -268,6 +381,7 @@ export async function connectSfuProducer(options: {
         e instanceof Error ? e.message : 'getRouterRtpCapabilities failed',
       )
       finish('signaling_close')
+      rejectReady(e instanceof Error ? e : new Error(String(e)))
       return
     }
 
@@ -279,85 +393,281 @@ export async function connectSfuProducer(options: {
     } catch {
       onMediaError?.('bad_capabilities', 'This browser cannot load the video relay codecs.')
       finish('signaling_close')
+      rejectReady(new Error('bad_capabilities'))
       return
     }
 
-    let created: Record<string, unknown>
-    try {
-      created = await signaling.request('createWebRtcTransport', { producer: true, consumer: false })
-    } catch (e) {
-      onMediaError?.(
-        'produce_failed',
-        e instanceof Error ? e.message : 'createWebRtcTransport failed',
+    const setupRecvTransport = async (): Promise<boolean> => {
+      let created: Record<string, unknown>
+      try {
+        created = await signaling.request('createWebRtcTransport', { producer: false, consumer: true })
+      } catch (e) {
+        onMediaError?.(
+          'consume_failed',
+          e instanceof Error ? e.message : 'createWebRtcTransport failed',
+        )
+        return false
+      }
+
+      recvTransportId = typeof created.transportId === 'string' ? created.transportId : ''
+      if (
+        !recvTransportId ||
+        !isRecord(created.iceParameters) ||
+        !Array.isArray(created.iceCandidates) ||
+        !isRecord(created.dtlsParameters)
+      ) {
+        onMediaError?.('consume_failed', 'Invalid transport response from video relay.')
+        return false
+      }
+
+      recvTransport = device.createRecvTransport({
+        id: recvTransportId,
+        iceParameters: created.iceParameters as IceParameters,
+        iceCandidates: created.iceCandidates as IceCandidate[],
+        dtlsParameters: created.dtlsParameters as DtlsParameters,
+        iceServers,
+      })
+
+      unwatchFns.push(
+        watchTransportUntilUnhealthy(recvTransport, signaling, (r) => {
+          finish(r)
+        }),
       )
-      finish('signaling_close')
-      return
+
+      recvTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
+        void signaling
+          .request('connectWebRtcTransport', { transportId: recvTransportId, dtlsParameters: dtls })
+          .then(() => callback())
+          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
+      })
+      return true
     }
 
-    const transportId = typeof created.transportId === 'string' ? created.transportId : ''
-    if (
-      !transportId ||
-      !isRecord(created.iceParameters) ||
-      !Array.isArray(created.iceCandidates) ||
-      !isRecord(created.dtlsParameters)
-    ) {
-      onMediaError?.('produce_failed', 'Invalid transport response from video relay.')
-      finish('signaling_close')
-      return
-    }
+    const consumeProducer = async (summary: ProducerSummary): Promise<void> => {
+      const { producerId, kind: kindHint } = summary
+      if (!recvTransport || !producerId || attachedProducerIds.has(producerId)) return
+      if (ownSessionId && summary.sessionId === ownSessionId) return
 
-    const sendTransport = device.createSendTransport({
-      id: transportId,
-      iceParameters: created.iceParameters as IceParameters,
-      iceCandidates: created.iceCandidates as IceCandidate[],
-      dtlsParameters: created.dtlsParameters as DtlsParameters,
-      iceServers,
-    })
-
-    let unwatch: (() => void) | null = null
-    unwatch = watchTransportUntilUnhealthy(sendTransport, signaling, (r) => {
-      unwatch?.()
-      finish(r)
-    })
-
-    sendTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
-      void signaling
-        .request('connectWebRtcTransport', { transportId, dtlsParameters: dtls })
-        .then(() => callback())
-        .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
-    })
-
-    sendTransport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
-      void appData
-      void signaling
-        .request('produce', { transportId, kind, rtpParameters })
-        .then((r) => {
-          const pid = typeof r.producerId === 'string' ? r.producerId : ''
-          if (!pid) throw new Error('no producerId')
-          callback({ id: pid })
+      let r: Record<string, unknown>
+      try {
+        r = await signaling.request('consume', {
+          transportId: recvTransportId,
+          producerId,
+          rtpCapabilities: device.rtpCapabilities,
         })
-        .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
-    })
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        onMediaError?.('consume_failed', msg.includes('gone') ? 'Host stream ended; waiting for share.' : msg)
+        return
+      }
+      const consumerId = typeof r.consumerId === 'string' ? r.consumerId : ''
+      const kind =
+        r.kind === 'audio' || r.kind === 'video'
+          ? r.kind
+          : kindHint === 'audio' || kindHint === 'video'
+            ? kindHint
+            : null
+      const rtpParameters = r.rtpParameters
+      if (!consumerId || !kind || !isRecord(rtpParameters)) return
+
+      let consumer: mediasoupClient.types.Consumer
+      try {
+        consumer = await recvTransport.consume({
+          id: consumerId,
+          producerId,
+          kind,
+          rtpParameters: rtpParameters as RtpParameters,
+        })
+      } catch (e) {
+        onMediaError?.(
+          'consume_failed',
+          e instanceof Error ? e.message : 'consume failed on device',
+        )
+        return
+      }
+      mediasoupConsumers.push(consumer)
+      attachedProducerIds.add(producerId)
+      const { track } = consumer
+      if (track && !remoteStream.getTracks().includes(track)) {
+        remoteStream.addTrack(track)
+      }
+    }
+
+    const syncFromList = async (list: ProducerSummary[]): Promise<void> => {
+      for (const row of list) {
+        await consumeProducer(row)
+      }
+      emitRemote()
+    }
+
+    signaling.onEvent = (name, data) => {
+      if (name === 'producerClosed') {
+        if (!isRecord(data)) return
+        const producerId = typeof data.producerId === 'string' ? data.producerId : ''
+        if (!producerId) return
+        const keep: typeof mediasoupConsumers = []
+        for (const c of mediasoupConsumers) {
+          if (c.producerId === producerId) {
+            try {
+              remoteStream.removeTrack(c.track)
+            } catch {
+              /* ignore */
+            }
+            try {
+              c.close()
+            } catch {
+              /* ignore */
+            }
+          } else {
+            keep.push(c)
+          }
+        }
+        mediasoupConsumers.length = 0
+        for (const k of keep) mediasoupConsumers.push(k)
+        attachedProducerIds.delete(producerId)
+        emitRemote()
+        return
+      }
+      if (name !== 'newProducer') return
+      if (!isRecord(data)) return
+      const producerId = typeof data.producerId === 'string' ? data.producerId : ''
+      const kind = typeof data.kind === 'string' ? data.kind : 'video'
+      const sessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined
+      const producerClass = parseProducerClass(data.producerClass) ?? undefined
+      if (!producerId) return
+      void consumeProducer({ producerId, kind, sessionId, producerClass }).then(() => emitRemote())
+    }
+
+    if (!(await setupRecvTransport())) {
+      finish('signaling_close')
+      rejectReady(new Error('recv_transport_failed'))
+      return
+    }
+
+    if (tokenRole === 'producer') {
+      let created: Record<string, unknown>
+      try {
+        created = await signaling.request('createWebRtcTransport', { producer: true, consumer: false })
+      } catch (e) {
+        onMediaError?.(
+          'produce_failed',
+          e instanceof Error ? e.message : 'createWebRtcTransport failed',
+        )
+        finish('signaling_close')
+        rejectReady(e instanceof Error ? e : new Error(String(e)))
+        return
+      }
+
+      const transportId = typeof created.transportId === 'string' ? created.transportId : ''
+      if (
+        !transportId ||
+        !isRecord(created.iceParameters) ||
+        !Array.isArray(created.iceCandidates) ||
+        !isRecord(created.dtlsParameters)
+      ) {
+        onMediaError?.('produce_failed', 'Invalid transport response from video relay.')
+        finish('signaling_close')
+        rejectReady(new Error('send_transport_invalid'))
+        return
+      }
+
+      sendTransport = device.createSendTransport({
+        id: transportId,
+        iceParameters: created.iceParameters as IceParameters,
+        iceCandidates: created.iceCandidates as IceCandidate[],
+        dtlsParameters: created.dtlsParameters as DtlsParameters,
+        iceServers,
+      })
+
+      unwatchFns.push(
+        watchTransportUntilUnhealthy(sendTransport, signaling, (r) => {
+          finish(r)
+        }),
+      )
+
+      sendTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
+        void signaling
+          .request('connectWebRtcTransport', { transportId, dtlsParameters: dtls })
+          .then(() => callback())
+          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
+      })
+
+      sendTransport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
+        const producerClass = isRecord(appData) ? parseProducerClass(appData.producerClass) : null
+        if (!producerClass) {
+          errback(new Error('producerClass required'))
+          return
+        }
+        void signaling
+          .request('produce', { transportId, kind, rtpParameters, producerClass })
+          .then((res) => {
+            const pid = typeof res.producerId === 'string' ? res.producerId : ''
+            if (!pid) throw new Error('no producerId')
+            callback({ id: pid })
+          })
+          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
+      })
+    }
 
     try {
-      for (const track of captureStream.getTracks()) {
-        await sendTransport.produce({ track })
+      const listRes = await signaling.request('listProducers')
+      const producersRaw = listRes.producers
+      const initial: ProducerSummary[] = []
+      if (Array.isArray(producersRaw)) {
+        for (const row of producersRaw) {
+          if (!isRecord(row)) continue
+          const producerId = typeof row.producerId === 'string' ? row.producerId : ''
+          const kind = typeof row.kind === 'string' ? row.kind : ''
+          const sessionId = typeof row.sessionId === 'string' ? row.sessionId : undefined
+          const producerClass = parseProducerClass(row.producerClass) ?? undefined
+          if (producerId) initial.push({ producerId, kind, sessionId, producerClass })
+        }
+      }
+      if (initial.length > 0) {
+        await syncFromList(initial)
       }
     } catch (e) {
       onMediaError?.(
-        'produce_failed',
-        e instanceof Error ? e.message : 'Failed to publish track to relay.',
+        'consume_failed',
+        e instanceof Error ? e.message : 'listProducers failed',
       )
-      unwatch?.()
-      finish('transport_failed')
+      finish('signaling_close')
+      rejectReady(e instanceof Error ? e : new Error(String(e)))
       return
     }
+
+    resolveReady()
   })()
 
   return {
+    ready,
+    publishStream,
+    unpublishProducerClass,
+    pauseProducerKind,
+    resumeProducerKind,
     close: (reason: SfuSessionEndReason = 'user_close') => {
       userClosed = true
       void reason
+      for (const fn of unwatchFns) fn()
+      unpublishProducerClass('host_screen')
+      unpublishProducerClass('participant_av')
+      for (const c of mediasoupConsumers) {
+        try {
+          c.close()
+        } catch {
+          /* ignore */
+        }
+      }
+      mediasoupConsumers.length = 0
+      attachedProducerIds.clear()
+      remoteStream.getTracks().forEach((t) => {
+        try {
+          remoteStream.removeTrack(t)
+        } catch {
+          /* ignore */
+        }
+      })
+      onRemoteStream(null)
       try {
         signaling.close()
       } catch {
@@ -369,8 +679,28 @@ export async function connectSfuProducer(options: {
   }
 }
 
-type ProducerSummary = { producerId: string; kind: string }
+/** @deprecated Use connectSfuUnifiedSession */
+export async function connectSfuProducer(options: {
+  wsBaseUrl: string
+  token: string
+  captureStream: MediaStream
+  getIceServers: () => Promise<RTCIceServer[]>
+  onMediaError?: (code: SfuMediaErrorCode, message: string) => void
+}): Promise<{ close: (reason?: SfuSessionEndReason) => void; sessionEnded: Promise<SfuSessionEndReason> }> {
+  const session = await connectSfuUnifiedSession({
+    wsBaseUrl: options.wsBaseUrl,
+    token: options.token,
+    tokenRole: 'producer',
+    getIceServers: options.getIceServers,
+    onRemoteStream: () => undefined,
+    onMediaError: options.onMediaError,
+  })
+  await session.ready
+  await session.publishStream(options.captureStream, 'host_screen')
+  return { close: session.close, sessionEnded: session.sessionEnded }
+}
 
+/** @deprecated Use connectSfuUnifiedSession */
 export async function connectSfuConsumer(options: {
   wsBaseUrl: string
   token: string
@@ -378,239 +708,16 @@ export async function connectSfuConsumer(options: {
   onRemoteStream: (stream: MediaStream | null) => void
   onMediaError?: (code: SfuMediaErrorCode, message: string) => void
 }): Promise<{ close: (reason?: SfuSessionEndReason) => void; sessionEnded: Promise<SfuSessionEndReason> }> {
-  const { wsBaseUrl, token, getIceServers, onRemoteStream, onMediaError } = options
-  const signaling = new SfuSignaling(signalingWsUrl(wsBaseUrl, token))
-  let userClosed = false
-  let settled = false
-  let resolveEnd!: (r: SfuSessionEndReason) => void
-  const sessionEnded = new Promise<SfuSessionEndReason>((resolve) => {
-    resolveEnd = resolve
+  const session = await connectSfuUnifiedSession({
+    wsBaseUrl: options.wsBaseUrl,
+    token: options.token,
+    tokenRole: 'consumer',
+    getIceServers: options.getIceServers,
+    onRemoteStream: options.onRemoteStream,
+    onMediaError: options.onMediaError,
   })
-  const finish = (r: SfuSessionEndReason) => {
-    if (settled) return
-    settled = true
-    resolveEnd(userClosed ? 'user_close' : r)
-  }
-
-  void (async () => {
-      try {
-        await signaling.connect()
-      } catch {
-        onMediaError?.('signaling_failed', 'Could not connect to video relay (signaling).')
-        finish('signaling_close')
-        return
-      }
-
-      const iceServers = await getIceServers()
-
-      let routerRtpCapabilities: Record<string, unknown>
-      try {
-        const capsRes = await signaling.request('getRouterRtpCapabilities')
-        if (!isRecord(capsRes.routerRtpCapabilities)) {
-          onMediaError?.('bad_capabilities', 'Video relay misconfigured (router capabilities).')
-          finish('signaling_close')
-          return
-        }
-        routerRtpCapabilities = capsRes.routerRtpCapabilities as Record<string, unknown>
-      } catch (e) {
-        onMediaError?.(
-          'consume_failed',
-          e instanceof Error ? e.message : 'getRouterRtpCapabilities failed',
-        )
-        finish('signaling_close')
-        return
-      }
-
-      const device = new mediasoupClient.Device()
-      try {
-        await device.load({
-          routerRtpCapabilities: routerRtpCapabilities as unknown as mediasoupClient.types.RtpCapabilities,
-        })
-      } catch {
-        onMediaError?.('bad_capabilities', 'This browser cannot load the video relay codecs.')
-        finish('signaling_close')
-        return
-      }
-
-      let created: Record<string, unknown>
-      try {
-        created = await signaling.request('createWebRtcTransport', { producer: false, consumer: true })
-      } catch (e) {
-        onMediaError?.(
-          'consume_failed',
-          e instanceof Error ? e.message : 'createWebRtcTransport failed',
-        )
-        finish('signaling_close')
-        return
-      }
-
-      const transportId = typeof created.transportId === 'string' ? created.transportId : ''
-      if (
-        !transportId ||
-        !isRecord(created.iceParameters) ||
-        !Array.isArray(created.iceCandidates) ||
-        !isRecord(created.dtlsParameters)
-      ) {
-        onMediaError?.('consume_failed', 'Invalid transport response from video relay.')
-        finish('signaling_close')
-        return
-      }
-
-      const recvTransport = device.createRecvTransport({
-        id: transportId,
-        iceParameters: created.iceParameters as IceParameters,
-        iceCandidates: created.iceCandidates as IceCandidate[],
-        dtlsParameters: created.dtlsParameters as DtlsParameters,
-        iceServers,
-      })
-
-      let unwatch: (() => void) | null = null
-      unwatch = watchTransportUntilUnhealthy(recvTransport, signaling, (r) => {
-        unwatch?.()
-        finish(r)
-      })
-
-      recvTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
-        void signaling
-          .request('connectWebRtcTransport', { transportId, dtlsParameters: dtls })
-          .then(() => callback())
-          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
-      })
-
-      const attachedProducerIds = new Set<string>()
-      const mediasoupConsumers: mediasoupClient.types.Consumer[] = []
-      const stream = new MediaStream()
-
-      const consumeProducer = async (producerId: string, kindHint: string): Promise<void> => {
-        if (attachedProducerIds.has(producerId)) return
-        let r: Record<string, unknown>
-        try {
-          r = await signaling.request('consume', {
-            transportId,
-            producerId,
-            rtpCapabilities: device.rtpCapabilities,
-          })
-        } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e)
-          onMediaError?.('consume_failed', msg.includes('gone') ? 'Host stream ended; waiting for share.' : msg)
-          return
-        }
-        const consumerId = typeof r.consumerId === 'string' ? r.consumerId : ''
-        const kind =
-          r.kind === 'audio' || r.kind === 'video'
-            ? r.kind
-            : kindHint === 'audio' || kindHint === 'video'
-              ? kindHint
-              : null
-        const rtpParameters = r.rtpParameters
-        if (!consumerId || !kind || !isRecord(rtpParameters)) return
-
-        let consumer: mediasoupClient.types.Consumer
-        try {
-          consumer = await recvTransport.consume({
-            id: consumerId,
-            producerId,
-            kind,
-            rtpParameters: rtpParameters as RtpParameters,
-          })
-        } catch (e) {
-          onMediaError?.(
-            'consume_failed',
-            e instanceof Error ? e.message : 'consume failed on device',
-          )
-          return
-        }
-        mediasoupConsumers.push(consumer)
-        attachedProducerIds.add(producerId)
-        const { track } = consumer
-        if (track && !stream.getTracks().includes(track)) {
-          stream.addTrack(track)
-        }
-      }
-
-      const syncFromList = async (list: ProducerSummary[]): Promise<void> => {
-        for (const { producerId, kind } of list) {
-          await consumeProducer(producerId, kind)
-        }
-        onRemoteStream(stream.getTracks().length > 0 ? stream : null)
-      }
-
-      signaling.onEvent = (name, data) => {
-        if (name === 'producerClosed') {
-          if (!isRecord(data)) return
-          const producerId = typeof data.producerId === 'string' ? data.producerId : ''
-          if (!producerId) return
-          const keep: typeof mediasoupConsumers = []
-          for (const c of mediasoupConsumers) {
-            if (c.producerId === producerId) {
-              try {
-                stream.removeTrack(c.track)
-              } catch {
-                /* ignore */
-              }
-              try {
-                c.close()
-              } catch {
-                /* ignore */
-              }
-            } else {
-              keep.push(c)
-            }
-          }
-          mediasoupConsumers.length = 0
-          for (const k of keep) mediasoupConsumers.push(k)
-          attachedProducerIds.delete(producerId)
-          onRemoteStream(stream.getTracks().length > 0 ? stream : null)
-          return
-        }
-        if (name !== 'newProducer') return
-        if (!isRecord(data)) return
-        const producerId = typeof data.producerId === 'string' ? data.producerId : ''
-        const kind = typeof data.kind === 'string' ? data.kind : 'video'
-        if (!producerId) return
-        void consumeProducer(producerId, kind).then(() => {
-          onRemoteStream(stream.getTracks().length > 0 ? stream : null)
-        })
-      }
-
-      try {
-        const listRes = await signaling.request('listProducers')
-        const producersRaw = listRes.producers
-        const initial: ProducerSummary[] = []
-        if (Array.isArray(producersRaw)) {
-          for (const row of producersRaw) {
-            if (!isRecord(row)) continue
-            const producerId = typeof row.producerId === 'string' ? row.producerId : ''
-            const kind = typeof row.kind === 'string' ? row.kind : ''
-            if (producerId) initial.push({ producerId, kind })
-          }
-        }
-        if (initial.length > 0) {
-          await syncFromList(initial)
-        }
-      } catch (e) {
-        onMediaError?.(
-          'consume_failed',
-          e instanceof Error ? e.message : 'listProducers failed',
-        )
-        finish('signaling_close')
-      }
-  })()
-
-  return {
-    close: (reason: SfuSessionEndReason = 'user_close') => {
-      userClosed = true
-      void reason
-      try {
-        signaling.close()
-      } catch {
-        /* ignore */
-      }
-      onRemoteStream(null)
-      if (!settled) finish('user_close')
-    },
-    sessionEnded,
-  }
+  await session.ready
+  return { close: session.close, sessionEnded: session.sessionEnded }
 }
 
 /** Resolve WS base from token response and build-time env (shared helper for session runner). */

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -236,6 +236,16 @@ type LiveProducer = {
   kind: 'audio' | 'video'
 }
 
+export type SfuConsumerTrackEvent =
+  | {
+      action: 'attach'
+      producerId: string
+      producerClass: SfuProducerClass | undefined
+      kind: 'audio' | 'video'
+      track: MediaStreamTrack
+    }
+  | { action: 'detach'; producerId: string }
+
 export type SfuUnifiedSessionHandle = {
   close: (reason?: SfuSessionEndReason) => void
   sessionEnded: Promise<SfuSessionEndReason>
@@ -257,11 +267,20 @@ export async function connectSfuUnifiedSession(options: {
   tokenRole: 'producer' | 'consumer'
   getIceServers: () => Promise<RTCIceServer[]>
   onRemoteStream: (stream: MediaStream | null) => void
+  onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
   ownSessionId?: string
   onMediaError?: (code: SfuMediaErrorCode, message: string) => void
 }): Promise<SfuUnifiedSessionHandle> {
-  const { wsBaseUrl, token, tokenRole, getIceServers, onRemoteStream, ownSessionId, onMediaError } =
-    options
+  const {
+    wsBaseUrl,
+    token,
+    tokenRole,
+    getIceServers,
+    onRemoteStream,
+    onConsumerTrack,
+    ownSessionId,
+    onMediaError,
+  } = options
   const signaling = new SfuSignaling(signalingWsUrl(wsBaseUrl, token))
   let userClosed = false
   let settled = false
@@ -491,6 +510,13 @@ export async function connectSfuUnifiedSession(options: {
       if (track && !remoteStream.getTracks().includes(track)) {
         remoteStream.addTrack(track)
       }
+      onConsumerTrack?.({
+        action: 'attach',
+        producerId,
+        producerClass: summary.producerClass,
+        kind,
+        track,
+      })
     }
 
     const syncFromList = async (list: ProducerSummary[]): Promise<void> => {
@@ -525,6 +551,7 @@ export async function connectSfuUnifiedSession(options: {
         mediasoupConsumers.length = 0
         for (const k of keep) mediasoupConsumers.push(k)
         attachedProducerIds.delete(producerId)
+        onConsumerTrack?.({ action: 'detach', producerId })
         emitRemote()
         return
       }
@@ -652,6 +679,7 @@ export async function connectSfuUnifiedSession(options: {
       unpublishProducerClass('host_screen')
       unpublishProducerClass('participant_av')
       for (const c of mediasoupConsumers) {
+        onConsumerTrack?.({ action: 'detach', producerId: c.producerId })
         try {
           c.close()
         } catch {

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -252,6 +252,7 @@ export type SfuUnifiedSessionHandle = {
   ready: Promise<void>
   publishStream: (stream: MediaStream, producerClass: SfuProducerClass) => Promise<void>
   unpublishProducerClass: (producerClass: SfuProducerClass) => void
+  detachConsumerClass: (producerClass: SfuProducerClass) => void
   pauseProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
   resumeProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
 }
@@ -306,6 +307,7 @@ export async function connectSfuUnifiedSession(options: {
   const liveProducers: LiveProducer[] = []
   const mediasoupConsumers: mediasoupClient.types.Consumer[] = []
   const attachedProducerIds = new Set<string>()
+  const consumerProducerClassById = new Map<string, SfuProducerClass>()
   const remoteStream = new MediaStream()
   const unwatchFns: Array<() => void> = []
 
@@ -328,6 +330,41 @@ export async function connectSfuUnifiedSession(options: {
     }
     liveProducers.length = 0
     for (const lp of keep) liveProducers.push(lp)
+  }
+
+  const detachConsumerByProducerId = (producerId: string) => {
+    const keep: typeof mediasoupConsumers = []
+    for (const c of mediasoupConsumers) {
+      if (c.producerId === producerId) {
+        try {
+          remoteStream.removeTrack(c.track)
+        } catch {
+          /* ignore */
+        }
+        try {
+          c.close()
+        } catch {
+          /* ignore */
+        }
+        consumerProducerClassById.delete(producerId)
+        onConsumerTrack?.({ action: 'detach', producerId })
+      } else {
+        keep.push(c)
+      }
+    }
+    mediasoupConsumers.length = 0
+    for (const k of keep) mediasoupConsumers.push(k)
+    attachedProducerIds.delete(producerId)
+  }
+
+  const detachConsumerClass = (producerClass: SfuProducerClass) => {
+    const toDetach = [...consumerProducerClassById.entries()]
+      .filter(([, pc]) => pc === producerClass)
+      .map(([producerId]) => producerId)
+    for (const producerId of toDetach) {
+      detachConsumerByProducerId(producerId)
+    }
+    emitRemote()
   }
 
   const findLiveProducer = (
@@ -506,6 +543,9 @@ export async function connectSfuUnifiedSession(options: {
       }
       mediasoupConsumers.push(consumer)
       attachedProducerIds.add(producerId)
+      if (summary.producerClass) {
+        consumerProducerClassById.set(producerId, summary.producerClass)
+      }
       const { track } = consumer
       if (track && !remoteStream.getTracks().includes(track)) {
         remoteStream.addTrack(track)
@@ -531,27 +571,7 @@ export async function connectSfuUnifiedSession(options: {
         if (!isRecord(data)) return
         const producerId = typeof data.producerId === 'string' ? data.producerId : ''
         if (!producerId) return
-        const keep: typeof mediasoupConsumers = []
-        for (const c of mediasoupConsumers) {
-          if (c.producerId === producerId) {
-            try {
-              remoteStream.removeTrack(c.track)
-            } catch {
-              /* ignore */
-            }
-            try {
-              c.close()
-            } catch {
-              /* ignore */
-            }
-          } else {
-            keep.push(c)
-          }
-        }
-        mediasoupConsumers.length = 0
-        for (const k of keep) mediasoupConsumers.push(k)
-        attachedProducerIds.delete(producerId)
-        onConsumerTrack?.({ action: 'detach', producerId })
+        detachConsumerByProducerId(producerId)
         emitRemote()
         return
       }
@@ -670,6 +690,7 @@ export async function connectSfuUnifiedSession(options: {
     ready,
     publishStream,
     unpublishProducerClass,
+    detachConsumerClass,
     pauseProducerKind,
     resumeProducerKind,
     close: (reason: SfuSessionEndReason = 'user_close') => {
@@ -688,6 +709,7 @@ export async function connectSfuUnifiedSession(options: {
       }
       mediasoupConsumers.length = 0
       attachedProducerIds.clear()
+      consumerProducerClassById.clear()
       remoteStream.getTracks().forEach((t) => {
         try {
           remoteStream.removeTrack(t)

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -44,4 +44,19 @@ describe('createParticipantAvController', () => {
       busy: false,
     })
   })
+
+  it('teardownPublishing clears publish intent for kill switch', () => {
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    controller.teardownPublishing()
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: false,
+      micEnabled: false,
+      micMuted: false,
+      needsProducerToken: false,
+      error: null,
+      busy: false,
+    })
+  })
 })

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { canParticipantAvPublish, createParticipantAvController } from './participantAvSession'
+
+describe('canParticipantAvPublish', () => {
+  it('requires open room websocket, fan JWT, and av enabled', () => {
+    expect(
+      canParticipantAvPublish({ wsOpen: true, fanToken: 'jwt', avDisabled: false }),
+    ).toBe(true)
+    expect(
+      canParticipantAvPublish({ wsOpen: false, fanToken: 'jwt', avDisabled: false }),
+    ).toBe(false)
+    expect(
+      canParticipantAvPublish({ wsOpen: true, fanToken: null, avDisabled: false }),
+    ).toBe(false)
+    expect(
+      canParticipantAvPublish({ wsOpen: true, fanToken: 'jwt', avDisabled: true }),
+    ).toBe(false)
+  })
+})
+
+describe('createParticipantAvController', () => {
+  it('defaults camera and mic off with no producer token intent', () => {
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: false,
+      micEnabled: false,
+      needsProducerToken: false,
+    })
+  })
+
+  it('resetOnReconnect clears publish intent', () => {
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    controller.resetOnReconnect()
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: false,
+      micEnabled: false,
+      micMuted: false,
+      needsProducerToken: false,
+      error: null,
+      busy: false,
+    })
+  })
+})

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -33,6 +33,8 @@ export type ParticipantAvController = {
   refreshPublishGate: () => void
   attachSession: (session: SfuUnifiedSessionHandle | null) => void
   resetOnReconnect: () => void
+  /** Stop local getUserMedia and close participant_av producers (kill switch / room leave). */
+  teardownPublishing: () => void
   enableCamera: () => Promise<void>
   disableCamera: () => void
   enableMic: () => Promise<void>
@@ -160,6 +162,16 @@ export function createParticipantAvController(options: {
       void syncPublish()
     },
     resetOnReconnect: () => {
+      cameraEnabled = false
+      micEnabled = false
+      micMuted = false
+      error = null
+      busy = false
+      stopLocalTracks()
+      session?.unpublishProducerClass('participant_av')
+      notify()
+    },
+    teardownPublishing: () => {
       cameraEnabled = false
       micEnabled = false
       micMuted = false

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -1,0 +1,278 @@
+import type { SfuUnifiedSessionHandle } from './mediasoupSharing'
+
+export const PARTICIPANT_AV_MEDIA_CONSTRAINTS: MediaStreamConstraints = {
+  video: {
+    width: { ideal: 1280, max: 1280 },
+    height: { ideal: 720, max: 720 },
+    frameRate: { ideal: 24, max: 30 },
+  },
+  audio: { echoCancellation: true, noiseSuppression: true },
+}
+
+export function canParticipantAvPublish(opts: {
+  wsOpen: boolean
+  fanToken: string | null
+  avDisabled: boolean
+}): boolean {
+  return opts.wsOpen && Boolean(opts.fanToken) && !opts.avDisabled
+}
+
+export type ParticipantAvPublishState = {
+  cameraEnabled: boolean
+  micEnabled: boolean
+  micMuted: boolean
+  canPublish: boolean
+  needsProducerToken: boolean
+  error: string | null
+  busy: boolean
+}
+
+export type ParticipantAvController = {
+  getState: () => ParticipantAvPublishState
+  subscribe: (listener: () => void) => () => void
+  refreshPublishGate: () => void
+  attachSession: (session: SfuUnifiedSessionHandle | null) => void
+  resetOnReconnect: () => void
+  enableCamera: () => Promise<void>
+  disableCamera: () => void
+  enableMic: () => Promise<void>
+  disableMic: () => void
+  toggleMicMute: () => void
+}
+
+export function createParticipantAvController(options: {
+  canPublish: () => boolean
+  onNeedsProducerTokenChange?: () => void
+}): ParticipantAvController {
+  let cameraEnabled = false
+  let micEnabled = false
+  let micMuted = false
+  let error: string | null = null
+  let busy = false
+  let localStream: MediaStream | null = null
+  let session: SfuUnifiedSessionHandle | null = null
+  const listeners = new Set<() => void>()
+
+  const notify = () => {
+    for (const fn of listeners) fn()
+  }
+
+  const getState = (): ParticipantAvPublishState => ({
+    cameraEnabled,
+    micEnabled,
+    micMuted,
+    canPublish: options.canPublish(),
+    needsProducerToken: cameraEnabled || micEnabled,
+    error,
+    busy,
+  })
+
+  const stopLocalTracks = () => {
+    if (!localStream) return
+    for (const track of localStream.getTracks()) {
+      try {
+        track.stop()
+      } catch {
+        /* ignore */
+      }
+    }
+    localStream = null
+  }
+
+  const syncPublish = async () => {
+    if (!session) return
+    if (!cameraEnabled && !micEnabled) {
+      session.unpublishProducerClass('participant_av')
+      stopLocalTracks()
+      return
+    }
+    if (!localStream) return
+    try {
+      await session.ready
+      await session.publishStream(localStream, 'participant_av')
+      if (micMuted) {
+        session.pauseProducerKind('participant_av', 'audio')
+      } else {
+        session.resumeProducerKind('participant_av', 'audio')
+      }
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Could not publish camera or microphone.'
+      notify()
+    }
+  }
+
+  const ensureUserMedia = async (wantVideo: boolean, wantAudio: boolean): Promise<MediaStream> => {
+    if (!options.canPublish()) {
+      throw new Error('Camera and microphone are unavailable until the room is connected.')
+    }
+    const constraints: MediaStreamConstraints = {
+      video: wantVideo ? PARTICIPANT_AV_MEDIA_CONSTRAINTS.video : false,
+      audio: wantAudio ? PARTICIPANT_AV_MEDIA_CONSTRAINTS.audio : false,
+    }
+    try {
+      return await navigator.mediaDevices.getUserMedia(constraints)
+    } catch (firstErr) {
+      if (wantVideo && wantAudio) {
+        try {
+          return await navigator.mediaDevices.getUserMedia({
+            video: false,
+            audio: PARTICIPANT_AV_MEDIA_CONSTRAINTS.audio,
+          })
+        } catch {
+          throw firstErr
+        }
+      }
+      throw firstErr
+    }
+  }
+
+  const mergeStream = async (wantVideo: boolean, wantAudio: boolean) => {
+    stopLocalTracks()
+    localStream = await ensureUserMedia(wantVideo, wantAudio)
+    const hasVideo = localStream.getVideoTracks().length > 0
+    const hasAudio = localStream.getAudioTracks().length > 0
+    cameraEnabled = hasVideo && wantVideo
+    micEnabled = hasAudio && wantAudio
+    if (!cameraEnabled && !micEnabled) {
+      stopLocalTracks()
+      throw new Error('Could not access camera or microphone.')
+    }
+    options.onNeedsProducerTokenChange?.()
+    await syncPublish()
+    notify()
+  }
+
+  return {
+    getState,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    refreshPublishGate: () => {
+      notify()
+    },
+    attachSession: (next) => {
+      session = next
+      if (!session) {
+        stopLocalTracks()
+        return
+      }
+      void syncPublish()
+    },
+    resetOnReconnect: () => {
+      cameraEnabled = false
+      micEnabled = false
+      micMuted = false
+      error = null
+      busy = false
+      stopLocalTracks()
+      session?.unpublishProducerClass('participant_av')
+      notify()
+    },
+    enableCamera: async () => {
+      if (busy || cameraEnabled) return
+      busy = true
+      error = null
+      notify()
+      try {
+        await mergeStream(true, micEnabled)
+      } catch (e) {
+        error = e instanceof Error ? e.message : 'Camera permission denied.'
+        notify()
+      } finally {
+        busy = false
+        notify()
+      }
+    },
+    disableCamera: () => {
+      if (!cameraEnabled) return
+      cameraEnabled = false
+      if (!micEnabled) {
+        session?.unpublishProducerClass('participant_av')
+        stopLocalTracks()
+        options.onNeedsProducerTokenChange?.()
+      } else if (localStream) {
+        for (const track of localStream.getVideoTracks()) {
+          try {
+            track.stop()
+            localStream.removeTrack(track)
+          } catch {
+            /* ignore */
+          }
+        }
+        void syncPublish()
+      }
+      notify()
+    },
+    enableMic: async () => {
+      if (busy || micEnabled) return
+      busy = true
+      error = null
+      notify()
+      try {
+        await mergeStream(cameraEnabled, true)
+        micMuted = false
+      } catch (e) {
+        error = e instanceof Error ? e.message : 'Microphone permission denied.'
+        notify()
+      } finally {
+        busy = false
+        notify()
+      }
+    },
+    disableMic: () => {
+      if (!micEnabled) return
+      micEnabled = false
+      micMuted = false
+      if (!cameraEnabled) {
+        session?.unpublishProducerClass('participant_av')
+        stopLocalTracks()
+        options.onNeedsProducerTokenChange?.()
+      } else if (localStream) {
+        for (const track of localStream.getAudioTracks()) {
+          try {
+            track.stop()
+            localStream.removeTrack(track)
+          } catch {
+            /* ignore */
+          }
+        }
+        void syncPublish()
+      }
+      notify()
+    },
+    toggleMicMute: () => {
+      if (!micEnabled || !session) return
+      micMuted = !micMuted
+      if (micMuted) {
+        session.pauseProducerKind('participant_av', 'audio')
+      } else {
+        session.resumeProducerKind('participant_av', 'audio')
+      }
+      notify()
+    },
+  }
+}
+
+export type ParticipantAvPublishGate = {
+  wsOpen: boolean
+  fanToken: string | null
+  avDisabled: boolean
+  onNeedsProducerTokenChange?: () => void
+}
+
+export function createBoundParticipantAvController(
+  readGate: () => ParticipantAvPublishGate,
+): ParticipantAvController {
+  return createParticipantAvController({
+    canPublish: () => {
+      const gate = readGate()
+      return canParticipantAvPublish({
+        wsOpen: gate.wsOpen,
+        fanToken: gate.fanToken,
+        avDisabled: gate.avDisabled,
+      })
+    },
+    onNeedsProducerTokenChange: () => readGate().onNeedsProducerTokenChange?.(),
+  })
+}

--- a/apps/web/src/room/sfu/sfuRoomSession.test.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatSfuTokenError,
+  isRosterConsistency403,
+  resolveSfuTokenProducerClass,
+} from './sfuRoomSession'
+import { createParticipantAvController } from './participantAvSession'
+
+describe('formatSfuTokenError', () => {
+  it('expands roster-related 403 copy', () => {
+    const msg = formatSfuTokenError(
+      new Error('sfu-token 403: Open the room WebSocket first (unknown session for this room).'),
+    )
+    expect(msg).toContain('Video relay denied access.')
+    expect(msg).toContain('Open the room WebSocket first')
+  })
+})
+
+describe('isRosterConsistency403', () => {
+  it('detects transient roster race errors', () => {
+    expect(
+      isRosterConsistency403(
+        new Error('sfu-token 403: Open the room WebSocket first (unknown session for this room).'),
+      ),
+    ).toBe(true)
+    expect(isRosterConsistency403(new Error('sfu-token 401: expired'))).toBe(false)
+  })
+})
+
+describe('resolveSfuTokenProducerClass', () => {
+  it('returns undefined when no publish intent exists', () => {
+    const participantAv = createParticipantAvController({ canPublish: () => true })
+    expect(
+      resolveSfuTokenProducerClass({
+        participantAv,
+        getHostScreenStream: () => null,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('requests host_screen when tab capture is live', () => {
+    const participantAv = createParticipantAvController({ canPublish: () => true })
+    const hostStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'live' }],
+    } as MediaStream
+
+    expect(
+      resolveSfuTokenProducerClass({
+        participantAv,
+        getHostScreenStream: () => hostStream,
+      }),
+    ).toBe('host_screen')
+  })
+})

--- a/apps/web/src/room/sfu/sfuRoomSession.test.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.test.ts
@@ -51,4 +51,49 @@ describe('resolveSfuTokenProducerClass', () => {
       }),
     ).toBe('host_screen')
   })
+
+  it('prefers host_screen when tab capture and participant AV are both active', () => {
+    const participantAv = {
+      getState: () => ({
+        cameraEnabled: true,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      }),
+    } as ReturnType<typeof createParticipantAvController>
+    const hostStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'live' }],
+    } as MediaStream
+
+    expect(
+      resolveSfuTokenProducerClass({
+        participantAv,
+        getHostScreenStream: () => hostStream,
+      }),
+    ).toBe('host_screen')
+  })
+
+  it('requests participant_av when only participant publish intent exists', () => {
+    const participantAv = {
+      getState: () => ({
+        cameraEnabled: false,
+        micEnabled: true,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      }),
+    } as ReturnType<typeof createParticipantAvController>
+
+    expect(
+      resolveSfuTokenProducerClass({
+        participantAv,
+        getHostScreenStream: () => null,
+      }),
+    ).toBe('participant_av')
+  })
 })

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -1,14 +1,15 @@
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import {
-  connectSfuConsumer,
-  connectSfuProducer,
+  connectSfuUnifiedSession,
   resolveSfuWsBaseForToken,
   type SfuMediaErrorCode,
-  type SfuSessionEndReason,
+  type SfuProducerClass,
+  type SfuUnifiedSessionHandle,
 } from './mediasoupSharing'
+import type { ParticipantAvController } from './participantAvSession'
 import { nextSfuReconnectDelayMs, sleepMs } from './sfuReconnectPolicy'
 
-export type SfuRoomSessionHandle = { close: (reason?: SfuSessionEndReason) => void }
+export type SfuRoomSessionHandle = SfuUnifiedSessionHandle
 
 type SessionHooks = {
   assignSession: (session: SfuRoomSessionHandle | null) => void
@@ -16,32 +17,21 @@ type SessionHooks = {
   onTokenError: (message: string) => void
   onMediaError: (code: SfuMediaErrorCode, message: string) => void
   onSessionClean?: () => void
-  /** Clears UI errors when a new SFU connection attempt is about to start. */
   onConnecting?: () => void
 }
 
-type ProducerSessionOpts = SessionHooks & {
-  role: 'producer'
+export type StartSfuRoomSessionOpts = SessionHooks & {
   apiBaseUrl: string | undefined
   roomId: string
   sessionId: string
   accessToken: string | null
-  captureStream: MediaStream
-  getIceServers: () => Promise<RTCIceServer[]>
-}
-
-type ConsumerSessionOpts = SessionHooks & {
-  role: 'consumer'
-  apiBaseUrl: string | undefined
-  roomId: string
-  sessionId: string
   getIceServers: () => Promise<RTCIceServer[]>
   onRemoteStream: (stream: MediaStream | null) => void
+  getHostScreenStream: () => MediaStream | null
+  participantAv: ParticipantAvController
 }
 
-export type StartSfuRoomSessionOpts = ProducerSessionOpts | ConsumerSessionOpts
-
-function formatSfuTokenError(e: unknown): string {
+export function formatSfuTokenError(e: unknown): string {
   const msg = e instanceof Error ? e.message : String(e)
   const m403 = /^sfu-token 403:\s*(.+)$/s.exec(msg)
   if (m403) {
@@ -53,12 +43,26 @@ function formatSfuTokenError(e: unknown): string {
 }
 
 /** Transient: WS is open but Dynamo roster GSI has not caught up yet (`webrtc-sfu-token` 403). */
-function isRosterConsistency403(e: unknown): boolean {
+export function isRosterConsistency403(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e)
   return (
     /sfu-token\s+403:/i.test(msg) &&
     /open the room websocket first|unknown session for this room/i.test(msg)
   )
+}
+
+export function resolveSfuTokenProducerClass(opts: {
+  participantAv: ParticipantAvController
+  getHostScreenStream: () => MediaStream | null
+}): SfuProducerClass | undefined {
+  if (opts.participantAv.getState().needsProducerToken) {
+    return 'participant_av'
+  }
+  const hostStream = opts.getHostScreenStream()
+  if (hostStream?.getTracks().some((track) => track.readyState === 'live')) {
+    return 'host_screen'
+  }
+  return undefined
 }
 
 async function sleepBackoffMs(ms: number, signal: AbortSignal): Promise<void> {
@@ -70,14 +74,35 @@ async function sleepBackoffMs(ms: number, signal: AbortSignal): Promise<void> {
   }
 }
 
+async function publishHostScreenIfNeeded(
+  session: SfuUnifiedSessionHandle,
+  getHostScreenStream: () => MediaStream | null,
+  onMediaError: (code: SfuMediaErrorCode, message: string) => void,
+): Promise<void> {
+  const stream = getHostScreenStream()
+  const live = stream?.getTracks().some((track) => track.readyState === 'live') ?? false
+  if (!live || !stream) {
+    session.unpublishProducerClass('host_screen')
+    return
+  }
+  try {
+    await session.ready
+    await session.publishStream(stream, 'host_screen')
+  } catch (e) {
+    onMediaError(
+      'produce_failed',
+      e instanceof Error ? e.message : 'Failed to publish host screen to relay.',
+    )
+  }
+}
+
 /**
- * Runs refetch-token + SFU connect in a loop until **`user_close`** or **`cancel()`**.
- * **`assignSession`** receives a handle whenever a new SFU connection is up (replace ref each reconnect).
+ * One SFU WebSocket per tab: shared consumers plus optional host_screen / participant_av producers.
  */
 export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: () => void } {
   const ac = new AbortController()
   const { signal } = ac
-  const { assignSession } = opts
+  const { assignSession, participantAv } = opts
   let attempt = 0
   let activeClose: (() => void) | null = null
 
@@ -85,6 +110,7 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
     ac.abort()
     activeClose?.()
     activeClose = null
+    participantAv.attachSession(null)
     assignSession(null)
     opts.onSessionClean?.()
   }
@@ -98,18 +124,23 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         continue
       }
 
+      const producerClass = resolveSfuTokenProducerClass({
+        participantAv,
+        getHostScreenStream: opts.getHostScreenStream,
+      })
+
       let tok
       try {
         tok = await fetchSfuJoinToken({
           apiBaseUrl: api,
           roomId,
           sessionId: opts.sessionId,
-          accessToken: opts.role === 'producer' ? opts.accessToken : null,
+          accessToken: opts.accessToken,
+          ...(producerClass ? { producerClass } : {}),
         })
       } catch (e) {
         if (signal.aborted) break
         const rosterRace = isRosterConsistency403(e)
-        /** Avoid flashing a scary denial while the connections roster GSI catches up (or before deploy picks up longer server-side retries). */
         if (!rosterRace || attempt >= 4) {
           opts.onTokenError(formatSfuTokenError(e))
         }
@@ -122,11 +153,13 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
       }
 
       if (signal.aborted) break
-      if (opts.role === 'producer' && tok.role !== 'producer') {
+
+      const wantsProducer = producerClass !== undefined
+      if (wantsProducer && tok.role !== 'producer') {
         await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
         continue
       }
-      if (opts.role === 'consumer' && tok.role !== 'consumer') {
+      if (!wantsProducer && tok.role !== 'consumer') {
         await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
         continue
       }
@@ -139,50 +172,35 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
       }
 
       attempt = 0
-
       opts.onConnecting?.()
 
-      if (opts.role === 'producer') {
-        const { close, sessionEnded } = await connectSfuProducer({
-          wsBaseUrl: wsBase,
-          token: tok.token,
-          captureStream: opts.captureStream,
-          getIceServers: opts.getIceServers,
-          onMediaError: opts.onMediaError,
-        })
-        if (signal.aborted) {
-          close()
-          break
-        }
-        activeClose = () => close()
-        assignSession({ close })
-        const reason = await sessionEnded
-        activeClose = null
-        assignSession(null)
-        opts.onSessionClean?.()
-        if (reason === 'user_close' || signal.aborted) break
-        await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
-        continue
-      }
-
-      const { close, sessionEnded } = await connectSfuConsumer({
+      const session = await connectSfuUnifiedSession({
         wsBaseUrl: wsBase,
         token: tok.token,
+        tokenRole: tok.role,
         getIceServers: opts.getIceServers,
         onRemoteStream: opts.onRemoteStream,
+        ownSessionId: opts.sessionId,
         onMediaError: opts.onMediaError,
       })
+
       if (signal.aborted) {
-        close()
+        session.close()
         break
       }
-      activeClose = () => close()
-      assignSession({ close })
-      const reason = await sessionEnded
+
+      activeClose = () => session.close()
+      assignSession(session)
+      participantAv.attachSession(session)
+      await publishHostScreenIfNeeded(session, opts.getHostScreenStream, opts.onMediaError)
+
+      const reason = await session.sessionEnded
       activeClose = null
+      participantAv.attachSession(null)
       assignSession(null)
       opts.onSessionClean?.()
       if (reason === 'user_close' || signal.aborted) break
+      participantAv.resetOnReconnect()
       await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
     }
   })()

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -2,6 +2,7 @@ import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import {
   connectSfuUnifiedSession,
   resolveSfuWsBaseForToken,
+  type SfuConsumerTrackEvent,
   type SfuMediaErrorCode,
   type SfuProducerClass,
   type SfuUnifiedSessionHandle,
@@ -27,6 +28,7 @@ export type StartSfuRoomSessionOpts = SessionHooks & {
   accessToken: string | null
   getIceServers: () => Promise<RTCIceServer[]>
   onRemoteStream: (stream: MediaStream | null) => void
+  onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
   getHostScreenStream: () => MediaStream | null
   participantAv: ParticipantAvController
 }
@@ -180,6 +182,7 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         tokenRole: tok.role,
         getIceServers: opts.getIceServers,
         onRemoteStream: opts.onRemoteStream,
+        onConsumerTrack: opts.onConsumerTrack,
         ownSessionId: opts.sessionId,
         onMediaError: opts.onMediaError,
       })

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -57,12 +57,12 @@ export function resolveSfuTokenProducerClass(opts: {
   participantAv: ParticipantAvController
   getHostScreenStream: () => MediaStream | null
 }): SfuProducerClass | undefined {
-  if (opts.participantAv.getState().needsProducerToken) {
-    return 'participant_av'
-  }
   const hostStream = opts.getHostScreenStream()
   if (hostStream?.getTracks().some((track) => track.readyState === 'live')) {
     return 'host_screen'
+  }
+  if (opts.participantAv.getState().needsProducerToken) {
+    return 'participant_av'
   }
   return undefined
 }

--- a/infra/cdk/lambda/webrtc-sfu-token.test.ts
+++ b/infra/cdk/lambda/webrtc-sfu-token.test.ts
@@ -136,20 +136,42 @@ describe('webrtc-sfu-token handler', () => {
     mocks.verifyAccessToken.mockResolvedValue(null);
   });
 
-  it('grants host_screen to the room host by default', async () => {
+  it('grants host_screen when the host requests producerClass host_screen', async () => {
     stubRoomAndPresence({
       myConn: { hostSub, fanSub: hostSub },
     });
     mocks.verifyAccessToken.mockResolvedValue({ sub: hostSub });
 
-    const res = await handler(tokenEvent({ authorization: 'Bearer host-jwt' }));
+    const res = await handler(
+      tokenEvent({
+        authorization: 'Bearer host-jwt',
+        body: { producerClass: 'host_screen' },
+      }),
+    );
     expect(res.statusCode).toBe(200);
     const body = parseBody(res);
     expect(body.role).toBe('producer');
     expect(body.producerClass).toBe('host_screen');
     const claims = verifySfuJoinToken(body.token as string, joinSecret);
-    expect(claims?.producerClass).toBe('host_screen');
+    expect(claims?.producerClass).toBeUndefined();
     expect(claims?.fanSub).toBeUndefined();
+  });
+
+  it('grants consumer to a signed-in fan before participant AV publish', async () => {
+    stubRoomAndPresence({
+      myConn: { fanSub },
+    });
+    mocks.verifyAccessToken.mockResolvedValue({ sub: fanSub });
+
+    const res = await handler(
+      tokenEvent({
+        authorization: 'Bearer fan-jwt',
+      }),
+    );
+    expect(res.statusCode).toBe(200);
+    const body = parseBody(res);
+    expect(body.role).toBe('consumer');
+    expect(body.producerClass).toBeUndefined();
   });
 
   it('grants participant_av to a signed-in fan when avDisabled is false', async () => {

--- a/infra/cdk/lambda/webrtc-sfu-token.ts
+++ b/infra/cdk/lambda/webrtc-sfu-token.ts
@@ -229,14 +229,6 @@ async function resolveGrant(
     return resolveParticipantAvGrant(room, presenceTable, roomId, jwtUser, connFanSub);
   }
 
-  if (isHostJwt && isHostConnection(myConn, roomHostSub)) {
-    return { role: 'producer', producerClass: 'host_screen' };
-  }
-
-  if (connFanSub && jwtUser && jwtUser.sub === connFanSub) {
-    return resolveParticipantAvGrant(room, presenceTable, roomId, jwtUser, connFanSub);
-  }
-
   return { role: 'consumer' };
 }
 
@@ -322,7 +314,7 @@ async function handleSfuToken(event: APIGatewayProxyEventV2): Promise<APIGateway
       roomId,
       sessionId,
       role: grant.role,
-      ...(grant.role === 'producer'
+      ...(grant.role === 'producer' && grant.producerClass === 'participant_av'
         ? {
             producerClass: grant.producerClass,
             ...(grant.fanSub ? { fanSub: grant.fanSub } : {}),

--- a/services/riffsync-sfu/dist/index.js
+++ b/services/riffsync-sfu/dist/index.js
@@ -335,12 +335,12 @@ async function onMessage(ws, p, raw) {
             case 'createWebRtcTransport': {
                 const asProducer = Boolean(data.producer);
                 const asConsumer = Boolean(data.consumer);
-                if (p.claims.role === 'producer' && !asProducer) {
-                    send(ws, errResponse(id, 'host transport must set producer: true'));
-                    return;
-                }
                 if (p.claims.role === 'consumer' && !asConsumer) {
                     send(ws, errResponse(id, 'guest transport must set consumer: true'));
+                    return;
+                }
+                if (p.claims.role === 'producer' && !asProducer && !asConsumer) {
+                    send(ws, errResponse(id, 'producer transport must set producer and/or consumer'));
                     return;
                 }
                 if (p.transports.size >= MAX_TRANSPORTS) {
@@ -461,7 +461,7 @@ async function onMessage(ws, p, raw) {
                 break;
             }
             case 'consume': {
-                if (p.claims.role !== 'consumer') {
+                if (p.claims.role !== 'consumer' && p.claims.role !== 'producer') {
                     send(ws, errResponse(id, 'forbidden'));
                     return;
                 }

--- a/services/riffsync-sfu/src/index.ts
+++ b/services/riffsync-sfu/src/index.ts
@@ -416,12 +416,12 @@ async function onMessage(ws: WebSocket, p: PendingSession, raw: string): Promise
       case 'createWebRtcTransport': {
         const asProducer = Boolean(data.producer);
         const asConsumer = Boolean(data.consumer);
-        if (p.claims.role === 'producer' && !asProducer) {
-          send(ws, errResponse(id, 'host transport must set producer: true'));
-          return;
-        }
         if (p.claims.role === 'consumer' && !asConsumer) {
           send(ws, errResponse(id, 'guest transport must set consumer: true'));
+          return;
+        }
+        if (p.claims.role === 'producer' && !asProducer && !asConsumer) {
+          send(ws, errResponse(id, 'producer transport must set producer and/or consumer'));
           return;
         }
         if (p.transports.size >= MAX_TRANSPORTS) {
@@ -546,7 +546,7 @@ async function onMessage(ws: WebSocket, p: PendingSession, raw: string): Promise
       }
 
       case 'consume': {
-        if (p.claims.role !== 'consumer') {
+        if (p.claims.role !== 'consumer' && p.claims.role !== 'producer') {
           send(ws, errResponse(id, 'forbidden'));
           return;
         }


### PR DESCRIPTION
## Summary

- Unifies room SFU to **one WebSocket per browser tab** via `connectSfuUnifiedSession` and a single `startSfuRoomSession` effect in `RoomPage`.
- Adds **participant AV bootstrap** (`participantAvSession.ts`): privacy-first defaults (cam/mic off), gated `getUserMedia`, mic pause/resume, and explicit `participant_av` token mint when publishing.
- Adds **Theater mode client-side audio mixing** (`theaterAudioMix.ts`): equal-gain Web Audio mix of host screen + `participant_av` consumers, `avDisabled` kill-switch, and cleanup on room leave (#118).
- **Video Chat host capture stop** (#119): `room_mode` fan-out stops tab-capture and `host_screen` producers without warm-resume `share_state`, detaches guest host-screen consumers, tears down participant AV on `av_disabled`, and follows documented leave cleanup order on the unified SFU session.

Closes #117. Closes #118. Closes #119. Part of parent #104.

## Test plan

- [x] `npm run test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [x] `npm test --prefix infra/cdk -- --run webrtc-sfu-token`
- [ ] Manual Theater smoke: two fans with mics + host tab share; kill switch stops participant audio; room leave tears down AudioContext
- [ ] Manual Video Chat smoke: host sharing tab switches to Video Chat (capture stops, no ghost `host_screen`); Theater return requires explicit re-share; kill switch stops local participant AV immediately