### PR TITLE
[M15][#136] Local watch-party media: disposable SFU stack and dev bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 node_modules
+infra/local-media/.env
+infra/local-media/coturn/turnserver.conf

--- a/README.md
+++ b/README.md
@@ -106,7 +106,41 @@ Fan support might fund clearer distribution paths (sales, bundles, partnerships)
 | AWS (baseline) | **IaC:** **`AWS CDK`** (TypeScript). **Compute:** **Lambda** in **TypeScript** (Node.js bundle) **serverless-first** — **API Gateway v2** (`HTTP` + `WEBSOCKET`), **DynamoDB**, **EventBridge / Scheduler**, **Secrets Manager**. **ElastiCache** (Redis/Valkey-compatible) **optional** for **`GET /v1/catalog`** or lobby caches (VPC-attached Lambdas). **S3** for SPA static hosting or exports if needed — **no ECS/EC2** in the default stack. Details: **`docs/architecture.server.md`**. |
 | Deploy / CI | **GitHub Actions**: **pull-request CI** runs **`cdk synth`** (+ **`cfn-lint`**) against **`infra/cdk`** ([**`.github/workflows/ci.yml`**](.github/workflows/ci.yml)). **Manual** **`Deploy CDK (production)`** deploys **`main`** on demand — see **`infra/cdk/README.md`**. See **`.ai/operations/build_packaging.md`** and **`docs/architecture.server.md`** (Delivery pipeline §). |
 
-**MVP cut:** catalog browse + **anonymous join/watch/chat**, **signed-in-only hosting** (**JWT** / **`hostSub`** via Cognito Hosted UI accounts), **room page** + **guest WebRTC viewing**, **canonical share URLs** + lobby discovery + join path, embedded YouTube on admin surface, **anonymous guest display names**, **self-reported “Premium” vs “free, ad-supported”** labels. Defer heavy moderation and polished private-room policy if you want speed. **Managed SFU / TURN** is optional when mesh/admin uplink is insufficient—see **`docs/architecture.frontend.md`**.
+**MVP cut:** catalog browse + **anonymous join/watch/chat**, **signed-in-only hosting** (**JWT** / **`hostSub`** via Cognito Hosted UI accounts), **room page** + **guest WebRTC viewing**, **canonical share URLs** + lobby discovery + join path, embedded YouTube on admin surface, **anonymous guest display names**, **self-reported “Premium” vs “free, ad-supported”** labels. Defer heavy moderation and polished private-room policy if you want speed. Watch-party media uses the **mediasoup SFU + coturn** path in all environments — see **`docs/architecture.frontend.md`**.
+
+## Local watch-party media
+
+Local dev uses the **prod control plane** (room WebSocket, HTTP API, Cognito) plus a **disposable SFU + coturn** stack on your workstation. There is no mesh fallback.
+
+**Prerequisites:** Docker Desktop or Docker Engine with Compose v2.
+
+```bash
+# One-time: infra/local-media/.env and coturn/turnserver.conf (see infra/local-media/README.md)
+cp infra/local-media/.env.example infra/local-media/.env
+cp infra/local-media/coturn/turnserver.conf.example infra/local-media/coturn/turnserver.conf
+
+# Start disposable media
+npm run media:local
+curl -sSf http://127.0.0.1:3000/healthz
+
+# SPA env (prod API + local SFU override)
+cd apps/web
+cp .env.example .env.local
+# Edit .env.local: set prod VITE_PUBLIC_API_BASE_URL, VITE_PUBLIC_WS_URL, Cognito vars, and:
+#   VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000
+
+npm ci
+npm test
+npm run dev
+```
+
+**Operator step:** When using prod **`POST /v1/webrtc/sfu-token`**, copy the real **`riffsync/sfu-join-hmac-secret`** from AWS Secrets Manager into **`SFU_JWT_SECRET`** in **`infra/local-media/.env`**. Tokens must verify against the disposable SFU.
+
+**Manual check:** Host shares a tab — browser Network shows WebSocket to **`ws://127.0.0.1:3000`**, not the prod signal host. Guest tab receives host screen via SFU consumers.
+
+**Teardown:** **`npm run media:local:down`** from the repo root.
+
+Full port map, cross-device LAN notes, and ICE overrides: **[`infra/local-media/README.md`](infra/local-media/README.md)**.
 
 ## Documentation
 
@@ -120,6 +154,7 @@ Fan support might fund clearer distribution paths (sales, bundles, partnerships)
 - [Server architecture (draft)](docs/architecture.server.md)
 - [Operator admin — users, reporting, catalog & lists (draft)](docs/architecture.admin.md)
 - [Frontend architecture (draft)](docs/architecture.frontend.md)
+- [Local watch-party media — disposable SFU + coturn (`infra/local-media/`)](infra/local-media/README.md)
 
 ## Naming
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -19,12 +19,27 @@
 # VITE_STAFF_COGNITO_HOSTED_UI_DOMAIN=
 # VITE_STAFF_COGNITO_CLIENT_ID=
 
-# Optional. JSON **`iceServers`** fallback when **`GET /v1/webrtc/ice`** is unavailable or when
-# **`VITE_PUBLIC_API_BASE_URL`** is unset (local dev). With API URL set, the app fetches ICE from the API first.
-#
-# Mediasoup signaling URL (no query string). GitHub: PROD_SFU_PUBLIC_WS_URL=wss://signal.riffsync.tv
-# or omit it and set PROD_SFU_SIGNALING_HOSTNAME=signal.riffsync.tv (API default wss://that host).
-# VITE_PUBLIC_SFU_WS_URL=wss://sfu.example.com
+# Mediasoup signaling base URL (no query string). Production: wss://signal.riffsync.tv (from CDK context
+# or PROD_SFU_PUBLIC_WS_URL / PROD_SFU_SIGNALING_HOSTNAME in CI). When set, overrides token-embedded
+# wsUrl from POST /v1/webrtc/sfu-token (see `.ai/runtime/configuration.md`).
+# VITE_PUBLIC_SFU_WS_URL=wss://signal.riffsync.tv
 
-# Local development: copy to `.env.development` and point at the production API (read-only paths) or mock.
-# Without `VITE_PUBLIC_API_BASE_URL`, `vite dev` loads `data/catalog/episodes.json` as a fallback only.
+# Optional. JSON iceServers array for RTCPeerConnection when GET /v1/webrtc/ice is unavailable or unsuitable.
+# With VITE_PUBLIC_API_BASE_URL set, the app fetches ICE from the API first.
+# VITE_WEBRTC_ICE_SERVERS_JSON=[{"urls":"stun:stun.l.google.com:19302"}]
+
+# --- Local watch-party media (disposable SFU + coturn) ---
+# Copy this file to `.env.local` (or `.env.development`) and uncomment the vars you need.
+# Prerequisites: Docker, `npm run media:local`, health probe OK — see README and infra/local-media/README.md.
+#
+# Override prod token wsUrl so the SPA connects to the workstation SFU while using prod room WebSocket/API:
+# VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000
+#
+# Optional when prod GET /v1/webrtc/ice TURN credentials do not match local coturn (static-auth-secret in
+# infra/local-media/coturn/turnserver.conf must match the credential generation you use):
+# VITE_WEBRTC_ICE_SERVERS_JSON=[{"urls":["stun:127.0.0.1:3478","turn:127.0.0.1:3478?transport=udp"],"username":"local","credential":"local-dev-turn-secret"}]
+#
+# Operator step: copy AWS Secrets Manager riffsync/sfu-join-hmac-secret into infra/local-media/.env as
+# SFU_JWT_SECRET so POST /v1/webrtc/sfu-token JWTs verify against the disposable SFU.
+
+# Local development: without `VITE_PUBLIC_API_BASE_URL`, `vite dev` loads `data/catalog/episodes.json` as fallback.

--- a/apps/web/src/room/sfu/mediasoupSharing.test.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../config/sfuWsUrl', () => ({
+  getPublicSfuWsUrl: vi.fn(),
+}))
+
+import { getPublicSfuWsUrl } from '../../config/sfuWsUrl'
+import { resolveSfuWsBaseForToken } from './mediasoupSharing'
+
+describe('resolveSfuWsBaseForToken', () => {
+  it('prefers VITE_PUBLIC_SFU_WS_URL over token wsUrl when env is set', () => {
+    vi.mocked(getPublicSfuWsUrl).mockReturnValue('ws://127.0.0.1:3000')
+    expect(
+      resolveSfuWsBaseForToken({
+        token: 't',
+        role: 'producer',
+        wsUrl: 'wss://signal.riffsync.tv',
+      }),
+    ).toBe('ws://127.0.0.1:3000')
+  })
+
+  it('uses token wsUrl when env override is unset', () => {
+    vi.mocked(getPublicSfuWsUrl).mockReturnValue(undefined)
+    expect(
+      resolveSfuWsBaseForToken({
+        token: 't',
+        role: 'producer',
+        wsUrl: 'wss://signal.riffsync.tv/',
+      }),
+    ).toBe('wss://signal.riffsync.tv')
+  })
+
+  it('returns env URL when token wsUrl is absent', () => {
+    vi.mocked(getPublicSfuWsUrl).mockReturnValue('ws://127.0.0.1:3000')
+    expect(
+      resolveSfuWsBaseForToken({
+        token: 't',
+        role: 'consumer',
+      }),
+    ).toBe('ws://127.0.0.1:3000')
+  })
+})

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -159,9 +159,11 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 function resolveWsBase(tok: SfuTokenResponse): string | undefined {
+  const fromEnv = getPublicSfuWsUrl()
+  if (fromEnv) return fromEnv
   const fromTok = tok.wsUrl?.trim()
   if (fromTok) return fromTok.replace(/\/$/, '')
-  return getPublicSfuWsUrl()
+  return undefined
 }
 
 export type SfuSessionEndReason =

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -17,7 +17,7 @@ interface ImportMetaEnv {
   readonly VITE_WEBRTC_ICE_SERVERS_JSON?: string
   /**
    * Mediasoup signaling **`ws://`** / **`wss://`** base (no path, no query). Baked in at **`npm run build`** only.
-   * After API deploy, **`POST /v1/webrtc/sfu-token`** also returns **`wsUrl`** from **`SFU_PUBLIC_WS_URL`** (from CDK context / hostname, not from a cross-stack EIP token).
+   * When set, takes precedence over token-embedded **`wsUrl`** from **`POST /v1/webrtc/sfu-token`** (local disposable SFU).
    */
   readonly VITE_PUBLIC_SFU_WS_URL?: string
 }

