### PR TITLE
[M15][#135] Remove API Gateway mesh signaling route (CDK + ws-route)

### DIFF
--- a/docs/architecture.frontend.md
+++ b/docs/architecture.frontend.md
@@ -55,9 +55,9 @@ flowchart LR
   end
 
   subgraph guest_path["Guests"]
-    ROOM --> WS[WebSocket signaling chat ping]
-    WS --> SRV[Backend]
-    RTC_OUT -.->|SDP ICE via WS or HTTP| GUEST[Guest WebRTC subscribe]
+    ROOM --> WS[WebSocket chat presence ping]
+    WS --> SRV[API Gateway control plane]
+    RTC_OUT -.->|RTP via SFU wss| GUEST[Guest WebRTC subscribe]
     GUEST --> VID[Inbound media element]
   end
 ```

--- a/docs/architecture.server.md
+++ b/docs/architecture.server.md
@@ -17,7 +17,7 @@ Infrastructure-as-code: **deploy with AWS CDK** (`cdk synth` emits CloudFormatio
 | Resource | Role |
 | --- | --- |
 | **API Gateway HTTP API** (`ProtocolType: HTTP`) | BFF JSON: **`GET /v1/catalog`**, curated **`GET /v1/lists`** (when shipped), room create/read/**patch** (current episode / metadata), lobby list, **`GET /v1/health`**, **`GET /v1/webrtc/ice`**, **`POST /v1/webrtc/sfu-token`** (mediasoup join), **`/v1/admin/*`** **operator** APIs (JWT + staff pool / groups — **`architecture.admin.md`**). |
-| **API Gateway WebSocket API** (`ProtocolType: WEBSOCKET`) | Realtime paths: `$connect` / `$disconnect`, **WebRTC signaling** (SDP / ICE relay—shape TBD), chat, ping, **`execute-api:ManageConnections`** fan-out. |
+| **API Gateway WebSocket API** (`ProtocolType: WEBSOCKET`) | **Control plane** realtime: `$connect` / `$disconnect`, **ping**, **presence**, **chat** / **react**, **`share_state`**, **`leave`**, **`execute-api:ManageConnections`** fan-out. **No** SDP / ICE mesh relay — media signaling is on **`RiffSyncTurn`** SFU WebSocket (**`.ai/integration/external_systems.md`**, **`.ai/integration/api_contracts.md`**). |
 | **AWS Lambda** | All synchronous route handlers + **EventBridge** consumers (sweeper, TMDB catalog reconciliation). |
 | **Amazon DynamoDB** | **All durable application state:** **rooms**, **connections**, **catalog**, plus **optional** **`profiles`** (fan **`USER#sub`**), **`lists` + memberships** (**`LIST#slug`** editorial rows), append-only **events**/**rollups** for admin reporting (**`architecture.admin.md`**). |
 | **Amazon EventBridge** (`AWS::Events::Rule` or **`AWS::Scheduler::Schedule`**) | Schedules for **stale-room housekeeping** and **TMDB reconciliation** batch jobs. |
@@ -49,7 +49,7 @@ flowchart TB
   subgraph compute["Compute — Lambda"]
     HREST["HTTP handlers\n/catalog / rooms / lobby"]
     HWSC["WS $connect / $disconnect"]
-    HWSR["WS routes:\nsignaling / chat / ping"]
+    HWSR["WS routes:\nchat / presence / share_state / ping"]
     HSWP["Sweeper + TMDB reconcile\n(EventBridge schedules)"]
   end
 
@@ -94,7 +94,7 @@ flowchart TB
 | Area | Responsibility |
 | --- | --- |
 | **HTTP API** | **`GET /v1/catalog`**, **`GET /v1/lists`** (when curated lists ship); room create/read/**update current episode**; **live public** lobby; **`GET /v1/health`**; **`/v1/admin/*`** behind **JWT** for operators (**catalog writes**, **lists**, **reporting**, **user roster**) — **`architecture.admin.md`**. Optional ElastiCache on hot reads. |
-| **WebSocket API** | **`$connect` / `$disconnect`** write the **connection → room** mapping; message routes relay **signaling** for admin→guest WebRTC, plus **chat**, **ping**, and **room metadata** updates in DynamoDB where durable state is required—then **`PostToConnection`** fan-out as appropriate. |
+| **WebSocket API** | **`$connect` / `$disconnect`** write the **connection → room** mapping; message routes fan out **chat**, **presence**, **`share_state`**, **ping**, and **`leave`** — then **`PostToConnection`** as appropriate. **WebRTC media** (host screen share, participant A/V) uses the **SFU signaling WebSocket** on **`RiffSyncTurn`**, not API Gateway. Durable room fields (**`roomMode`**, **`avDisabled`**, episode selection) use **HTTP `PATCH`**, not inbound WebSocket application routes. |
 | **DynamoDB (rooms)** | Source of truth: **current** catalog episode / `videoId` (**admin-updatable**), **`hostSub`** (**Cognito `sub`** of creator), **`playbackExpectation`**, **`lastActivityAt`**, **`roomId`**, optional flags for **broadcast lifecycle / visibility**. Admin capability belongs only to principal **`JWT.sub === hostSub`**; **no guest promotion / reclaim token** in MVP. |
 | **DynamoDB (connections)** | **`connectionId → roomId`** (and optional **`sessionId`**) for targeting fan-out and teardown. |
 | **DynamoDB (catalog)** | Canonical **`youtubeVideoId`**, **`youtubeWatchUrl`**, **`title`**, **`era`**, **`id`**, optional curator hints; reconcile **writes** TMDB-aligned **`tagline`**, **`posterImageUrl`**, **`backdropImageUrl`**, **`tmdbMovieId`**, **`tmdbArtworkSyncedAt`** plus Dynamo-only copy/paths (**`tmdbOverview`**, **`tmdbPopularity`**, raw poster/backdrop paths) per **`architecture.catalog-images.md`**. TMDB **`original_title`** / **`title`** are **not** persisted — catalog **`title`** is source of truth for display. Bootstrap **seed** (**`data/catalog/episodes.json`**) conforms to **`catalog.schema.json`** — not every Dynamo attribute need appear in git. |

--- a/docs/contracts.websocket.md
+++ b/docs/contracts.websocket.md
@@ -17,18 +17,19 @@ On **`$connect`**, the server stores **`expiresAt`** on the connections row (**a
 
 ## Route selection (`$request.body.action`)
 
-Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, **`chat_gif`**, **`react`**, `signaling`, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
+Each routed message SHOULD be JSON with **`"action"`** matching the [**API Gateway**](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-develop-routes.html) route (`ping`, `presence_request`, `chat`, **`chat_gif`**, **`react`**, **`share_state`**, **`leave`**). **`$default`** maps **`body.action`** when the route selector misses.
 
 | **`action`** | Purpose | Auth |
 | --- | --- | --- |
 | **`ping`** | Heartbeat — bumps **`lastActivityAt`** (and **`lobbySk`** when room is **`public`**); also refreshes this socket's connections-row **`lastSeenAt`** and **`expiresAt`** (**about 90 minutes**, sliding) so stale rows age out when **`$disconnect`** never runs. | **Guest OK** once connected. |
 | **`presence_request`** | Ask the server to fan out a fresh **`presence`** roster snapshot to **all** connections in this room (no body). Use after connect/reconnect or when the UI suspects a stale roster; idempotent. | **Guest OK** once connected. |
 | **`leave`** | Best-effort client goodbye — deletes this **`connectionId`** from the connections table and fan-outs **`presence`** (same pattern as **`$disconnect`**). Clients may send on **`pagehide`** when teardown is uncertain; safe if the row is already gone. | **Guest OK** once connected. |
-| **`share_state`** | Host announces screen-share lifecycle so guests can reset the guest **video** surface without inferring teardown only from WebRTC. Body: **`state`**: **`started`** \| **`stopped`**; optional **`shareGeneration`** (non-negative int, matches v1 signaling generations). | **Host (publisher JWT)** only. Fan-out shape below. |
+| **`share_state`** | Host announces screen-share lifecycle so guests can reset the guest **video** surface without inferring teardown only from SFU media. Body: **`state`**: **`started`** \| **`stopped`**; optional **`shareGeneration`** (non-negative int, monotonic host share session id). | **Host (publisher JWT)** only. Fan-out shape below. |
 | **`chat`** | Fan-out text to sockets in **`roomId`**. | **Signed-in fan only** (**`fanSub`** on connection from **`$connect`**). **403** when absent. Body: **`text`** (**required**, ≤ 2000 chars), **`messageId`** (**required**, UUID RFC 4122 string). |
 | **`chat_gif`** | Fan-out Giphy GIF post to sockets in **`roomId`**. | **Signed-in fan only** (**`fanSub`** on connection from **`$connect`**). **403** when absent. Body: **`messageId`** (**required**, UUID), **`giphyId`** (**required**, non-empty), **`renditionUrl`** (**required**, HTTPS URL on Giphy CDN, e.g. **`media*.giphy.com`**, **`i.giphy.com`**), optional **`title`** (≤ 200 chars), **`width`** / **`height`** (positive integers, ≤ 4096). Clients MUST NOT upload GIF bytes or supply arbitrary image URLs. |
 | **`react`** | Fan-out ephemeral emoji reaction toggle on a chat line. | **Signed-in fan only** (**`fanSub`** on connection from **`$connect`**). **403** when absent. Body: **`messageId`** (**required**, non-empty, ≤ 64 chars), **`emoji`** (**required**, trimmed non-empty, ≤ 32 chars), **`reactionAction`**: **`add`** \| **`remove`** (not the route **`action`** field). No Dynamo persistence. |
-| **`signaling`** | WebRTC relay to peers (`**envelope`** JSON). | **Host:** publisher **`JWT`** on **`$connect`**. **Guest:** only **`guestSignaling`** with **`kind`** **`ready`**, **`answer`**, or **`ice`** (see below). |
+
+**WebRTC media** (SDP / ICE, mediasoup produce/consume) uses the **SFU signaling WebSocket** on **`RiffSyncTurn`**, not this API Gateway room WebSocket. See **`.ai/integration/api_contracts.md`** and **`.ai/integration/external_systems.md`**.
 
 ## Server → client fan-out (`PostToConnection`)
 
@@ -127,48 +128,5 @@ Broadcast to **every** connection in **`roomId`** when the host sends **`share_s
 ```
 
 **`shareGeneration`** is omitted when the host did not include it (or it was not applicable). Guests should clear inbound share UI on **`state: stopped`** regardless of generation.
-
-### Signaling
-
-Outbound fan-out payloads share a common envelope (**`Publishers`** and **`guest`** relay):
-
-```json
-{
-  "type": "signaling",
-  "roomId": "<id>",
-  "fromSessionId": "<sender session opaque id>",
-  "role": "host" | "guest",
-  "envelope": {}
-}
-```
-
-### Guest → relay (**`guestSignaling`**)
-
-Guests may **`POST`** messages on the **`signaling`** route only when **`envelope`** is **`{ guestSignaling: true, kind: … }`**:
-
-| **`kind`** | Purpose |
-| --- | --- |
-| **`ready`** | Guest announces WebRTC handshake readiness (prompts host to **`createOffer`** for that **`fromSessionId`**). |
-| **`answer`** | WebRTC SDP answer (`**sdp`** object: **`type`** + **`sdp`** string). |
-| **`ice`** | ICE candidate (**`candidate`** ICE payload). |
-
-**`offer`** and arbitrary publisher envelopes **must not** arrive on the guest path (**`403`** otherwise).
-
-Hosts send **`signaling`** without **`guestSignaling`** (publisher path). Typical host **`envelope`** fields: **`kind`**: **`offer`** | **`ice`**, **`sdp`** / **`candidate`**, **`targetSessionId`** (which guest applies the payload).
-
-SDP and ICE blobs are forwarded without semantic validation (**SPA-owned** contract).
-
-#### Signaling protocol version 1 (optional)
-
-Clients MAY include on **`envelope`**:
-
-| Field | Type | Meaning |
-| ----- | ---- | ------- |
-| **`protocolVersion`** | `1` | Enables generation guards below. |
-| **`shareGeneration`** | positive integer | Monotonic **host capture session** id; host increments when a new share starts; guest echoes it on **`answer`** / **`ice`**. |
-
-**`ready`** MAY include these fields so the host can correlate (optional).
-
-When **`protocolVersion`** is absent or **`shareGeneration`** is missing / `0`, peers treat the message as **legacy** and apply only pre-v1 behavior.
 
 **`chat`** payloads include client-provided **`messageId`** plus server **`Date.now()`** timestamp.

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -15,7 +15,7 @@ The CDK app **no longer defines** `RiffSyncFanAuth-staging`, `RiffSyncApi-stagin
 | --- | --- |
 | `bin/riffsync.ts` | App entry; **`--context environment=prod`** (default in `cdk.json`) |
 | `lib/static-site-stack.ts` | Private **S3** origin + **CloudFront** with **origin access control (OAC)** |
-| `lib/api-catalog-stack.ts` | **Catalog** + **Rooms** + **Connections** Dynamo tables, **HTTP API** (catalog, rooms, lobby), **JWT** (**fan pool**), **WebSocket API** (ping/chat/signaling), **TMDB reconcile** + schedules |
+| `lib/api-catalog-stack.ts` | **Catalog** + **Rooms** + **Connections** Dynamo tables, **HTTP API** (catalog, rooms, lobby), **JWT** (**fan pool**), **WebSocket API** (ping, presence_request, chat, chat_gif, react, share_state, leave), **TMDB reconcile** + schedules |
 | `lib/media-server-stack.ts` | **Singleton** **`RiffSyncTurn`** — **one VPC**, **coturn** (**`t3.small`**) + **mediasoup SFU** (**`t3.medium`**), two EIPs, **`riffsync/turn-static-auth-secret`**, S3 bundle deploy for **`services/riffsync-sfu`**, **`riffsync/sfu-join-hmac-secret`** (reference by name) |
 | `lib/fan-auth-stack.ts` | **Fan** Cognito **User Pool** + **Hosted UI** domain + SPA app client (**local** email/password sign-up & sign-in, OAuth code + PKCE) |
 | `lib/staff-auth-stack.ts` | **Staff** Cognito **User Pool** (invite-only) + **Hosted UI** + SPA app client (**`/admin/*`** OAuth callbacks, **`admin`** / **`curator`** groups) |

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -392,53 +392,6 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     return { statusCode: 200, body: 'OK' };
   }
 
-  if (routeKey === 'signaling') {
-    const envelope = body.envelope;
-    if (envelope === undefined) {
-      return { statusCode: 400, body: 'envelope required' };
-    }
-
-    const hostSubConn = typeof conn.hostSub === 'string' ? conn.hostSub : undefined;
-    const isPublisher = Boolean(hostSubConn && hostSubConn === room.hostSub);
-
-    let allowGuestRelay = false;
-    if (
-      envelope !== null &&
-      typeof envelope === 'object' &&
-      (envelope as { guestSignaling?: unknown }).guestSignaling === true
-    ) {
-      const kind = (envelope as { kind?: unknown }).kind;
-      allowGuestRelay = kind === 'ready' || kind === 'answer' || kind === 'ice';
-    }
-
-    if (!isPublisher && !allowGuestRelay) {
-      console.warn(
-        JSON.stringify({
-          riffsyncDiag: 'ws_signaling',
-          outcome: 'forbidden_non_publisher',
-          connectionIdTail: connectionId.slice(-12),
-          sessionHead: sessionId.slice(0, 8),
-          roomIdHead: roomId.slice(0, 8),
-          dynamoStoresPublisherRole: Boolean(hostSubConn),
-        }),
-      );
-      return { statusCode: 403, body: 'Publisher JWT required (or guest ready/answer/ice only)' };
-    }
-
-    const mgmt = wsManagementClient();
-    const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
-    const out = {
-      type: 'signaling',
-      roomId,
-      fromSessionId: sessionId,
-      role: isPublisher ? 'host' : 'guest',
-      envelope,
-    };
-    const buf = encoder.encode(JSON.stringify(out));
-    await postToConnections(mgmt, doc, connTable, ids, buf, connectionId, presenceTable);
-    return { statusCode: 200, body: 'OK' };
-  }
-
   return { statusCode: 400, body: `Unknown route ${routeKey}` };
 }
 

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -738,7 +738,7 @@ export class ApiCatalogStack extends cdk.Stack {
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
-      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, chat_gif, react, signaling, share_state, leave`,
+      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, chat_gif, react, share_state, leave`,
       routeSelectionExpression: '$request.body.action',
     });
 
@@ -836,7 +836,6 @@ export class ApiCatalogStack extends cdk.Stack {
       'chat',
       'chat_gif',
       'react',
-      'signaling',
       'share_state',
       'leave',
     ] as const) {


### PR DESCRIPTION
## Summary

- Removes the mesh WebRTC `signaling` route from the API Gateway WebSocket API in `api-catalog-stack.ts` (route array and API description).
- Deletes the `signaling` handler block from `ws-route.ts` so mesh SDP/ICE relay is no longer served by the control plane.
- Retires mesh signaling from operator WebSocket docs (`contracts.websocket.md`, `architecture.server.md`, `infra/cdk/README.md`) and updates the frontend architecture diagram to reflect SFU-only media.

Closes #162.
Closes #163.

Part of parent #135 (M15 SFU-only media topology).

## Test plan

- [x] `cd infra/cdk && npm test` (217 tests passed)
- [x] `cd infra/cdk && npm run synth`
- [x] Grep: no `'signaling'` in `api-catalog-stack.ts` route list
- [x] Grep: no `routeKey === 'signaling'` in `ws-route.ts`
- [x] Grep: no API Gateway mesh `signaling` relay in updated doc files