### PR TITLE
feat(room): M14 participant AV and stage layouts (#105)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -78,6 +78,15 @@ import {
   mergeRoomPatchResult,
   roomModeAnnounceCopy,
 } from '../room/hostRoomControls'
+import type { SfuConsumerTrackEvent } from '../room/sfu/mediasoupSharing'
+import {
+  applyParticipantAvConsumerEvent,
+  type ParticipantAvVideoConsumer,
+} from '../room/stage/participantAvConsumers'
+import { StageParticipantLayout } from '../room/stage/StageParticipantLayout'
+import { buildStageParticipantTiles } from '../room/stage/stageParticipantTiles'
+import { useStageLayoutTransition } from '../room/stage/useStageLayoutTransition'
+import { useViewportWide } from '../room/stage/useViewportWide'
 
 const DISPLAY_TITLE_MAX_LEN = 120
 
@@ -180,6 +189,10 @@ export function RoomPage() {
   const [patchErr, setPatchErr] = useState<string | null>(null)
   const [hostBarBusy, setHostBarBusy] = useState(false)
   const [hostBarErr, setHostBarErr] = useState<string | null>(null)
+  const [participantAvVideoConsumers, setParticipantAvVideoConsumers] = useState(
+    () => new Map<string, ParticipantAvVideoConsumer>(),
+  )
+  const [participantAvPublishTick, setParticipantAvPublishTick] = useState(0)
   const [shareHint, setShareHint] = useState<string | null>(null)
   const [captureErr, setCaptureErr] = useState<string | null>(null)
   const [sfuRoomErr, setSfuRoomErr] = useState<string | null>(null)
@@ -461,6 +474,9 @@ export function RoomPage() {
     })
     return list
   }, [presenceRoster.members, presenceRoster.roomId, canonicalRoomId, sessionId, displayName, isPublisher])