--- a/infra/local-media/.env.example
+++ b/infra/local-media/.env.example
@@ -1,0 +1,18 @@
+# Copy to infra/local-media/.env (gitignored). Fixture values are fine for compose smoke tests.
+#
+# When the SPA uses prod POST /v1/webrtc/sfu-token, SFU_JWT_SECRET must match AWS Secrets Manager
+# riffsync/sfu-join-hmac-secret (operator copy — never commit the prod value).
+
+SFU_JWT_SECRET=local-dev-sfu-join-secret-replace-me
+SFU_ADMIN_SECRET=local-dev-sfu-admin-secret-replace-me
+
+# Same-machine dev default. Use your LAN IP when testing across devices on the same network.
+MEDIASOUP_ANNOUNCED_IP=127.0.0.1
+MEDIASOUP_RTC_MIN_PORT=40000
+MEDIASOUP_RTC_MAX_PORT=40199
+
+# Participant AV caps — defaults mirror SFU_CAP_ENV in infra/cdk/lib/sfu-env-lines.ts
+SFU_MAX_PRODUCERS_PER_SESSION=3
+SFU_MAX_PRODUCERS_PER_ROOM=24
+SFU_MAX_WEBRTC_TRANSPORTS_PER_SESSION=8
+SFU_MAX_CONSUMERS_PER_SESSION=64

