### PR TITLE
[M15][#137] SFU config errors, copy, tests, and deploy checklist (#166, #167)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -42,6 +42,15 @@ import {
 } from '../room/roomMediaLifecycle'
 import type { SfuUnifiedSessionHandle } from '../room/sfu/mediasoupSharing'
 import { startSfuRoomSession } from '../room/sfu/sfuRoomSession'
+import {
+  messageForSfuRelayConfigError,
+  type SfuRelayConfigErrorCode,
+} from '../room/sfu/sfuConfigErrors'
+import {
+  resolveGuestVideoRelayStatusLine,
+  resolveHostVideoRelayStatusLine,
+  type GuestHostScreenFsm,
+} from '../room/sfu/sfuRelayStatusCopy'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { ChatComposeMediaPicker } from '../room/ChatComposeMediaPicker'
 import { isEmojiOnlyChatMessage } from '../room/chatEmojiDisplay'
@@ -76,10 +85,6 @@ import { useStageLayoutTransition } from '../room/stage/useStageLayoutTransition
 import { useViewportWide } from '../room/stage/useViewportWide'
 
 const DISPLAY_TITLE_MAX_LEN = 120
-
-/** Shown when neither token **`wsUrl`** nor **`import.meta.env.VITE_PUBLIC_SFU_WS_URL`** resolves. */
-const SFU_RELAY_URL_MISSING_MSG =
-  'Video relay URL is missing. Fix: (1) Redeploy RiffSyncApi-prod so POST /v1/webrtc/sfu-token returns wsUrl (from CDK context / signaling hostname). (2) Or set VITE_PUBLIC_SFU_WS_URL in the environment when you run npm run build (Vite bakes it in then, not from S3 at runtime). For https fan sites use wss via CDK context sfuPublicWsUrl or the same Vite variable.'
 
 type ChatTextLine = {
   kind: 'text'
@@ -135,20 +140,12 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null
 }
 
