### PR TITLE
fix(room): keep camera alive through SFU producer reconnect

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -847,6 +847,12 @@ export function RoomPage() {
     })
   }, [participantAvController])
 
+  useEffect(() => {
+    return () => {
+      participantAvController.teardownPublishing()
+    }
+  }, [participantAvController])
+
   void participantAvPublishTick
   const participantAvPublishState = participantAvController.getState()
   const stageParticipantTiles = buildStageParticipantTiles({
@@ -1122,11 +1128,9 @@ export function RoomPage() {
       },
       onConnecting: () => {
         setSfuRoomErr(null)
-        participantAvController.clearError()
       },
     })
     return () => {
-      participantAvController.teardownPublishing()
       sfuSessionRef.current?.unpublishProducerClass('host_screen')
       cancel()
     }

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -251,6 +251,8 @@ export type SfuUnifiedSessionHandle = {
   close: (reason?: SfuSessionEndReason) => void
   sessionEnded: Promise<SfuSessionEndReason>
   ready: Promise<void>
+  /** False for consumer-only SFU tokens (no send transport until producer reconnect). */
+  supportsPublish: boolean
   publishStream: (stream: MediaStream, producerClass: SfuProducerClass) => Promise<void>
   unpublishProducerClass: (producerClass: SfuProducerClass) => void
   detachConsumerClass: (producerClass: SfuProducerClass) => void
@@ -695,6 +697,7 @@ export async function connectSfuUnifiedSession(options: {
 
   return {
     ready,
+    supportsPublish: tokenRole === 'producer',
     publishStream,
     unpublishProducerClass,
     detachConsumerClass,

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { canParticipantAvPublish, createParticipantAvController } from './participantAvSession'
 
 describe('canParticipantAvPublish', () => {
@@ -72,5 +72,75 @@ describe('createParticipantAvController', () => {
       error: null,
       busy: false,
     })
+  })
+
+  it('attachSession(null) does not clear publish intent', () => {
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    controller.attachSession(null)
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: false,
+      micEnabled: false,
+      needsProducerToken: false,
+    })
+  })
+
+  it('syncPublish waits for a producer session instead of failing on consumer-only attach', async () => {
+    const publishStream = vi.fn()
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    const consumerSession = {
+      supportsPublish: false,
+      ready: Promise.resolve(),
+      publishStream,
+      unpublishProducerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    } as unknown as import('./mediasoupSharing').SfuUnifiedSessionHandle
+
+    controller.attachSession(consumerSession)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(publishStream).not.toHaveBeenCalled()
+    expect(controller.getState().error).toBeNull()
+  })
+
+  it('syncPublish runs after attaching a producer session', async () => {
+    const publishStream = vi.fn().mockResolvedValue(undefined)
+    const mockTrack = { kind: 'video', readyState: 'live', stop: vi.fn() }
+    const stream = {
+      getVideoTracks: () => [mockTrack],
+      getAudioTracks: () => [],
+      getTracks: () => [mockTrack],
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    await controller.enableCamera()
+    expect(controller.getState().cameraEnabled).toBe(true)
+
+    const producerSession = {
+      supportsPublish: true,
+      ready: Promise.resolve(),
+      publishStream,
+      unpublishProducerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    } as unknown as import('./mediasoupSharing').SfuUnifiedSessionHandle
+
+    controller.attachSession(producerSession)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(publishStream).toHaveBeenCalledWith(stream, 'participant_av')
+    expect(controller.getState().error).toBeNull()
+
+    vi.unstubAllGlobals()
   })
 })

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -90,6 +90,34 @@ export function createParticipantAvController(options: {
     localStream = null
   }
 
+  const localTracksLive = (): boolean =>
+    localStream?.getTracks().some((track) => track.readyState === 'live') ?? false
+
+  const ensureLocalMedia = async (): Promise<boolean> => {
+    if (!cameraEnabled && !micEnabled) return false
+    if (localStream && localTracksLive()) return true
+    try {
+      localStream = await ensureUserMedia(cameraEnabled, micEnabled)
+      const hasVideo = localStream.getVideoTracks().length > 0
+      const hasAudio = localStream.getAudioTracks().length > 0
+      cameraEnabled = hasVideo && cameraEnabled
+      micEnabled = hasAudio && micEnabled
+      if (!cameraEnabled && !micEnabled) {
+        stopLocalTracks()
+        throw new Error('Could not access camera or microphone.')
+      }
+      return true
+    } catch (e) {
+      cameraEnabled = false
+      micEnabled = false
+      micMuted = false
+      stopLocalTracks()
+      error = participantAvErrorFromDomException(e)
+      notify()
+      return false
+    }
+  }
+
   const syncPublish = async () => {
     if (!session) return
     if (!cameraEnabled && !micEnabled) {
@@ -97,6 +125,8 @@ export function createParticipantAvController(options: {
       stopLocalTracks()
       return
     }
+    if (!session.supportsPublish) return
+    if (!(await ensureLocalMedia())) return
     if (!localStream) return
     try {
       await session.ready
@@ -175,10 +205,7 @@ export function createParticipantAvController(options: {
     },
     attachSession: (next) => {
       session = next
-      if (!session) {
-        stopLocalTracks()
-        return
-      }
+      if (!session) return
       void syncPublish()
     },
     resetOnReconnect: () => {


### PR DESCRIPTION
## Summary
- Preserve local camera/mic tracks while the SFU session upgrades from consumer-only to producer token
- Wait for a producer-capable session before publishing instead of failing silently on consumer attach
- Stop tearing down participant AV on SFU reconnect; only tear down on room leave
- Surface publish errors instead of clearing them when the relay reconnects

## Test plan
- [x] `npm test -- src/room/sfu/participantAvSession.test.ts src/room/sfu/sfuRoomSession.test.ts`
- [ ] Join a room signed in with host A/V enabled, enable camera, confirm **You** tile appears and stays on
- [ ] Confirm camera light stays on after producer reconnect completes