--- a/infra/local-media/README.md
+++ b/infra/local-media/README.md
@@ -1,0 +1,68 @@
+# Local watch-party media (disposable SFU + coturn)
+
+Workstation profile that runs **`services/riffsync-sfu`** and **coturn** with the same signaling and producer semantics as **`RiffSyncTurn`**, without touching hosted prod media.
+
+## Prerequisites
+
+- Docker Desktop or Docker Engine with Compose v2
+- Copy **`.env.example`** to **`.env`** and set secrets (fixture values are fine for smoke tests)
+- Copy **`coturn/turnserver.conf.example`** to **`coturn/turnserver.conf`** and set **`static-auth-secret`**
+
+## Port map
+
+| Service | Host bind | Purpose |
+| --- | --- | --- |
+| **sfu** | **`127.0.0.1:3000`** (TCP) | HTTP **`/healthz`**, WebSocket mediasoup signaling |
+| **sfu** | **`40000-40199`** (UDP + TCP) | mediasoup RTC (matches **`MEDIASOUP_RTC_*`** in **`.env`**) |
+| **turn** | **`3478`** (UDP + TCP) | STUN/TURN |
+| **turn** | **`49152-65535`** (UDP + TCP) | TURN relay allocation range |
+
+## Bootstrap
+
+From the repository root:
+
+```bash
+npm run media:local
+curl -sSf http://127.0.0.1:3000/healthz
+npm run media:local:down
+```
+
+Or directly:
+
+```bash
+docker compose -f infra/local-media/compose.yml up -d --build
+docker compose -f infra/local-media/compose.yml ps
+docker compose -f infra/local-media/compose.yml down
+```
+
+**Expected:** **`/healthz`** returns JSON with **`ok: true`**; both **`sfu`** and **`turn`** reach running state.
+
+## Prod API coupling (operator step)
+
+When **`apps/web`** still targets prod **`RiffSyncApi-prod`** for room WebSocket and HTTP:
+
+1. Copy the real value of **`riffsync/sfu-join-hmac-secret`** from AWS Secrets Manager into **`SFU_JWT_SECRET`** in **`.env`**. Tokens from **`POST /v1/webrtc/sfu-token`** must verify against this secret.
+2. Set **`VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000`** in **`apps/web/.env.local`** so the SPA overrides token-embedded **`wsUrl`**.
+3. Optional: point **`VITE_WEBRTC_ICE_SERVERS_JSON`** at local coturn when prod **`GET /v1/webrtc/ice`** TURN credentials are unsuitable.
+
+Never commit prod secret values.
+
+## Cross-device testing
+
+Default **`MEDIASOUP_ANNOUNCED_IP=127.0.0.1`** and **`external-ip=127.0.0.1`** in coturn work for same-machine tabs. For phones or other machines on your LAN:
+
+1. Set **`MEDIASOUP_ANNOUNCED_IP`** in **`.env`** to your workstation LAN IP.
+2. Set **`external-ip`** in **`coturn/turnserver.conf`** to the same LAN IP.
+3. Point **`VITE_PUBLIC_SFU_WS_URL`** at **`ws://<LAN-IP>:3000`** (signaling is bound to localhost only today — use SSH tunnel or adjust compose bind if you need remote signaling).
+
+## Health probe
+
+```bash
+curl -sSf http://127.0.0.1:3000/healthz
+```
+
+Success body includes **`ok`**, **`workerAlive`**, **`routerRoomCount`**, and **`signalingConnections`**.
+
+## Idempotency
+
+**`docker compose up -d`** and **`down`** only publish the ports above. No host paths outside this directory are modified at runtime (config is read-only mounts + gitignored **`.env`**).