-type GuestHostScreenFsm = 'idle' | 'verifying_media' | 'running'
-
-function guestShareStatusLine(fsm: GuestHostScreenFsm, wsDisconnected: boolean): string | null {
-  if (wsDisconnected) return 'Reconnecting chat… Video may pause briefly.'
-  switch (fsm) {
-    case 'idle':
-      return 'Waiting for host to share…'
-    case 'verifying_media':
-      return 'Connecting to video relay…'
-    case 'running':
-      return null
-    default:
-      return null
-  }
+function isSfuRelayConfigErrorCode(code: string): code is SfuRelayConfigErrorCode {
+  return (
+    code === 'missing_ws_url' ||
+    code === 'local_sfu_unreachable' ||
+    code === 'sfu_relay_unreachable'
+  )
 }
 
 export function RoomPage() {
@@ -803,15 +800,12 @@ export function RoomPage() {
       assignSession: (s) => {
         sfuSessionRef.current = s
       },
-      onMissingWsUrl: () => setSfuRoomErr(SFU_RELAY_URL_MISSING_MSG),
+      onMissingWsUrl: () =>
+        setSfuRoomErr(messageForSfuRelayConfigError('missing_ws_url')),
       onTokenError: (msg) => setSfuRoomErr(msg),
       onMediaError: (code, msg) => {
-        if (
-          code === 'missing_ws_url' ||
-          code === 'local_sfu_unreachable' ||
-          code === 'sfu_relay_unreachable'
-        ) {
-          setSfuRoomErr(msg)
+        if (isSfuRelayConfigErrorCode(code)) {
+          setSfuRoomErr(messageForSfuRelayConfigError(code))
           return
         }
         if (participantAvController.getState().needsProducerToken) {
@@ -1262,8 +1256,15 @@ export function RoomPage() {
 
   const guestVideoStatusSentence =
     !isPublisher ?
-      guestShareStatusLine(guestShareFsmUi, Boolean(wsBase) && wsStatus !== 'open')
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: sfuRoomErr,
+        guestShareFsm: guestShareFsmUi,
+        chatWsDisconnected: Boolean(wsBase) && wsStatus !== 'open',
+      })
     : null
+
+  const hostVideoRelayStatusSentence =
+    isPublisher ? resolveHostVideoRelayStatusLine(sfuRoomErr) : null
 
   return (
     <div
@@ -1350,6 +1351,12 @@ export function RoomPage() {
                     </div>
                   )}
                 </div>
+
+                {hostVideoRelayStatusSentence ? (
+                  <p className="riffsync-muted" role="status">
+                    {hostVideoRelayStatusSentence}
+                  </p>
+                ) : null}
 
                 {isPublisher && (captureErr || (patchErr && !renameModalOpen)) ? (
                   <div className="riffsync-room-page__host-feedback" aria-label="Host notices">

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -806,6 +806,14 @@ export function RoomPage() {
       onMissingWsUrl: () => setSfuRoomErr(SFU_RELAY_URL_MISSING_MSG),
       onTokenError: (msg) => setSfuRoomErr(msg),
       onMediaError: (code, msg) => {
+        if (
+          code === 'missing_ws_url' ||
+          code === 'local_sfu_unreachable' ||
+          code === 'sfu_relay_unreachable'
+        ) {
+          setSfuRoomErr(msg)
+          return
+        }
         if (participantAvController.getState().needsProducerToken) {
           participantAvController.failPublish(participantAvErrorFromSfuMediaCode(code))
           return
@@ -813,6 +821,9 @@ export function RoomPage() {
         setSfuRoomErr(msg)
       },
       onConnecting: () => {
+        setSfuRoomErr(null)
+      },
+      onSessionReady: () => {
         setSfuRoomErr(null)
       },
     })

--- a/apps/web/src/room/av/participantAvErrors.test.ts
+++ b/apps/web/src/room/av/participantAvErrors.test.ts
@@ -66,6 +66,12 @@ describe('isParticipantAvTokenHardFail', () => {
 })
 
 describe('participantAvErrorFromSfuMediaCode', () => {
+  it('maps configuration-class SFU codes to sfu_signaling_failed', () => {
+    expect(participantAvErrorFromSfuMediaCode('missing_ws_url')).toBe('sfu_signaling_failed')
+    expect(participantAvErrorFromSfuMediaCode('local_sfu_unreachable')).toBe('sfu_signaling_failed')
+    expect(participantAvErrorFromSfuMediaCode('sfu_relay_unreachable')).toBe('sfu_signaling_failed')
+  })
+
   it('maps signaling failures to sfu_signaling_failed', () => {
     expect(participantAvErrorFromSfuMediaCode('signaling_failed')).toBe('sfu_signaling_failed')
     expect(participantAvErrorFromSfuMediaCode('signaling_closed')).toBe('sfu_signaling_failed')

--- a/apps/web/src/room/av/participantAvErrors.ts
+++ b/apps/web/src/room/av/participantAvErrors.ts
@@ -105,6 +105,13 @@ export function isParticipantAvTokenHardFail(code: string | undefined): boolean 
 }
 
 export function participantAvErrorFromSfuMediaCode(code: SfuMediaErrorCode): ParticipantAvErrorCode {
+  if (
+    code === 'local_sfu_unreachable' ||
+    code === 'sfu_relay_unreachable' ||
+    code === 'missing_ws_url'
+  ) {
+    return 'sfu_signaling_failed'
+  }
   if (code === 'signaling_failed' || code === 'signaling_closed') {
     return 'sfu_signaling_failed'
   }

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -17,6 +17,8 @@ export type SfuTokenResponse = {
 
 export type SfuMediaErrorCode =
   | 'missing_ws_url'
+  | 'local_sfu_unreachable'
+  | 'sfu_relay_unreachable'
   | 'signaling_failed'
   | 'signaling_closed'
   | 'transport_failed'

--- a/apps/web/src/room/sfu/sfuConfigErrors.test.ts
+++ b/apps/web/src/room/sfu/sfuConfigErrors.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  classifySignalingOpenFailure,
+  isConfigClassSfuMediaError,
+  isLocalDisposableSfuHost,
+  LOCAL_SFU_UNREACHABLE_MSG,
+  probeSfuHealthz,
+  SFU_RELAY_UNREACHABLE_MSG,
+  wsBaseToHealthzUrl,
+} from './sfuConfigErrors'
+
+describe('isLocalDisposableSfuHost', () => {
+  it('detects local disposable signaling hosts', () => {
+    expect(isLocalDisposableSfuHost('ws://127.0.0.1:3000')).toBe(true)
+    expect(isLocalDisposableSfuHost('ws://localhost:3000')).toBe(true)
+    expect(isLocalDisposableSfuHost('ws://host.docker.internal:3000')).toBe(true)
+    expect(isLocalDisposableSfuHost('wss://signal.riffsync.tv')).toBe(false)
+  })
+})
+
+describe('wsBaseToHealthzUrl', () => {
+  it('maps ws and wss bases to http health probes', () => {
+    expect(wsBaseToHealthzUrl('ws://127.0.0.1:3000/signaling')).toBe(
+      'http://127.0.0.1:3000/healthz',
+    )
+    expect(wsBaseToHealthzUrl('wss://signal.riffsync.tv')).toBe(
+      'https://signal.riffsync.tv/healthz',
+    )
+  })
+})
+
+describe('isConfigClassSfuMediaError', () => {
+  it('includes configuration-class SFU media codes', () => {
+    expect(isConfigClassSfuMediaError('local_sfu_unreachable')).toBe(true)
+    expect(isConfigClassSfuMediaError('sfu_relay_unreachable')).toBe(true)
+    expect(isConfigClassSfuMediaError('missing_ws_url')).toBe(true)
+    expect(isConfigClassSfuMediaError('signaling_failed')).toBe(false)
+  })
+})
+
+describe('classifySignalingOpenFailure', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies local disposable host after two open failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+      }),
+    )
+
+    expect(await classifySignalingOpenFailure('ws://127.0.0.1:3000', 1)).toEqual({
+      code: null,
+      message: null,
+    })
+    expect(await classifySignalingOpenFailure('ws://127.0.0.1:3000', 2)).toEqual({
+      code: 'local_sfu_unreachable',
+      message: LOCAL_SFU_UNREACHABLE_MSG,
+    })
+  })
+
+  it('classifies local disposable host on first failure when healthz is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+
+    expect(await classifySignalingOpenFailure('ws://localhost:3000', 1)).toEqual({
+      code: 'local_sfu_unreachable',
+      message: LOCAL_SFU_UNREACHABLE_MSG,
+    })
+  })
+
+  it('classifies prod signaling host after four open failures', async () => {
+    expect(await classifySignalingOpenFailure('wss://signal.riffsync.tv', 3)).toEqual({
+      code: null,
+      message: null,
+    })
+    expect(await classifySignalingOpenFailure('wss://signal.riffsync.tv', 4)).toEqual({
+      code: 'sfu_relay_unreachable',
+      message: SFU_RELAY_UNREACHABLE_MSG,
+    })
+  })
+})
+
+describe('probeSfuHealthz', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns false when health probe cannot connect', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')))
+    await expect(probeSfuHealthz('ws://127.0.0.1:3000')).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/room/sfu/sfuConfigErrors.test.ts
+++ b/apps/web/src/room/sfu/sfuConfigErrors.test.ts
@@ -4,8 +4,10 @@ import {
   isConfigClassSfuMediaError,
   isLocalDisposableSfuHost,
   LOCAL_SFU_UNREACHABLE_MSG,
+  messageForSfuRelayConfigError,
   probeSfuHealthz,
   SFU_RELAY_UNREACHABLE_MSG,
+  SFU_RELAY_URL_MISSING_MSG,
   wsBaseToHealthzUrl,
 } from './sfuConfigErrors'
 
@@ -35,6 +37,14 @@ describe('isConfigClassSfuMediaError', () => {
     expect(isConfigClassSfuMediaError('sfu_relay_unreachable')).toBe(true)
     expect(isConfigClassSfuMediaError('missing_ws_url')).toBe(true)
     expect(isConfigClassSfuMediaError('signaling_failed')).toBe(false)
+  })
+})
+
+describe('messageForSfuRelayConfigError', () => {
+  it('returns contract copy for every SFU_RELAY_* code', () => {
+    expect(messageForSfuRelayConfigError('missing_ws_url')).toContain(SFU_RELAY_URL_MISSING_MSG)
+    expect(messageForSfuRelayConfigError('local_sfu_unreachable')).toBe(LOCAL_SFU_UNREACHABLE_MSG)
+    expect(messageForSfuRelayConfigError('sfu_relay_unreachable')).toBe(SFU_RELAY_UNREACHABLE_MSG)
   })
 })
 

--- a/apps/web/src/room/sfu/sfuConfigErrors.ts
+++ b/apps/web/src/room/sfu/sfuConfigErrors.ts
@@ -3,11 +3,19 @@ import type { SfuMediaErrorCode } from './mediasoupSharing'
 /** Stable configuration-class SFU errors (`.ai/business_logic/error_state.md`). */
 export type SfuConfigMediaErrorCode = 'local_sfu_unreachable' | 'sfu_relay_unreachable'
 
+export type SfuRelayConfigErrorCode = 'missing_ws_url' | SfuConfigMediaErrorCode
+
+export const SFU_RELAY_URL_MISSING_MSG =
+  'Video relay URL is missing. Set VITE_PUBLIC_SFU_WS_URL at build time or redeploy API so POST /v1/webrtc/sfu-token returns wsUrl.'
+
 export const LOCAL_SFU_UNREACHABLE_MSG =
   'Local video relay is not running. Run npm run media:local, then confirm curl -sSf http://127.0.0.1:3000/healthz.'
 
 export const SFU_RELAY_UNREACHABLE_MSG =
   'Video relay is unreachable. Check docs/sfu-deploy-checklist.md and /healthz on the signaling host.'
+
+const SFU_RELAY_URL_MISSING_DEV_HINT =
+  'Dev hint: redeploy RiffSyncApi-prod for CDK sfuPublicWsUrl, or set VITE_PUBLIC_SFU_WS_URL when running npm run build.'
 
 const LOCAL_WS_OPEN_FAILURE_THRESHOLD = 2
 const PROD_WS_OPEN_FAILURE_THRESHOLD = 4
@@ -53,6 +61,17 @@ export function isConfigClassSfuMediaError(code: SfuMediaErrorCode): boolean {
 
 export function messageForConfigSfuMediaError(code: SfuConfigMediaErrorCode): string {
   return code === 'local_sfu_unreachable' ? LOCAL_SFU_UNREACHABLE_MSG : SFU_RELAY_UNREACHABLE_MSG
+}
+
+/** Production copy from `.ai/business_logic/error_state.md`; dev may append a short hint. */
+export function messageForSfuRelayConfigError(code: SfuRelayConfigErrorCode): string {
+  if (code === 'missing_ws_url') {
+    if (import.meta.env.DEV) {
+      return `${SFU_RELAY_URL_MISSING_MSG} ${SFU_RELAY_URL_MISSING_DEV_HINT}`
+    }
+    return SFU_RELAY_URL_MISSING_MSG
+  }
+  return messageForConfigSfuMediaError(code)
 }
 
 export type ClassifySignalingOpenFailureResult = {

--- a/apps/web/src/room/sfu/sfuConfigErrors.ts
+++ b/apps/web/src/room/sfu/sfuConfigErrors.ts
@@ -1,0 +1,100 @@
+import type { SfuMediaErrorCode } from './mediasoupSharing'
+
+/** Stable configuration-class SFU errors (`.ai/business_logic/error_state.md`). */
+export type SfuConfigMediaErrorCode = 'local_sfu_unreachable' | 'sfu_relay_unreachable'
+
+export const LOCAL_SFU_UNREACHABLE_MSG =
+  'Local video relay is not running. Run npm run media:local, then confirm curl -sSf http://127.0.0.1:3000/healthz.'
+
+export const SFU_RELAY_UNREACHABLE_MSG =
+  'Video relay is unreachable. Check docs/sfu-deploy-checklist.md and /healthz on the signaling host.'
+
+const LOCAL_WS_OPEN_FAILURE_THRESHOLD = 2
+const PROD_WS_OPEN_FAILURE_THRESHOLD = 4
+
+const LOCAL_DISPOSABLE_HOSTS = new Set(['127.0.0.1', 'localhost', 'host.docker.internal'])
+
+export function isLocalDisposableSfuHost(wsBaseUrl: string): boolean {
+  try {
+    return LOCAL_DISPOSABLE_HOSTS.has(new URL(wsBaseUrl).hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+export function wsBaseToHealthzUrl(wsBaseUrl: string): string {
+  const u = new URL(wsBaseUrl)
+  u.protocol = u.protocol === 'wss:' ? 'https:' : 'http:'
+  u.pathname = '/healthz'
+  u.search = ''
+  u.hash = ''
+  return u.toString()
+}
+
+export async function probeSfuHealthz(wsBaseUrl: string, signal?: AbortSignal): Promise<boolean> {
+  try {
+    const res = await fetch(wsBaseToHealthzUrl(wsBaseUrl), {
+      method: 'GET',
+      signal: signal ?? AbortSignal.timeout(4000),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export function isConfigClassSfuMediaError(code: SfuMediaErrorCode): boolean {
+  return (
+    code === 'missing_ws_url' ||
+    code === 'local_sfu_unreachable' ||
+    code === 'sfu_relay_unreachable'
+  )
+}
+
+export function messageForConfigSfuMediaError(code: SfuConfigMediaErrorCode): string {
+  return code === 'local_sfu_unreachable' ? LOCAL_SFU_UNREACHABLE_MSG : SFU_RELAY_UNREACHABLE_MSG
+}
+
+export type ClassifySignalingOpenFailureResult = {
+  code: SfuConfigMediaErrorCode | null
+  message: string | null
+}
+
+/**
+ * Classify consecutive signaling WebSocket open failures per `.ai/runtime/configuration.md`.
+ * Returns a config error when the contract threshold is met; otherwise null (transient retry).
+ */
+export async function classifySignalingOpenFailure(
+  wsBaseUrl: string,
+  consecutiveFailures: number,
+  signal?: AbortSignal,
+): Promise<ClassifySignalingOpenFailureResult> {
+  const isLocal = isLocalDisposableSfuHost(wsBaseUrl)
+
+  if (isLocal) {
+    if (consecutiveFailures === 1) {
+      const healthy = await probeSfuHealthz(wsBaseUrl, signal)
+      if (!healthy) {
+        return {
+          code: 'local_sfu_unreachable',
+          message: LOCAL_SFU_UNREACHABLE_MSG,
+        }
+      }
+    }
+    if (consecutiveFailures >= LOCAL_WS_OPEN_FAILURE_THRESHOLD) {
+      return {
+        code: 'local_sfu_unreachable',
+        message: LOCAL_SFU_UNREACHABLE_MSG,
+      }
+    }
+    return { code: null, message: null }
+  }
+
+  if (consecutiveFailures >= PROD_WS_OPEN_FAILURE_THRESHOLD) {
+    return {
+      code: 'sfu_relay_unreachable',
+      message: SFU_RELAY_UNREACHABLE_MSG,
+    }
+  }
+  return { code: null, message: null }
+}

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { LOCAL_SFU_UNREACHABLE_MSG } from './sfuConfigErrors'
+import {
+  resolveGuestVideoRelayStatusLine,
+  resolveHostVideoRelayStatusLine,
+} from './sfuRelayStatusCopy'
+
+describe('resolveGuestVideoRelayStatusLine', () => {
+  it('prefers configuration-class SFU errors over connecting copy', () => {
+    expect(
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: LOCAL_SFU_UNREACHABLE_MSG,
+        guestShareFsm: 'verifying_media',
+        chatWsDisconnected: false,
+      }),
+    ).toBe(LOCAL_SFU_UNREACHABLE_MSG)
+  })
+
+  it('shows chat reconnect copy only when no SFU config error is active', () => {
+    expect(
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: null,
+        guestShareFsm: 'running',
+        chatWsDisconnected: true,
+      }),
+    ).toBe('Reconnecting chat… Video may pause briefly.')
+  })
+
+  it('shows host-screen FSM copy when relay is healthy', () => {
+    expect(
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: null,
+        guestShareFsm: 'idle',
+        chatWsDisconnected: false,
+      }),
+    ).toBe('Waiting for host to share…')
+  })
+})
+
+describe('resolveHostVideoRelayStatusLine', () => {
+  it('surfaces configuration-class SFU errors on the host relay status', () => {
+    expect(resolveHostVideoRelayStatusLine(LOCAL_SFU_UNREACHABLE_MSG)).toBe(
+      LOCAL_SFU_UNREACHABLE_MSG,
+    )
+    expect(resolveHostVideoRelayStatusLine(null)).toBeNull()
+  })
+})

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.ts
@@ -1,0 +1,30 @@
+/** Guest host-screen attach FSM labels for the video-relay status surface. */
+export type GuestHostScreenFsm = 'idle' | 'verifying_media' | 'running'
+
+/**
+ * Video-relay drawer status for guests. Configuration-class SFU errors persist here
+ * (and in the page alert) until signaling `session.ready` clears them.
+ */
+export function resolveGuestVideoRelayStatusLine(opts: {
+  sfuRelayError: string | null
+  guestShareFsm: GuestHostScreenFsm
+  chatWsDisconnected: boolean
+}): string | null {
+  if (opts.sfuRelayError) return opts.sfuRelayError
+  if (opts.chatWsDisconnected) return 'Reconnecting chat… Video may pause briefly.'
+  switch (opts.guestShareFsm) {
+    case 'idle':
+      return 'Waiting for host to share…'
+    case 'verifying_media':
+      return 'Connecting to video relay…'
+    case 'running':
+      return null
+    default:
+      return null
+  }
+}
+
+/** Host video-relay status mirrors config-class errors; transient states stay in capture chrome. */
+export function resolveHostVideoRelayStatusLine(sfuRelayError: string | null): string | null {
+  return sfuRelayError
+}

--- a/apps/web/src/room/sfu/sfuRoomSession.test.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.test.ts
@@ -1,11 +1,28 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import { SfuTokenHttpError } from '../av/participantAvErrors'
+import { connectSfuUnifiedSession } from './mediasoupSharing'
 import {
   formatSfuTokenError,
   isRosterConsistency403,
   resolveSfuTokenProducerClass,
+  startSfuRoomSession,
 } from './sfuRoomSession'
 import { createParticipantAvController } from './participantAvSession'
+import { LOCAL_SFU_UNREACHABLE_MSG } from './sfuConfigErrors'
+
+vi.mock('../../api/webrtcSfuApi', () => ({
+  fetchSfuJoinToken: vi.fn(),
+}))
+
+vi.mock('./mediasoupSharing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./mediasoupSharing')>()
+  return {
+    ...actual,
+    connectSfuUnifiedSession: vi.fn(),
+    resolveSfuWsBaseForToken: vi.fn((tok: { wsUrl?: string }) => tok.wsUrl ?? null),
+  }
+})
 
 describe('formatSfuTokenError', () => {
   it('expands structured SfuTokenHttpError copy', () => {
@@ -107,5 +124,77 @@ describe('resolveSfuTokenProducerClass', () => {
         getHostScreenStream: () => null,
       }),
     ).toBe('participant_av')
+  })
+})
+
+describe('startSfuRoomSession config error banner persistence', () => {
+  beforeEach(() => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+    )
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async (opts) => {
+      opts.onMediaError?.('signaling_failed', 'Could not connect to video relay (signaling).')
+      return {
+        ready: Promise.reject(new Error('signaling failed')),
+        sessionEnded: Promise.resolve('signaling_close'),
+        close: vi.fn(),
+        unpublishProducerClass: vi.fn(),
+        publishStream: vi.fn(),
+        supportsPublish: false,
+        detachConsumerClass: vi.fn(),
+        pauseProducerKind: vi.fn(),
+        resumeProducerKind: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof connectSfuUnifiedSession>>
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('skips onConnecting after a configuration-class error is active', async () => {
+    const onConnecting = vi.fn()
+    const onMediaError = vi.fn()
+    const participantAv = createParticipantAvController({ canPublish: () => false })
+
+    const { cancel } = startSfuRoomSession({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      participantAv,
+      onRemoteStream: () => {},
+      assignSession: () => {},
+      onMissingWsUrl: vi.fn(),
+      onTokenError: vi.fn(),
+      onMediaError,
+      onConnecting,
+    })
+
+    await vi.waitFor(() => {
+      expect(onMediaError).toHaveBeenCalledWith(
+        'local_sfu_unreachable',
+        LOCAL_SFU_UNREACHABLE_MSG,
+      )
+    })
+
+    await vi.waitFor(() => {
+      expect(onConnecting.mock.calls.length).toBeGreaterThanOrEqual(1)
+    })
+
+    const connectingCallsAfterConfigError = onConnecting.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 800))
+    expect(onConnecting.mock.calls.length).toBe(connectingCallsAfterConfigError)
+
+    cancel()
   })
 })

--- a/apps/web/src/room/sfu/sfuRoomSession.ts
+++ b/apps/web/src/room/sfu/sfuRoomSession.ts
@@ -13,6 +13,7 @@ import {
   type SfuProducerClass,
   type SfuUnifiedSessionHandle,
 } from './mediasoupSharing'
+import { classifySignalingOpenFailure, type SfuConfigMediaErrorCode } from './sfuConfigErrors'
 import type { ParticipantAvController } from './participantAvSession'
 import { nextSfuReconnectDelayMs, sleepMs } from './sfuReconnectPolicy'
 
@@ -24,7 +25,10 @@ type SessionHooks = {
   onTokenError: (message: string) => void
   onMediaError: (code: SfuMediaErrorCode, message: string) => void
   onSessionClean?: () => void
+  /** Clears transient SFU banners only; skipped while a configuration-class error is active. */
   onConnecting?: () => void
+  /** Clears SFU error banner after signaling `session.ready` succeeds. */
+  onSessionReady?: () => void
 }
 
 export type StartSfuRoomSessionOpts = SessionHooks & {
@@ -136,6 +140,9 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
   const { assignSession, participantAv } = opts
   let attempt = 0
   let activeClose: (() => void) | null = null
+  let consecutiveWsOpenFailures = 0
+  let activeConfigError: SfuConfigMediaErrorCode | null = null
+  let signalingClassificationGen = 0
 
   const cancel = () => {
     ac.abort()
@@ -206,7 +213,9 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
       }
 
       attempt = 0
-      opts.onConnecting?.()
+      if (!activeConfigError) {
+        opts.onConnecting?.()
+      }
 
       const session = await connectSfuUnifiedSession({
         wsBaseUrl: wsBase,
@@ -216,13 +225,48 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         onRemoteStream: opts.onRemoteStream,
         onConsumerTrack: opts.onConsumerTrack,
         ownSessionId: opts.sessionId,
-        onMediaError: opts.onMediaError,
+        onMediaError: (code, message) => {
+          if (code !== 'signaling_failed') {
+            opts.onMediaError(code, message)
+            return
+          }
+          consecutiveWsOpenFailures++
+          const classificationGen = ++signalingClassificationGen
+          void (async () => {
+            const classified = await classifySignalingOpenFailure(
+              wsBase,
+              consecutiveWsOpenFailures,
+              signal,
+            )
+            if (signal.aborted || classificationGen !== signalingClassificationGen) return
+            if (classified.code && classified.message) {
+              activeConfigError = classified.code
+              opts.onMediaError(classified.code, classified.message)
+              return
+            }
+            if (!activeConfigError) {
+              opts.onMediaError(code, message)
+            }
+          })()
+        },
       })
 
       if (signal.aborted) {
         session.close()
         break
       }
+
+      try {
+        await session.ready
+      } catch {
+        await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
+        continue
+      }
+
+      consecutiveWsOpenFailures = 0
+      activeConfigError = null
+      signalingClassificationGen++
+      opts.onSessionReady?.()
 
       activeClose = () => session.close()
       assignSession(session)

--- a/docs/sfu-deploy-checklist.md
+++ b/docs/sfu-deploy-checklist.md
@@ -23,33 +23,36 @@ Manual verification after deploys that touch **`RiffSyncTurn`** (mediasoup SFU +
 7. **Misconfiguration**  
    Temporarily unset **`VITE_PUBLIC_SFU_WS_URL`** and omit **`wsUrl`** from token wiring; production build should show a **visible** room error (not only a console message) about missing relay URL.
 
+8. **Local disposable SFU down (`LOCAL_SFU_UNREACHABLE`)**  
+   With **`VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000`** (or **`ws://localhost:3000`**) and **`npm run media:local`** / compose **stopped**, open a room page. Within two signaling open attempts (or on the first failure when **`curl -sSf http://127.0.0.1:3000/healthz`** fails), the page **`role="alert"`** and guest/host **video-relay status** show **`LOCAL_SFU_UNREACHABLE`** copy from **`.ai/business_logic/error_state.md`** — not console-only and not a cleared "Connecting to video relay…" banner.
+
 ## Multi-publisher participant AV (#106)
 
 Prerequisites: M14 sub-issues through #102–#105 landed; room has **`avDisabled: false`**; at least one signed-in host and **three** signed-in fans for cap smoke.
 
-8. **N fans publish camera+mic**  
+9. **N fans publish camera+mic**  
    Three signed-in fans enable camera and microphone. SFU **`listProducers`** (or signaling logs) shows distinct **`participant_av`** rows per **`sessionId`**. Remote tiles appear in Theater strip (desktop) or horizontal scroll row (narrow).
 
-9. **Theater mixed audio**  
+10. **Theater mixed audio**  
    Host shares tab; two fans mic-on (one camera-off). Movie audio and both mic streams audible at equal gain (**#118** mixer). Mic-only fan not in strip but listed in **People** tab.
 
-10. **Video Chat grid**  
+11. **Video Chat grid**  
     Host switches **`roomMode: videoChat`**. Grid shows video-on fans; mic-only remain audible, not in grid. Empty grid shows contract copy when no cameras on.
 
-11. **Host AV kill switch**  
+12. **Host AV kill switch**  
     Host **`PATCH { "avDisabled": true }`**. Confirm SFU admin teardown: **`curl -sS -X POST "${SFU_HTTP}/admin/teardown-producers" -H "content-type: application/json" -H "x-sfu-admin-secret: ${SFU_ADMIN_SECRET}" -d '{"env":"prod","roomId":"<roomId>"}'`** returns **`closedCount`** (repeat is idempotent). All fans' participant producers tear down on SFU; **`host_screen`** remains if active; toggles disabled with **"The host turned room A/V off."**; new participant token mint returns **`403`** **`av_disabled`**.
 
-12. **Mid-party join with publishers**  
+13. **Mid-party join with publishers**  
     With two fans already publishing, open a third signed-in fan window. New fan consumes existing **`participant_av`** producers without requiring incumbents to toggle off/on.
 
-13. **Publisher cap hard-fail**  
+14. **Publisher cap hard-fail**  
     With **8** fans publishing (or mint estimate at cap), ninth fan enabling camera receives inline **`publisher_cap_exceeded`** copy; toggle returns off.
 
-14. **SFU signaling drop with multiple producers**  
+15. **SFU signaling drop with multiple producers**  
     On one guest, close only the **SFU** WebSocket while two remote **`participant_av`** streams are active. Guest recovers via token refetch + reconnect; remote video returns or visible **`sfu_signaling_failed`** copy after backoff.
 
-15. **Post-deploy health**  
+16. **Post-deploy health**  
     After media deploy: **`curl -sSf "${SFU_HTTP}/healthz"`** → **`ok`**, **`workerAlive: true`**. Optional: check CloudWatch **`RiffSync/Media`** gauges if wired.
 
-16. **Worker failure drill (optional)**  
+17. **Worker failure drill (optional)**  
     If **`/healthz`** reports **`workerAlive: false`**, use SSM + **`journalctl -u riffsync-sfu`** for the **`worker died`** JSON line, then **`sudo systemctl restart riffsync-sfu`** and re-probe. See **`infra/cdk/README.md`** SFU worker runbook for reboot escalation.


### PR DESCRIPTION
## Summary

Parent epic #137: SFU configuration-class failure detection, user-visible copy, tests, and operator checklist on shared branch `feature/issue-137`.

- **#166** — Classify signaling WebSocket open failures (local `/healthz` + thresholds), persist config banners through reconnect backoff until `session.ready`.
- **#167** — Centralize `SFU_RELAY_*` copy from `error_state.md`, wire guest/host video-relay status, extend `docs/sfu-deploy-checklist.md`, and add banner persistence unit tests.

## Test plan

- [x] `cd apps/web && npm ci && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] Manual: `VITE_PUBLIC_SFU_WS_URL=ws://127.0.0.1:3000` with compose stopped shows `LOCAL_SFU_UNREACHABLE` on page alert + video-relay status; banner persists across backoff
- [ ] Manual: start `npm run media:local`, refresh room, error clears after connect
- [ ] Manual: production build with missing relay URL shows `SFU_RELAY_URL_MISSING` copy (not console-only)

Part of #137. Closes #166 and #167 when merged.