### PR TITLE
[M16][#139] RoomRealtimeSdk facade and RoomPage rewire (#172-#175)

### DIFF
--- a/apps/web/src/pages/RoomPage.test.tsx
+++ b/apps/web/src/pages/RoomPage.test.tsx
@@ -57,6 +57,7 @@ vi.mock('../room/audio/theaterAudioMix', () => ({
     setHostVideoElement: vi.fn(),
     onConsumerEvent: vi.fn(),
     resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn(() => 'running'),
   })),
 }))
 
@@ -160,11 +161,12 @@ describe('RoomPage session integration', () => {
     root = createRoot(container)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 100))
     container.remove()
     vi.unstubAllGlobals()
-    vi.restoreAllMocks()
+    vi.clearAllMocks()
   })
 
   function renderRoom() {
@@ -181,6 +183,29 @@ describe('RoomPage session integration', () => {
     })
   }
 
+  it('does not import legacy session wiring or SFU modules directly', async () => {
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const src = fs.readFileSync(path.join(__dirname, 'RoomPage.tsx'), 'utf8')
+    const forbidden = [
+      'useRoomWebSocket',
+      'useRoomSessionWiring',
+      'startSfuRoomSession',
+      'useChatSession',
+      'useSfuMediaSession',
+      'useTheaterPlayback',
+      'mediasoupSharing',
+      'sfuRelayStatusCopy',
+      'sessions/ChatSession',
+      'sessions/SfuMediaSession',
+      'sessions/TheaterPlayback',
+    ]
+    for (const token of forbidden) {
+      expect(src).not.toContain(token)
+    }
+    expect(src).toContain('useRoomRealtimeSdk')
+  })
+
   it('constructs session modules on mount and tears them down on unmount', async () => {
     renderRoom()
 
@@ -193,6 +218,7 @@ describe('RoomPage session integration', () => {
     const theaterDisposesBeforeUnmount = theaterDisposeSpy.mock.calls.length
 
     act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 50))
 
     expect(chatDisconnectSpy.mock.calls.length).toBeGreaterThan(chatDisconnectsBeforeUnmount)
     expect(sfuDisconnectSpy.mock.calls.length).toBeGreaterThan(sfuDisconnectsBeforeUnmount)

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -8,10 +8,6 @@ import { getPublicWsUrl } from '../config/wsUrl'
 import { getPublicOrigin } from '../config/publicOrigin'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { announceWebrtcDebugOnRoomMount } from '../room/webrtcDebug'
-import {
-  resolveGuestVideoRelayStatusLine,
-  resolveHostVideoRelayStatusLine,
-} from '../room/sfu/sfuRelayStatusCopy'
 import { useViewportWide } from '../room/stage/useViewportWide'
 import { HostControlBar } from '../room/HostControlBar'
 import {
@@ -23,7 +19,7 @@ import {
 import { StageParticipantLayout } from '../room/stage/StageParticipantLayout'
 import { enteredVideoChatMode } from '../room/roomMediaLifecycle'
 import { useRoomSnapshot } from '../room/useRoomSnapshot'
-import { useRoomSessionWiring } from '../room/useRoomSessionWiring'
+import { useRoomRealtimeSdk } from '../room/useRoomRealtimeSdk'
 import { useHostScreenCapture } from '../room/useHostScreenCapture'
 import { useRoomProfileTab } from '../room/useRoomProfileTab'
 import { RoomPlaybackPanel } from '../room/RoomPlaybackPanel'
@@ -108,7 +104,6 @@ export function RoomPage() {
   )
 
   const {
-    wsStatus,
     sendJson,
     chat,
     chatReactions,
@@ -130,7 +125,9 @@ export function RoomPage() {
     bindHostCaptureVideo,
     stageParticipantTiles,
     stageLayoutUpdating,
-  } = useRoomSessionWiring({
+    guestVideoStatusSentence,
+    hostVideoRelayStatusSentence,
+  } = useRoomRealtimeSdk({
     wsBase,
     canonicalRoomId,
     roomId,
@@ -138,7 +135,6 @@ export function RoomPage() {
     displayName,
     fanToken,
     room,
-    avDisabled,
     roomMode,
     isPublisher,
     captureStream,
@@ -310,16 +306,6 @@ export function RoomPage() {
   const viewerCount = peopleShown.length
   const activeSidebarTab =
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
-
-  const guestVideoStatusSentence = !isPublisher
-    ? resolveGuestVideoRelayStatusLine({
-        sfuRelayError: sfuRoomErr,
-        guestShareFsm: theaterPlaybackSnapshot.guestShareFsm,
-        chatWsDisconnected: Boolean(wsBase) && wsStatus !== 'open',
-      })
-    : null
-
-  const hostVideoRelayStatusSentence = isPublisher ? resolveHostVideoRelayStatusLine(sfuRoomErr) : null
 
   return (
     <div

--- a/apps/web/src/room/audio/theaterAudioMix.ts
+++ b/apps/web/src/room/audio/theaterAudioMix.ts
@@ -23,6 +23,7 @@ export type TheaterAudioMix = {
   setHostVideoElement: (element: HTMLVideoElement | null) => void
   onConsumerEvent: (event: TheaterAudioConsumerEvent) => void
   resumeIfSuspended: () => Promise<void>
+  getAudioContextState: () => AudioContextState | undefined
 }
 
 export type CreateTheaterAudioMixOptions = {
@@ -222,5 +223,6 @@ export function createTheaterAudioMix(options: CreateTheaterAudioMixOptions = {}
         /* ignore autoplay policy */
       }
     },
+    getAudioContextState: () => ctx?.state,
   }
 }

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RoomSnapshot } from '../../api/roomsApi'
+import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
 import { ChatSession } from './ChatSession'
 import { SfuMediaSession } from './SfuMediaSession'
 import { TheaterPlayback } from './TheaterPlayback'
@@ -385,5 +386,203 @@ describe('RoomRealtimeSdk public surface', () => {
     expect(diag.drawers.chat.state).toBe('connected')
     expect(diag.drawers.sfuSignaling.state).toBe('connected')
     expect(diag.drawers.theaterPlayback.state).toBe('connected')
+  })
+})
+
+describe('RoomRealtimeSdk.publishAv', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('is idempotent when camera and mic state already match', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-publish',
+    })
+
+    const av = (sdk as unknown as { sfu: SfuMediaSession }).sfu.participantAv
+    const enableCamera = vi.spyOn(av, 'enableCamera')
+    const disableCamera = vi.spyOn(av, 'disableCamera')
+    const enableMic = vi.spyOn(av, 'enableMic')
+    const disableMic = vi.spyOn(av, 'disableMic')
+    vi.spyOn(av, 'getState').mockReturnValue({
+      cameraEnabled: true,
+      micEnabled: false,
+      micMuted: false,
+      canPublish: true,
+      needsProducerToken: true,
+      error: null,
+      busy: false,
+    })
+
+    sdk.publishAv({ camera: true, mic: false })
+    sdk.publishAv({ camera: true, mic: false })
+
+    expect(enableCamera).not.toHaveBeenCalled()
+    expect(disableCamera).not.toHaveBeenCalled()
+    expect(enableMic).not.toHaveBeenCalled()
+    expect(disableMic).not.toHaveBeenCalled()
+  })
+
+  it('toggles only the AV axis that changed', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-publish-partial',
+    })
+
+    const av = (sdk as unknown as { sfu: SfuMediaSession }).sfu.participantAv
+    const disableCamera = vi.spyOn(av, 'disableCamera')
+    const enableMic = vi.spyOn(av, 'enableMic')
+    vi.spyOn(av, 'getState').mockReturnValue({
+      cameraEnabled: true,
+      micEnabled: false,
+      micMuted: false,
+      canPublish: true,
+      needsProducerToken: true,
+      error: null,
+      busy: false,
+    })
+
+    sdk.publishAv({ camera: false, mic: true })
+
+    expect(disableCamera).toHaveBeenCalledTimes(1)
+    expect(enableMic).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RoomRealtimeSdk.subscribe', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('re-registers handlers and replaces prior host screen listener', () => {
+    const onRemoteStreamA = vi.fn()
+    const onRemoteStreamB = vi.fn()
+    const remoteStreamListeners: Array<(stream: MediaStream | null) => void> = []
+    vi.spyOn(SfuMediaSession.prototype, 'onRemoteStream').mockImplementation(function (
+      this: SfuMediaSession,
+      listener,
+    ) {
+      remoteStreamListeners.push(listener)
+      return () => {
+        const idx = remoteStreamListeners.indexOf(listener)
+        if (idx >= 0) remoteStreamListeners.splice(idx, 1)
+      }
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-sub',
+    })
+
+    sdk.subscribe({ hostScreen: { onRemoteStream: onRemoteStreamA } })
+    sdk.subscribe({ hostScreen: { onRemoteStream: onRemoteStreamB } })
+
+    expect(remoteStreamListeners).toHaveLength(1)
+    const stream = { id: 'remote' } as MediaStream
+    remoteStreamListeners[0]?.(stream)
+    expect(onRemoteStreamA).not.toHaveBeenCalled()
+    expect(onRemoteStreamB).toHaveBeenCalledWith(stream)
+  })
+
+  it('does not tear down chat when subscribe handlers detach', () => {
+    const disconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-sub-detach',
+      wsUrl: 'wss://ws.test',
+    })
+
+    const onConsumerTrack = vi.fn()
+    sdk.subscribe({ participantAv: { onConsumerTrack } })
+    sdk.subscribe({})
+
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(sdk.getDiagnostics().drawers.chat.state).not.toBe('torn-down')
+  })
+
+  it('routes participant_av consumer events into TheaterPlayback via subscribe', async () => {
+    mockChatConnectOpensImmediately()
+    const routeSfuConsumerEvent = vi
+      .spyOn(TheaterPlayback.prototype, 'routeSfuConsumerEvent')
+      .mockImplementation(() => undefined)
+    const consumerListeners: Array<(event: SfuConsumerTrackEvent) => void> = []
+    vi.spyOn(SfuMediaSession.prototype, 'onConsumerTrack').mockImplementation(function (
+      listener: (event: SfuConsumerTrackEvent) => void,
+    ) {
+      consumerListeners.push(listener)
+      return () => {
+        const idx = consumerListeners.indexOf(listener)
+        if (idx >= 0) consumerListeners.splice(idx, 1)
+      }
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-theater-sub',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    const onConsumerTrack = vi.fn()
+    sdk.subscribe({ participantAv: { onConsumerTrack } })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+    await vi.waitFor(() => expect(consumerListeners.length).toBeGreaterThan(0))
+
+    const event: SfuConsumerTrackEvent = {
+      action: 'attach',
+      producerId: 'p-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: { id: 'a1' } as MediaStreamTrack,
+    }
+    consumerListeners[0]?.(event)
+
+    expect(routeSfuConsumerEvent).toHaveBeenCalledWith(event)
+    expect(onConsumerTrack).toHaveBeenCalledWith(event)
+  })
+})
+
+describe('RoomRealtimeSdk.getDiagnostics SFU counts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes optional SFU role and producer/consumer counts when session is open', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    vi.spyOn(SfuMediaSession.prototype, 'getSignalingDiagnostics').mockReturnValue({
+      role: 'consumer',
+      producerCount: 0,
+      consumerCount: 2,
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-sfu-diag',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    await vi.waitFor(() => {
+      expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+    })
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.role).toBe('consumer')
+    expect(diag.drawers.sfuSignaling.producerCount).toBe(0)
+    expect(diag.drawers.sfuSignaling.consumerCount).toBe(2)
   })
 })

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RoomSnapshot } from '../../api/roomsApi'
+import { ChatSession } from './ChatSession'
+import { SfuMediaSession } from './SfuMediaSession'
+import { TheaterPlayback } from './TheaterPlayback'
 import {
   DRAWER_LIFECYCLE_STATES,
   RoomRealtimeSdk,
@@ -47,6 +50,18 @@ function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
   expect(diag.asOf).toMatch(/^\d{4}-\d{2}-\d{2}T/)
 }
 