--- a/infra/local-media/compose.yml
+++ b/infra/local-media/compose.yml
@@ -1,0 +1,33 @@
+# Disposable local watch-party media: mediasoup SFU + coturn (same semantics as RiffSyncTurn).
+# Bootstrap: copy .env.example -> .env and coturn/turnserver.conf.example -> coturn/turnserver.conf
+# See README.md for port map, health probe, and prod join-secret coupling.
+
+services:
+  sfu:
+    build:
+      context: ../../services/riffsync-sfu
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      PORT: "3000"
+    ports:
+      # HTTP + WebSocket signaling (localhost only)
+      - "127.0.0.1:3000:3000"
+      # mediasoup RTC (match MEDIASOUP_RTC_MIN_PORT / MEDIASOUP_RTC_MAX_PORT in .env)
+      - "40000-40199:40000-40199/udp"
+      - "40000-40199:40000-40199/tcp"
+    restart: unless-stopped
+
+  turn:
+    image: coturn/coturn:4.6.2-r9
+    volumes:
+      - ./coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro
+    ports:
+      # STUN/TURN (3478 UDP + TCP)
+      - "3478:3478"
+      - "3478:3478/udp"
+      # TURN relay range (must match min-port/max-port in turnserver.conf and prod SG 49152-65535)
+      - "49152-65535:49152-65535/udp"
+      - "49152-65535:49152-65535/tcp"
+    restart: unless-stopped

