### PR TITLE
fix(room): SFU session on mode switch + Node 22 SFU bootstrap

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -1090,9 +1090,9 @@ export function RoomPage() {
   }, [theaterMixEnabled, isPublisher, captureStream, guestRemote])
 
   useEffect(() => {
-    if (!sfuEnabled || wsStatus !== 'open' || !room) return
+    if (!sfuEnabled || wsStatus !== 'open' || !canonicalRoomId) return
     const api = getPublicApiBaseUrl()
-    if (!api || !canonicalRoomId) return
+    if (!api) return
 
     const { cancel } = startSfuRoomSession({
       apiBaseUrl: api,
@@ -1127,25 +1127,54 @@ export function RoomPage() {
     })
     return () => {
       participantAvController.teardownPublishing()
-      stopMediaStreamTracks(captureStreamRef.current)
-      captureStreamRef.current = null
       sfuSessionRef.current?.unpublishProducerClass('host_screen')
       cancel()
     }
   }, [
     sfuEnabled,
     wsStatus,
-    room,
     avDisabled,
     canonicalRoomId,
     sessionId,
     fanToken,
     getIceServers,
-    captureStream,
     sfuTokenIntentTick,
     participantAvController,
     onParticipantAvConsumerTrack,
   ])
+
+  /** Publish or unpublish host tab capture on the existing SFU session (no full reconnect). */
+  useEffect(() => {
+    if (!sfuEnabled || wsStatus !== 'open' || !isPublisher) return
+    const session = sfuSessionRef.current
+    if (!session) return
+
+    if (roomMode === 'videoChat') {
+      session.unpublishProducerClass('host_screen')
+      return
+    }
+
+    const stream = captureStream
+    const live = stream?.getTracks().some((track) => track.readyState === 'live') ?? false
+    if (!live || !stream) {
+      session.unpublishProducerClass('host_screen')
+      return
+    }
+
+    let cancelled = false
+    void (async () => {
+      try {
+        await session.ready
+        if (cancelled) return
+        await session.publishStream(stream, 'host_screen')
+      } catch {
+        /* session closed or reconnecting */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [captureStream, roomMode, sfuEnabled, wsStatus, isPublisher])
 
   useEffect(() => {
     if (isPublisher) return

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -414,6 +414,11 @@ export async function connectSfuUnifiedSession(options: {
     try {
       await signaling.connect()
     } catch {
+      if (userClosed) {
+        finish('user_close')
+        rejectReady(new Error('user_close'))
+        return
+      }
       onMediaError?.('signaling_failed', 'Could not connect to video relay (signaling).')
       finish('signaling_close')
       rejectReady(new Error('signaling_failed'))

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -114,6 +114,10 @@ async function publishHostScreenIfNeeded(
   }
   try {
     await session.ready
+  } catch {
+    return
+  }
+  try {
     await session.publishStream(stream, 'host_screen')
   } catch (e) {
     onMediaError(

--- a/infra/cdk/lib/media-server-stack.ts
+++ b/infra/cdk/lib/media-server-stack.ts
@@ -302,7 +302,7 @@ export class MediaServerStack extends cdk.Stack {
     sfuUserData.addCommands(
       'set -euxo pipefail',
       'dnf install -y gcc-c++ make python3 python3-pip',
-      'curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -',
+      'curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -',
       'dnf install -y nodejs awscli',
       `SFU_JOIN_SECRET_ID='${SFU_JOIN_SECRET_NAME}'`,
       `SFU_ADMIN_SECRET_ID='${SFU_ADMIN_SECRET_NAME}'`,

--- a/services/riffsync-sfu/package-lock.json
+++ b/services/riffsync-sfu/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "~5.6.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/services/riffsync-sfu/package.json
+++ b/services/riffsync-sfu/package.json
@@ -9,7 +9,7 @@
     "dev": "node --import tsx src/index.ts"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "mediasoup": "^3.14.14",


### PR DESCRIPTION
## Summary

- **Room mode switch:** Stop tearing down the full SFU WebSocket when toggling Theater ↔ Video Chat. `room` and `captureStream` were SFU session effect deps, which caused `signaling closed` / `signaling_failed` console spam. Host screen publish/unpublish now runs on the existing session; mode-specific detach logic is unchanged.
- **SFU EC2 bootstrap:** Install **Node 22** in `RiffSyncTurn` UserData and set `@riffsync/sfu` engines to `>=22` so mediasoup 3.19+ first-boot completes (cloud-init previously failed before systemd units were created when Node 20 was installed).

## Test plan

- [ ] Deploy fan SPA; join a watch party room with SFU enabled
- [ ] Switch host between **Theater** and **Video Chat** several times; confirm no `signaling closed` / `signaling_failed` in console and chat/A/V stay connected
- [ ] In Theater, start tab share; confirm guests receive video without SFU reconnect
- [ ] After merge, redeploy **`RiffSyncTurn`** (or replace SFU instance) and confirm `curl -sSf https://signal.riffsync.tv/healthz` returns `ok` + `workerAlive: true` on fresh bootstrap
- [ ] `npm test -- --run src/room/sfu/sfuRoomSession.test.ts src/room/roomMediaLifecycle.test.ts` (CI)