+function mockChatConnectOpensImmediately(): void {
+  vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+  })
+}
+
+function mockSfuConnectOpensImmediately(): void {
+  vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (this: SfuMediaSession) {
+    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+  })
+}
+
 describe('RoomRealtimeSdk lifecycle mappers', () => {
   it('maps chat session statuses to drawer lifecycle enum strings', () => {
     expect(mapChatSessionStatusToDrawerState('open')).toBe('connected')
@@ -67,6 +82,10 @@ describe('RoomRealtimeSdk lifecycle mappers', () => {
 })
 
 describe('RoomRealtimeSdk.getDiagnostics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns stable JSON field names before join', () => {
     const sdk = new RoomRealtimeSdk()
     const diag = sdk.getDiagnostics()
@@ -77,7 +96,7 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
     expect(diag.activeErrorCodes).toEqual([])
   })
 
-  it('returns stable diagnostics shape after join with theater layout', () => {
+  it('returns stable diagnostics shape after join without URLs (modules constructed, not bootstrapped)', () => {
     const sdk = new RoomRealtimeSdk()
     sdk.join('room-abc', {
       roomSnapshot: baseSnapshot,
@@ -88,15 +107,47 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
     assertStableDiagnosticsContract(diag)
     expect(diag.roomId).toBe('room-abc')
     expect(diag.sessionId).toBe('sess-diag-1')
-    expect(diag.drawers.theaterPlayback.state).toBe('connected')
+    expect(diag.drawers.theaterPlayback.state).toBe('torn-down')
   })
 
-  it('marks theater drawer torn-down when layout is video chat', () => {
+  it('marks theater drawer connected after media bootstrap on theater layout', async () => {
+    const getIceServers = vi.fn(async () => [{ urls: 'stun:stun.test' }])
+    mockChatConnectOpensImmediately()
+    const sfuConnectSpy = vi.spyOn(SfuMediaSession.prototype, 'connect')
+    const theaterConfigureSpy = vi.spyOn(TheaterPlayback.prototype, 'configure')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-diag-1',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers,
+    })
+
+    await vi.waitFor(() => expect(theaterConfigureSpy).toHaveBeenCalled())
+
+    const diag = sdk.getDiagnostics()
+    assertStableDiagnosticsContract(diag)
+    expect(diag.drawers.chat.state).toBe('connected')
+    expect(diag.drawers.theaterPlayback.state).toBe('connected')
+    expect(sfuConnectSpy).toHaveBeenCalled()
+    expect(theaterConfigureSpy).toHaveBeenCalled()
+  })
+
+  it('marks theater drawer torn-down when layout is video chat', async () => {
+    mockChatConnectOpensImmediately()
+
     const sdk = new RoomRealtimeSdk()
     sdk.join('room-abc', {
       roomSnapshot: { ...baseSnapshot, roomMode: 'videoChat' },
       sessionId: 'sess-diag-2',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
     })
+
+    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected'))
 
     const diag = sdk.getDiagnostics()
     assertStableDiagnosticsContract(diag)
@@ -148,7 +199,7 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
               "state": "torn-down",
             },
             "theaterPlayback": {
-              "state": "connected",
+              "state": "torn-down",
             },
           },
           "roomId": "room-abc",
@@ -166,7 +217,106 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
   })
 })
 
+describe('RoomRealtimeSdk.join bootstrap order', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('warms ICE then connects SFU then initializes theater after chat opens', async () => {
+    const order: string[] = []
+    const getIceServers = vi.fn(async () => {
+      order.push('ice')
+      return [{ urls: 'stun:stun.test' }]
+    })
+
+    vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+      order.push('chat-connect')
+      ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    })
+    vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (
+      this: SfuMediaSession,
+    ) {
+      order.push('sfu-connect')
+    })
+    vi.spyOn(TheaterPlayback.prototype, 'configure').mockImplementation(function (
+      this: TheaterPlayback,
+    ) {
+      order.push('theater-configure')
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-order',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers,
+    })
+
+    await vi.waitFor(() => expect(order).toContain('theater-configure'))
+
+    expect(order.indexOf('chat-connect')).toBeLessThan(order.indexOf('ice'))
+    expect(order.indexOf('ice')).toBeLessThan(order.indexOf('sfu-connect'))
+    expect(order.indexOf('sfu-connect')).toBeLessThan(order.indexOf('theater-configure'))
+  })
+})
+
+describe('RoomRealtimeSdk media policy wiring', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forwards share_state stopped to SfuMediaSession without tearing down chat', () => {
+    const handleShareStateStopped = vi.spyOn(SfuMediaSession.prototype, 'handleShareStateStopped')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-policy',
+      wsUrl: 'wss://ws.test',
+      isHost: false,
+    })
+
+    const chat = (sdk as unknown as { chat: ChatSession }).chat
+    const shareListeners = (chat as unknown as {
+      shareStateListeners: Set<(ev: { roomId: string; state: unknown }) => void>
+    }).shareStateListeners
+    for (const listener of shareListeners) {
+      listener({ roomId: 'room-abc', state: 'stopped' })
+    }
+
+    expect(handleShareStateStopped).toHaveBeenCalledWith(false)
+  })
+
+  it('forwards av_disabled kill switch to SfuMediaSession', () => {
+    const handleAvDisabledKillSwitch = vi.spyOn(SfuMediaSession.prototype, 'handleAvDisabledKillSwitch')
+    const updatePublishGate = vi.spyOn(SfuMediaSession.prototype, 'updatePublishGate')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-av',
+      wsUrl: 'wss://ws.test',
+    })
+
+    const chat = (sdk as unknown as { chat: ChatSession }).chat
+    const avListeners = (chat as unknown as {
+      avDisabledListeners: Set<(ev: { avDisabled: boolean }) => void>
+    }).avDisabledListeners
+    for (const listener of avListeners) {
+      listener({ avDisabled: true })
+    }
+
+    expect(updatePublishGate).toHaveBeenCalledWith({ avDisabled: true })
+    expect(handleAvDisabledKillSwitch).toHaveBeenCalled()
+  })
+})
+
 describe('RoomRealtimeSdk public surface', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('exposes join, publishAv, subscribe, getDiagnostics, and teardown', () => {
     const sdk = new RoomRealtimeSdk()
     expect(typeof sdk.join).toBe('function')
@@ -191,5 +341,49 @@ describe('RoomRealtimeSdk public surface', () => {
     expect(diag.drawers.chat.state).toBe('torn-down')
     expect(diag.drawers.sfuSignaling.state).toBe('torn-down')
     expect(diag.drawers.theaterPlayback.state).toBe('torn-down')
+  })
+
+  it('calls onDiagnosticsChange when drawer status changes', async () => {
+    mockChatConnectOpensImmediately()
+    const onDiagnosticsChange = vi.fn()
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-cb',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      onDiagnosticsChange,
+    })
+
+    await vi.waitFor(() => {
+      const lastCall = onDiagnosticsChange.mock.calls.at(-1)?.[0]
+      expect(lastCall?.drawers.chat.state).toBe('connected')
+    })
+  })
+
+  it('reports connected chat and SFU drawers when modules are healthy after bootstrap', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-healthy',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    })
+
+    await vi.waitFor(() => {
+      const diag = sdk.getDiagnostics()
+      expect(diag.drawers.sfuSignaling.state).toBe('connected')
+    })
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.chat.state).toBe('connected')
+    expect(diag.drawers.sfuSignaling.state).toBe('connected')
+    expect(diag.drawers.theaterPlayback.state).toBe('connected')
   })
 })

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import type { RoomSnapshot } from '../../api/roomsApi'
+import {
+  DRAWER_LIFECYCLE_STATES,
+  RoomRealtimeSdk,
+  mapChatSessionStatusToDrawerState,
+  mapSfuMediaSessionStatusToDrawerState,
+  type RoomRealtimeDiagnostics,
+} from './RoomRealtimeSdk'
+
+const baseSnapshot: RoomSnapshot = {
+  roomId: 'room-abc',
+  hostSub: 'host-sub',
+  catalogEpisodeId: 'ep-1',
+  youtubeVideoId: 'yt-1',
+  playbackExpectation: 'free',
+  visibility: 'public',
+  lastActivityAt: 1,
+  version: 1,
+  roomMode: 'theater',
+  avDisabled: false,
+  broadcastCaptureActive: false,
+}
+
+const REQUIRED_DIAGNOSTIC_KEYS = [
+  'roomId',
+  'sessionId',
+  'asOf',
+  'drawers',
+  'activeErrorCodes',
+] as const satisfies readonly (keyof RoomRealtimeDiagnostics)[]
+
+const REQUIRED_DRAWER_KEYS = ['chat', 'sfuSignaling', 'theaterPlayback'] as const
+
+function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
+  for (const key of REQUIRED_DIAGNOSTIC_KEYS) {
+    expect(diag).toHaveProperty(key)
+  }
+
+  for (const drawerKey of REQUIRED_DRAWER_KEYS) {
+    expect(diag.drawers).toHaveProperty(drawerKey)
+    expect(diag.drawers[drawerKey]).toHaveProperty('state')
+    expect(DRAWER_LIFECYCLE_STATES).toContain(diag.drawers[drawerKey].state)
+  }
+
+  expect(Array.isArray(diag.activeErrorCodes)).toBe(true)
+  expect(diag.asOf).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+}
+
+describe('RoomRealtimeSdk lifecycle mappers', () => {
+  it('maps chat session statuses to drawer lifecycle enum strings', () => {
+    expect(mapChatSessionStatusToDrawerState('open')).toBe('connected')
+    expect(mapChatSessionStatusToDrawerState('connecting')).toBe('reconnecting')
+    expect(mapChatSessionStatusToDrawerState('error')).toBe('degraded')
+    expect(mapChatSessionStatusToDrawerState('idle')).toBe('torn-down')
+    expect(mapChatSessionStatusToDrawerState('closed')).toBe('torn-down')
+  })
+
+  it('maps SFU session statuses to drawer lifecycle enum strings', () => {
+    expect(mapSfuMediaSessionStatusToDrawerState('open')).toBe('connected')
+    expect(mapSfuMediaSessionStatusToDrawerState('connecting')).toBe('reconnecting')
+    expect(mapSfuMediaSessionStatusToDrawerState('reconnecting')).toBe('reconnecting')
+    expect(mapSfuMediaSessionStatusToDrawerState('error')).toBe('degraded')
+    expect(mapSfuMediaSessionStatusToDrawerState('idle')).toBe('torn-down')
+    expect(mapSfuMediaSessionStatusToDrawerState('closed')).toBe('torn-down')
+  })
+})
+
+describe('RoomRealtimeSdk.getDiagnostics', () => {
+  it('returns stable JSON field names before join', () => {
+    const sdk = new RoomRealtimeSdk()
+    const diag = sdk.getDiagnostics()
+    assertStableDiagnosticsContract(diag)
+    expect(diag.drawers.chat.state).toBe('torn-down')
+    expect(diag.drawers.sfuSignaling.state).toBe('torn-down')
+    expect(diag.drawers.theaterPlayback.state).toBe('torn-down')
+    expect(diag.activeErrorCodes).toEqual([])
+  })
+
+  it('returns stable diagnostics shape after join with theater layout', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-diag-1',
+    })
+
+    const diag = sdk.getDiagnostics()
+    assertStableDiagnosticsContract(diag)
+    expect(diag.roomId).toBe('room-abc')
+    expect(diag.sessionId).toBe('sess-diag-1')
+    expect(diag.drawers.theaterPlayback.state).toBe('connected')
+  })
+
+  it('marks theater drawer torn-down when layout is video chat', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: { ...baseSnapshot, roomMode: 'videoChat' },
+      sessionId: 'sess-diag-2',
+    })
+
+    const diag = sdk.getDiagnostics()
+    assertStableDiagnosticsContract(diag)
+    expect(diag.drawers.theaterPlayback.state).toBe('torn-down')
+  })
+
+  it('matches diagnostics contract snapshot for harness assertions', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-snapshot',
+    })
+
+    const diag = sdk.getDiagnostics()
+    expect({
+      topLevelKeys: REQUIRED_DIAGNOSTIC_KEYS.slice().sort(),
+      drawerKeys: REQUIRED_DRAWER_KEYS.slice().sort(),
+      lifecycleStates: DRAWER_LIFECYCLE_STATES.slice(),
+      sample: {
+        roomId: diag.roomId,
+        sessionId: diag.sessionId,
+        drawers: {
+          chat: { state: diag.drawers.chat.state },
+          sfuSignaling: { state: diag.drawers.sfuSignaling.state },
+          theaterPlayback: { state: diag.drawers.theaterPlayback.state },
+        },
+        activeErrorCodes: diag.activeErrorCodes,
+      },
+    }).toMatchInlineSnapshot(`
+      {
+        "drawerKeys": [
+          "chat",
+          "sfuSignaling",
+          "theaterPlayback",
+        ],
+        "lifecycleStates": [
+          "connected",
+          "reconnecting",
+          "degraded",
+          "torn-down",
+        ],
+        "sample": {
+          "activeErrorCodes": [],
+          "drawers": {
+            "chat": {
+              "state": "torn-down",
+            },
+            "sfuSignaling": {
+              "state": "torn-down",
+            },
+            "theaterPlayback": {
+              "state": "connected",
+            },
+          },
+          "roomId": "room-abc",
+          "sessionId": "sess-snapshot",
+        },
+        "topLevelKeys": [
+          "activeErrorCodes",
+          "asOf",
+          "drawers",
+          "roomId",
+          "sessionId",
+        ],
+      }
+    `)
+  })
+})
+
+describe('RoomRealtimeSdk public surface', () => {
+  it('exposes join, publishAv, subscribe, getDiagnostics, and teardown', () => {
+    const sdk = new RoomRealtimeSdk()
+    expect(typeof sdk.join).toBe('function')
+    expect(typeof sdk.publishAv).toBe('function')
+    expect(typeof sdk.subscribe).toBe('function')
+    expect(typeof sdk.getDiagnostics).toBe('function')
+    expect(typeof sdk.teardown).toBe('function')
+  })
+
+  it('teardown resets diagnostics to torn-down drawers', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-teardown',
+    })
+    sdk.teardown()
+
+    const diag = sdk.getDiagnostics()
+    assertStableDiagnosticsContract(diag)
+    expect(diag.roomId).toBe('')
+    expect(diag.sessionId).toBe('')
+    expect(diag.drawers.chat.state).toBe('torn-down')
+    expect(diag.drawers.sfuSignaling.state).toBe('torn-down')
+    expect(diag.drawers.theaterPlayback.state).toBe('torn-down')
+  })
+})

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -1,0 +1,342 @@
+/**
+ * Narrow public realtime API for room sessions.
+ *
+ * Maintainer tooling: `realtimeDiagnostics.ts` (`?diag=1`, `window.riffsyncRealtimeDiag`) is
+ * dev-only WS timeline counters and JWT probes. `getDiagnostics()` on this class is the
+ * normative fan-visible / harness contract per `.ai/integration/api_contracts.md`.
+ */
+
+import type { RoomSnapshot } from '../../api/roomsApi'
+import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
+import { ChatSession, type ChatSessionStatus } from './ChatSession'
+import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
+import { TheaterPlayback } from './TheaterPlayback'
+
+export const DRAWER_LIFECYCLE_STATES = [
+  'connected',
+  'reconnecting',
+  'degraded',
+  'torn-down',
+] as const
+
+export type DrawerLifecycleState = (typeof DRAWER_LIFECYCLE_STATES)[number]
+
+export type ChatDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+}
+
+export type SfuSignalingDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+  role?: 'producer' | 'consumer'
+  producerCount?: number
+  consumerCount?: number
+}
+
+export type TheaterPlaybackDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+  audioContextState?: AudioContextState
+}
+
+export type RoomRealtimeDiagnostics = {
+  roomId: string
+  sessionId: string
+  asOf: string
+  drawers: {
+    chat: ChatDrawerDiagnostics
+    sfuSignaling: SfuSignalingDrawerDiagnostics
+    theaterPlayback: TheaterPlaybackDrawerDiagnostics
+  }
+  activeErrorCodes: string[]
+}
+
+export type JoinOptions = {
+  roomSnapshot: RoomSnapshot
+  sessionId: string
+  displayName?: string
+  accessToken?: string | null
+  wsUrl?: string
+  apiBaseUrl?: string
+  isHost?: boolean
+  getIceServers?: () => Promise<RTCIceServer[]>
+}
+
+export type PublishAvOptions = {
+  camera: boolean
+  mic: boolean
+}
+
+export type HostScreenSubscribeHandlers = {
+  onRemoteStream?: (stream: MediaStream | null) => void
+}
+
+export type ParticipantAvSubscribeHandlers = {
+  onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
+  onConsumersClear?: () => void
+}
+
+export type SubscribeHandlers = {
+  hostScreen?: HostScreenSubscribeHandlers
+  participantAv?: ParticipantAvSubscribeHandlers
+}
+
+export function mapChatSessionStatusToDrawerState(status: ChatSessionStatus): DrawerLifecycleState {
+  switch (status) {
+    case 'open':
+      return 'connected'
+    case 'connecting':
+      return 'reconnecting'
+    case 'error':
+      return 'degraded'
+    case 'idle':
+    case 'closed':
+    default:
+      return 'torn-down'
+  }
+}
+
+export function mapSfuMediaSessionStatusToDrawerState(
+  status: SfuMediaSessionStatus,
+): DrawerLifecycleState {
+  switch (status) {
+    case 'open':
+      return 'connected'
+    case 'connecting':
+    case 'reconnecting':
+      return 'reconnecting'
+    case 'error':
+      return 'degraded'
+    case 'idle':
+    case 'closed':
+    default:
+      return 'torn-down'
+  }
+}
+
+function collectActiveErrorCodes(
+  drawers: RoomRealtimeDiagnostics['drawers'],
+): string[] {
+  const codes: string[] = []
+  const maybePush = (code: string | undefined) => {
+    if (code && !codes.includes(code)) codes.push(code)
+  }
+  maybePush(drawers.chat.lastErrorCode)
+  maybePush(drawers.sfuSignaling.lastErrorCode)
+  maybePush(drawers.theaterPlayback.lastErrorCode)
+  return codes
+}
+
+/**
+ * Framework-agnostic facade over ChatSession, SfuMediaSession, and TheaterPlayback.
+ */
+export class RoomRealtimeSdk {
+  private roomId = ''
+  private sessionId = ''
+  private theaterLayoutActive = false
+  private chatLastErrorCode: string | undefined
+  private sfuLastErrorCode: string | undefined
+  private theaterLastErrorCode: string | undefined
+
+  private chat: ChatSession | null = null
+  private sfu: SfuMediaSession | null = null
+  private theater: TheaterPlayback | null = null
+
+  private chatStatusUnsub: (() => void) | null = null
+  private sfuStatusUnsub: (() => void) | null = null
+  private sfuErrorUnsub: (() => void) | null = null
+  private hostScreenStreamUnsub: (() => void) | null = null
+  private participantAvTrackUnsub: (() => void) | null = null
+  private participantAvClearUnsub: (() => void) | null = null
+
+  join(roomId: string, options: JoinOptions): this {
+    this.teardownModules({ intentional: false })
+
+    this.roomId = roomId
+    this.sessionId = options.sessionId
+    this.theaterLayoutActive = options.roomSnapshot.roomMode === 'theater'
+
+    this.chat = new ChatSession()
+    this.sfu = new SfuMediaSession()
+    this.theater = new TheaterPlayback()
+
+    this.chatStatusUnsub = this.chat.onStatusChange((status) => {
+      if (status === 'error' && !this.chatLastErrorCode) {
+        this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
+      }
+      if (status === 'open') {
+        this.chatLastErrorCode = undefined
+      }
+    })
+
+    this.sfuStatusUnsub = this.sfu.onStatusChange((status) => {
+      if (status === 'error' && !this.sfuLastErrorCode) {
+        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+      }
+      if (status === 'open') {
+        this.sfuLastErrorCode = undefined
+      }
+    })
+
+    this.sfuErrorUnsub = this.sfu.onError((message) => {
+      if (message) {
+        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+      }
+    })
+
+    if (this.theaterLayoutActive) {
+      this.theater.configure({
+        enabled: true,
+        isPublisher: options.isHost === true,
+        avDisabled: options.roomSnapshot.avDisabled,
+      })
+      this.theater.attachSfuSession(this.sfu)
+    }
+
+    if (options.wsUrl) {
+      this.chat.connect({
+        url: options.wsUrl,
+        roomId,
+        sessionId: options.sessionId,
+        displayName: options.displayName,
+        accessToken: options.accessToken ?? null,
+        enabled: true,
+      })
+    }
+
+    if (options.apiBaseUrl) {
+      this.sfu.connect({
+        apiBaseUrl: options.apiBaseUrl,
+        roomId,
+        sessionId: options.sessionId,
+        accessToken: options.accessToken ?? null,
+        getIceServers: options.getIceServers ?? (async () => []),
+        getHostScreenStream: () => null,
+        enabled: true,
+      })
+    }
+
+    return this
+  }
+
+  publishAv(options: PublishAvOptions): void {
+    const sfu = this.sfu
+    if (!sfu) return
+    const av = sfu.participantAv
+    if (options.camera) {
+      void av.enableCamera()
+    } else {
+      av.disableCamera()
+    }
+    if (options.mic) {
+      void av.enableMic()
+    } else {
+      av.disableMic()
+    }
+  }
+
+  subscribe(handlers: SubscribeHandlers): void {
+    const sfu = this.sfu
+    if (!sfu) return
+
+    this.hostScreenStreamUnsub?.()
+    this.participantAvTrackUnsub?.()
+    this.participantAvClearUnsub?.()
+
+    if (handlers.hostScreen?.onRemoteStream) {
+      this.hostScreenStreamUnsub = sfu.onRemoteStream(handlers.hostScreen.onRemoteStream)
+    } else {
+      this.hostScreenStreamUnsub = null
+    }
+
+    if (handlers.participantAv?.onConsumerTrack) {
+      this.participantAvTrackUnsub = sfu.onConsumerTrack(handlers.participantAv.onConsumerTrack)
+    } else {
+      this.participantAvTrackUnsub = null
+    }
+
+    if (handlers.participantAv?.onConsumersClear) {
+      this.participantAvClearUnsub = sfu.onParticipantAvConsumersClear(
+        handlers.participantAv.onConsumersClear,
+      )
+    } else {
+      this.participantAvClearUnsub = null
+    }
+  }
+
+  getDiagnostics(): RoomRealtimeDiagnostics {
+    const chatState = this.chat
+      ? mapChatSessionStatusToDrawerState(this.chat.getStatus())
+      : 'torn-down'
+    const sfuState = this.sfu
+      ? mapSfuMediaSessionStatusToDrawerState(this.sfu.getStatus())
+      : 'torn-down'
+    const theaterState: DrawerLifecycleState = this.theaterLayoutActive
+      ? this.theater
+        ? 'connected'
+        : 'degraded'
+      : 'torn-down'
+
+    const drawers: RoomRealtimeDiagnostics['drawers'] = {
+      chat: {
+        state: chatState,
+        ...(this.chatLastErrorCode ? { lastErrorCode: this.chatLastErrorCode } : {}),
+      },
+      sfuSignaling: {
+        state: sfuState,
+        ...(this.sfuLastErrorCode ? { lastErrorCode: this.sfuLastErrorCode } : {}),
+      },
+      theaterPlayback: {
+        state: theaterState,
+        ...(this.theaterLastErrorCode ? { lastErrorCode: this.theaterLastErrorCode } : {}),
+      },
+    }
+
+    return {
+      roomId: this.roomId,
+      sessionId: this.sessionId,
+      asOf: new Date().toISOString(),
+      drawers,
+      activeErrorCodes: collectActiveErrorCodes(drawers),
+    }
+  }
+
+  teardown(): void {
+    this.teardownModules({ intentional: true })
+  }
+
+  private teardownModules(opts: { intentional: boolean }): void {
+    this.chatStatusUnsub?.()
+    this.sfuStatusUnsub?.()
+    this.sfuErrorUnsub?.()
+    this.hostScreenStreamUnsub?.()
+    this.participantAvTrackUnsub?.()
+    this.participantAvClearUnsub?.()
+    this.chatStatusUnsub = null
+    this.sfuStatusUnsub = null
+    this.sfuErrorUnsub = null
+    this.hostScreenStreamUnsub = null
+    this.participantAvTrackUnsub = null
+    this.participantAvClearUnsub = null
+
+    if (opts.intentional) {
+      this.chat?.disconnect()
+      this.sfu?.disconnect()
+      this.theater?.dispose()
+    }
+
+    this.chat = null
+    this.sfu = null
+    this.theater = null
+    this.theaterLayoutActive = false
+    this.chatLastErrorCode = undefined
+    this.sfuLastErrorCode = undefined
+    this.theaterLastErrorCode = undefined
+
+    if (opts.intentional) {
+      this.roomId = ''
+      this.sessionId = ''
+    }
+  }
+}

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -160,6 +160,8 @@ export class RoomRealtimeSdk {
   private hostScreenStreamUnsub: (() => void) | null = null
   private participantAvTrackUnsub: (() => void) | null = null
   private participantAvClearUnsub: (() => void) | null = null
+  private participantAvStateUnsub: (() => void) | null = null
+  private activeSubscribeHandlers: SubscribeHandlers | null = null
 
   join(roomId: string, options: JoinOptions): this {
     this.teardownModules({ intentional: false })
@@ -201,45 +203,34 @@ export class RoomRealtimeSdk {
     const sfu = this.sfu
     if (!sfu) return
     const av = sfu.participantAv
-    if (options.camera) {
-      void av.enableCamera()
-    } else {
-      av.disableCamera()
+    const state = av.getState()
+    let changed = false
+
+    if (options.camera !== state.cameraEnabled) {
+      changed = true
+      if (options.camera) {
+        void av.enableCamera()
+      } else {
+        av.disableCamera()
+      }
     }
-    if (options.mic) {
-      void av.enableMic()
-    } else {
-      av.disableMic()
+    if (options.mic !== state.micEnabled) {
+      changed = true
+      if (options.mic) {
+        void av.enableMic()
+      } else {
+        av.disableMic()
+      }
+    }
+
+    if (changed) {
+      this.emitDiagnosticsChange()
     }
   }
 
   subscribe(handlers: SubscribeHandlers): void {
-    const sfu = this.sfu
-    if (!sfu) return
-
-    this.hostScreenStreamUnsub?.()
-    this.participantAvTrackUnsub?.()
-    this.participantAvClearUnsub?.()
-
-    if (handlers.hostScreen?.onRemoteStream) {
-      this.hostScreenStreamUnsub = sfu.onRemoteStream(handlers.hostScreen.onRemoteStream)
-    } else {
-      this.hostScreenStreamUnsub = null
-    }
-
-    if (handlers.participantAv?.onConsumerTrack) {
-      this.participantAvTrackUnsub = sfu.onConsumerTrack(handlers.participantAv.onConsumerTrack)
-    } else {
-      this.participantAvTrackUnsub = null
-    }
-
-    if (handlers.participantAv?.onConsumersClear) {
-      this.participantAvClearUnsub = sfu.onParticipantAvConsumersClear(
-        handlers.participantAv.onConsumersClear,
-      )
-    } else {
-      this.participantAvClearUnsub = null
-    }
+    this.activeSubscribeHandlers = handlers
+    this.applySubscribeHandlers()
   }
 
   getDiagnostics(): RoomRealtimeDiagnostics {
@@ -254,6 +245,9 @@ export class RoomRealtimeSdk {
         ? 'connected'
         : 'torn-down'
 
+    const sfuDiag = this.sfu?.getSignalingDiagnostics() ?? {}
+    const theaterAudioContextState = this.theater?.getAudioContextState()
+
     const drawers: RoomRealtimeDiagnostics['drawers'] = {
       chat: {
         state: chatState,
@@ -262,10 +256,14 @@ export class RoomRealtimeSdk {
       sfuSignaling: {
         state: sfuState,
         ...(this.sfuLastErrorCode ? { lastErrorCode: this.sfuLastErrorCode } : {}),
+        ...(sfuDiag.role ? { role: sfuDiag.role } : {}),
+        ...(sfuDiag.producerCount !== undefined ? { producerCount: sfuDiag.producerCount } : {}),
+        ...(sfuDiag.consumerCount !== undefined ? { consumerCount: sfuDiag.consumerCount } : {}),
       },
       theaterPlayback: {
         state: theaterState,
         ...(this.theaterLastErrorCode ? { lastErrorCode: this.theaterLastErrorCode } : {}),
+        ...(theaterAudioContextState ? { audioContextState: theaterAudioContextState } : {}),
       },
     }
 
@@ -311,6 +309,16 @@ export class RoomRealtimeSdk {
     this.sfuErrorUnsub = sfu.onError((message) => {
       if (message) {
         this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+      }
+      this.emitDiagnosticsChange()
+    })
+
+    this.participantAvStateUnsub = sfu.participantAv.subscribe(() => {
+      const avError = sfu.participantAv.getState().error
+      if (avError) {
+        this.sfuLastErrorCode = avError
+      } else if (this.sfu?.getStatus() === 'open') {
+        this.sfuLastErrorCode = undefined
       }
       this.emitDiagnosticsChange()
     })
@@ -411,8 +419,53 @@ export class RoomRealtimeSdk {
       isPublisher: this.isHost,
       avDisabled: this.avDisabled,
     })
-    theater.attachSfuSession(sfu)
     this.theaterBootstrapped = true
+    this.applySubscribeHandlers()
+  }
+
+  private applySubscribeHandlers(): void {
+    const sfu = this.sfu
+    if (!sfu) return
+
+    this.hostScreenStreamUnsub?.()
+    this.participantAvTrackUnsub?.()
+    this.participantAvClearUnsub?.()
+
+    const handlers = this.activeSubscribeHandlers
+    if (!handlers) {
+      this.hostScreenStreamUnsub = null
+      this.participantAvTrackUnsub = null
+      this.participantAvClearUnsub = null
+      return
+    }
+
+    const theater = this.theater
+    const routeTheaterMix =
+      this.theaterLayoutActive && this.theaterBootstrapped && theater !== null
+
+    this.hostScreenStreamUnsub = sfu.onRemoteStream((stream) => {
+      if (routeTheaterMix && !this.isHost) {
+        theater.setGuestRemote(stream)
+      }
+      handlers.hostScreen?.onRemoteStream?.(stream)
+      this.emitDiagnosticsChange()
+    })
+
+    this.participantAvTrackUnsub = sfu.onConsumerTrack((event) => {
+      if (routeTheaterMix) {
+        theater.routeSfuConsumerEvent(event)
+      }
+      handlers.participantAv?.onConsumerTrack?.(event)
+      this.emitDiagnosticsChange()
+    })
+
+    if (handlers.participantAv?.onConsumersClear) {
+      this.participantAvClearUnsub = sfu.onParticipantAvConsumersClear(
+        handlers.participantAv.onConsumersClear,
+      )
+    } else {
+      this.participantAvClearUnsub = null
+    }
   }
 
   private emitDiagnosticsChange(): void {
@@ -427,6 +480,7 @@ export class RoomRealtimeSdk {
     this.hostScreenStreamUnsub?.()
     this.participantAvTrackUnsub?.()
     this.participantAvClearUnsub?.()
+    this.participantAvStateUnsub?.()
     this.chatStatusUnsub = null
     this.sfuStatusUnsub = null
     this.sfuErrorUnsub = null
@@ -434,6 +488,8 @@ export class RoomRealtimeSdk {
     this.hostScreenStreamUnsub = null
     this.participantAvTrackUnsub = null
     this.participantAvClearUnsub = null
+    this.participantAvStateUnsub = null
+    this.activeSubscribeHandlers = null
 
     if (opts.intentional) {
       this.chat?.disconnect()

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -8,10 +8,22 @@
 
 import type { RoomMode, RoomSnapshot } from '../../api/roomsApi'
 import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
+import type { ParticipantAvController } from '../sfu/participantAvSession'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
-import { ChatSession, type ChatSessionStatus } from './ChatSession'
+import {
+  ChatSession,
+  type AvDisabledEvent,
+  type ChatGifLine,
+  type ChatReactionEvent,
+  type ChatSessionStatus,
+  type ChatTextLine,
+  type PresenceEvent,
+  type RoomModeEvent,
+} from './ChatSession'
 import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
-import { TheaterPlayback } from './TheaterPlayback'
+import { TheaterPlayback, type TheaterPlaybackSnapshot } from './TheaterPlayback'
+
+export type { TheaterPlaybackSnapshot }
 
 export const DRAWER_LIFECYCLE_STATES = [
   'connected',
@@ -53,6 +65,15 @@ export type RoomRealtimeDiagnostics = {
   activeErrorCodes: string[]
 }
 
+export type RoomControlHandlers = {
+  onChatText?: (line: ChatTextLine) => void
+  onChatGif?: (line: ChatGifLine) => void
+  onChatReaction?: (event: ChatReactionEvent) => void
+  onPresence?: (event: PresenceEvent) => void
+  onRoomModeUi?: (event: RoomModeEvent) => void
+  onAvDisabledUi?: (event: AvDisabledEvent) => void
+}
+
 export type JoinOptions = {
   roomSnapshot: RoomSnapshot
   sessionId: string
@@ -62,6 +83,9 @@ export type JoinOptions = {
   apiBaseUrl?: string
   isHost?: boolean
   getIceServers?: () => Promise<RTCIceServer[]>
+  getHostScreenStream?: () => MediaStream | null
+  youtubeVideoId?: string | null
+  roomControlHandlers?: RoomControlHandlers
   onDiagnosticsChange?: (diagnostics: RoomRealtimeDiagnostics) => void
 }
 
@@ -148,6 +172,10 @@ export class RoomRealtimeSdk {
   private chatLastErrorCode: string | undefined
   private sfuLastErrorCode: string | undefined
   private theaterLastErrorCode: string | undefined
+  private sfuRelayErrorMessage: string | null = null
+  private getHostScreenStream: () => MediaStream | null = () => null
+  private roomControlUnsubs: Array<() => void> = []
+  private theaterSnapshotUnsub: (() => void) | null = null
 
   private chat: ChatSession | null = null
   private sfu: SfuMediaSession | null = null
@@ -176,6 +204,8 @@ export class RoomRealtimeSdk {
     this.mediaBootstrapStarted = false
     this.joinOptions = options
     this.onDiagnosticsChange = options.onDiagnosticsChange
+    this.getHostScreenStream = options.getHostScreenStream ?? (() => null)
+    this.sfuRelayErrorMessage = null
 
     this.chat = new ChatSession()
     this.sfu = new SfuMediaSession()
@@ -183,6 +213,10 @@ export class RoomRealtimeSdk {
 
     this.wireDrawerStatusListeners()
     this.wireMediaPolicyCallbacks()
+    this.wireRoomControlHandlers(options.roomControlHandlers)
+    if (options.youtubeVideoId !== undefined) {
+      this.theater.setYoutubeVideoId(options.youtubeVideoId)
+    }
 
     if (options.wsUrl) {
       this.chat.connect({
@@ -280,6 +314,72 @@ export class RoomRealtimeSdk {
     this.teardownModules({ intentional: true })
   }
 
+  sendControl(payload: Record<string, unknown>): void {
+    this.chat?.send(payload)
+  }
+
+  getChatStatus(): ChatSessionStatus {
+    return this.chat?.getStatus() ?? 'idle'
+  }
+
+  getSfuRelayError(): string | null {
+    return this.sfuRelayErrorMessage
+  }
+
+  getParticipantAvController(): ParticipantAvController | null {
+    return this.sfu?.participantAv ?? null
+  }
+
+  unpublishHostScreen(): void {
+    this.sfu?.unpublishHostScreen()
+  }
+
+  syncHostScreenPublish(opts: {
+    stream: MediaStream | null
+    roomMode: RoomMode
+    isPublisher: boolean
+  }): void {
+    this.sfu?.syncHostScreenPublish(opts)
+  }
+
+  getTheaterSnapshot(): TheaterPlaybackSnapshot {
+    return this.theater?.getSnapshot() ?? {
+      guestShareFsm: 'idle',
+      guestPlayHint: false,
+      hostCapturePlayHint: false,
+    }
+  }
+
+  onTheaterSnapshotChange(listener: (snapshot: TheaterPlaybackSnapshot) => void): () => void {
+    const theater = this.theater
+    if (!theater) return () => undefined
+    return theater.onSnapshotChange(listener)
+  }
+
+  setCaptureStreamForTheater(stream: MediaStream | null): void {
+    this.theater?.setCaptureStream(stream)
+  }
+
+  setYoutubeVideoIdForTheater(videoId: string | null | undefined): void {
+    this.theater?.setYoutubeVideoId(videoId ?? null)
+  }
+
+  bindGuestVideo(element: HTMLVideoElement | null): void {
+    this.theater?.setGuestVideoElement(element)
+  }
+
+  bindHostCaptureVideo(element: HTMLVideoElement | null): void {
+    this.theater?.setHostCaptureVideoElement(element)
+  }
+
+  playGuestVideo(): Promise<void> {
+    return this.theater?.playGuestVideo() ?? Promise.resolve()
+  }
+
+  playHostCapturePreview(): Promise<void> {
+    return this.theater?.playHostCapturePreview() ?? Promise.resolve()
+  }
+
   private wireDrawerStatusListeners(): void {
     const chat = this.chat
     const sfu = this.sfu
@@ -307,6 +407,7 @@ export class RoomRealtimeSdk {
     })
 
     this.sfuErrorUnsub = sfu.onError((message) => {
+      this.sfuRelayErrorMessage = message
       if (message) {
         this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
       }
@@ -351,6 +452,7 @@ export class RoomRealtimeSdk {
           theater.detachSfuSession()
           this.theaterBootstrapped = false
         }
+        this.joinOptions?.roomControlHandlers?.onRoomModeUi?.(event)
         this.emitDiagnosticsChange()
       }),
       chat.onAvDisabled((event) => {
@@ -367,9 +469,26 @@ export class RoomRealtimeSdk {
             avDisabled: event.avDisabled,
           })
         }
+        this.joinOptions?.roomControlHandlers?.onAvDisabledUi?.(event)
         this.emitDiagnosticsChange()
       }),
     ]
+  }
+
+  private wireRoomControlHandlers(handlers: RoomControlHandlers | undefined): void {
+    for (const unsub of this.roomControlUnsubs) unsub()
+    this.roomControlUnsubs = []
+
+    const chat = this.chat
+    if (!chat || !handlers) return
+
+    const maybePush = (unsub: () => void) => {
+      this.roomControlUnsubs.push(unsub)
+    }
+    if (handlers.onChatText) maybePush(chat.onChatText(handlers.onChatText))
+    if (handlers.onChatGif) maybePush(chat.onChatGif(handlers.onChatGif))
+    if (handlers.onChatReaction) maybePush(chat.onChatReaction(handlers.onChatReaction))
+    if (handlers.onPresence) maybePush(chat.onPresence(handlers.onPresence))
   }
 
   private async bootstrapMediaPlanes(): Promise<void> {
@@ -397,7 +516,7 @@ export class RoomRealtimeSdk {
         sessionId: options.sessionId,
         accessToken: options.accessToken ?? null,
         getIceServers,
-        getHostScreenStream: () => null,
+        getHostScreenStream: () => this.getHostScreenStream(),
         enabled: true,
       })
     }
@@ -477,6 +596,8 @@ export class RoomRealtimeSdk {
     this.sfuStatusUnsub?.()
     this.sfuErrorUnsub?.()
     for (const unsub of this.mediaPolicyUnsubs) unsub()
+    for (const unsub of this.roomControlUnsubs) unsub()
+    this.theaterSnapshotUnsub?.()
     this.hostScreenStreamUnsub?.()
     this.participantAvTrackUnsub?.()
     this.participantAvClearUnsub?.()
@@ -485,6 +606,8 @@ export class RoomRealtimeSdk {
     this.sfuStatusUnsub = null
     this.sfuErrorUnsub = null
     this.mediaPolicyUnsubs = []
+    this.roomControlUnsubs = []
+    this.theaterSnapshotUnsub = null
     this.hostScreenStreamUnsub = null
     this.participantAvTrackUnsub = null
     this.participantAvClearUnsub = null
@@ -508,6 +631,7 @@ export class RoomRealtimeSdk {
     this.chatLastErrorCode = undefined
     this.sfuLastErrorCode = undefined
     this.theaterLastErrorCode = undefined
+    this.sfuRelayErrorMessage = null
 
     if (opts.intentional) {
       this.roomId = ''

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -6,7 +6,8 @@
  * normative fan-visible / harness contract per `.ai/integration/api_contracts.md`.
  */
 
-import type { RoomSnapshot } from '../../api/roomsApi'
+import type { RoomMode, RoomSnapshot } from '../../api/roomsApi'
+import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
 import { ChatSession, type ChatSessionStatus } from './ChatSession'
 import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
@@ -61,6 +62,7 @@ export type JoinOptions = {
   apiBaseUrl?: string
   isHost?: boolean
   getIceServers?: () => Promise<RTCIceServer[]>
+  onDiagnosticsChange?: (diagnostics: RoomRealtimeDiagnostics) => void
 }
 
 export type PublishAvOptions = {
@@ -134,7 +136,15 @@ function collectActiveErrorCodes(
 export class RoomRealtimeSdk {
   private roomId = ''
   private sessionId = ''
+  private roomMode: RoomMode = 'theater'
+  private avDisabled = false
+  private isHost = false
   private theaterLayoutActive = false
+  private theaterBootstrapped = false
+  private mediaBootstrapStarted = false
+  private joinOptions: JoinOptions | null = null
+  private onDiagnosticsChange: ((diagnostics: RoomRealtimeDiagnostics) => void) | undefined
+
   private chatLastErrorCode: string | undefined
   private sfuLastErrorCode: string | undefined
   private theaterLastErrorCode: string | undefined
@@ -146,6 +156,7 @@ export class RoomRealtimeSdk {
   private chatStatusUnsub: (() => void) | null = null
   private sfuStatusUnsub: (() => void) | null = null
   private sfuErrorUnsub: (() => void) | null = null
+  private mediaPolicyUnsubs: Array<() => void> = []
   private hostScreenStreamUnsub: (() => void) | null = null
   private participantAvTrackUnsub: (() => void) | null = null
   private participantAvClearUnsub: (() => void) | null = null
@@ -155,44 +166,21 @@ export class RoomRealtimeSdk {
 
     this.roomId = roomId
     this.sessionId = options.sessionId
-    this.theaterLayoutActive = options.roomSnapshot.roomMode === 'theater'
+    this.roomMode = options.roomSnapshot.roomMode
+    this.avDisabled = options.roomSnapshot.avDisabled
+    this.isHost = options.isHost === true
+    this.theaterLayoutActive = this.roomMode === 'theater'
+    this.theaterBootstrapped = false
+    this.mediaBootstrapStarted = false
+    this.joinOptions = options
+    this.onDiagnosticsChange = options.onDiagnosticsChange
 
     this.chat = new ChatSession()
     this.sfu = new SfuMediaSession()
     this.theater = new TheaterPlayback()
 
-    this.chatStatusUnsub = this.chat.onStatusChange((status) => {
-      if (status === 'error' && !this.chatLastErrorCode) {
-        this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
-      }
-      if (status === 'open') {
-        this.chatLastErrorCode = undefined
-      }
-    })
-
-    this.sfuStatusUnsub = this.sfu.onStatusChange((status) => {
-      if (status === 'error' && !this.sfuLastErrorCode) {
-        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
-      }
-      if (status === 'open') {
-        this.sfuLastErrorCode = undefined
-      }
-    })
-
-    this.sfuErrorUnsub = this.sfu.onError((message) => {
-      if (message) {
-        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
-      }
-    })
-
-    if (this.theaterLayoutActive) {
-      this.theater.configure({
-        enabled: true,
-        isPublisher: options.isHost === true,
-        avDisabled: options.roomSnapshot.avDisabled,
-      })
-      this.theater.attachSfuSession(this.sfu)
-    }
+    this.wireDrawerStatusListeners()
+    this.wireMediaPolicyCallbacks()
 
     if (options.wsUrl) {
       this.chat.connect({
@@ -205,18 +193,7 @@ export class RoomRealtimeSdk {
       })
     }
 
-    if (options.apiBaseUrl) {
-      this.sfu.connect({
-        apiBaseUrl: options.apiBaseUrl,
-        roomId,
-        sessionId: options.sessionId,
-        accessToken: options.accessToken ?? null,
-        getIceServers: options.getIceServers ?? (async () => []),
-        getHostScreenStream: () => null,
-        enabled: true,
-      })
-    }
-
+    this.emitDiagnosticsChange()
     return this
   }
 
@@ -272,11 +249,10 @@ export class RoomRealtimeSdk {
     const sfuState = this.sfu
       ? mapSfuMediaSessionStatusToDrawerState(this.sfu.getStatus())
       : 'torn-down'
-    const theaterState: DrawerLifecycleState = this.theaterLayoutActive
-      ? this.theater
+    const theaterState: DrawerLifecycleState =
+      this.theaterLayoutActive && this.theaterBootstrapped && this.theater
         ? 'connected'
-        : 'degraded'
-      : 'torn-down'
+        : 'torn-down'
 
     const drawers: RoomRealtimeDiagnostics['drawers'] = {
       chat: {
@@ -306,16 +282,155 @@ export class RoomRealtimeSdk {
     this.teardownModules({ intentional: true })
   }
 
+  private wireDrawerStatusListeners(): void {
+    const chat = this.chat
+    const sfu = this.sfu
+    if (!chat || !sfu) return
+
+    this.chatStatusUnsub = chat.onStatusChange((status) => {
+      if (status === 'error' && !this.chatLastErrorCode) {
+        this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
+      }
+      if (status === 'open') {
+        this.chatLastErrorCode = undefined
+        void this.bootstrapMediaPlanes()
+      }
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuStatusUnsub = sfu.onStatusChange((status) => {
+      if (status === 'error' && !this.sfuLastErrorCode) {
+        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+      }
+      if (status === 'open') {
+        this.sfuLastErrorCode = undefined
+      }
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuErrorUnsub = sfu.onError((message) => {
+      if (message) {
+        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+      }
+      this.emitDiagnosticsChange()
+    })
+  }
+
+  private wireMediaPolicyCallbacks(): void {
+    const chat = this.chat
+    const sfu = this.sfu
+    const theater = this.theater
+    if (!chat || !sfu || !theater) return
+
+    this.mediaPolicyUnsubs = [
+      chat.onShareState((event) => {
+        if (event.state !== 'stopped') return
+        sfu.handleShareStateStopped(this.isHost)
+      }),
+      chat.onRoomMode((event) => {
+        const previousMode = this.roomMode
+        this.roomMode = event.roomMode
+        this.theaterLayoutActive = event.roomMode === 'theater'
+        sfu.handleRoomModeTransition(previousMode, event.roomMode, this.isHost)
+        if (event.roomMode === 'theater') {
+          this.initTheaterPlayback()
+        } else {
+          theater.configure({
+            enabled: false,
+            isPublisher: this.isHost,
+            avDisabled: this.avDisabled,
+          })
+          theater.detachSfuSession()
+          this.theaterBootstrapped = false
+        }
+        this.emitDiagnosticsChange()
+      }),
+      chat.onAvDisabled((event) => {
+        const previous = this.avDisabled
+        this.avDisabled = event.avDisabled
+        sfu.updatePublishGate({ avDisabled: event.avDisabled })
+        if (event.avDisabled && !previous) {
+          sfu.handleAvDisabledKillSwitch()
+        }
+        if (this.theaterLayoutActive && this.theaterBootstrapped) {
+          theater.configure({
+            enabled: true,
+            isPublisher: this.isHost,
+            avDisabled: event.avDisabled,
+          })
+        }
+        this.emitDiagnosticsChange()
+      }),
+    ]
+  }
+
+  private async bootstrapMediaPlanes(): Promise<void> {
+    if (this.mediaBootstrapStarted) return
+    this.mediaBootstrapStarted = true
+
+    const options = this.joinOptions
+    const sfu = this.sfu
+    const chat = this.chat
+    if (!options || !sfu || !chat) return
+
+    const getIceServers = options.getIceServers ?? fetchRtcIceServers
+    await getIceServers().catch(() => undefined)
+
+    sfu.updatePublishGate({
+      wsOpen: chat.getStatus() === 'open',
+      fanToken: options.accessToken ?? null,
+      avDisabled: this.avDisabled,
+    })
+
+    if (options.apiBaseUrl) {
+      sfu.connect({
+        apiBaseUrl: options.apiBaseUrl,
+        roomId: this.roomId,
+        sessionId: options.sessionId,
+        accessToken: options.accessToken ?? null,
+        getIceServers,
+        getHostScreenStream: () => null,
+        enabled: true,
+      })
+    }
+
+    if (this.theaterLayoutActive) {
+      this.initTheaterPlayback()
+    }
+
+    this.emitDiagnosticsChange()
+  }
+
+  private initTheaterPlayback(): void {
+    const sfu = this.sfu
+    const theater = this.theater
+    if (!sfu || !theater || !this.theaterLayoutActive) return
+
+    theater.configure({
+      enabled: true,
+      isPublisher: this.isHost,
+      avDisabled: this.avDisabled,
+    })
+    theater.attachSfuSession(sfu)
+    this.theaterBootstrapped = true
+  }
+
+  private emitDiagnosticsChange(): void {
+    this.onDiagnosticsChange?.(this.getDiagnostics())
+  }
+
   private teardownModules(opts: { intentional: boolean }): void {
     this.chatStatusUnsub?.()
     this.sfuStatusUnsub?.()
     this.sfuErrorUnsub?.()
+    for (const unsub of this.mediaPolicyUnsubs) unsub()
     this.hostScreenStreamUnsub?.()
     this.participantAvTrackUnsub?.()
     this.participantAvClearUnsub?.()
     this.chatStatusUnsub = null
     this.sfuStatusUnsub = null
     this.sfuErrorUnsub = null
+    this.mediaPolicyUnsubs = []
     this.hostScreenStreamUnsub = null
     this.participantAvTrackUnsub = null
     this.participantAvClearUnsub = null
@@ -330,6 +445,10 @@ export class RoomRealtimeSdk {
     this.sfu = null
     this.theater = null
     this.theaterLayoutActive = false
+    this.theaterBootstrapped = false
+    this.mediaBootstrapStarted = false
+    this.joinOptions = null
+    this.onDiagnosticsChange = undefined
     this.chatLastErrorCode = undefined
     this.sfuLastErrorCode = undefined
     this.theaterLastErrorCode = undefined

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -372,6 +372,20 @@ export class SfuMediaSession {
     return this.sessionHandle
   }
 
+  getSignalingDiagnostics(): {
+    role?: 'producer' | 'consumer'
+    producerCount?: number
+    consumerCount?: number
+  } {
+    const handle = this.sessionHandle
+    if (!handle || this.status !== 'open') return {}
+    return {
+      role: handle.tokenRole,
+      producerCount: handle.getProducerCount(),
+      consumerCount: handle.getConsumerCount(),
+    }
+  }
+
   onRemoteStream(listener: Listener<MediaStream | null>): () => void {
     this.remoteStreamListeners.add(listener)
     return () => this.remoteStreamListeners.delete(listener)

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -21,6 +21,7 @@ function makeMixMock() {
     setHostVideoElement: vi.fn(),
     onConsumerEvent: vi.fn(),
     resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn().mockReturnValue(undefined),
   }
 }
 

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -98,8 +98,17 @@ export class TheaterPlayback {
   attachSfuSession(session: SfuMediaSession): void {
     this.sfuConsumerUnsub?.()
     this.sfuConsumerUnsub = session.onConsumerTrack((event) => {
-      this.onSfuConsumerEvent(event)
+      this.routeSfuConsumerEvent(event)
     })
+  }
+
+  /** Route SFU consumer attach/detach into the theater audio mix graph. */
+  routeSfuConsumerEvent(event: SfuConsumerTrackEvent): void {
+    this.onSfuConsumerEvent(event)
+  }
+
+  getAudioContextState(): AudioContextState | undefined {
+    return this.mix?.getAudioContextState()
   }
 
   detachSfuSession(): void {

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -257,6 +257,9 @@ export type SfuUnifiedSessionHandle = {
   ready: Promise<void>
   /** False for consumer-only SFU tokens (no send transport until producer reconnect). */
   supportsPublish: boolean
+  tokenRole: 'producer' | 'consumer'
+  getProducerCount: () => number
+  getConsumerCount: () => number
   publishStream: (stream: MediaStream, producerClass: SfuProducerClass) => Promise<void>
   unpublishProducerClass: (producerClass: SfuProducerClass) => void
   detachConsumerClass: (producerClass: SfuProducerClass) => void
@@ -733,6 +736,9 @@ export async function connectSfuUnifiedSession(options: {
   return {
     ready,
     supportsPublish: tokenRole === 'producer',
+    tokenRole,
+    getProducerCount: () => liveProducers.length,
+    getConsumerCount: () => mediasoupConsumers.length,
     publishStream,
     unpublishProducerClass,
     detachConsumerClass,

--- a/apps/web/src/room/useRoomRealtimeSdk.ts
+++ b/apps/web/src/room/useRoomRealtimeSdk.ts
@@ -125,9 +125,11 @@ export function useRoomRealtimeSdk(options: {
   const icePromiseByRoomRef = useRef<{ roomId: string; promise: Promise<RTCIceServer[]> } | null>(
     null,
   )
-  const hostPatchSuppressAnnounceUntilRefStable = hostPatchSuppressAnnounceUntilRef
   const announceRoomA11yRef = useRef(announceRoomA11y)
-  announceRoomA11yRef.current = announceRoomA11y
+
+  useEffect(() => {
+    announceRoomA11yRef.current = announceRoomA11y
+  }, [announceRoomA11y])
 
   const getIceServers = useCallback((): Promise<RTCIceServer[]> => {
     let entry = icePromiseByRoomRef.current
@@ -186,20 +188,22 @@ export function useRoomRealtimeSdk(options: {
               ...(event.roomMode === 'videoChat' ? { broadcastCaptureActive: false } : {}),
             }
           })
-          if (Date.now() > (hostPatchSuppressAnnounceUntilRefStable.current ?? 0)) {
+          if (Date.now() > (hostPatchSuppressAnnounceUntilRef.current ?? 0)) {
             announceRoomA11yRef.current(roomModeAnnounceCopy(event.roomMode))
           }
         },
         onAvDisabledUi: (event) => {
           setRoom((prev) => (prev ? { ...prev, avDisabled: event.avDisabled } : prev))
-          if (Date.now() > (hostPatchSuppressAnnounceUntilRefStable.current ?? 0)) {
+          if (Date.now() > (hostPatchSuppressAnnounceUntilRef.current ?? 0)) {
             announceRoomA11yRef.current(avDisabledAnnounceCopy(event.avDisabled))
           }
         },
       },
       onDiagnosticsChange: () => {
-        setWsStatus(sdk.getChatStatus())
-        setSfuRoomErr(sdk.getSfuRelayError())
+        queueMicrotask(() => {
+          setWsStatus(sdk.getChatStatus())
+          setSfuRoomErr(sdk.getSfuRelayError())
+        })
       },
     })
 
@@ -219,11 +223,10 @@ export function useRoomRealtimeSdk(options: {
       },
     })
 
-    setWsStatus(sdk.getChatStatus())
-    setSfuRoomErr(sdk.getSfuRelayError())
-    setTheaterPlaybackSnapshot(sdk.getTheaterSnapshot())
-
     const theaterUnsub = sdk.onTheaterSnapshotChange(setTheaterPlaybackSnapshot)
+    queueMicrotask(() => {
+      setTheaterPlaybackSnapshot(sdk.getTheaterSnapshot())
+    })
     const chatPoll = window.setInterval(() => {
       setWsStatus(sdk.getChatStatus())
     }, 500)
@@ -248,6 +251,7 @@ export function useRoomRealtimeSdk(options: {
     sessionId,
     wsBase,
     youtubeVideoId,
+    hostPatchSuppressAnnounceUntilRef,
     setRoom,
   ])
 

--- a/apps/web/src/room/useRoomRealtimeSdk.ts
+++ b/apps/web/src/room/useRoomRealtimeSdk.ts
@@ -1,0 +1,452 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react'
+import type { RoomMode, RoomSnapshot } from '../api/roomsApi'
+import { fetchRtcIceServers } from '../config/fetchRtcIceServers'
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+import {
+  applyChatReactionEvent,
+  canAcceptReactionAdd,
+  type ReactionsByMessage,
+} from './chatReactions'
+import { createChatMessageId } from './chatMessageId'
+import { avDisabledAnnounceCopy, roomModeAnnounceCopy } from './hostRoomControls'
+import type { GiphySearchResult } from '../api/giphySearchApi'
+import type { SfuConsumerTrackEvent } from './sfu/mediasoupSharing'
+import {
+  resolveGuestVideoRelayStatusLine,
+  resolveHostVideoRelayStatusLine,
+} from './sfu/sfuRelayStatusCopy'
+import {
+  applyParticipantAvConsumerEvent,
+  type ParticipantAvVideoConsumer,
+} from './stage/participantAvConsumers'
+import { buildStageParticipantTiles } from './stage/stageParticipantTiles'
+import { useStageLayoutTransition } from './stage/useStageLayoutTransition'
+import type { ChatLine, PresenceMember } from './roomPageTypes'
+import {
+  RoomRealtimeSdk,
+  type TheaterPlaybackSnapshot,
+} from './sessions/RoomRealtimeSdk'
+import type { ChatSessionStatus } from './sessions/ChatSession'
+import type { ParticipantAvController } from './sfu/participantAvSession'
+
+export function useRoomRealtimeSdk(options: {
+  wsBase: string | undefined
+  canonicalRoomId: string
+  roomId: string
+  sessionId: string
+  displayName: string
+  fanToken: string | null
+  room: RoomSnapshot | null | undefined
+  roomMode: RoomMode
+  isPublisher: boolean
+  captureStream: MediaStream | null
+  captureStreamRef: RefObject<MediaStream | null>
+  youtubeVideoId: string | null | undefined
+  announceRoomA11y: (message: string) => void
+  hostPatchSuppressAnnounceUntilRef: RefObject<number>
+  setRoom: Dispatch<SetStateAction<RoomSnapshot | null | undefined>>
+}): {
+  wsStatus: ChatSessionStatus
+  sendJson: (payload: Record<string, unknown>) => void
+  chat: ChatLine[]
+  chatReactions: ReactionsByMessage
+  chatDraft: string
+  setChatDraft: (draft: string) => void
+  sendChat: () => void
+  sendChatGif: (result: GiphySearchResult) => void
+  toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
+  peopleShown: PresenceMember[]
+  chatMemberLabels: Map<string, string>
+  sfuRoomErr: string | null
+  guestRemote: MediaStream | null
+  participantAvController: ParticipantAvController
+  unpublishHostScreen: () => void
+  theaterPlaybackSnapshot: TheaterPlaybackSnapshot
+  playGuestVideo: () => Promise<void>
+  playHostCapturePreview: () => Promise<void>
+  bindGuestVideo: (element: HTMLVideoElement | null) => void
+  bindHostCaptureVideo: (element: HTMLVideoElement | null) => void
+  stageParticipantTiles: ReturnType<typeof buildStageParticipantTiles>
+  stageLayoutUpdating: boolean
+  guestVideoStatusSentence: string | null
+  hostVideoRelayStatusSentence: string | null
+} {
+  const {
+    wsBase,
+    canonicalRoomId,
+    roomId,
+    sessionId,
+    displayName,
+    fanToken,
+    room,
+    roomMode,
+    isPublisher,
+    captureStream,
+    captureStreamRef,
+    youtubeVideoId,
+    announceRoomA11y,
+    hostPatchSuppressAnnounceUntilRef,
+    setRoom,
+  } = options
+
+  const [sdk] = useState(() => new RoomRealtimeSdk())
+  const [wsStatus, setWsStatus] = useState<ChatSessionStatus>('idle')
+  const [sfuRoomErr, setSfuRoomErr] = useState<string | null>(null)
+  const [guestRemote, setGuestRemote] = useState<MediaStream | null>(null)
+  const [theaterPlaybackSnapshot, setTheaterPlaybackSnapshot] = useState<TheaterPlaybackSnapshot>(
+    () => sdk.getTheaterSnapshot(),
+  )
+  const [chat, setChat] = useState<ChatLine[]>([])
+  const [chatReactions, setChatReactions] = useState<ReactionsByMessage>({})
+  const [chatDraft, setChatDraft] = useState('')
+  const [participantAvVideoConsumers, setParticipantAvVideoConsumers] = useState(
+    () => new Map<string, ParticipantAvVideoConsumer>(),
+  )
+  const [presenceRoster, setPresenceRoster] = useState<{
+    roomId: string
+    members: PresenceMember[]
+  }>(() => ({
+    roomId: '',
+    members: [],
+  }))
+  const [participantAvPublishTick, setParticipantAvPublishTick] = useState(0)
+
+  void participantAvPublishTick
+
+  const icePromiseByRoomRef = useRef<{ roomId: string; promise: Promise<RTCIceServer[]> } | null>(
+    null,
+  )
+  const hostPatchSuppressAnnounceUntilRefStable = hostPatchSuppressAnnounceUntilRef
+  const announceRoomA11yRef = useRef(announceRoomA11y)
+  announceRoomA11yRef.current = announceRoomA11y
+
+  const getIceServers = useCallback((): Promise<RTCIceServer[]> => {
+    let entry = icePromiseByRoomRef.current
+    if (!entry || entry.roomId !== roomId) {
+      entry = { roomId, promise: fetchRtcIceServers() }
+      icePromiseByRoomRef.current = entry
+    }
+    return entry.promise
+  }, [roomId])
+
+  useEffect(() => {
+    if (!room || !canonicalRoomId) {
+      sdk.teardown()
+      return
+    }
+
+    sdk.join(canonicalRoomId, {
+      roomSnapshot: room,
+      sessionId,
+      displayName,
+      accessToken: fanToken,
+      wsUrl: wsBase,
+      apiBaseUrl: getPublicApiBaseUrl(),
+      isHost: isPublisher,
+      getIceServers,
+      getHostScreenStream: () => captureStreamRef.current,
+      youtubeVideoId,
+      roomControlHandlers: {
+        onChatText: (line) => {
+          setChat((prev) => [...prev, line])
+        },
+        onChatGif: (line) => {
+          setChat((prev) => [...prev, line])
+        },
+        onChatReaction: (event) => {
+          setChatReactions((prev) =>
+            applyChatReactionEvent(
+              prev,
+              event.messageId,
+              event.emoji,
+              event.action,
+              event.sessionId,
+              sessionId,
+            ),
+          )
+        },
+        onPresence: (event) => {
+          setPresenceRoster(event)
+        },
+        onRoomModeUi: (event) => {
+          setRoom((prev) => {
+            if (!prev) return prev
+            return {
+              ...prev,
+              roomMode: event.roomMode,
+              ...(event.roomMode === 'videoChat' ? { broadcastCaptureActive: false } : {}),
+            }
+          })
+          if (Date.now() > (hostPatchSuppressAnnounceUntilRefStable.current ?? 0)) {
+            announceRoomA11yRef.current(roomModeAnnounceCopy(event.roomMode))
+          }
+        },
+        onAvDisabledUi: (event) => {
+          setRoom((prev) => (prev ? { ...prev, avDisabled: event.avDisabled } : prev))
+          if (Date.now() > (hostPatchSuppressAnnounceUntilRefStable.current ?? 0)) {
+            announceRoomA11yRef.current(avDisabledAnnounceCopy(event.avDisabled))
+          }
+        },
+      },
+      onDiagnosticsChange: () => {
+        setWsStatus(sdk.getChatStatus())
+        setSfuRoomErr(sdk.getSfuRelayError())
+      },
+    })
+
+    sdk.subscribe({
+      hostScreen: {
+        onRemoteStream: (stream) => {
+          if (!isPublisher) setGuestRemote(stream)
+        },
+      },
+      participantAv: {
+        onConsumerTrack: (event: SfuConsumerTrackEvent) => {
+          setParticipantAvVideoConsumers((prev) => applyParticipantAvConsumerEvent(prev, event))
+        },
+        onConsumersClear: () => {
+          setParticipantAvVideoConsumers(new Map())
+        },
+      },
+    })
+
+    setWsStatus(sdk.getChatStatus())
+    setSfuRoomErr(sdk.getSfuRelayError())
+    setTheaterPlaybackSnapshot(sdk.getTheaterSnapshot())
+
+    const theaterUnsub = sdk.onTheaterSnapshotChange(setTheaterPlaybackSnapshot)
+    const chatPoll = window.setInterval(() => {
+      setWsStatus(sdk.getChatStatus())
+    }, 500)
+
+    return () => {
+      window.clearInterval(chatPoll)
+      theaterUnsub()
+      sdk.teardown()
+      setGuestRemote(null)
+      setWsStatus('idle')
+      setSfuRoomErr(null)
+    }
+  }, [
+    canonicalRoomId,
+    captureStreamRef,
+    displayName,
+    fanToken,
+    getIceServers,
+    isPublisher,
+    room,
+    sdk,
+    sessionId,
+    wsBase,
+    youtubeVideoId,
+    setRoom,
+  ])
+
+  useEffect(() => {
+    sdk.setCaptureStreamForTheater(captureStream)
+  }, [captureStream, sdk])
+
+  useEffect(() => {
+    sdk.setYoutubeVideoIdForTheater(youtubeVideoId)
+  }, [sdk, youtubeVideoId])
+
+  useEffect(() => {
+    if (!room || !canonicalRoomId) return
+    sdk.syncHostScreenPublish({
+      stream: captureStream,
+      roomMode,
+      isPublisher,
+    })
+  }, [captureStream, canonicalRoomId, isPublisher, room, roomMode, sdk])
+
+  const participantAvController = sdk.getParticipantAvController()
+  useEffect(() => {
+    if (!participantAvController) return
+    return participantAvController.subscribe(() => {
+      setParticipantAvPublishTick((n) => n + 1)
+    })
+  }, [participantAvController, sdk])
+
+  useEffect(() => {
+    return () => {
+      sdk.getParticipantAvController()?.teardownPublishing()
+    }
+  }, [sdk])
+
+  const sendJson = useCallback(
+    (payload: Record<string, unknown>) => {
+      sdk.sendControl(payload)
+    },
+    [sdk],
+  )
+
+  const unpublishHostScreen = useCallback(() => {
+    sdk.unpublishHostScreen()
+  }, [sdk])
+
+  const playGuestVideo = useCallback(() => sdk.playGuestVideo(), [sdk])
+  const playHostCapturePreview = useCallback(() => sdk.playHostCapturePreview(), [sdk])
+  const bindGuestVideo = useCallback(
+    (element: HTMLVideoElement | null) => sdk.bindGuestVideo(element),
+    [sdk],
+  )
+  const bindHostCaptureVideo = useCallback(
+    (element: HTMLVideoElement | null) => sdk.bindHostCaptureVideo(element),
+    [sdk],
+  )
+
+  const peopleShown = useMemo(() => {
+    const roster = presenceRoster.roomId === canonicalRoomId ? presenceRoster.members : []
+    const merged = new Map<string, PresenceMember>()
+    for (const m of roster) {
+      merged.set(m.sessionId, m)
+    }
+    if (!merged.has(sessionId)) {
+      merged.set(sessionId, { sessionId, displayName, isHost: isPublisher })
+    }
+    return [...merged.values()].sort((a, b) => {
+      if (a.isHost !== b.isHost) return a.isHost ? -1 : 1
+      return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' })
+    })
+  }, [presenceRoster.members, presenceRoster.roomId, canonicalRoomId, sessionId, displayName, isPublisher])
+
+  const chatMemberLabels = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const p of peopleShown) {
+      m.set(p.sessionId, p.displayName)
+    }
+    return m
+  }, [peopleShown])
+
+  const participantAvPublishState = participantAvController?.getState() ?? {
+    cameraEnabled: false,
+    micEnabled: false,
+    micMuted: false,
+    canPublish: false,
+    needsProducerToken: false,
+    error: null,
+    busy: false,
+  }
+  const stageParticipantTiles = buildStageParticipantTiles({
+    roster: peopleShown,
+    videoConsumers: participantAvVideoConsumers,
+    ownSessionId: sessionId,
+    localCameraOn: participantAvPublishState.cameraEnabled,
+    localPreviewStream: participantAvController?.getLocalPreviewStream() ?? null,
+  })
+
+  const stageLayoutUpdating = useStageLayoutTransition(roomMode, stageParticipantTiles.length)
+
+  const sendChat = useCallback(() => {
+    if (!fanToken) return
+    const txt = chatDraft.trim()
+    if (!txt) return
+    sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
+    setChatDraft('')
+  }, [chatDraft, fanToken, sendJson])
+
+  const sendChatGif = useCallback(
+    (result: GiphySearchResult) => {
+      if (!fanToken) return
+      sendJson({
+        action: 'chat_gif',
+        messageId: createChatMessageId(),
+        giphyId: result.giphyId,
+        renditionUrl: result.renditionUrl,
+        ...(result.title !== undefined && result.title.trim() !== '' ? { title: result.title.trim() } : {}),
+        ...(result.width !== undefined ? { width: result.width } : {}),
+        ...(result.height !== undefined ? { height: result.height } : {}),
+      })
+    },
+    [fanToken, sendJson],
+  )
+
+  const sendChatReaction = useCallback(
+    (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => {
+      if (!fanToken) return
+      const trimmedEmoji = emoji.trim()
+      if (trimmedEmoji === '') return
+      if (reactionAction === 'add') {
+        const chips = chatReactions[messageId] ?? {}
+        if (!canAcceptReactionAdd(chips, trimmedEmoji)) return
+      }
+      sendJson({
+        action: 'react',
+        messageId,
+        emoji: trimmedEmoji,
+        reactionAction,
+      })
+    },
+    [chatReactions, fanToken, sendJson],
+  )
+
+  const toggleChatReaction = useCallback(
+    (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => {
+      sendChatReaction(messageId, emoji, reactionAction)
+    },
+    [sendChatReaction],
+  )
+
+  const guestVideoStatusSentence = !isPublisher
+    ? resolveGuestVideoRelayStatusLine({
+        sfuRelayError: sfuRoomErr,
+        guestShareFsm: theaterPlaybackSnapshot.guestShareFsm,
+        chatWsDisconnected: Boolean(wsBase) && wsStatus !== 'open',
+      })
+    : null
+
+  const hostVideoRelayStatusSentence = isPublisher ? resolveHostVideoRelayStatusLine(sfuRoomErr) : null
+
+  const noopParticipantAvController: ParticipantAvController = {
+    getState: () => participantAvPublishState,
+    getLocalPreviewStream: () => null,
+    subscribe: () => () => undefined,
+    refreshPublishGate: () => undefined,
+    attachSession: () => undefined,
+    resetOnReconnect: () => undefined,
+    enableCamera: async () => undefined,
+    disableCamera: () => undefined,
+    enableMic: async () => undefined,
+    disableMic: () => undefined,
+    toggleMicMute: () => undefined,
+    teardownPublishing: () => undefined,
+    failPublish: () => undefined,
+    clearError: () => undefined,
+  }
+
+  return {
+    wsStatus,
+    sendJson,
+    chat,
+    chatReactions,
+    chatDraft,
+    setChatDraft,
+    sendChat,
+    sendChatGif,
+    toggleChatReaction,
+    peopleShown,
+    chatMemberLabels,
+    sfuRoomErr,
+    guestRemote: isPublisher ? null : guestRemote,
+    participantAvController: participantAvController ?? noopParticipantAvController,
+    unpublishHostScreen,
+    theaterPlaybackSnapshot,
+    playGuestVideo,
+    playHostCapturePreview,
+    bindGuestVideo,
+    bindHostCaptureVideo,
+    stageParticipantTiles,
+    stageLayoutUpdating,
+    guestVideoStatusSentence,
+    hostVideoRelayStatusSentence,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `RoomRealtimeSdk` with typed `getDiagnostics()` returning the stable `RoomRealtimeDiagnostics` contract from `.ai/integration/api_contracts.md` (#172).
- Implements `join()` bootstrap per `startup_bootstrap.md`: snapshot apply, chat WS, ICE warm, SFU connect, theater init when layout is Theater (#173).
- Implements `publishAv({ camera, mic })` as an idempotent delegate to the participant AV publish gate (#174).
- Implements `subscribe({ hostScreen, participantAv })` with handler re-registration, host-screen routing, participant_av tile callbacks, and theater mix wiring via SDK subscribe (#174).
- Extends `getDiagnostics()` with optional SFU `role`, `producerCount`, `consumerCount`, and theater `audioContextState` (#174).
- Rewires `RoomPage` through `useRoomRealtimeSdk` so the page no longer imports session modules, legacy websocket wiring, or SFU status helpers directly (#175).
- Extends the SDK with room-control handlers, theater UI delegates, host-screen sync, and `sendControl` for chat/share_state outbound frames (#175).
- Vitest coverage for bootstrap order, media-policy forwarding, publishAv idempotency, subscribe routing, diagnostics callbacks, harness contract shape, and RoomPage import guard (#175).

Part of parent epic #139.

## Test plan

- [x] `npm test --prefix apps/web -- RoomRealtimeSdk`
- [x] `npm test --prefix apps/web -- RoomPage`
- [x] `npm test --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [x] `npm run verify:push:web`

Closes #172
Closes #173
Closes #174
Closes #175