--- a/infra/local-media/coturn/turnserver.conf.example
+++ b/infra/local-media/coturn/turnserver.conf.example
@@ -1,0 +1,24 @@
+# Copy to coturn/turnserver.conf (gitignored) and set static-auth-secret to match
+# TURN_STATIC_AUTH_SECRET / prod riffsync/turn-static-auth-secret when coupling ICE with prod API.
+#
+# Aligned with RiffSyncTurn UserData in infra/cdk/lib/media-server-stack.ts (use-auth-secret pattern).
+
+listening-port=3478
+listening-ip=0.0.0.0
+fingerprint
+
+use-auth-secret
+static-auth-secret=REPLACE_WITH_TURN_STATIC_AUTH_SECRET
+
+realm=riffsync-turn
+server-name=riffsync-turn
+
+# Same-machine: 127.0.0.1. Cross-device on LAN: your workstation LAN IP.
+external-ip=127.0.0.1
+
+# Relay range — must match compose published ports and prod EC2 security group (49152-65535).
+min-port=49152
+max-port=65535
+
+verbose
+no-cli

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "scripts": {
     "prepare": "husky",
+    "media:local": "docker compose -f infra/local-media/compose.yml up -d --build",
+    "media:local:down": "docker compose -f infra/local-media/compose.yml down",
     "verify:push": "npm run verify:push:cdk && npm run verify:push:web && npm run verify:push:sfu",
     "verify:push:cdk": "npm ci --prefix infra/cdk && npm run test --prefix infra/cdk && npm run synth --prefix infra/cdk",
     "verify:push:web": "npm ci --prefix apps/web && npm test --prefix apps/web",

--- a/services/riffsync-sfu/Dockerfile
+++ b/services/riffsync-sfu/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

- Adds **`infra/local-media/`** disposable docker compose profile: **`services/riffsync-sfu`** + **coturn** on **`127.0.0.1:3000`** (#164)
- Root **`npm run media:local`** / **`media:local:down`** wrap compose; gitignores runtime **`.env`** and **`coturn/turnserver.conf`**
- **`apps/web/.env.example`** documents **`VITE_PUBLIC_SFU_WS_URL`** and optional **`VITE_WEBRTC_ICE_SERVERS_JSON`** for local disposable media (#165)
- **`resolveWsBase`** prefers build-time **`VITE_PUBLIC_SFU_WS_URL`** over token-embedded **`wsUrl`** so prod control plane + local SFU works without API changes (#165)
- README **Local watch-party media** section with copy-paste bootstrap; mesh-only local dev copy retired (#165)

Implements sub-issues **#164** and **#165** on parent epic **#136**.

## Test plan

- [x] `npm run verify:push` (cdk tests + synth, web tests, sfu build)
- [x] `apps/web` unit tests including **`resolveSfuWsBaseForToken`** precedence
- [ ] `cp infra/local-media/.env.example infra/local-media/.env`
- [ ] `cp infra/local-media/coturn/turnserver.conf.example infra/local-media/coturn/turnserver.conf` and set secret
- [ ] `npm run media:local`
- [ ] `curl -sSf http://127.0.0.1:3000/healthz` returns JSON with **`ok: true`**
- [ ] `cd apps/web && cp .env.example .env.local` — set prod API/WS vars and **`VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000`**
- [ ] Host tab: Network shows WebSocket to **`ws://127.0.0.1:3000`**, not prod signal host
- [ ] Guest tab receives host screen via SFU consumers
- [ ] `npm run media:local:down`

Closes #164
Closes #165