### PR TITLE
feat(room): M14 participant A/V and accessibility (#106)

### DIFF
--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -76,6 +76,8 @@ SPA build-time: **`VITE_PUBLIC_WS_URL`**, **`VITE_PUBLIC_API_BASE_URL`**, SFU We
 | --- | --- | --- |
 | **`SFU_MAX_PRODUCERS_PER_SESSION`** | **3** | Max mediasoup producers one signaling session may create (host screen + participant video + participant audio on one tab). |
 | **`SFU_MAX_PRODUCERS_PER_ROOM`** | **24** | Max producers per **`env:roomId`** router (~8 fans × 2 tracks + host screen + headroom). |
+| **`SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION`** | **8** | Max WebRTC transports per signaling session (producer + consumer paths). |
+| **`SFU_MAX_CONSUMERS_PER_SESSION`** | **64** | Max mediasoup consumers per session (theater grid + strip). |
 | **`SFU_ADMIN_SECRET`** | (required prod) | Shared secret for **`POST /admin/teardown-producers`**; also on room **`PATCH`** Lambda env. |
 
 - **SPA feature gate:** No new build flag for participant AV beyond existing **`VITE_WEBRTC_USE_MEDIASOU_SFU`** (#104 gates UI on snapshot + JWT).

--- a/apps/web/src/api/webrtcSfuApi.ts
+++ b/apps/web/src/api/webrtcSfuApi.ts
@@ -1,3 +1,7 @@
+import {
+  parseSfuTokenHttpErrorPayload,
+  SfuTokenHttpError,
+} from '../room/av/participantAvErrors'
 import type { SfuTokenResponse } from '../room/sfu/mediasoupSharing'
 
 function requireApiBase(apiBase: string | undefined): string {
@@ -33,19 +37,7 @@ export async function fetchSfuJoinToken(options: {
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
-    let detail = text || res.statusText
-    try {
-      const j = JSON.parse(text) as { error?: unknown; detail?: unknown }
-      if (typeof j.error === 'string') {
-        detail =
-          typeof j.detail === 'string' && j.detail.trim() !== ''
-            ? `${j.error} (${j.detail})`
-            : j.error
-      }
-    } catch {
-      /* keep raw body */
-    }
-    throw new Error(`sfu-token ${res.status}: ${detail}`)
+    throw new SfuTokenHttpError(res.status, parseSfuTokenHttpErrorPayload(text || res.statusText))
   }
   return (await res.json()) as SfuTokenResponse
 }

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -70,6 +70,7 @@ import {
 import { createChatMessageId, parseInboundChatMessageId } from '../room/chatMessageId'
 import { isContinuedChatLine } from '../room/chatMessageGrouping'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
+import { participantAvErrorFromSfuMediaCode } from '../room/av/participantAvErrors'
 import { ParticipantAvToggles } from '../room/ParticipantAvToggles'
 import { HostControlBar } from '../room/HostControlBar'
 import {
@@ -1112,8 +1113,17 @@ export function RoomPage() {
       },
       onMissingWsUrl: () => setSfuRoomErr(SFU_RELAY_URL_MISSING_MSG),
       onTokenError: (msg) => setSfuRoomErr(msg),
-      onMediaError: (_code, msg) => setSfuRoomErr(msg),
-      onConnecting: () => setSfuRoomErr(null),
+      onMediaError: (code, msg) => {
+        if (participantAvController.getState().needsProducerToken) {
+          participantAvController.failPublish(participantAvErrorFromSfuMediaCode(code))
+          return
+        }
+        setSfuRoomErr(msg)
+      },
+      onConnecting: () => {
+        setSfuRoomErr(null)
+        participantAvController.clearError()
+      },
     })
     return () => {
       participantAvController.teardownPublishing()
@@ -1967,7 +1977,6 @@ export function RoomPage() {
                   <ParticipantAvToggles
                     controller={participantAvController}
                     avDisabled={avDisabled}
-                    sfuRoomErr={sfuRoomErr}
                     onLocalToggleAnnounce={announceRoomA11y}
                   />
                 ) : null}

--- a/apps/web/src/room/HostControlBar.test.tsx
+++ b/apps/web/src/room/HostControlBar.test.tsx
@@ -76,4 +76,12 @@ describe('HostControlBar', () => {
     const kill = container.querySelector('.riffsync-room-page__host-bar-kill') as HTMLButtonElement
     expect(kill.getAttribute('aria-pressed')).toBe('true')
   })
+
+  it('exposes room mode radio selection to assistive tech', () => {
+    renderBar({ roomMode: 'videoChat' })
+    const modeButtons = container.querySelectorAll('button.riffsync-room-page__host-bar-mode')
+    expect(modeButtons[0]?.getAttribute('aria-checked')).toBe('false')
+    expect(modeButtons[1]?.getAttribute('aria-checked')).toBe('true')
+    expect(container.querySelector('[role="radiogroup"]')).not.toBeNull()
+  })
 })

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -115,6 +115,96 @@ describe('ParticipantAvToggles', () => {
     expect(camera.getAttribute('aria-describedby')).toContain(err?.id ?? '')
   })
 
+  it('announces local camera toggle via callback', () => {
+    const onLocalToggleAnnounce = vi.fn()
+    const controller = {
+      getState: () => ({
+        cameraEnabled: true,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: false,
+        error: null,
+        busy: false,
+      }),
+      subscribe: () => () => undefined,
+      getLocalPreviewStream: () => null,
+      refreshPublishGate: vi.fn(),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      teardownPublishing: vi.fn(),
+      enableCamera: vi.fn(),
+      disableCamera: vi.fn(),
+      enableMic: vi.fn(),
+      disableMic: vi.fn(),
+      toggleMicMute: vi.fn(),
+      failPublish: vi.fn(),
+      clearError: vi.fn(),
+    }
+    act(() => {
+      root.render(
+        <ParticipantAvToggles
+          controller={controller}
+          avDisabled={false}
+          onLocalToggleAnnounce={onLocalToggleAnnounce}
+        />,
+      )
+    })
+    const camera = container.querySelector('button.riffsync-room-av-toggle') as HTMLButtonElement
+    act(() => {
+      camera.click()
+    })
+    expect(onLocalToggleAnnounce).toHaveBeenCalledWith('Camera off')
+    expect(controller.disableCamera).toHaveBeenCalled()
+  })
+
+  it('announces local microphone toggle via callback', async () => {
+    const onLocalToggleAnnounce = vi.fn()
+    let micEnabled = false
+    const controller = {
+      getState: () => ({
+        cameraEnabled: false,
+        micEnabled,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: false,
+        error: null,
+        busy: false,
+      }),
+      subscribe: () => () => undefined,
+      getLocalPreviewStream: () => null,
+      refreshPublishGate: vi.fn(),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      teardownPublishing: vi.fn(),
+      enableCamera: vi.fn(),
+      disableCamera: vi.fn(),
+      enableMic: vi.fn(async () => {
+        micEnabled = true
+      }),
+      disableMic: vi.fn(),
+      toggleMicMute: vi.fn(),
+      failPublish: vi.fn(),
+      clearError: vi.fn(),
+    }
+    act(() => {
+      root.render(
+        <ParticipantAvToggles
+          controller={controller}
+          avDisabled={false}
+          onLocalToggleAnnounce={onLocalToggleAnnounce}
+        />,
+      )
+    })
+    const buttons = container.querySelectorAll('button.riffsync-room-av-toggle')
+    const mic = buttons[1] as HTMLButtonElement
+    await act(async () => {
+      mic.click()
+      await Promise.resolve()
+    })
+    expect(onLocalToggleAnnounce).toHaveBeenCalledWith('Microphone on')
+  })
+
   it('reflects aria-pressed for local camera and microphone state', () => {
     const controller = {
       getState: () => ({

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -24,7 +24,6 @@ describe('ParticipantAvToggles', () => {
   function renderToggles(opts: {
     avDisabled?: boolean
     canPublish?: boolean
-    sfuRoomErr?: string | null
   } = {}) {
     const controller = createParticipantAvController({
       canPublish: () => opts.canPublish ?? true,
@@ -34,7 +33,6 @@ describe('ParticipantAvToggles', () => {
         <ParticipantAvToggles
           controller={controller}
           avDisabled={opts.avDisabled ?? false}
-          sfuRoomErr={opts.sfuRoomErr ?? null}
           onLocalToggleAnnounce={vi.fn()}
         />,
       )
@@ -57,7 +55,6 @@ describe('ParticipantAvToggles', () => {
           <ParticipantAvToggles
             controller={createParticipantAvController({ canPublish: () => false })}
             avDisabled={false}
-            sfuRoomErr={null}
             onLocalToggleAnnounce={vi.fn()}
           />
         ) : null,
@@ -75,6 +72,47 @@ describe('ParticipantAvToggles', () => {
     ) as HTMLButtonElement
     expect(camera.getAttribute('aria-disabled')).toBe('true')
     expect(camera.getAttribute('aria-describedby')).toBe(killSwitch?.id)
+  })
+
+  it('shows inline error copy with aria-describedby on toggles', () => {
+    const controller = {
+      getState: () => ({
+        cameraEnabled: false,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: false,
+        error: 'publisher_cap_exceeded' as const,
+        busy: false,
+      }),
+      subscribe: () => () => undefined,
+      getLocalPreviewStream: () => null,
+      refreshPublishGate: vi.fn(),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      teardownPublishing: vi.fn(),
+      enableCamera: vi.fn(),
+      disableCamera: vi.fn(),
+      enableMic: vi.fn(),
+      disableMic: vi.fn(),
+      toggleMicMute: vi.fn(),
+      failPublish: vi.fn(),
+      clearError: vi.fn(),
+    }
+    act(() => {
+      root.render(
+        <ParticipantAvToggles
+          controller={controller}
+          avDisabled={false}
+          onLocalToggleAnnounce={vi.fn()}
+        />,
+      )
+    })
+    const err = container.querySelector('.riffsync-room-av__err')
+    expect(err?.getAttribute('role')).toBe('status')
+    expect(err?.textContent).toContain('maximum number of live')
+    const camera = container.querySelector('button.riffsync-room-av-toggle') as HTMLButtonElement
+    expect(camera.getAttribute('aria-describedby')).toContain(err?.id ?? '')
   })
 
   it('reflects aria-pressed for local camera and microphone state', () => {
@@ -99,13 +137,14 @@ describe('ParticipantAvToggles', () => {
       enableMic: vi.fn(),
       disableMic: vi.fn(),
       toggleMicMute: vi.fn(),
+      failPublish: vi.fn(),
+      clearError: vi.fn(),
     }
     act(() => {
       root.render(
         <ParticipantAvToggles
           controller={controller}
           avDisabled={false}
-          sfuRoomErr={null}
           onLocalToggleAnnounce={vi.fn()}
         />,
       )

--- a/apps/web/src/room/ParticipantAvToggles.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.tsx
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useId, useState } from 'react'
 import type { ParticipantAvController } from './sfu/participantAvSession'
 import {
-  formatParticipantAvToggleError,
   PARTICIPANT_AV_DISABLED_COPY,
+  participantAvErrorMessage,
 } from './participantAvErrorCopy'
 
 export type ParticipantAvTogglesProps = {
   controller: ParticipantAvController
   avDisabled: boolean
-  /** Top-of-page SFU banner text; surfaced inline when publish is blocked. */
-  sfuRoomErr: string | null
   onLocalToggleAnnounce: (message: string) => void
 }
 
@@ -52,7 +50,6 @@ function MicrophoneIcon() {
 export function ParticipantAvToggles({
   controller,
   avDisabled,
-  sfuRoomErr,
   onLocalToggleAnnounce,
 }: ParticipantAvTogglesProps) {
   const killSwitchId = useId()
@@ -65,10 +62,9 @@ export function ParticipantAvToggles({
   const killSwitchActive = avDisabled
   const activationBlocked = killSwitchActive || !state.canPublish || state.busy
 
-  const relayErr =
-    state.needsProducerToken && sfuRoomErr ? formatParticipantAvToggleError(sfuRoomErr) : null
-  const cameraErr = formatParticipantAvToggleError(state.error)
-  const micErr = relayErr ?? cameraErr
+  const inlineErr = state.error ? participantAvErrorMessage(state.error) : null
+  const cameraErr = inlineErr
+  const micErr = inlineErr
 
   const cameraDescribedBy = [
     killSwitchActive ? killSwitchId : null,

--- a/apps/web/src/room/av/participantAvErrors.test.ts
+++ b/apps/web/src/room/av/participantAvErrors.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isParticipantAvTokenHardFail,
+  participantAvErrorFromDomException,
+  participantAvErrorFromSfuMediaCode,
+  participantAvErrorFromSfuSessionEnd,
+  participantAvErrorFromSfuTokenDenial,
+  participantAvErrorMessage,
+  parseSfuTokenHttpErrorPayload,
+} from './participantAvErrors'
+
+describe('participantAvErrorMessage', () => {
+  it('returns contract copy for every taxonomy code', () => {
+    expect(participantAvErrorMessage('permission_denied')).toContain('permission was blocked')
+    expect(participantAvErrorMessage('publisher_cap_exceeded')).toContain('maximum number of live')
+    expect(participantAvErrorMessage('token_expired')).toContain('connection expired')
+    expect(participantAvErrorMessage('sfu_signaling_failed')).toContain('Video relay connection lost')
+  })
+})
+
+describe('participantAvErrorFromDomException', () => {
+  it('maps NotAllowedError to permission_denied', () => {
+    expect(
+      participantAvErrorFromDomException(new DOMException('denied', 'NotAllowedError')),
+    ).toBe('permission_denied')
+  })
+
+  it('maps NotFoundError to device_unavailable', () => {
+    expect(
+      participantAvErrorFromDomException(new DOMException('missing', 'NotFoundError')),
+    ).toBe('device_unavailable')
+  })
+
+  it('maps NotReadableError and OverconstrainedError to device_unavailable', () => {
+    expect(
+      participantAvErrorFromDomException(new DOMException('busy', 'NotReadableError')),
+    ).toBe('device_unavailable')
+    expect(
+      participantAvErrorFromDomException(new DOMException('bad', 'OverconstrainedError')),
+    ).toBe('device_unavailable')
+  })
+})
+
+describe('participantAvErrorFromSfuTokenDenial', () => {
+  it('maps API denial codes to participant taxonomy', () => {
+    expect(participantAvErrorFromSfuTokenDenial(403, 'publisher_cap_exceeded')).toBe(
+      'publisher_cap_exceeded',
+    )
+    expect(participantAvErrorFromSfuTokenDenial(403, 'av_disabled')).toBe('av_disabled')
+    expect(participantAvErrorFromSfuTokenDenial(403, 'fan_auth_required')).toBe('fan_auth_required')
+    expect(participantAvErrorFromSfuTokenDenial(429, 'rate_limited')).toBe('rate_limited')
+    expect(participantAvErrorFromSfuTokenDenial(429, undefined)).toBe('rate_limited')
+  })
+
+  it('returns null for unmapped token codes', () => {
+    expect(participantAvErrorFromSfuTokenDenial(403, 'unknown_session')).toBeNull()
+  })
+})
+
+describe('isParticipantAvTokenHardFail', () => {
+  it('flags capacity and auth denials as hard-fail', () => {
+    expect(isParticipantAvTokenHardFail('publisher_cap_exceeded')).toBe(true)
+    expect(isParticipantAvTokenHardFail('av_disabled')).toBe(true)
+    expect(isParticipantAvTokenHardFail('unknown_session')).toBe(false)
+  })
+})
+
+describe('participantAvErrorFromSfuMediaCode', () => {
+  it('maps signaling failures to sfu_signaling_failed', () => {
+    expect(participantAvErrorFromSfuMediaCode('signaling_failed')).toBe('sfu_signaling_failed')
+    expect(participantAvErrorFromSfuMediaCode('signaling_closed')).toBe('sfu_signaling_failed')
+  })
+
+  it('maps produce failures to sfu_publish_rejected', () => {
+    expect(participantAvErrorFromSfuMediaCode('produce_failed')).toBe('sfu_publish_rejected')
+  })
+})
+
+describe('participantAvErrorFromSfuSessionEnd', () => {
+  it('returns sfu_signaling_failed after reconnect exhaustion with publish intent', () => {
+    expect(
+      participantAvErrorFromSfuSessionEnd('signaling_close', {
+        hadPublishIntent: true,
+        reconnectAttempts: 5,
+      }),
+    ).toBe('sfu_signaling_failed')
+  })
+
+  it('returns null while reconnect attempts remain', () => {
+    expect(
+      participantAvErrorFromSfuSessionEnd('signaling_close', {
+        hadPublishIntent: true,
+        reconnectAttempts: 2,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('parseSfuTokenHttpErrorPayload', () => {
+  it('parses code and error from JSON body', () => {
+    expect(
+      parseSfuTokenHttpErrorPayload(
+        JSON.stringify({
+          code: 'publisher_cap_exceeded',
+          error: 'This room has reached the maximum number of live cameras and microphones.',
+        }),
+      ),
+    ).toEqual({
+      code: 'publisher_cap_exceeded',
+      error: 'This room has reached the maximum number of live cameras and microphones.',
+      detail: undefined,
+    })
+  })
+})

--- a/apps/web/src/room/av/participantAvErrors.ts
+++ b/apps/web/src/room/av/participantAvErrors.ts
@@ -1,0 +1,172 @@
+import type { SfuMediaErrorCode } from '../sfu/mediasoupSharing'
+import type { SfuSessionEndReason } from '../sfu/mediasoupSharing'
+
+/** Stable client codes (`.ai/business_logic/error_state.md`). */
+export type ParticipantAvErrorCode =
+  | 'permission_denied'
+  | 'device_unavailable'
+  | 'av_disabled'
+  | 'publisher_cap_exceeded'
+  | 'rate_limited'
+  | 'fan_auth_required'
+  | 'sfu_publish_rejected'
+  | 'token_expired'
+  | 'sfu_signaling_failed'
+
+/** `POST /v1/webrtc/sfu-token` denial `code` values mapped for participant producers. */
+export type SfuTokenDenialCode =
+  | 'av_disabled'
+  | 'fan_auth_required'
+  | 'not_host'
+  | 'unknown_session'
+  | 'publisher_cap_exceeded'
+  | 'rate_limited'
+
+const ERROR_COPY: Record<ParticipantAvErrorCode, string> = {
+  permission_denied:
+    'Camera/microphone permission was blocked. Check browser or system settings, then try again.',
+  device_unavailable:
+    'No camera or microphone was found, or the device is in use by another app.',
+  av_disabled: 'The host turned room A/V off.',
+  publisher_cap_exceeded:
+    'This room has reached the maximum number of live cameras and microphones. Wait for someone to turn off A/V or ask the host.',
+  rate_limited: 'Too many connection attempts. Wait a moment and try again.',
+  fan_auth_required: 'Sign in to use camera and microphone in this room.',
+  sfu_publish_rejected: 'Could not publish your camera/microphone. Try again in a moment.',
+  token_expired: 'Your video relay connection expired. Turn the control off and on again.',
+  sfu_signaling_failed:
+    'Video relay connection lost. Refresh the page or wait for automatic reconnect.',
+}
+
+/** Host AV kill switch copy (same string as `av_disabled`). */
+export const PARTICIPANT_AV_DISABLED_COPY = ERROR_COPY.av_disabled
+
+export function participantAvErrorMessage(code: ParticipantAvErrorCode): string {
+  return ERROR_COPY[code]
+}
+
+const DOM_EXCEPTION_CODES: Record<string, ParticipantAvErrorCode> = {
+  NotAllowedError: 'permission_denied',
+  PermissionDeniedError: 'permission_denied',
+  NotFoundError: 'device_unavailable',
+  NotReadableError: 'device_unavailable',
+  OverconstrainedError: 'device_unavailable',
+  AbortError: 'device_unavailable',
+}
+
+export function participantAvErrorFromDomException(error: unknown): ParticipantAvErrorCode {
+  if (error instanceof DOMException && error.name in DOM_EXCEPTION_CODES) {
+    return DOM_EXCEPTION_CODES[error.name]!
+  }
+  if (error instanceof Error) {
+    const lower = error.message.toLowerCase()
+    if (lower.includes('permission') || lower.includes('notallowed')) {
+      return 'permission_denied'
+    }
+    if (
+      lower.includes('notfound') ||
+      lower.includes('notreadable') ||
+      lower.includes('overconstrained') ||
+      lower.includes('no camera or microphone') ||
+      lower.includes('could not access camera or microphone')
+    ) {
+      return 'device_unavailable'
+    }
+  }
+  return 'permission_denied'
+}
+
+const TOKEN_DENIAL_TO_AV: Partial<Record<SfuTokenDenialCode, ParticipantAvErrorCode>> = {
+  av_disabled: 'av_disabled',
+  fan_auth_required: 'fan_auth_required',
+  publisher_cap_exceeded: 'publisher_cap_exceeded',
+  rate_limited: 'rate_limited',
+}
+
+export function participantAvErrorFromSfuTokenDenial(
+  status: number,
+  code: string | undefined,
+): ParticipantAvErrorCode | null {
+  if (code && code in TOKEN_DENIAL_TO_AV) {
+    return TOKEN_DENIAL_TO_AV[code as SfuTokenDenialCode] ?? null
+  }
+  if (status === 429) return 'rate_limited'
+  return null
+}
+
+/** Token denials that should hard-fail participant publish (toggle off, no auto-retry). */
+export function isParticipantAvTokenHardFail(code: string | undefined): boolean {
+  return (
+    code === 'publisher_cap_exceeded' ||
+    code === 'av_disabled' ||
+    code === 'fan_auth_required' ||
+    code === 'rate_limited'
+  )
+}
+
+export function participantAvErrorFromSfuMediaCode(code: SfuMediaErrorCode): ParticipantAvErrorCode {
+  if (code === 'signaling_failed' || code === 'signaling_closed') {
+    return 'sfu_signaling_failed'
+  }
+  return 'sfu_publish_rejected'
+}
+
+const SFU_SIGNALING_EXHAUSTED_ATTEMPTS = 5
+
+export function participantAvErrorFromSfuSessionEnd(
+  reason: SfuSessionEndReason,
+  opts: { hadPublishIntent: boolean; reconnectAttempts: number },
+): ParticipantAvErrorCode | null {
+  if (!opts.hadPublishIntent) return null
+  if (reason === 'user_close') return null
+  const lowerReason = String(reason).toLowerCase()
+  if (lowerReason.includes('expired') || lowerReason.includes('jwt')) {
+    return 'token_expired'
+  }
+  if (opts.reconnectAttempts >= SFU_SIGNALING_EXHAUSTED_ATTEMPTS) {
+    return 'sfu_signaling_failed'
+  }
+  if (
+    reason === 'signaling_close' ||
+    reason === 'transport_failed' ||
+    reason === 'transport_disconnected_timeout'
+  ) {
+    return null
+  }
+  return null
+}
+
+export function parseSfuTokenHttpErrorPayload(text: string): {
+  code?: string
+  error?: string
+  detail?: string
+} {
+  try {
+    const j = JSON.parse(text) as { code?: unknown; error?: unknown; detail?: unknown }
+    return {
+      code: typeof j.code === 'string' ? j.code : undefined,
+      error: typeof j.error === 'string' ? j.error : undefined,
+      detail: typeof j.detail === 'string' ? j.detail : undefined,
+    }
+  } catch {
+    return {}
+  }
+}
+
+export class SfuTokenHttpError extends Error {
+  readonly status: number
+  readonly code?: string
+  readonly apiError?: string
+
+  constructor(status: number, body: { code?: string; error?: string; detail?: string }) {
+    const apiError =
+      body.error && body.detail?.trim()
+        ? `${body.error} (${body.detail})`
+        : body.error
+    super(`sfu-token ${status}: ${apiError ?? 'request failed'}`)
+    this.name = 'SfuTokenHttpError'
+    this.status = status
+    this.code = body.code
+    this.apiError = body.error
+  }
+}

--- a/apps/web/src/room/hostRoomControls.test.ts
+++ b/apps/web/src/room/hostRoomControls.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  avDisabledAnnounceCopy,
   buildAvDisabledPatch,
   buildRoomModePatch,
   formatHostRoomPatchError,
   mergeRoomPatchResult,
+  roomModeAnnounceCopy,
 } from './hostRoomControls'
 import type { RoomSnapshot } from '../api/roomsApi'
 
@@ -52,5 +54,15 @@ describe('hostRoomControls patch helpers', () => {
     expect(formatHostRoomPatchError(new Error('Update room failed (409): Conflict'))).toContain(
       'Refresh and try again',
     )
+  })
+
+  it('roomModeAnnounceCopy describes layout for live region announcements', () => {
+    expect(roomModeAnnounceCopy('theater')).toBe('Room layout Theater')
+    expect(roomModeAnnounceCopy('videoChat')).toBe('Room layout Video Chat')
+  })
+
+  it('avDisabledAnnounceCopy describes kill switch for live region announcements', () => {
+    expect(avDisabledAnnounceCopy(true)).toBe('Room camera and microphone disabled by host')
+    expect(avDisabledAnnounceCopy(false)).toBe('Room camera and microphone enabled by host')
   })
 })

--- a/apps/web/src/room/participantAvErrorCopy.ts
+++ b/apps/web/src/room/participantAvErrorCopy.ts
@@ -1,50 +1,5 @@
-/** Host AV kill switch copy (`.ai/business_logic/error_state.md`). */
-export const PARTICIPANT_AV_DISABLED_COPY = 'The host turned room A/V off.'
-
-const PERMISSION_DENIED_COPY =
-  'Camera/microphone permission was blocked. Check browser or system settings, then try again.'
-
-const DEVICE_UNAVAILABLE_COPY =
-  'No camera or microphone was found, or the device is in use by another app.'
-
-const SFU_PUBLISH_REJECTED_COPY =
-  'Could not publish your camera/microphone. Try again in a moment.'
-
-const SFU_SIGNALING_FAILED_COPY =
-  'Video relay connection lost. Refresh the page or wait for automatic reconnect.'
-
-const PUBLISHER_CAP_COPY =
-  'This room has reached the maximum number of live cameras and microphones. Wait for someone to turn off A/V or ask the host.'
-
-const RATE_LIMITED_COPY = 'Too many connection attempts. Wait a moment and try again.'
-
-/** Map controller / relay errors to recoverable inline copy at toggles. */
-export function formatParticipantAvToggleError(error: string | null): string | null {
-  if (!error || error.trim() === '') return null
-  const lower = error.toLowerCase()
-  if (lower.includes('permission') || lower.includes('notallowed')) {
-    return PERMISSION_DENIED_COPY
-  }
-  if (
-    lower.includes('notfound') ||
-    lower.includes('notreadable') ||
-    lower.includes('overconstrained') ||
-    lower.includes('no camera or microphone') ||
-    lower.includes('could not access camera or microphone')
-  ) {
-    return DEVICE_UNAVAILABLE_COPY
-  }
-  if (lower.includes('publisher_cap') || lower.includes('maximum number of live')) {
-    return PUBLISHER_CAP_COPY
-  }
-  if (lower.includes('rate_limited') || lower.includes('too many connection')) {
-    return RATE_LIMITED_COPY
-  }
-  if (lower.includes('relay connection lost') || lower.includes('signaling')) {
-    return SFU_SIGNALING_FAILED_COPY
-  }
-  if (lower.includes('publish') || lower.includes('relay denied') || lower.includes('video relay')) {
-    return SFU_PUBLISH_REJECTED_COPY
-  }
-  return error
-}
+export {
+  PARTICIPANT_AV_DISABLED_COPY,
+  participantAvErrorMessage,
+  type ParticipantAvErrorCode,
+} from './av/participantAvErrors'

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -45,6 +45,20 @@ describe('createParticipantAvController', () => {
     })
   })
 
+  it('failPublish turns toggles off and sets stable error code', () => {
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    controller.failPublish('publisher_cap_exceeded')
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: false,
+      micEnabled: false,
+      needsProducerToken: false,
+      error: 'publisher_cap_exceeded',
+      busy: false,
+    })
+  })
+
   it('teardownPublishing clears publish intent for kill switch', () => {
     const controller = createParticipantAvController({
       canPublish: () => true,

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -1,3 +1,8 @@
+import {
+  participantAvErrorFromDomException,
+  participantAvErrorFromSfuMediaCode,
+  type ParticipantAvErrorCode,
+} from '../av/participantAvErrors'
 import type { SfuUnifiedSessionHandle } from './mediasoupSharing'
 
 export const PARTICIPANT_AV_MEDIA_CONSTRAINTS: MediaStreamConstraints = {
@@ -23,7 +28,7 @@ export type ParticipantAvPublishState = {
   micMuted: boolean
   canPublish: boolean
   needsProducerToken: boolean
-  error: string | null
+  error: ParticipantAvErrorCode | null
   busy: boolean
 }
 
@@ -41,6 +46,9 @@ export type ParticipantAvController = {
   enableMic: () => Promise<void>
   disableMic: () => void
   toggleMicMute: () => void
+  /** Hard-fail publish: toggles off, clears tracks, sets stable error code. */
+  failPublish: (code: ParticipantAvErrorCode) => void
+  clearError: () => void
 }
 
 export function createParticipantAvController(options: {
@@ -50,7 +58,7 @@ export function createParticipantAvController(options: {
   let cameraEnabled = false
   let micEnabled = false
   let micMuted = false
-  let error: string | null = null
+  let error: ParticipantAvErrorCode | null = null
   let busy = false
   let localStream: MediaStream | null = null
   let session: SfuUnifiedSessionHandle | null = null
@@ -98,8 +106,14 @@ export function createParticipantAvController(options: {
       } else {
         session.resumeProducerKind('participant_av', 'audio')
       }
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Could not publish camera or microphone.'
+    } catch {
+      cameraEnabled = false
+      micEnabled = false
+      micMuted = false
+      stopLocalTracks()
+      session.unpublishProducerClass('participant_av')
+      options.onNeedsProducerTokenChange?.()
+      error = participantAvErrorFromSfuMediaCode('produce_failed')
       notify()
     }
   }
@@ -194,8 +208,11 @@ export function createParticipantAvController(options: {
       notify()
       try {
         await mergeStream(true, micEnabled)
+        error = null
       } catch (e) {
-        error = e instanceof Error ? e.message : 'Camera permission denied.'
+        cameraEnabled = false
+        if (!micEnabled) stopLocalTracks()
+        error = participantAvErrorFromDomException(e)
         notify()
       } finally {
         busy = false
@@ -230,8 +247,12 @@ export function createParticipantAvController(options: {
       try {
         await mergeStream(cameraEnabled, true)
         micMuted = false
+        error = null
       } catch (e) {
-        error = e instanceof Error ? e.message : 'Microphone permission denied.'
+        micEnabled = false
+        micMuted = false
+        if (!cameraEnabled) stopLocalTracks()
+        error = participantAvErrorFromDomException(e)
         notify()
       } finally {
         busy = false
@@ -267,6 +288,22 @@ export function createParticipantAvController(options: {
       } else {
         session.resumeProducerKind('participant_av', 'audio')
       }
+      notify()
+    },
+    failPublish: (code) => {
+      cameraEnabled = false
+      micEnabled = false
+      micMuted = false
+      busy = false
+      error = code
+      stopLocalTracks()
+      session?.unpublishProducerClass('participant_av')
+      options.onNeedsProducerTokenChange?.()
+      notify()
+    },
+    clearError: () => {
+      if (!error) return
+      error = null
       notify()
     },
   }

--- a/apps/web/src/room/sfu/sfuRoomSession.test.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { SfuTokenHttpError } from '../av/participantAvErrors'
 import {
   formatSfuTokenError,
   isRosterConsistency403,
@@ -7,6 +8,17 @@ import {
 import { createParticipantAvController } from './participantAvSession'
 
 describe('formatSfuTokenError', () => {
+  it('expands structured SfuTokenHttpError copy', () => {
+    const msg = formatSfuTokenError(
+      new SfuTokenHttpError(403, {
+        code: 'publisher_cap_exceeded',
+        error: 'This room has reached the maximum number of live cameras and microphones.',
+      }),
+    )
+    expect(msg).toContain('Video relay denied access.')
+    expect(msg).toContain('maximum number of live')
+  })
+
   it('expands roster-related 403 copy', () => {
     const msg = formatSfuTokenError(
       new Error('sfu-token 403: Open the room WebSocket first (unknown session for this room).'),

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -1,5 +1,11 @@
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import {
+  isParticipantAvTokenHardFail,
+  participantAvErrorFromSfuSessionEnd,
+  participantAvErrorFromSfuTokenDenial,
+  SfuTokenHttpError,
+} from '../av/participantAvErrors'
+import {
   connectSfuUnifiedSession,
   resolveSfuWsBaseForToken,
   type SfuConsumerTrackEvent,
@@ -34,6 +40,12 @@ export type StartSfuRoomSessionOpts = SessionHooks & {
 }
 
 export function formatSfuTokenError(e: unknown): string {
+  if (e instanceof SfuTokenHttpError) {
+    const fromApi = e.apiError?.trim()
+    if (fromApi) {
+      return `Video relay denied access. ${fromApi} If this persists, wait until the room shows connected, refresh, or sign in again.`
+    }
+  }
   const msg = e instanceof Error ? e.message : String(e)
   const m403 = /^sfu-token 403:\s*(.+)$/s.exec(msg)
   if (m403) {
@@ -42,6 +54,19 @@ export function formatSfuTokenError(e: unknown): string {
       return `Video relay denied access. ${fromApi} If this persists, wait until the room shows connected, refresh, or sign in again.`
   }
   return msg
+}
+
+function routeParticipantAvTokenDenial(
+  participantAv: ParticipantAvController,
+  producerClass: SfuProducerClass | undefined,
+  e: unknown,
+): boolean {
+  if (producerClass !== 'participant_av') return false
+  if (!(e instanceof SfuTokenHttpError)) return false
+  const avCode = participantAvErrorFromSfuTokenDenial(e.status, e.code)
+  if (!avCode) return false
+  participantAv.failPublish(avCode)
+  return isParticipantAvTokenHardFail(e.code)
 }
 
 /** Transient: WS is open but Dynamo roster GSI has not caught up yet (`webrtc-sfu-token` 403). */
@@ -142,13 +167,16 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         })
       } catch (e) {
         if (signal.aborted) break
+        const hardFail = routeParticipantAvTokenDenial(participantAv, producerClass, e)
         const rosterRace = isRosterConsistency403(e)
-        if (!rosterRace || attempt >= 4) {
+        if (!hardFail && (!rosterRace || attempt >= 4)) {
           opts.onTokenError(formatSfuTokenError(e))
         }
-        const delayMs = rosterRace
-          ? Math.min(2500, 200 + 350 * Math.max(0, attempt))
-          : nextSfuReconnectDelayMs(attempt)
+        const delayMs = hardFail
+          ? nextSfuReconnectDelayMs(attempt)
+          : rosterRace
+            ? Math.min(2500, 200 + 350 * Math.max(0, attempt))
+            : nextSfuReconnectDelayMs(attempt)
         await sleepBackoffMs(delayMs, signal)
         attempt++
         continue
@@ -203,7 +231,16 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
       assignSession(null)
       opts.onSessionClean?.()
       if (reason === 'user_close' || signal.aborted) break
-      participantAv.resetOnReconnect()
+      const hadPublishIntent = participantAv.getState().needsProducerToken
+      const sessionErr = participantAvErrorFromSfuSessionEnd(reason, {
+        hadPublishIntent,
+        reconnectAttempts: attempt,
+      })
+      if (sessionErr) {
+        participantAv.failPublish(sessionErr)
+      } else {
+        participantAv.resetOnReconnect()
+      }
       await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
     }
   })()

--- a/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ParticipantVideoTile } from './ParticipantVideoTile'
+import type { StageParticipantTile } from './stageParticipantTiles'
+
+describe('ParticipantVideoTile', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderTile(label: string, isSelf: boolean) {
+    const stream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    const tile: StageParticipantTile = {
+      key: isSelf ? 'self' : 'remote-1',
+      sessionId: isSelf ? 'me' : 'remote-1',
+      label,
+      isSelf,
+      stream,
+    }
+    act(() => {
+      root.render(<ParticipantVideoTile tile={tile} />)
+    })
+  }
+
+  it('exposes per-tile accessible name for local You tile', () => {
+    renderTile('You', true)
+    const figure = container.querySelector('figure.riffsync-room-page__participant-tile')
+    expect(figure?.getAttribute('aria-label')).toBe('You')
+    expect(figure?.textContent).toContain('You')
+  })
+
+  it('exposes per-tile accessible name for remote display name', () => {
+    renderTile('Alice', false)
+    const figure = container.querySelector('figure.riffsync-room-page__participant-tile')
+    expect(figure?.getAttribute('aria-label')).toBe('Alice')
+    expect(figure?.textContent).toContain('Alice')
+  })
+})

--- a/apps/web/src/room/stage/ParticipantVideoTile.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.tsx
@@ -21,6 +21,7 @@ export function ParticipantVideoTile({ tile }: ParticipantVideoTileProps) {
   return (
     <figure
       className={`riffsync-room-page__participant-tile${tile.isSelf ? ' riffsync-room-page__participant-tile--self' : ''}`}
+      aria-label={tile.label}
     >
       <video
         ref={videoRef}

--- a/docs/sfu-deploy-checklist.md
+++ b/docs/sfu-deploy-checklist.md
@@ -50,3 +50,6 @@ Prerequisites: M14 sub-issues through #102–#105 landed; room has **`avDisabled
 
 15. **Post-deploy health**  
     After media deploy: **`curl -sSf "${SFU_HTTP}/healthz"`** → **`ok`**, **`workerAlive: true`**. Optional: check CloudWatch **`RiffSync/Media`** gauges if wired.
+
+16. **Worker failure drill (optional)**  
+    If **`/healthz`** reports **`workerAlive: false`**, use SSM + **`journalctl -u riffsync-sfu`** for the **`worker died`** JSON line, then **`sudo systemctl restart riffsync-sfu`** and re-probe. See **`infra/cdk/README.md`** SFU worker runbook for reboot escalation.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -199,6 +199,17 @@ One account, **one CloudFormation stack** **`RiffSyncTurn`** ([`lib/media-server
 
 **Session Manager:** no inbound **SSH**; use **SSM** for troubleshooting (**`/var/log/cloud-init-output.log`** if UserData fails).
 
+**SFU producer / transport caps:** UserData writes **`/etc/riffsync-sfu.env`** with **`SFU_MAX_PRODUCERS_PER_SESSION=3`**, **`SFU_MAX_PRODUCERS_PER_ROOM=24`**, **`SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION=8`**, **`SFU_MAX_CONSUMERS_PER_SESSION=64`** (defaults in [`lib/sfu-env-lines.ts`](lib/sfu-env-lines.ts); **`riffsync-sfu`** reads them at startup). Optional CloudWatch alarm **`riffsync-sfu-high-cpu`** fires when SFU EC2 **CPUUtilization** exceeds **80%** for **5** minutes (no SNS in OSS default — attach a topic in IaC if desired).
+
+**Worker failure runbook (mediasoup `worker.on('died')`):**
+
+1. Confirm **`curl -sSf "${SFU_HTTP}/healthz"`** shows **`workerAlive: false`** or probe failure.
+2. **SSM** into the SFU instance; check **`journalctl -u riffsync-sfu`** for a **`worker died`** JSON line.
+3. **Restart** the SFU unit: **`sudo systemctl restart riffsync-sfu`**.
+4. Re-probe **`/healthz`** — expect **`workerAlive: true`**, **`routerRoomCount: 0`** until rooms reconnect.
+5. If restart fails twice, **reboot** the EC2 instance (**`aws ec2 reboot-instances --instance-ids <id>`** or console).
+6. Notify active parties via your community channel if outage persists.
+
 **Secret rotation / first-boot placeholder:** UserData runs **once**. After you set the real value for **`riffsync/turn-static-auth-secret`**, use **Session Manager** to re-fetch into **`/etc/coturn/turnserver.conf`** and **`sudo systemctl restart coturn`**, or replace the instance.
 
 **Migrating from older `RiffSyncTurn-staging` / `RiffSyncTurn-prod`:** delete those stacks after this change, copy secret material from **`riffsync/staging/turn-static-auth-secret`** (or prod) into **`riffsync/turn-static-auth-secret`**, then deploy **`RiffSyncTurn`**. Per-environment turn secrets are **removed** from **`RiffSyncApi-*`** templates (old AWS secrets may **RETAIN** — clean up manually if desired).

--- a/infra/cdk/lib/media-server-stack.ts
+++ b/infra/cdk/lib/media-server-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as route53 from 'aws-cdk-lib/aws-route53';
@@ -9,6 +10,7 @@ import * as path from 'node:path';
 import type { Construct } from 'constructs';
 
 import { dnsRecordConstructSuffix } from './cloudfront-canonical-redirect';
+import { sfuCapEnvPrintfFragments } from './sfu-env-lines';
 
 /** One account-wide secret for ICE Lambdas + one coturn process. */
 export const TURN_SHARED_SECRET_NAME = 'riffsync/turn-static-auth-secret';
@@ -313,7 +315,7 @@ export class MediaServerStack extends cdk.Stack {
       'ADMIN_SECRET=$(aws secretsmanager get-secret-value --secret-id "$SFU_ADMIN_SECRET_ID" --region "$AWS_REGION" --query=SecretString --output text | tr -d \'\\n\\r\')',
       'TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")',
       'PUBLIC_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)',
-      'printf "%s\\n" "SFU_JWT_SECRET=$SECRET" "SFU_ADMIN_SECRET=$ADMIN_SECRET" "PORT=3000" "MEDIASOUP_ANNOUNCED_IP=$PUBLIC_IP" "MEDIASOUP_RTC_MIN_PORT=$RTC_MIN" "MEDIASOUP_RTC_MAX_PORT=$RTC_MAX" "SFU_MAX_PRODUCERS_PER_SESSION=3" "SFU_MAX_PRODUCERS_PER_ROOM=24" > /etc/riffsync-sfu.env',
+      `printf "%s\\n" "SFU_JWT_SECRET=$SECRET" "SFU_ADMIN_SECRET=$ADMIN_SECRET" "PORT=3000" "MEDIASOUP_ANNOUNCED_IP=$PUBLIC_IP" "MEDIASOUP_RTC_MIN_PORT=$RTC_MIN" "MEDIASOUP_RTC_MAX_PORT=$RTC_MAX" ${sfuCapEnvPrintfFragments().join(' ')} > /etc/riffsync-sfu.env`,
       'chmod 0600 /etc/riffsync-sfu.env',
       'aws s3 sync "s3://$S3_BUCKET/" /opt/riffsync-sfu --delete',
       'cd /opt/riffsync-sfu && npm ci && npm run build && npm prune --omit=dev',
@@ -379,6 +381,25 @@ SVCEOF`,
       sourceDestCheck: true,
     });
     sfuInstance.node.addDependency(codeDeploy);
+
+    new cloudwatch.Alarm(this, 'SfuHighCpuAlarm', {
+      alarmName: 'riffsync-sfu-high-cpu',
+      alarmDescription:
+        'SFU EC2 CPU > 80% for 5 minutes — optional maintainer alert (no SNS in OSS default).',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        dimensionsMap: {
+          InstanceId: sfuInstance.instanceId,
+        },
+        statistic: 'Average',
+        period: cdk.Duration.minutes(1),
+      }),
+      threshold: 80,
+      evaluationPeriods: 5,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
 
     const sfuEip = new ec2.CfnEIP(this, 'SfuEip', {
       domain: 'vpc',

--- a/infra/cdk/lib/sfu-env-lines.test.ts
+++ b/infra/cdk/lib/sfu-env-lines.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { SFU_CAP_ENV, sfuCapEnvPrintfFragments } from './sfu-env-lines';
+
+describe('sfu-env-lines', () => {
+  it('exports participant AV cap defaults aligned with deployment_environments.md', () => {
+    expect(SFU_CAP_ENV).toEqual({
+      SFU_MAX_PRODUCERS_PER_SESSION: '3',
+      SFU_MAX_PRODUCERS_PER_ROOM: '24',
+      SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION: '8',
+      SFU_MAX_CONSUMERS_PER_SESSION: '64',
+    });
+  });
+
+  it('formats shell printf fragments for CDK user-data', () => {
+    expect(sfuCapEnvPrintfFragments()).toEqual([
+      '"SFU_MAX_PRODUCERS_PER_SESSION=3"',
+      '"SFU_MAX_PRODUCERS_PER_ROOM=24"',
+      '"SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION=8"',
+      '"SFU_MAX_CONSUMERS_PER_SESSION=64"',
+    ]);
+  });
+});

--- a/infra/cdk/lib/sfu-env-lines.ts
+++ b/infra/cdk/lib/sfu-env-lines.ts
@@ -1,0 +1,14 @@
+/** Participant AV capacity env defaults — mirrored in `services/riffsync-sfu` and `.ai/runtime/configuration.md`. */
+export const SFU_CAP_ENV = {
+  SFU_MAX_PRODUCERS_PER_SESSION: '3',
+  SFU_MAX_PRODUCERS_PER_ROOM: '24',
+  SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION: '8',
+  SFU_MAX_CONSUMERS_PER_SESSION: '64',
+} as const;
+
+/** Shell `printf` fragments for `/etc/riffsync-sfu.env` (CDK EC2 user-data). */
+export function sfuCapEnvPrintfFragments(): string[] {
+  return (Object.entries(SFU_CAP_ENV) as Array<[keyof typeof SFU_CAP_ENV, string]>).map(
+    ([key, value]) => `"${key}=${value}"`,
+  );
+}

--- a/infra/cdk/vitest.config.ts
+++ b/infra/cdk/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['lambda/**/*.test.ts'],
+    include: ['lambda/**/*.test.ts', 'lib/**/*.test.ts'],
     environment: 'node',
   },
 });

--- a/services/riffsync-sfu/dist/index.js
+++ b/services/riffsync-sfu/dist/index.js
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { WebSocketServer } from 'ws';
 import { attachTransportHandlers, closeSessionTransports, countProducersForSession, countProducersInRoom, getOrCreateRoom, getMediasoupHealthSnapshot, getProducerEntry, hasProducerForTuple, listProducerSummaries, removeProducer, removeProducersByProducerClass, removeProducersForSession, roomKeyFromClaims, shutdownMediasoup, transportListenIps, upsertProducer, verifySfuJoinToken, } from './rooms.js';
 import { isProducerClass } from './jwt.js';
+import { emitMediaLimitRejected } from './media-observability.js';
 const PORT = Number.parseInt(process.env.PORT ?? '3000', 10);
 const JWT_SECRET = process.env.SFU_JWT_SECRET?.trim() ?? '';
 const SFU_ADMIN_SECRET = process.env.SFU_ADMIN_SECRET?.trim() ?? '';
@@ -344,6 +345,8 @@ async function onMessage(ws, p, raw) {
                     return;
                 }
                 if (p.transports.size >= MAX_TRANSPORTS) {
+                    logJson('warn', 'transport limit reached', { signal: 'TransportLimitRejected' });
+                    emitMediaLimitRejected('TransportLimitRejected');
                     send(ws, errResponse(id, 'transport limit reached'));
                     return;
                 }
@@ -484,6 +487,8 @@ async function onMessage(ws, p, raw) {
                     return;
                 }
                 if (p.consumers.size >= MAX_CONSUMERS) {
+                    logJson('warn', 'consumer limit reached', { signal: 'ConsumerLimitRejected' });
+                    emitMediaLimitRejected('ConsumerLimitRejected');
                     send(ws, errResponse(id, 'consumer limit reached'));
                     return;
                 }

--- a/services/riffsync-sfu/dist/media-observability.js
+++ b/services/riffsync-sfu/dist/media-observability.js
@@ -1,0 +1,22 @@
+function riffsyncEnvironment() {
+    return process.env.RIFFSYNC_ENVIRONMENT?.trim() || 'shared';
+}
+/** EMF counter via stdout (no PutMetricData IAM on SFU EC2). */
+export function emitMediaLimitRejected(signal) {
+    const env = riffsyncEnvironment();
+    console.log(JSON.stringify({
+        _aws: {
+            Timestamp: Date.now(),
+            CloudWatchMetrics: [
+                {
+                    Namespace: 'RiffSync/Media',
+                    Dimensions: [['Environment', 'Signal']],
+                    Metrics: [{ Name: signal, Unit: 'Count' }],
+                },
+            ],
+        },
+        Environment: env,
+        Signal: signal,
+        [signal]: 1,
+    }));
+}

--- a/services/riffsync-sfu/dist/rooms.js
+++ b/services/riffsync-sfu/dist/rooms.js
@@ -35,6 +35,11 @@ export async function getOrCreateWorker() {
         rtcMaxPort: Number.isFinite(max) ? max : 40_199,
     });
     worker.on('died', () => {
+        console.error(JSON.stringify({
+            ts: new Date().toISOString(),
+            level: 'error',
+            msg: 'worker died',
+        }));
         worker = null;
         for (const [, r] of roomMap) {
             r.router.close();

--- a/services/riffsync-sfu/src/index.ts
+++ b/services/riffsync-sfu/src/index.ts
@@ -32,6 +32,7 @@ import {
   type RoomRuntime,
 } from './rooms.js';
 import { isProducerClass, type ProducerClass, type SfuJoinClaims } from './jwt.js';
+import { emitMediaLimitRejected } from './media-observability.js';
 
 const PORT = Number.parseInt(process.env.PORT ?? '3000', 10);
 const JWT_SECRET = process.env.SFU_JWT_SECRET?.trim() ?? '';
@@ -425,6 +426,8 @@ async function onMessage(ws: WebSocket, p: PendingSession, raw: string): Promise
           return;
         }
         if (p.transports.size >= MAX_TRANSPORTS) {
+          logJson('warn', 'transport limit reached', { signal: 'TransportLimitRejected' });
+          emitMediaLimitRejected('TransportLimitRejected');
           send(ws, errResponse(id, 'transport limit reached'));
           return;
         }
@@ -569,6 +572,8 @@ async function onMessage(ws: WebSocket, p: PendingSession, raw: string): Promise
           return;
         }
         if (p.consumers.size >= MAX_CONSUMERS) {
+          logJson('warn', 'consumer limit reached', { signal: 'ConsumerLimitRejected' });
+          emitMediaLimitRejected('ConsumerLimitRejected');
           send(ws, errResponse(id, 'consumer limit reached'));
           return;
         }

--- a/services/riffsync-sfu/src/media-observability.ts
+++ b/services/riffsync-sfu/src/media-observability.ts
@@ -1,0 +1,27 @@
+export type MediaLimitSignal = 'TransportLimitRejected' | 'ConsumerLimitRejected';
+
+function riffsyncEnvironment(): string {
+  return process.env.RIFFSYNC_ENVIRONMENT?.trim() || 'shared';
+}
+
+/** EMF counter via stdout (no PutMetricData IAM on SFU EC2). */
+export function emitMediaLimitRejected(signal: MediaLimitSignal): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Media',
+            Dimensions: [['Environment', 'Signal']],
+            Metrics: [{ Name: signal, Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Signal: signal,
+      [signal]: 1,
+    }),
+  );
+}

--- a/services/riffsync-sfu/src/rooms.ts
+++ b/services/riffsync-sfu/src/rooms.ts
@@ -60,6 +60,13 @@ export async function getOrCreateWorker(): Promise<mediasoup.types.Worker> {
     rtcMaxPort: Number.isFinite(max) ? max : 40_199,
   });
   worker.on('died', () => {
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'error',
+        msg: 'worker died',
+      }),
+    );
     worker = null;
     for (const [, r] of roomMap) {
       r.router.close();


### PR DESCRIPTION
## Summary

- Adds `participantAvErrors` module with stable `ParticipantAvErrorCode` values, contract copy, DOMException classification, and SFU token denial mapping per `error_state.md` (#123).
- Wires SFU session and `participantAvSession` to hard-fail publish: toggles return off on token cap/auth denials, `getUserMedia` failures, and SFU produce errors; inline copy at toggles via `aria-describedby`.
- Completes M14 AV accessibility baselines (#124): per-tile `aria-label` on participant video tiles, live-region announce copy tests, host radio/kill-switch semantics tests, and local toggle announcer callback tests.
- Wires SFU producer/transport/consumer cap env vars through CDK user-data, adds optional SFU CPU alarm, documents worker-failure runbook, and emits `RiffSync/Media` limit-rejection EMF from the SFU process (#125).

Closes #123
Closes #124
Closes #125

Part of #106 (parent epic).

## Test plan

- [x] `npm ci --prefix apps/web && npm run test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [x] `npm ci --prefix infra/cdk && npm run test --prefix infra/cdk && npm run synth --prefix infra/cdk`
- [x] `npm ci --prefix services/riffsync-sfu && npm run build --prefix services/riffsync-sfu`
- [ ] Manual: deny camera permission shows `permission_denied` copy; toggle off
- [ ] Manual: trigger `publisher_cap_exceeded` token 403; hard-fail copy; toggle off
- [ ] Manual: host AV kill switch shows `av_disabled` explanation (not publish error)
- [ ] Manual a11y: host mode change announces via polite live region; local camera/mic toggles announce on user action
- [ ] Manual a11y: narrow viewport participant tiles expose You / display name to screen readers
- [ ] Post-deploy: `curl -sSf "${SFU_HTTP}/healthz"` after media deploy; optional `docs/sfu-deploy-checklist.md` steps 8-16