+
+  const viewportWide = useViewportWide()
+  const avSurfacesEnabled = sfuEnabled && !avDisabled
 
   const chatMemberLabels = useMemo(() => {
     const m = new Map<string, string>()
@@ -825,6 +841,28 @@ export function RoomPage() {
   }, [wsStatus, fanToken, avDisabled, participantAvController, participantAvGate])
 
   useEffect(() => {
+    return participantAvController.subscribe(() => {
+      setParticipantAvPublishTick((n) => n + 1)
+    })
+  }, [participantAvController])
+
+  void participantAvPublishTick
+  const participantAvPublishState = participantAvController.getState()
+  const stageParticipantTiles = buildStageParticipantTiles({
+    roster: peopleShown,
+    videoConsumers: participantAvVideoConsumers,
+    ownSessionId: sessionId,
+    localCameraOn: participantAvPublishState.cameraEnabled,
+    localPreviewStream: participantAvController.getLocalPreviewStream(),
+  })
+
+  const stageLayoutUpdating = useStageLayoutTransition(roomMode, stageParticipantTiles.length)
+
+  const onParticipantAvConsumerTrack = useCallback((event: SfuConsumerTrackEvent) => {
+    setParticipantAvVideoConsumers((prev) => applyParticipantAvConsumerEvent(prev, event))
+  }, [])
+
+  useEffect(() => {
     captureStreamRef.current = captureStream
   }, [captureStream])
 
@@ -1040,6 +1078,7 @@ export function RoomPage() {
 
     participantAvController.teardownPublishing()
     sfuSessionRef.current?.detachConsumerClass('participant_av')
+    setParticipantAvVideoConsumers(new Map())
   }, [avDisabled, participantAvController])
 
   useEffect(() => {
@@ -1064,6 +1103,7 @@ export function RoomPage() {
       participantAv: participantAvController,
       onRemoteStream: setGuestRemote,
       onConsumerTrack: (event) => {
+        onParticipantAvConsumerTrack(event)
         theaterAudioMixRef.current?.onConsumerEvent(event)
         void theaterAudioMixRef.current?.resumeIfSuspended()
       },
@@ -1094,6 +1134,7 @@ export function RoomPage() {
     captureStream,
     sfuTokenIntentTick,
     participantAvController,
+    onParticipantAvConsumerTrack,
   ])
 
   useEffect(() => {
@@ -1551,7 +1592,14 @@ export function RoomPage() {
         ) : null}
         <div className="riffsync-room-page__stage">
           <div className="riffsync-room-page__theater">
-            {isPublisher ? (
+            <StageParticipantLayout
+              roomMode={roomMode}
+              tiles={stageParticipantTiles}
+              layoutUpdating={stageLayoutUpdating}
+              viewportWide={viewportWide}
+              avSurfacesEnabled={avSurfacesEnabled}
+              playback={
+                isPublisher ? (
               <section className="riffsync-room-page__playback" aria-label="Your shared stream preview">
                 {captureStream && hostCapturePlayHint ? (
                   <p className="riffsync-room-page__guest-actions">
@@ -1652,7 +1700,9 @@ export function RoomPage() {
                   </p>
                 )}
               </section>
-            )}
+            )
+              }
+            />
           </div>
 
           <aside className="riffsync-room-page__chat-column" aria-label="Room sidebar">

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -70,6 +70,7 @@ import {
 import { createChatMessageId, parseInboundChatMessageId } from '../room/chatMessageId'
 import { isContinuedChatLine } from '../room/chatMessageGrouping'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
+import { ParticipantAvToggles } from '../room/ParticipantAvToggles'
 
 const DISPLAY_TITLE_MAX_LEN = 120
 
@@ -198,6 +199,7 @@ export function RoomPage() {
   const [myAvatarUrl, setMyAvatarUrl] = useState<string | null>(null)
   const [profileAvatarLoading, setProfileAvatarLoading] = useState(false)
   const [profileAvatarUploading, setProfileAvatarUploading] = useState(false)
+  const a11yAnnouncerRef = useRef<HTMLDivElement | null>(null)
   const [profileAvatarErr, setProfileAvatarErr] = useState<string | null>(null)
   const profileTabLoadedRef = useRef(false)
   const profileAvatarInputRef = useRef<HTMLInputElement>(null)
@@ -1415,6 +1417,13 @@ export function RoomPage() {
     }
   }
 
+  const announceLocalAvToggle = useCallback((message: string) => {
+    const node = a11yAnnouncerRef.current
+    if (!node) return
+    node.textContent = ''
+    node.textContent = message
+  }, [])
+
   if (!roomId) {
     return (
       <div className="container">
@@ -1460,6 +1469,7 @@ export function RoomPage() {
         backdropImageUrl ? 'riffsync-room-shell riffsync-room-shell--backdrop' : 'riffsync-room-shell'
       }
     >
+      <div id="riffsync-a11y-announcer" ref={a11yAnnouncerRef} aria-live="polite" className="sr-only" />
       {backdropImageUrl ? (
         <div
           className="riffsync-room-shell__backdrop"
@@ -1712,70 +1722,6 @@ export function RoomPage() {
                       )
                     })}
                   </ul>
-                  <div className="riffsync-room-chat-compose-holder">
-                    {showJumpToLatest ? (
-                      <button
-                        type="button"
-                        className="riffsync-room-chat-jump-latest gen-button"
-                        aria-label="Jump to latest messages"
-                        onClick={jumpToLatest}
-                      >
-                        {jumpToLatestLabel}
-                      </button>
-                    ) : null}
-                    <div
-                      className={`riffsync-room-chat-compose${fanToken ? '' : ' riffsync-room-chat-compose--inactive'}`}
-                    >
-                      {fanToken ? (
-                        <ChatComposeMediaPicker
-                          draft={chatDraft}
-                          onDraftChange={setChatDraft}
-                          inputRef={chatInputRef}
-                          accessToken={fanToken}
-                          onGifSelect={sendChatGif}
-                        />
-                      ) : null}
-                      <input
-                        ref={chatInputRef}
-                        type="text"
-                        maxLength={2000}
-                        value={fanToken ? chatDraft : ''}
-                        placeholder="Say something…"
-                        disabled={!fanToken}
-                        onChange={(e) => {
-                          if (fanToken) setChatDraft(e.target.value)
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && fanToken) sendChat()
-                        }}
-                      />
-                      <button
-                        type="button"
-                        className="riffsync-room-chat-compose-send gen-button"
-                        disabled={!fanToken}
-                        onClick={sendChat}
-                      >
-                        Send
-                      </button>
-                    </div>
-                    {!fanToken ? (
-                      <div
-                        className="riffsync-room-chat-signin-overlay"
-                        role="region"
-                        aria-label="Sign in to participate in chat"
-                      >
-                        <button
-                          type="button"
-                          className="gen-button"
-                          onClick={() =>
-                            void startFanHostedUiSignIn(`/room/${encodeURIComponent(roomId)}`).catch(console.error)
-                          }
-                        >
-                          Sign In to Chat
-                        </button>
-                      </div>
-                    ) : null}
-                  </div>
                 </div>
               ) : null}
               {activeSidebarTab === 'people' ? (
@@ -1917,6 +1863,82 @@ export function RoomPage() {
                   </button>
                 </div>
               ) : null}
+              <div className="riffsync-room-page__sidebar-footer">
+                {fanToken ? (
+                  <ParticipantAvToggles
+                    controller={participantAvController}
+                    avDisabled={avDisabled}
+                    sfuRoomErr={sfuRoomErr}
+                    onLocalToggleAnnounce={announceLocalAvToggle}
+                  />
+                ) : null}
+                {activeSidebarTab === 'chat' ? (
+                  <div className="riffsync-room-chat-compose-holder">
+                    {showJumpToLatest ? (
+                      <button
+                        type="button"
+                        className="riffsync-room-chat-jump-latest gen-button"
+                        aria-label="Jump to latest messages"
+                        onClick={jumpToLatest}
+                      >
+                        {jumpToLatestLabel}
+                      </button>
+                    ) : null}
+                    <div
+                      className={`riffsync-room-chat-compose${fanToken ? '' : ' riffsync-room-chat-compose--inactive'}`}
+                    >
+                      {fanToken ? (
+                        <ChatComposeMediaPicker
+                          draft={chatDraft}
+                          onDraftChange={setChatDraft}
+                          inputRef={chatInputRef}
+                          accessToken={fanToken}
+                          onGifSelect={sendChatGif}
+                        />
+                      ) : null}
+                      <input
+                        ref={chatInputRef}
+                        type="text"
+                        maxLength={2000}
+                        value={fanToken ? chatDraft : ''}
+                        placeholder="Say something…"
+                        disabled={!fanToken}
+                        onChange={(e) => {
+                          if (fanToken) setChatDraft(e.target.value)
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && fanToken) sendChat()
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="riffsync-room-chat-compose-send gen-button"
+                        disabled={!fanToken}
+                        onClick={sendChat}
+                      >
+                        Send
+                      </button>
+                    </div>
+                    {!fanToken ? (
+                      <div
+                        className="riffsync-room-chat-signin-overlay"
+                        role="region"
+                        aria-label="Sign in to participate in chat"
+                      >
+                        <button
+                          type="button"
+                          className="gen-button"
+                          onClick={() =>
+                            void startFanHostedUiSignIn(`/room/${encodeURIComponent(roomId)}`).catch(console.error)
+                          }
+                        >
+                          Sign In to Chat
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
             </section>
           </aside>
         </div>

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -71,6 +71,13 @@ import { createChatMessageId, parseInboundChatMessageId } from '../room/chatMess
 import { isContinuedChatLine } from '../room/chatMessageGrouping'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
 import { ParticipantAvToggles } from '../room/ParticipantAvToggles'
+import { HostControlBar } from '../room/HostControlBar'
+import {
+  avDisabledAnnounceCopy,
+  formatHostRoomPatchError,
+  mergeRoomPatchResult,
+  roomModeAnnounceCopy,
+} from '../room/hostRoomControls'
 
 const DISPLAY_TITLE_MAX_LEN = 120
 
@@ -171,6 +178,8 @@ export function RoomPage() {
   const [chatReactions, setChatReactions] = useState<ReactionsByMessage>({})
   const [chatDraft, setChatDraft] = useState('')
   const [patchErr, setPatchErr] = useState<string | null>(null)
+  const [hostBarBusy, setHostBarBusy] = useState(false)
+  const [hostBarErr, setHostBarErr] = useState<string | null>(null)
   const [shareHint, setShareHint] = useState<string | null>(null)
   const [captureErr, setCaptureErr] = useState<string | null>(null)
   const [sfuRoomErr, setSfuRoomErr] = useState<string | null>(null)
@@ -200,6 +209,7 @@ export function RoomPage() {
   const [profileAvatarLoading, setProfileAvatarLoading] = useState(false)
   const [profileAvatarUploading, setProfileAvatarUploading] = useState(false)
   const a11yAnnouncerRef = useRef<HTMLDivElement | null>(null)
+  const hostPatchSuppressAnnounceUntilRef = useRef(0)
   const [profileAvatarErr, setProfileAvatarErr] = useState<string | null>(null)
   const profileTabLoadedRef = useRef(false)
   const profileAvatarInputRef = useRef<HTMLInputElement>(null)
@@ -260,6 +270,44 @@ export function RoomPage() {
   const canonicalRoomId = useMemo(() => room?.roomId ?? roomId, [room?.roomId, roomId])
   const sfuEnabled = isMediasoupSfuEnabled()
   const theaterMixEnabled = sfuEnabled && roomMode === 'theater'
+
+  const announceRoomA11y = useCallback((message: string) => {
+    const node = a11yAnnouncerRef.current
+    if (!node) return
+    node.textContent = ''
+    node.textContent = message
+  }, [])
+
+  const patchHostRoomFields = useCallback(
+    async (patch: { roomMode?: RoomMode; avDisabled?: boolean }) => {
+      if (!room || !fanToken || !isPublisher || hostBarBusy) return
+      const snapshot = room
+      setHostBarBusy(true)
+      setHostBarErr(null)
+      hostPatchSuppressAnnounceUntilRef.current = Date.now() + 3000
+      setRoom({
+        ...snapshot,
+        ...(patch.roomMode !== undefined ? { roomMode: patch.roomMode } : {}),
+        ...(patch.avDisabled !== undefined ? { avDisabled: patch.avDisabled } : {}),
+      })
+      try {
+        const res = await patchRoom(fanToken, roomId, patch)
+        setRoom((prev) => (prev ? mergeRoomPatchResult(prev, res) : prev))
+        if (patch.roomMode !== undefined) {
+          announceRoomA11y(roomModeAnnounceCopy(patch.roomMode))
+        }
+        if (patch.avDisabled !== undefined) {
+          announceRoomA11y(avDisabledAnnounceCopy(patch.avDisabled))
+        }
+      } catch (e) {
+        setRoom(snapshot)
+        setHostBarErr(formatHostRoomPatchError(e))
+      } finally {
+        setHostBarBusy(false)
+      }
+    },
+    [room, fanToken, isPublisher, hostBarBusy, roomId, announceRoomA11y],
+  )
   const meshUnsupportedProdBuild = import.meta.env.PROD && isMeshWatchPartyMediaEnabled()
 
   useEffect(() => {
@@ -660,10 +708,17 @@ export function RoomPage() {
             ...(nextMode === 'videoChat' ? { broadcastCaptureActive: false } : {}),
           }
         })
+        if (Date.now() > hostPatchSuppressAnnounceUntilRef.current) {
+          announceRoomA11y(roomModeAnnounceCopy(nextMode))
+        }
         return
       }
       if (t === 'av_disabled' && typeof data.avDisabled === 'boolean') {
-        setRoom((prev) => (prev ? { ...prev, avDisabled: data.avDisabled as boolean } : prev))
+        const nextAvDisabled = data.avDisabled as boolean
+        setRoom((prev) => (prev ? { ...prev, avDisabled: nextAvDisabled } : prev))
+        if (Date.now() > hostPatchSuppressAnnounceUntilRef.current) {
+          announceRoomA11y(avDisabledAnnounceCopy(nextAvDisabled))
+        }
         return
       }
       if (t !== 'signaling' || sfuEnabled) return
@@ -726,6 +781,7 @@ export function RoomPage() {
       canonicalRoomId,
       sessionId,
       sfuEnabled,
+      announceRoomA11y,
     ],
   )
 
@@ -1417,13 +1473,6 @@ export function RoomPage() {
     }
   }
 
-  const announceLocalAvToggle = useCallback((message: string) => {
-    const node = a11yAnnouncerRef.current
-    if (!node) return
-    node.textContent = ''
-    node.textContent = message
-  }, [])
-
   if (!roomId) {
     return (
       <div className="container">
@@ -1869,7 +1918,7 @@ export function RoomPage() {
                     controller={participantAvController}
                     avDisabled={avDisabled}
                     sfuRoomErr={sfuRoomErr}
-                    onLocalToggleAnnounce={announceLocalAvToggle}
+                    onLocalToggleAnnounce={announceRoomA11y}
                   />
                 ) : null}
                 {activeSidebarTab === 'chat' ? (
@@ -1942,6 +1991,16 @@ export function RoomPage() {
             </section>
           </aside>
         </div>
+        {isPublisher ? (
+          <HostControlBar
+            roomMode={roomMode}
+            avDisabled={avDisabled}
+            busy={hostBarBusy}
+            error={hostBarErr}
+            onSelectRoomMode={(mode) => void patchHostRoomFields({ roomMode: mode })}
+            onToggleAvDisabled={(next) => void patchHostRoomFields({ avDisabled: next })}
+          />
+        ) : null}
       </div>
 
       {renameModalOpen && isPublisher ? (

--- a/apps/web/src/room/HostControlBar.test.tsx
+++ b/apps/web/src/room/HostControlBar.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HostControlBar } from './HostControlBar'
+
+describe('HostControlBar', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderBar(overrides: Partial<Parameters<typeof HostControlBar>[0]> = {}) {
+    const onSelectRoomMode = vi.fn()
+    const onToggleAvDisabled = vi.fn()
+    act(() => {
+      root.render(
+        <HostControlBar
+          roomMode="theater"
+          avDisabled={false}
+          busy={false}
+          error={null}
+          onSelectRoomMode={onSelectRoomMode}
+          onToggleAvDisabled={onToggleAvDisabled}
+          {...overrides}
+        />,
+      )
+    })
+    return { onSelectRoomMode, onToggleAvDisabled }
+  }
+
+  it('does not render when parent omits bar for non-host viewers', () => {
+    const isHost = false
+    act(() => {
+      root.render(
+        isHost ? (
+          <HostControlBar
+            roomMode="theater"
+            avDisabled={false}
+            busy={false}
+            error={null}
+            onSelectRoomMode={vi.fn()}
+            onToggleAvDisabled={vi.fn()}
+          />
+        ) : null,
+      )
+    })
+    expect(container.querySelector('.riffsync-room-page__host-bar')).toBeNull()
+  })
+
+  it('renders host layout and kill switch for room host', () => {
+    renderBar()
+    expect(container.textContent).toContain('Theater')
+    expect(container.textContent).toContain('Video Chat')
+    expect(container.textContent).toContain('Disable room A/V')
+  })
+
+  it('marks Video Chat inert when avDisabled kill switch is on', () => {
+    renderBar({ avDisabled: true })
+    const modeButtons = container.querySelectorAll('button.riffsync-room-page__host-bar-mode')
+    expect(modeButtons.length).toBe(2)
+    expect(modeButtons[1]?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('exposes kill switch pressed state to assistive tech', () => {
+    renderBar({ avDisabled: true })
+    const kill = container.querySelector('.riffsync-room-page__host-bar-kill') as HTMLButtonElement
+    expect(kill.getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/apps/web/src/room/HostControlBar.tsx
+++ b/apps/web/src/room/HostControlBar.tsx
@@ -1,0 +1,77 @@
+import type { RoomMode } from '../api/roomsApi'
+
+export type HostControlBarProps = {
+  roomMode: RoomMode
+  avDisabled: boolean
+  busy: boolean
+  error: string | null
+  onSelectRoomMode: (mode: RoomMode) => void
+  onToggleAvDisabled: (next: boolean) => void
+}
+
+const MODE_OPTIONS: Array<{ value: RoomMode; label: string }> = [
+  { value: 'theater', label: 'Theater' },
+  { value: 'videoChat', label: 'Video Chat' },
+]
+
+export function HostControlBar({
+  roomMode,
+  avDisabled,
+  busy,
+  error,
+  onSelectRoomMode,
+  onToggleAvDisabled,
+}: HostControlBarProps) {
+  const barDisabled = busy
+
+  return (
+    <div
+      className="riffsync-room-page__host-bar"
+      role="region"
+      aria-label="Host room controls"
+      aria-busy={busy || undefined}
+    >
+      <div
+        className="riffsync-room-page__host-bar-layout"
+        role="radiogroup"
+        aria-label="Room layout"
+      >
+        {MODE_OPTIONS.map((opt) => {
+          const videoChatInert = avDisabled && opt.value === 'videoChat'
+          const optionDisabled = barDisabled || videoChatInert
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              className={`gen-button riffsync-room-page__host-bar-mode${roomMode === opt.value ? ' riffsync-room-page__host-bar-mode--on' : ''}`}
+              aria-checked={roomMode === opt.value}
+              aria-disabled={optionDisabled || undefined}
+              disabled={barDisabled}
+              onClick={() => {
+                if (optionDisabled || roomMode === opt.value) return
+                onSelectRoomMode(opt.value)
+              }}
+            >
+              {opt.label}
+            </button>
+          )
+        })}
+      </div>
+      <button
+        type="button"
+        className={`gen-button riffsync-room-page__host-bar-kill${avDisabled ? ' riffsync-room-page__host-bar-kill--on' : ''}`}
+        aria-pressed={avDisabled}
+        disabled={barDisabled}
+        onClick={() => onToggleAvDisabled(!avDisabled)}
+      >
+        Disable room A/V
+      </button>
+      {error ? (
+        <p className="riffsync-room-page__host-bar-err" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -89,6 +89,7 @@ describe('ParticipantAvToggles', () => {
         busy: false,
       }),
       subscribe: () => () => undefined,
+      getLocalPreviewStream: () => null,
       refreshPublishGate: vi.fn(),
       attachSession: vi.fn(),
       resetOnReconnect: vi.fn(),

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ParticipantAvToggles } from './ParticipantAvToggles'
+import { PARTICIPANT_AV_DISABLED_COPY } from './participantAvErrorCopy'
+import { createParticipantAvController } from './sfu/participantAvSession'
+
+describe('ParticipantAvToggles', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderToggles(opts: {
+    avDisabled?: boolean
+    canPublish?: boolean
+    sfuRoomErr?: string | null
+  } = {}) {
+    const controller = createParticipantAvController({
+      canPublish: () => opts.canPublish ?? true,
+    })
+    act(() => {
+      root.render(
+        <ParticipantAvToggles
+          controller={controller}
+          avDisabled={opts.avDisabled ?? false}
+          sfuRoomErr={opts.sfuRoomErr ?? null}
+          onLocalToggleAnnounce={vi.fn()}
+        />,
+      )
+    })
+    return controller
+  }
+
+  it('renders camera and microphone controls for signed-in session chrome', () => {
+    renderToggles()
+    expect(container.querySelector('.riffsync-room-av-toggle')).not.toBeNull()
+    expect(container.textContent).toContain('Camera')
+    expect(container.textContent).toContain('Microphone')
+  })
+
+  it('does not render when parent omits toggles for guests (signed-in guard)', () => {
+    const fanToken: string | null = null
+    act(() => {
+      root.render(
+        fanToken ? (
+          <ParticipantAvToggles
+            controller={createParticipantAvController({ canPublish: () => false })}
+            avDisabled={false}
+            sfuRoomErr={null}
+            onLocalToggleAnnounce={vi.fn()}
+          />
+        ) : null,
+      )
+    })
+    expect(container.querySelector('.riffsync-room-av')).toBeNull()
+  })
+
+  it('shows kill-switch copy and blocks activation when avDisabled', () => {
+    renderToggles({ avDisabled: true, canPublish: false })
+    expect(container.textContent).toContain(PARTICIPANT_AV_DISABLED_COPY)
+    const killSwitch = container.querySelector('.riffsync-room-av__kill-switch')
+    const camera = container.querySelector(
+      'button.riffsync-room-av-toggle',
+    ) as HTMLButtonElement
+    expect(camera.getAttribute('aria-disabled')).toBe('true')
+    expect(camera.getAttribute('aria-describedby')).toBe(killSwitch?.id)
+  })
+
+  it('reflects aria-pressed for local camera and microphone state', () => {
+    const controller = {
+      getState: () => ({
+        cameraEnabled: true,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      }),
+      subscribe: () => () => undefined,
+      refreshPublishGate: vi.fn(),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      teardownPublishing: vi.fn(),
+      enableCamera: vi.fn(),
+      disableCamera: vi.fn(),
+      enableMic: vi.fn(),
+      disableMic: vi.fn(),
+      toggleMicMute: vi.fn(),
+    }
+    act(() => {
+      root.render(
+        <ParticipantAvToggles
+          controller={controller}
+          avDisabled={false}
+          sfuRoomErr={null}
+          onLocalToggleAnnounce={vi.fn()}
+        />,
+      )
+    })
+    const buttons = container.querySelectorAll('button.riffsync-room-av-toggle')
+    expect(buttons[0]?.getAttribute('aria-pressed')).toBe('true')
+    expect(buttons[1]?.getAttribute('aria-pressed')).toBe('false')
+  })
+})

--- a/apps/web/src/room/ParticipantAvToggles.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import type { ParticipantAvController } from './sfu/participantAvSession'
+import {
+  formatParticipantAvToggleError,
+  PARTICIPANT_AV_DISABLED_COPY,
+} from './participantAvErrorCopy'
+
+export type ParticipantAvTogglesProps = {
+  controller: ParticipantAvController
+  avDisabled: boolean
+  /** Top-of-page SFU banner text; surfaced inline when publish is blocked. */
+  sfuRoomErr: string | null
+  onLocalToggleAnnounce: (message: string) => void
+}
+
+function CameraIcon() {
+  return (
+    <svg
+      className="riffsync-room-av-toggle__icon"
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fill="currentColor"
+        d="M17 10.5V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-3.5l4 3v-9l-4 3z"
+      />
+    </svg>
+  )
+}
+
+function MicrophoneIcon() {
+  return (
+    <svg
+      className="riffsync-room-av-toggle__icon"
+      width={18}
+      height={18}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fill="currentColor"
+        d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11h-2z"
+      />
+    </svg>
+  )
+}
+
+export function ParticipantAvToggles({
+  controller,
+  avDisabled,
+  sfuRoomErr,
+  onLocalToggleAnnounce,
+}: ParticipantAvTogglesProps) {
+  const killSwitchId = useId()
+  const cameraErrId = useId()
+  const micErrId = useId()
+  const [state, setState] = useState(() => controller.getState())
+
+  useEffect(() => controller.subscribe(() => setState(controller.getState())), [controller])
+
+  const killSwitchActive = avDisabled
+  const activationBlocked = killSwitchActive || !state.canPublish || state.busy
+
+  const relayErr =
+    state.needsProducerToken && sfuRoomErr ? formatParticipantAvToggleError(sfuRoomErr) : null
+  const cameraErr = formatParticipantAvToggleError(state.error)
+  const micErr = relayErr ?? cameraErr
+
+  const cameraDescribedBy = [
+    killSwitchActive ? killSwitchId : null,
+    cameraErr ? cameraErrId : null,
+  ]
+    .filter(Boolean)
+    .join(' ') || undefined
+
+  const micDescribedBy = [
+    killSwitchActive ? killSwitchId : null,
+    micErr ? micErrId : null,
+  ]
+    .filter(Boolean)
+    .join(' ') || undefined
+
+  const toggleCamera = useCallback(() => {
+    if (activationBlocked) return
+    if (state.cameraEnabled) {
+      controller.disableCamera()
+      onLocalToggleAnnounce('Camera off')
+      return
+    }
+    void controller.enableCamera().then(() => {
+      if (controller.getState().cameraEnabled) {
+        onLocalToggleAnnounce('Camera on')
+      }
+    })
+  }, [activationBlocked, controller, onLocalToggleAnnounce, state.cameraEnabled])
+
+  const toggleMic = useCallback(() => {
+    if (activationBlocked) return
+    if (state.micEnabled) {
+      controller.disableMic()
+      onLocalToggleAnnounce('Microphone off')
+      return
+    }
+    void controller.enableMic().then(() => {
+      if (controller.getState().micEnabled) {
+        onLocalToggleAnnounce('Microphone on')
+      }
+    })
+  }, [activationBlocked, controller, onLocalToggleAnnounce, state.micEnabled])
+
+  return (
+    <div className="riffsync-room-av" role="group" aria-label="Camera and microphone">
+      {killSwitchActive ? (
+        <p className="riffsync-room-av__kill-switch" id={killSwitchId}>
+          {PARTICIPANT_AV_DISABLED_COPY}
+        </p>
+      ) : null}
+      <div className="riffsync-room-av__toggles">
+        <button
+          type="button"
+          className={`gen-button riffsync-room-av-toggle${state.cameraEnabled ? ' riffsync-room-av-toggle--on' : ''}`}
+          aria-pressed={state.cameraEnabled}
+          aria-disabled={activationBlocked || undefined}
+          aria-describedby={cameraDescribedBy}
+          disabled={state.busy}
+          onClick={toggleCamera}
+        >
+          <CameraIcon />
+          <span className="riffsync-room-av-toggle__label">Camera</span>
+        </button>
+        <button
+          type="button"
+          className={`gen-button riffsync-room-av-toggle${state.micEnabled ? ' riffsync-room-av-toggle--on' : ''}`}
+          aria-pressed={state.micEnabled}
+          aria-disabled={activationBlocked || undefined}
+          aria-describedby={micDescribedBy}
+          disabled={state.busy}
+          onClick={toggleMic}
+        >
+          <MicrophoneIcon />
+          <span className="riffsync-room-av-toggle__label">Microphone</span>
+        </button>
+      </div>
+      {cameraErr ? (
+        <p className="riffsync-room-av__err" id={cameraErrId} role="status">
+          {cameraErr}
+        </p>
+      ) : null}
+      {micErr && micErr !== cameraErr ? (
+        <p className="riffsync-room-av__err" id={micErrId} role="status">
+          {micErr}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/hostRoomControls.test.ts
+++ b/apps/web/src/room/hostRoomControls.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAvDisabledPatch,
+  buildRoomModePatch,
+  formatHostRoomPatchError,
+  mergeRoomPatchResult,
+} from './hostRoomControls'
+import type { RoomSnapshot } from '../api/roomsApi'
+
+const baseSnapshot: RoomSnapshot = {
+  roomId: 'room-1',
+  hostSub: 'host-sub',
+  catalogEpisodeId: 'ep-1',
+  youtubeVideoId: 'yt-1',
+  playbackExpectation: 'free',
+  visibility: 'public',
+  lastActivityAt: 1,
+  version: 2,
+  roomMode: 'theater',
+  avDisabled: false,
+  broadcastCaptureActive: false,
+}
+
+describe('hostRoomControls patch helpers', () => {
+  it('buildRoomModePatch sends only roomMode', () => {
+    expect(buildRoomModePatch('videoChat')).toEqual({ roomMode: 'videoChat' })
+  })
+
+  it('buildAvDisabledPatch sends only avDisabled', () => {
+    expect(buildAvDisabledPatch(true)).toEqual({ avDisabled: true })
+  })
+
+  it('mergeRoomPatchResult bumps version and layout fields', () => {
+    const merged = mergeRoomPatchResult(baseSnapshot, {
+      ok: true,
+      roomId: 'room-1',
+      version: 3,
+      catalogEpisodeId: 'ep-1',
+      youtubeVideoId: 'yt-1',
+      visibility: 'public',
+      lastActivityAt: 99,
+      roomMode: 'videoChat',
+      avDisabled: true,
+      broadcastCaptureActive: false,
+    })
+    expect(merged.version).toBe(3)
+    expect(merged.roomMode).toBe('videoChat')
+    expect(merged.avDisabled).toBe(true)
+  })
+
+  it('formatHostRoomPatchError maps stale version to recoverable copy', () => {
+    expect(formatHostRoomPatchError(new Error('Update room failed (409): Conflict'))).toContain(
+      'Refresh and try again',
+    )
+  })
+})

--- a/apps/web/src/room/hostRoomControls.ts
+++ b/apps/web/src/room/hostRoomControls.ts
@@ -1,0 +1,42 @@
+import type { RoomMode, RoomPatchResult, RoomSnapshot } from '../api/roomsApi'
+
+export function buildRoomModePatch(nextMode: RoomMode): { roomMode: RoomMode } {
+  return { roomMode: nextMode }
+}
+
+export function buildAvDisabledPatch(next: boolean): { avDisabled: boolean } {
+  return { avDisabled: next }
+}
+
+export function formatHostRoomPatchError(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e)
+  if (/409/.test(msg) || /stale version/i.test(msg) || /conflict/i.test(msg)) {
+    return 'Room settings changed elsewhere. Refresh and try again.'
+  }
+  return msg
+}
+
+export function mergeRoomPatchResult(snapshot: RoomSnapshot, res: RoomPatchResult): RoomSnapshot {
+  return {
+    ...snapshot,
+    version: res.version,
+    catalogEpisodeId: res.catalogEpisodeId,
+    youtubeVideoId: res.youtubeVideoId,
+    visibility: res.visibility,
+    lastActivityAt: res.lastActivityAt,
+    roomMode: res.roomMode,
+    avDisabled: res.avDisabled,
+    broadcastCaptureActive: res.broadcastCaptureActive,
+    ...(res.displayTitle !== undefined ? { displayTitle: res.displayTitle } : {}),
+  }
+}
+
+export function roomModeAnnounceCopy(mode: RoomMode): string {
+  return mode === 'videoChat' ? 'Room layout Video Chat' : 'Room layout Theater'
+}
+
+export function avDisabledAnnounceCopy(disabled: boolean): string {
+  return disabled
+    ? 'Room camera and microphone disabled by host'
+    : 'Room camera and microphone enabled by host'
+}

--- a/apps/web/src/room/participantAvErrorCopy.ts
+++ b/apps/web/src/room/participantAvErrorCopy.ts
@@ -1,0 +1,50 @@
+/** Host AV kill switch copy (`.ai/business_logic/error_state.md`). */
+export const PARTICIPANT_AV_DISABLED_COPY = 'The host turned room A/V off.'
+
+const PERMISSION_DENIED_COPY =
+  'Camera/microphone permission was blocked. Check browser or system settings, then try again.'
+
+const DEVICE_UNAVAILABLE_COPY =
+  'No camera or microphone was found, or the device is in use by another app.'
+
+const SFU_PUBLISH_REJECTED_COPY =
+  'Could not publish your camera/microphone. Try again in a moment.'
+
+const SFU_SIGNALING_FAILED_COPY =
+  'Video relay connection lost. Refresh the page or wait for automatic reconnect.'
+
+const PUBLISHER_CAP_COPY =
+  'This room has reached the maximum number of live cameras and microphones. Wait for someone to turn off A/V or ask the host.'
+
+const RATE_LIMITED_COPY = 'Too many connection attempts. Wait a moment and try again.'
+
+/** Map controller / relay errors to recoverable inline copy at toggles. */
+export function formatParticipantAvToggleError(error: string | null): string | null {
+  if (!error || error.trim() === '') return null
+  const lower = error.toLowerCase()
+  if (lower.includes('permission') || lower.includes('notallowed')) {
+    return PERMISSION_DENIED_COPY
+  }
+  if (
+    lower.includes('notfound') ||
+    lower.includes('notreadable') ||
+    lower.includes('overconstrained') ||
+    lower.includes('no camera or microphone') ||
+    lower.includes('could not access camera or microphone')
+  ) {
+    return DEVICE_UNAVAILABLE_COPY
+  }
+  if (lower.includes('publisher_cap') || lower.includes('maximum number of live')) {
+    return PUBLISHER_CAP_COPY
+  }
+  if (lower.includes('rate_limited') || lower.includes('too many connection')) {
+    return RATE_LIMITED_COPY
+  }
+  if (lower.includes('relay connection lost') || lower.includes('signaling')) {
+    return SFU_SIGNALING_FAILED_COPY
+  }
+  if (lower.includes('publish') || lower.includes('relay denied') || lower.includes('video relay')) {
+    return SFU_PUBLISH_REJECTED_COPY
+  }
+  return error
+}

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -240,6 +240,7 @@ export type SfuConsumerTrackEvent =
   | {
       action: 'attach'
       producerId: string
+      sessionId?: string
       producerClass: SfuProducerClass | undefined
       kind: 'audio' | 'video'
       track: MediaStreamTrack
@@ -553,6 +554,7 @@ export async function connectSfuUnifiedSession(options: {
       onConsumerTrack?.({
         action: 'attach',
         producerId,
+        sessionId: summary.sessionId,
         producerClass: summary.producerClass,
         kind,
         track,

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -29,6 +29,7 @@ export type ParticipantAvPublishState = {
 
 export type ParticipantAvController = {
   getState: () => ParticipantAvPublishState
+  getLocalPreviewStream: () => MediaStream | null
   subscribe: (listener: () => void) => () => void
   refreshPublishGate: () => void
   attachSession: (session: SfuUnifiedSessionHandle | null) => void
@@ -146,6 +147,11 @@ export function createParticipantAvController(options: {
 
   return {
     getState,
+    getLocalPreviewStream: () => {
+      if (!cameraEnabled || !localStream) return null
+      if (localStream.getVideoTracks().length === 0) return null
+      return localStream
+    },
     subscribe: (listener) => {
       listeners.add(listener)
       return () => listeners.delete(listener)

--- a/apps/web/src/room/stage/ParticipantVideoTile.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+import type { StageParticipantTile } from './stageParticipantTiles'
+
+type ParticipantVideoTileProps = {
+  tile: StageParticipantTile
+}
+
+export function ParticipantVideoTile({ tile }: ParticipantVideoTileProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+
+  useEffect(() => {
+    const el = videoRef.current
+    if (!el) return
+    el.srcObject = tile.stream
+    void el.play().catch(() => undefined)
+    return () => {
+      el.srcObject = null
+    }
+  }, [tile.stream])
+
+  return (
+    <figure
+      className={`riffsync-room-page__participant-tile${tile.isSelf ? ' riffsync-room-page__participant-tile--self' : ''}`}
+    >
+      <video
+        ref={videoRef}
+        className="riffsync-room-page__participant-tile-video"
+        playsInline
+        muted
+        autoPlay
+      />
+      <figcaption className="riffsync-room-page__participant-tile-label">{tile.label}</figcaption>
+    </figure>
+  )
+}

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { StageParticipantLayout } from './StageParticipantLayout'
+import { VIDEO_CHAT_EMPTY_COPY } from './stageParticipantTiles'
+
+describe('StageParticipantLayout', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderLayout(
+    overrides: Partial<Parameters<typeof StageParticipantLayout>[0]> = {},
+  ) {
+    act(() => {
+      root.render(
+        <StageParticipantLayout
+          roomMode="theater"
+          tiles={[]}
+          layoutUpdating={false}
+          viewportWide
+          avSurfacesEnabled
+          playback={<div className="playback-fixture">Movie</div>}
+          {...overrides}
+        />,
+      )
+    })
+  }
+
+  it('renders theater playback on theater mode', () => {
+    renderLayout({ roomMode: 'theater' })
+    expect(container.querySelector('.playback-fixture')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__stage-media--theater')).not.toBeNull()
+  })
+
+  it('shows video chat empty copy when grid has no tiles', () => {
+    renderLayout({ roomMode: 'videoChat', viewportWide: true })
+    expect(container.textContent).toContain(VIDEO_CHAT_EMPTY_COPY)
+    expect(container.querySelector('.playback-fixture')).toBeNull()
+  })
+
+  it('shows layout updating status while transitioning', () => {
+    renderLayout({ layoutUpdating: true })
+    expect(container.textContent).toContain('Updating room layout')
+  })
+
+  it('renders self tile in desktop theater strip', () => {
+    const stream = new MediaStream()
+    renderLayout({
+      roomMode: 'theater',
+      viewportWide: true,
+      tiles: [
+        {
+          key: 'self',
+          sessionId: 'me',
+          label: 'You',
+          isSelf: true,
+          stream,
+        },
+      ],
+    })
+    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).not.toBeNull()
+    expect(container.textContent).toContain('You')
+  })
+
+  it('renders narrow horizontal row below primary on small viewport', () => {
+    const stream = new MediaStream()
+    renderLayout({
+      roomMode: 'theater',
+      viewportWide: false,
+      tiles: [
+        {
+          key: 'self',
+          sessionId: 'me',
+          label: 'You',
+          isSelf: true,
+          stream,
+        },
+      ],
+    })
+    expect(container.querySelector('.riffsync-room-page__participant-row--narrow')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
+  })
+})

--- a/apps/web/src/room/stage/StageParticipantLayout.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+import type { RoomMode } from '../../api/roomsApi'
+import { ParticipantVideoTile } from './ParticipantVideoTile'
+import {
+  LAYOUT_UPDATING_COPY,
+  VIDEO_CHAT_EMPTY_COPY,
+  type StageParticipantTile,
+  stageLayoutSurfaceClass,
+} from './stageParticipantTiles'
+
+type StageParticipantLayoutProps = {
+  roomMode: RoomMode
+  tiles: StageParticipantTile[]
+  layoutUpdating: boolean
+  viewportWide: boolean
+  avSurfacesEnabled: boolean
+  playback: ReactNode
+}
+
+export function StageParticipantLayout({
+  roomMode,
+  tiles,
+  layoutUpdating,
+  viewportWide,
+  avSurfacesEnabled,
+  playback,
+}: StageParticipantLayoutProps) {
+  const showDesktopStrip = avSurfacesEnabled && viewportWide && roomMode === 'theater' && tiles.length > 0
+  const showNarrowRow = avSurfacesEnabled && !viewportWide && tiles.length > 0
+  const showVideoChatEmpty =
+    roomMode === 'videoChat' && viewportWide && tiles.length === 0 && !layoutUpdating
+
+  const tileList = (
+    <>
+      {tiles.map((tile) => (
+        <ParticipantVideoTile key={tile.key} tile={tile} />
+      ))}
+    </>
+  )
+
+  return (
+    <div
+      className={`riffsync-room-page__stage-media ${stageLayoutSurfaceClass(roomMode)}${layoutUpdating ? ' riffsync-room-page__stage-media--updating' : ''}`}
+      data-room-mode={roomMode}
+    >
+      {layoutUpdating ? (
+        <p className="riffsync-room-page__stage-layout-status" role="status">
+          {LAYOUT_UPDATING_COPY}
+        </p>
+      ) : null}
+      <div className="riffsync-room-page__stage-primary-wrap">
+        {roomMode === 'theater' ? (
+          <div className="riffsync-room-page__theater-row">
+            <div className="riffsync-room-page__theater-playback">{playback}</div>
+            {showDesktopStrip ? (
+              <div
+                className="riffsync-room-page__participant-strip riffsync-room-page__participant-strip--desktop"
+                aria-label="Participant cameras"
+              >
+                {tileList}
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div
+            className="riffsync-room-page__participant-grid"
+            aria-label="Participant cameras"
+          >
+            {showVideoChatEmpty ? (
+              <p className="riffsync-room-page__participant-grid-empty" role="status">
+                {VIDEO_CHAT_EMPTY_COPY}
+              </p>
+            ) : (
+              tileList
+            )}
+          </div>
+        )}
+      </div>
+      {showNarrowRow ? (
+        <div
+          className="riffsync-room-page__participant-row riffsync-room-page__participant-row--narrow"
+          aria-label="Participant cameras"
+        >
+          {tileList}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/room/stage/participantAvConsumers.test.ts
+++ b/apps/web/src/room/stage/participantAvConsumers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { applyParticipantAvConsumerEvent } from './participantAvConsumers'
+
+describe('participantAvConsumers', () => {
+  it('tracks participant_av video attach events', () => {
+    const track = { kind: 'video' } as MediaStreamTrack
+    const next = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p1',
+      sessionId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+      track,
+    })
+    expect(next.get('p1')?.sessionId).toBe('fan-1')
+    expect(next.get('p1')?.track).toBe(track)
+  })
+
+  it('ignores host_screen and audio attach events', () => {
+    const track = { kind: 'audio' } as MediaStreamTrack
+    const next = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p1',
+      producerClass: 'host_screen',
+      kind: 'video',
+      track,
+    })
+    expect(next.size).toBe(0)
+    const next2 = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p2',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track,
+    })
+    expect(next2.size).toBe(0)
+  })
+
+  it('removes producer on detach', () => {
+    const track = { kind: 'video' } as MediaStreamTrack
+    const seeded = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p1',
+      sessionId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+      track,
+    })
+    const next = applyParticipantAvConsumerEvent(seeded, {
+      action: 'detach',
+      producerId: 'p1',
+    })
+    expect(next.size).toBe(0)
+  })
+})

--- a/apps/web/src/room/stage/participantAvConsumers.ts
+++ b/apps/web/src/room/stage/participantAvConsumers.ts
@@ -1,0 +1,29 @@
+import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
+
+export type ParticipantAvVideoConsumer = {
+  producerId: string
+  sessionId: string | undefined
+  track: MediaStreamTrack
+}
+
+export function applyParticipantAvConsumerEvent(
+  state: Map<string, ParticipantAvVideoConsumer>,
+  event: SfuConsumerTrackEvent,
+): Map<string, ParticipantAvVideoConsumer> {
+  if (event.action === 'detach') {
+    if (!state.has(event.producerId)) return state
+    const next = new Map(state)
+    next.delete(event.producerId)
+    return next
+  }
+  if (event.producerClass !== 'participant_av' || event.kind !== 'video') {
+    return state
+  }
+  const next = new Map(state)
+  next.set(event.producerId, {
+    producerId: event.producerId,
+    sessionId: event.sessionId,
+    track: event.track,
+  })
+  return next
+}

--- a/apps/web/src/room/stage/stageParticipantTiles.test.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import type { ParticipantAvVideoConsumer } from './participantAvConsumers'
+import {
+  VIDEO_CHAT_EMPTY_COPY,
+  buildStageParticipantTiles,
+  sortRosterForStage,
+  stageLayoutSurfaceClass,
+  stageLayoutUsesDesktopStrip,
+  stageLayoutUsesNarrowRow,
+} from './stageParticipantTiles'
+
+function consumer(
+  producerId: string,
+  sessionId: string,
+): ParticipantAvVideoConsumer {
+  return {
+    producerId,
+    sessionId,
+    track: { kind: 'video' } as MediaStreamTrack,
+  }
+}
+
+describe('stageParticipantTiles', () => {
+  const roster = [
+    { sessionId: 'host-1', displayName: 'Host', isHost: true },
+    { sessionId: 'fan-a', displayName: 'Alice', isHost: false },
+    { sessionId: 'fan-b', displayName: 'Bob', isHost: false },
+  ]
+
+  it('orders roster with host first then display name', () => {
+    const shuffled = [roster[2], roster[1], roster[0]]
+    const sorted = sortRosterForStage(shuffled)
+    expect(sorted.map((m) => m.sessionId)).toEqual(['host-1', 'fan-a', 'fan-b'])
+  })
+
+  it('includes self You tile when local camera is on', () => {
+    const local = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    const tiles = buildStageParticipantTiles({
+      roster,
+      videoConsumers: new Map(),
+      ownSessionId: 'fan-a',
+      localCameraOn: true,
+      localPreviewStream: local,
+    })
+    expect(tiles).toHaveLength(1)
+    expect(tiles[0]?.label).toBe('You')
+    expect(tiles[0]?.isSelf).toBe(true)
+  })
+
+  it('excludes mic-only participants without video consumers', () => {
+    const tiles = buildStageParticipantTiles({
+      roster,
+      videoConsumers: new Map([['p1', consumer('p1', 'fan-b')]]),
+      ownSessionId: 'fan-a',
+      localCameraOn: false,
+      localPreviewStream: null,
+    })
+    expect(tiles.map((t) => t.sessionId)).toEqual(['fan-b'])
+  })
+
+  it('orders tiles by roster join order', () => {
+    const tiles = buildStageParticipantTiles({
+      roster,
+      videoConsumers: new Map([
+        ['p-host', consumer('p-host', 'host-1')],
+        ['p-b', consumer('p-b', 'fan-b')],
+      ]),
+      ownSessionId: 'fan-a',
+      localCameraOn: false,
+      localPreviewStream: null,
+    })
+    expect(tiles.map((t) => t.sessionId)).toEqual(['host-1', 'fan-b'])
+  })
+
+  it('exposes video chat empty copy constant', () => {
+    expect(VIDEO_CHAT_EMPTY_COPY).toContain('No cameras on yet')
+    expect(VIDEO_CHAT_EMPTY_COPY).toContain('Mic-only')
+  })
+
+  it('selects layout surface class by room mode', () => {
+    expect(stageLayoutSurfaceClass('theater')).toBe('riffsync-room-page__stage-media--theater')
+    expect(stageLayoutSurfaceClass('videoChat')).toBe('riffsync-room-page__stage-media--video-chat')
+  })
+
+  it('uses narrow row only below desktop breakpoint', () => {
+    expect(stageLayoutUsesNarrowRow(false)).toBe(true)
+    expect(stageLayoutUsesNarrowRow(true)).toBe(false)
+  })
+
+  it('uses desktop strip only in theater with tiles on wide viewport', () => {
+    expect(stageLayoutUsesDesktopStrip(true, 'theater', 2)).toBe(true)
+    expect(stageLayoutUsesDesktopStrip(true, 'videoChat', 2)).toBe(false)
+    expect(stageLayoutUsesDesktopStrip(true, 'theater', 0)).toBe(false)
+    expect(stageLayoutUsesDesktopStrip(false, 'theater', 2)).toBe(false)
+  })
+})

--- a/apps/web/src/room/stage/stageParticipantTiles.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.ts
@@ -1,0 +1,116 @@
+import type { ParticipantAvVideoConsumer } from './participantAvConsumers'
+
+export type RosterMember = {
+  sessionId: string
+  displayName: string
+  isHost: boolean
+}
+
+export type StageParticipantTile = {
+  key: string
+  sessionId: string
+  label: string
+  isSelf: boolean
+  stream: MediaStream
+}
+
+export const VIDEO_CHAT_EMPTY_COPY =
+  'No cameras on yet. Mic-only participants are still audible.'
+
+export const LAYOUT_UPDATING_COPY = 'Updating room layout…'
+
+export function sortRosterForStage(members: RosterMember[]): RosterMember[] {
+  return [...members].sort((a, b) => {
+    if (a.isHost !== b.isHost) return a.isHost ? -1 : 1
+    return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' })
+  })
+}
+
+function videoConsumersBySession(
+  consumers: Iterable<ParticipantAvVideoConsumer>,
+): Map<string, ParticipantAvVideoConsumer> {
+  const bySession = new Map<string, ParticipantAvVideoConsumer>()
+  for (const row of consumers) {
+    const sid = row.sessionId?.trim()
+    if (!sid) continue
+    bySession.set(sid, row)
+  }
+  return bySession
+}
+
+function memberHasVideoOn(opts: {
+  member: RosterMember
+  ownSessionId: string
+  localCameraOn: boolean
+  remoteBySession: Map<string, ParticipantAvVideoConsumer>
+}): boolean {
+  if (opts.member.sessionId === opts.ownSessionId) {
+    return opts.localCameraOn
+  }
+  return opts.remoteBySession.has(opts.member.sessionId)
+}
+
+export function buildStageParticipantTiles(opts: {
+  roster: RosterMember[]
+  videoConsumers: Map<string, ParticipantAvVideoConsumer>
+  ownSessionId: string
+  localCameraOn: boolean
+  localPreviewStream: MediaStream | null
+}): StageParticipantTile[] {
+  const remoteBySession = videoConsumersBySession(opts.videoConsumers.values())
+  const ordered = sortRosterForStage(opts.roster)
+  const tiles: StageParticipantTile[] = []
+
+  for (const member of ordered) {
+    if (
+      !memberHasVideoOn({
+        member,
+        ownSessionId: opts.ownSessionId,
+        localCameraOn: opts.localCameraOn,
+        remoteBySession,
+      })
+    ) {
+      continue
+    }
+
+    const isSelf = member.sessionId === opts.ownSessionId
+    let stream: MediaStream | null = null
+    if (isSelf) {
+      stream = opts.localPreviewStream
+    } else {
+      const remote = remoteBySession.get(member.sessionId)
+      if (remote) {
+        stream = new MediaStream([remote.track])
+      }
+    }
+    if (!stream || stream.getVideoTracks().length === 0) continue
+
+    tiles.push({
+      key: isSelf ? 'self' : member.sessionId,
+      sessionId: member.sessionId,
+      label: isSelf ? 'You' : member.displayName,
+      isSelf,
+      stream,
+    })
+  }
+
+  return tiles
+}
+
+export function stageLayoutSurfaceClass(roomMode: 'theater' | 'videoChat'): string {
+  return roomMode === 'videoChat'
+    ? 'riffsync-room-page__stage-media--video-chat'
+    : 'riffsync-room-page__stage-media--theater'
+}
+
+export function stageLayoutUsesNarrowRow(viewportWide: boolean): boolean {
+  return !viewportWide
+}
+
+export function stageLayoutUsesDesktopStrip(
+  viewportWide: boolean,
+  roomMode: 'theater' | 'videoChat',
+  tileCount: number,
+): boolean {
+  return viewportWide && roomMode === 'theater' && tileCount > 0
+}

--- a/apps/web/src/room/stage/useStageLayoutTransition.ts
+++ b/apps/web/src/room/stage/useStageLayoutTransition.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react'
+import type { RoomMode } from '../../api/roomsApi'
+
+const LAYOUT_STABLE_MS = 400
+const LAYOUT_MAX_MS = 3000
+
+export function useStageLayoutTransition(roomMode: RoomMode, videoTileCount: number): boolean {
+  const [updating, setUpdating] = useState(false)
+  const prevModeRef = useRef(roomMode)
+  const maxTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const stableTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (prevModeRef.current === roomMode) return
+    prevModeRef.current = roomMode
+    setUpdating(true)
+    if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
+    maxTimerRef.current = setTimeout(() => {
+      maxTimerRef.current = null
+      setUpdating(false)
+    }, LAYOUT_MAX_MS)
+    return () => {
+      if (maxTimerRef.current) {
+        clearTimeout(maxTimerRef.current)
+        maxTimerRef.current = null
+      }
+    }
+  }, [roomMode])
+
+  useEffect(() => {
+    if (!updating) return
+    if (stableTimerRef.current) clearTimeout(stableTimerRef.current)
+    stableTimerRef.current = setTimeout(() => {
+      stableTimerRef.current = null
+      setUpdating(false)
+      if (maxTimerRef.current) {
+        clearTimeout(maxTimerRef.current)
+        maxTimerRef.current = null
+      }
+    }, LAYOUT_STABLE_MS)
+    return () => {
+      if (stableTimerRef.current) {
+        clearTimeout(stableTimerRef.current)
+        stableTimerRef.current = null
+      }
+    }
+  }, [updating, videoTileCount, roomMode])
+
+  return updating
+}

--- a/apps/web/src/room/stage/useViewportWide.ts
+++ b/apps/web/src/room/stage/useViewportWide.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+const DESKTOP_STAGE_MQ = '(min-width: 992px)'
+
+export function useViewportWide(): boolean {
+  const [wide, setWide] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return true
+    return window.matchMedia(DESKTOP_STAGE_MQ).matches
+  })
+
+  useEffect(() => {
+    const mq = window.matchMedia(DESKTOP_STAGE_MQ)
+    const onChange = () => setWide(mq.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  return wide
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1345,20 +1345,82 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   overflow: visible;
   min-height: 0;
   flex: 1 1 auto;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  grid-template-columns: minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
 }
 
 .riffsync-room-page__tab-panel--chat .riffsync-room-chat-log {
-  grid-row: 1;
+  flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
-.riffsync-room-page__tab-panel--chat .riffsync-room-chat-compose-holder {
-  grid-row: 2;
+.riffsync-room-page__sidebar-footer {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid rgb(255 255 255 / 0.08);
+  background: rgb(5 8 11 / 0.55);
+}
+
+.riffsync-room-av {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.45rem 0.5rem 0.35rem;
+}
+
+.riffsync-room-av__kill-switch {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: rgb(255 255 255 / 0.72);
+}
+
+.riffsync-room-av__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.riffsync-room-av-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  flex: 1 1 calc(50% - 0.2rem);
+  min-width: 0;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.riffsync-room-av-toggle--on {
+  color: var(--primary-color);
+  border-color: rgb(255 255 255 / 0.28);
+  background: rgb(255 255 255 / 0.12);
+}
+
+.riffsync-room-av-toggle[aria-disabled='true'] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.riffsync-room-av-toggle__icon {
+  flex-shrink: 0;
+}
+
+.riffsync-room-av-toggle__label {
+  white-space: nowrap;
+}
+
+.riffsync-room-av__err {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: #ffb4b4;
 }
 
 .riffsync-room-page__room-panel {
@@ -1416,8 +1478,8 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   align-items: stretch;
   gap: 0.35rem;
   padding: 0.5rem;
-  border-top: 1px solid rgb(255 255 255 / 0.08);
-  background: rgb(5 8 11 / 0.55);
+  border-top: none;
+  background: transparent;
 }
 
 .riffsync-room-chat-compose-holder {

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -732,6 +732,64 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   }
 }
 
+.riffsync-room-page__host-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  margin-top: 0.65rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid rgb(255 255 255 / 0.08);
+  background: rgb(7 10 14 / 0.72);
+}
+
+.riffsync-room-page__host-bar-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.riffsync-room-page__host-bar-mode {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.75rem;
+  padding: 0.4rem 0.65rem;
+}
+
+.riffsync-room-page__host-bar-mode--on {
+  color: var(--primary-color);
+  border-color: rgb(255 255 255 / 0.28);
+  background: rgb(255 255 255 / 0.12);
+}
+
+.riffsync-room-page__host-bar-mode[aria-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.riffsync-room-page__host-bar-kill {
+  flex: 0 1 auto;
+  font-size: 0.75rem;
+  padding: 0.4rem 0.75rem;
+  margin-left: auto;
+}
+
+.riffsync-room-page__host-bar-kill--on {
+  color: #ffb4b4;
+  border-color: rgb(255 120 120 / 0.45);
+  background: rgb(120 30 30 / 0.35);
+}
+
+.riffsync-room-page__host-bar-err {
+  flex: 1 1 100%;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ffb4b4;
+}
+
 .riffsync-room-page__theater {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -798,6 +798,166 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   overflow: hidden;
 }
 
+.riffsync-room-page__stage-media {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  gap: 0.5rem;
+}
+
+.riffsync-room-page__stage-layout-status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgb(255 255 255 / 0.82);
+}
+
+.riffsync-room-page__stage-primary-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .riffsync-room-page__stage-media--updating .riffsync-room-page__stage-primary-wrap {
+    transition: opacity 200ms ease;
+  }
+}
+
+.riffsync-room-page__stage-media--updating .riffsync-room-page__stage-primary-wrap {
+  opacity: 0.72;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .riffsync-room-page__stage-media--updating .riffsync-room-page__stage-primary-wrap {
+    opacity: 1;
+  }
+}
+
+.riffsync-room-page__theater-row {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  gap: 0.5rem;
+}
+
+@media (min-width: 992px) {
+  .riffsync-room-page__theater-row {
+    flex-direction: row;
+    align-items: stretch;
+  }
+}
+
+.riffsync-room-page__theater-playback {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.riffsync-room-page__participant-strip--desktop {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .riffsync-room-page__participant-strip--desktop {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 148px;
+    gap: 0.45rem;
+    max-height: 100%;
+    overflow-y: auto;
+    padding-inline: 0.1rem;
+  }
+}
+
+.riffsync-room-page__participant-grid {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.55rem;
+  align-content: start;
+  overflow-y: auto;
+  padding: 0.15rem;
+}
+
+.riffsync-room-page__participant-grid-empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 2rem 1rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgb(255 255 255 / 0.78);
+}
+
+.riffsync-room-page__participant-row--narrow {
+  display: flex;
+  flex-direction: row;
+  gap: 0.45rem;
+  overflow-x: auto;
+  padding-bottom: 0.15rem;
+}
+
+@media (min-width: 992px) {
+  .riffsync-room-page__participant-row--narrow {
+    display: none;
+  }
+}
+
+.riffsync-room-page__participant-tile {
+  position: relative;
+  margin: 0;
+  flex: 0 0 auto;
+  width: min(42vw, 168px);
+  aspect-ratio: 16 / 9;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgb(4 6 10 / 0.88);
+  border: 1px solid rgb(255 255 255 / 0.1);
+}
+
+@media (min-width: 992px) {
+  .riffsync-room-page__participant-strip--desktop .riffsync-room-page__participant-tile {
+    width: 100%;
+  }
+
+  .riffsync-room-page__participant-grid .riffsync-room-page__participant-tile {
+    width: auto;
+  }
+}
+
+.riffsync-room-page__participant-tile-video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #000;
+}
+
+.riffsync-room-page__participant-tile-label {
+  position: absolute;
+  left: 0.35rem;
+  bottom: 0.3rem;
+  margin: 0;
+  padding: 0.12rem 0.4rem;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  border-radius: 4px;
+  background: rgb(0 0 0 / 0.62);
+  color: #fff;
+  max-width: calc(100% - 0.7rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .riffsync-room-page__masthead {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- **#120** — Participant camera/mic toggle chrome above chat compose for signed-in fans on all sidebar tabs, wired to the #117 publish gate with kill-switch disabled state, inline recoverable errors, and `#riffsync-a11y-announcer` local toggle announcements.
- **#121** — Host control bar below the stage: Theater / Video Chat layout selector and **Disable room A/V** kill switch. Host-only PATCH of `roomMode` / `avDisabled` with optimistic UI, inline errors on stale version, WebSocket convergence, and polite announcer copy for mode and kill-switch changes.
- **#122** — Stage participant video layouts: Theater vertical strip and Video Chat grid from `roomMode` and SFU `participant_av` consumers, local **You** preview, narrow-viewport horizontal scroll row, empty states, and layout transition UX per `.ai/interface/presentation.md`.
- Parent branch `feature/issue-105` for M14 watch-party participant AV and stage work.

## Test plan

- [x] `npm ci --prefix apps/web && npm run test --prefix apps/web && npm run lint --prefix apps/web && npm run build --prefix apps/web`
- [ ] Anonymous guest: no host bar, no camera/mic toggles
- [ ] Signed-in fan: Camera/Microphone toggles on every sidebar tab
- [ ] Host: Theater / Video Chat selector and kill switch below stage; Video Chat inert when kill switch on
- [ ] Host PATCH stale version: inline error, local state rolls back
- [ ] Guest tab receives layout / kill-switch updates via WebSocket
- [ ] Theater strip / Video Chat grid follow presentation placement; local **You** tile when camera on
- [ ] Narrow viewport: horizontal participant row below primary region
- [ ] Video Chat with zero cameras: empty state copy visible
- [ ] Keyboard: Tab reaches host bar and participant toggles; Enter/Space activates when enabled

Closes #120
Closes #121
Closes #122