### PR TITLE
[M16][#140] Realtime drawer lifecycle FSM (#182, #183, #184)

### DIFF
--- a/apps/web/src/pages/RoomPage.test.tsx
+++ b/apps/web/src/pages/RoomPage.test.tsx
@@ -58,6 +58,10 @@ vi.mock('../room/audio/theaterAudioMix', () => ({
     onConsumerEvent: vi.fn(),
     resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
     getAudioContextState: vi.fn(() => 'running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
   })),
 }))
 

--- a/apps/web/src/room/audio/theaterAudioMix.ts
+++ b/apps/web/src/room/audio/theaterAudioMix.ts
@@ -24,6 +24,7 @@ export type TheaterAudioMix = {
   onConsumerEvent: (event: TheaterAudioConsumerEvent) => void
   resumeIfSuspended: () => Promise<void>
   getAudioContextState: () => AudioContextState | undefined
+  watchAudioContextState: (listener: (state: AudioContextState | undefined) => void) => () => void
 }
 
 export type CreateTheaterAudioMixOptions = {
@@ -52,9 +53,27 @@ export function createTheaterAudioMix(options: CreateTheaterAudioMixOptions = {}
   const hostScreenConsumers = new Map<string, AudioNodeBundle>()
   const participantConsumers = new Map<string, AudioNodeBundle>()
 
+  const contextStateListeners = new Set<(state: AudioContextState | undefined) => void>()
+  let contextStateListenerAttached = false
+
+  const emitContextState = () => {
+    const state = ctx?.state
+    for (const listener of contextStateListeners) listener(state)
+  }
+
+  const attachContextStateListener = (audioCtx: AudioContext) => {
+    if (contextStateListenerAttached) return
+    contextStateListenerAttached = true
+    if (typeof audioCtx.addEventListener === 'function') {
+      audioCtx.addEventListener('statechange', emitContextState)
+    }
+  }
+
   const ensureContext = (): AudioContext => {
     if (!ctx) {
       ctx = createContext()
+      attachContextStateListener(ctx)
+      emitContextState()
     }
     return ctx
   }
@@ -182,7 +201,16 @@ export function createTheaterAudioMix(options: CreateTheaterAudioMixOptions = {}
       clearHostElementSource()
       clearHostScreenConsumers()
       clearParticipantConsumers()
+      contextStateListeners.clear()
       if (ctx) {
+        if (typeof ctx.removeEventListener === 'function') {
+          try {
+            ctx.removeEventListener('statechange', emitContextState)
+          } catch {
+            /* ignore */
+          }
+        }
+        contextStateListenerAttached = false
         try {
           void ctx.close()
         } catch {
@@ -219,10 +247,16 @@ export function createTheaterAudioMix(options: CreateTheaterAudioMixOptions = {}
       if (!audioCtx || audioCtx.state !== 'suspended') return
       try {
         await audioCtx.resume()
+        emitContextState()
       } catch {
         /* ignore autoplay policy */
       }
     },
     getAudioContextState: () => ctx?.state,
+    watchAudioContextState: (listener) => {
+      contextStateListeners.add(listener)
+      listener(ctx?.state)
+      return () => contextStateListeners.delete(listener)
+    },
   }
 }

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -152,7 +152,8 @@ describe('ChatSession lifecycle FSM', () => {
     readyState = 0
     listeners = new Map<string, Array<(ev?: unknown) => void>>()
 
-    constructor(_url: string) {
+    constructor(url: string) {
+      void url
       MockWebSocket.instances.push(this)
     }
 

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ChatSession,
   routeInboundChatMessage,
@@ -124,14 +124,108 @@ describe('ChatSession send', () => {
     vi.mocked(realtimeDiagnostics.recordOutboundSent).mockClear()
   })
 
-  it('records outbound drop when socket is not open', () => {
+  it('records outbound drop when socket is not open and returns false', () => {
     const session = new ChatSession()
-    session.send({ action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440002' })
+    const dropped = session.send({ action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440002' })
+    expect(dropped).toBe(false)
     expect(realtimeDiagnostics.recordOutboundDropped).toHaveBeenCalledWith(
       { action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440002' },
       -1,
     )
     expect(realtimeDiagnostics.recordOutboundSent).not.toHaveBeenCalled()
+    expect(session.getLastErrorCode()).toBe('CHAT_SEND_DROPPED')
+  })
+
+  it('notifies send-dropped listeners without queueing', () => {
+    const session = new ChatSession()
+    const dropped = vi.fn()
+    session.onSendDropped(dropped)
+    session.send({ action: 'ping' })
+    expect(dropped).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ChatSession lifecycle FSM', () => {
+  class MockWebSocket {
+    static OPEN = 1
+    static instances: MockWebSocket[] = []
+    readyState = 0
+    listeners = new Map<string, Array<(ev?: unknown) => void>>()
+
+    constructor(_url: string) {
+      MockWebSocket.instances.push(this)
+    }
+
+    send = vi.fn()
+
+    addEventListener(type: string, fn: (ev?: unknown) => void) {
+      const list = this.listeners.get(type) ?? []
+      list.push(fn)
+      this.listeners.set(type, list)
+    }
+
+    close() {
+      this.readyState = 3
+    }
+
+    emit(type: string, ev?: unknown) {
+      for (const fn of this.listeners.get(type) ?? []) fn(ev)
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    Object.assign(MockWebSocket, { OPEN: 1, CONNECTING: 0, CLOSING: 2, CLOSED: 3 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('promotes to degraded after three failed reconnect cycles', () => {
+    const session = new ChatSession()
+    session.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-fsm',
+      accessToken: null,
+      enabled: true,
+    })
+
+    expect(session.getLifecycleState()).toBe('reconnecting')
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const ws = MockWebSocket.instances.at(-1)!
+      ws.emit('close', { code: 1006, reason: '' })
+      vi.runOnlyPendingTimers()
+    }
+
+    expect(session.getLifecycleState()).toBe('degraded')
+  })
+
+  it('resets failed cycles and returns to connected after a successful open', () => {
+    const session = new ChatSession()
+    session.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-recover',
+      accessToken: null,
+      enabled: true,
+    })
+
+    const first = MockWebSocket.instances.at(-1)!
+    first.emit('close', { code: 1006, reason: '' })
+    vi.runOnlyPendingTimers()
+
+    const second = MockWebSocket.instances.at(-1)!
+    second.readyState = MockWebSocket.OPEN
+    second.emit('open')
+
+    expect(session.getLifecycleState()).toBe('connected')
+    expect(session.getStatus()).toBe('open')
   })
 })
 

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -12,10 +12,22 @@ import {
   recordWsOpen,
 } from '../realtimeDiagnostics'
 import { webrtcDebugEnabled, webrtcLog } from '../webrtcDebug'
+import {
+  CHAT_RECONNECT_BACKOFF_INITIAL_MS,
+  chatLifecycleAfterFailedCycle,
+  nextChatReconnectBackoffMs,
+} from './drawerReconnectPolicy'
 
 const PING_MS = 25_000
 
 export type ChatSessionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
+
+/** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
+export type ChatSessionLifecycleState =
+  | 'connected'
+  | 'reconnecting'
+  | 'degraded'
+  | 'torn-down'
 
 export type ChatTextLine = {
   kind: 'text'
@@ -177,10 +189,13 @@ type Listener<T> = (event: T) => void
 
 export class ChatSession {
   private status: ChatSessionStatus = 'idle'
+  private lifecycleState: ChatSessionLifecycleState = 'torn-down'
+  private failedReconnectCycles = 0
+  private lastErrorCode: string | undefined
   private ws: WebSocket | null = null
   private pingTimer: ReturnType<typeof setInterval> | null = null
   private reconnectTimer: number | null = null
-  private backoffMs = 1000
+  private backoffMs = CHAT_RECONNECT_BACKOFF_INITIAL_MS
   private cancelled = false
   private enabled = false
   private connectOptions: ChatSessionConnectOptions | null = null
@@ -194,9 +209,19 @@ export class ChatSession {
   private roomModeListeners = new Set<Listener<RoomModeEvent>>()
   private avDisabledListeners = new Set<Listener<AvDisabledEvent>>()
   private statusListeners = new Set<Listener<ChatSessionStatus>>()
+  private lifecycleListeners = new Set<Listener<ChatSessionLifecycleState>>()
+  private sendDroppedListeners = new Set<Listener<void>>()
 
   getStatus(): ChatSessionStatus {
     return this.status
+  }
+
+  getLifecycleState(): ChatSessionLifecycleState {
+    return this.lifecycleState
+  }
+
+  getLastErrorCode(): string | undefined {
+    return this.lastErrorCode
   }
 
   onChatText(listener: Listener<ChatTextLine>): () => void {
@@ -242,6 +267,17 @@ export class ChatSession {
     return () => this.statusListeners.delete(listener)
   }
 
+  onLifecycleChange(listener: Listener<ChatSessionLifecycleState>): () => void {
+    this.lifecycleListeners.add(listener)
+    return () => this.lifecycleListeners.delete(listener)
+  }
+
+  /** Fired when outbound send is dropped because room WS is not open. */
+  onSendDropped(listener: Listener<void>): () => void {
+    this.sendDroppedListeners.add(listener)
+    return () => this.sendDroppedListeners.delete(listener)
+  }
+
   connect(options: ChatSessionConnectOptions & { enabled?: boolean }): void {
     this.connectOptions = {
       url: options.url,
@@ -255,9 +291,12 @@ export class ChatSession {
     this.teardownSocket()
     if (!this.enabled || !options.url) {
       this.setStatus('idle')
+      this.setLifecycleState('torn-down')
       return
     }
-    this.backoffMs = 1000
+    this.backoffMs = CHAT_RECONNECT_BACKOFF_INITIAL_MS
+    this.failedReconnectCycles = 0
+    this.lastErrorCode = undefined
     this.attachPageHide()
     this.openSocket()
   }
@@ -270,23 +309,36 @@ export class ChatSession {
     this.clearReconnectTimer()
     this.ws?.close()
     this.ws = null
+    this.failedReconnectCycles = 0
+    this.lastErrorCode = undefined
     this.setStatus('idle')
+    this.setLifecycleState('torn-down')
   }
 
-  send(payload: Record<string, unknown>): void {
+  /** Returns false when the send is dropped (no queue while WS is not open). */
+  send(payload: Record<string, unknown>): boolean {
     const ws = this.ws
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       recordOutboundDropped(payload, ws?.readyState ?? -1)
-      return
+      this.lastErrorCode = 'CHAT_SEND_DROPPED'
+      for (const listener of this.sendDroppedListeners) listener()
+      return false
     }
     recordOutboundSent(payload)
     ws.send(JSON.stringify(payload))
+    return true
   }
 
   private setStatus(next: ChatSessionStatus): void {
     if (this.status === next) return
     this.status = next
     for (const listener of this.statusListeners) listener(next)
+  }
+
+  private setLifecycleState(next: ChatSessionLifecycleState): void {
+    if (this.lifecycleState === next) return
+    this.lifecycleState = next
+    for (const listener of this.lifecycleListeners) listener(next)
   }
 
   private clearPing(): void {
@@ -368,6 +420,11 @@ export class ChatSession {
 
     this.teardownSocket()
     this.setStatus('connecting')
+    this.setLifecycleState(
+      this.failedReconnectCycles > 0
+        ? chatLifecycleAfterFailedCycle(this.failedReconnectCycles)
+        : 'reconnecting',
+    )
 
     const qp = new URLSearchParams({ roomId: opts.roomId, sessionId: opts.sessionId })
     if (opts.displayName && opts.displayName.trim() !== '') {
@@ -390,6 +447,7 @@ export class ChatSession {
     try {
       ws = new WebSocket(wsUrlBase)
     } catch {
+      this.recordReconnectFailure()
       this.setStatus('error')
       return
     }
@@ -397,8 +455,11 @@ export class ChatSession {
 
     ws.addEventListener('open', () => {
       if (this.cancelled || this.ws !== ws) return
-      this.backoffMs = 1000
+      this.backoffMs = CHAT_RECONNECT_BACKOFF_INITIAL_MS
+      this.failedReconnectCycles = 0
+      this.lastErrorCode = undefined
       this.setStatus('open')
+      this.setLifecycleState('connected')
       recordWsOpen()
       if (webrtcDebugEnabled()) webrtcLog('ws open')
       if (ws.readyState === WebSocket.OPEN) {
@@ -436,14 +497,19 @@ export class ChatSession {
         })
       }
       if (this.cancelled) return
+      this.recordReconnectFailure()
       this.setStatus('closed')
-      if (!this.enabled) return
-      const delay = Math.min(this.backoffMs, 60_000)
-      this.backoffMs = Math.min(this.backoffMs * 2, 60_000)
-      this.reconnectTimer = window.setTimeout(() => {
+      if (!this.enabled) {
+        this.setLifecycleState('torn-down')
+        return
+      }
+      this.setLifecycleState(chatLifecycleAfterFailedCycle(this.failedReconnectCycles))
+      const { delayMs, nextBackoffMs } = nextChatReconnectBackoffMs(this.backoffMs)
+      this.backoffMs = nextBackoffMs
+      this.reconnectTimer = globalThis.setTimeout(() => {
         this.reconnectTimer = null
         this.openSocket()
-      }, delay)
+      }, delayMs) as unknown as number
     })
 
     ws.addEventListener('error', () => {
@@ -451,6 +517,14 @@ export class ChatSession {
       recordWsErrorEvent()
       if (webrtcDebugEnabled()) webrtcLog('ws error event')
       this.setStatus('error')
+      if (this.enabled) {
+        this.setLifecycleState(chatLifecycleAfterFailedCycle(this.failedReconnectCycles))
+      }
     })
+  }
+
+  private recordReconnectFailure(): void {
+    if (this.cancelled || !this.enabled) return
+    this.failedReconnectCycles += 1
   }
 }

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -54,12 +54,18 @@ function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
 function mockChatConnectOpensImmediately(): void {
   vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
     ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'connected',
+    )
   })
 }
 
 function mockSfuConnectOpensImmediately(): void {
   vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (this: SfuMediaSession) {
     ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'connected',
+    )
   })
 }
 
@@ -67,15 +73,15 @@ describe('RoomRealtimeSdk lifecycle mappers', () => {
   it('maps chat session statuses to drawer lifecycle enum strings', () => {
     expect(mapChatSessionStatusToDrawerState('open')).toBe('connected')
     expect(mapChatSessionStatusToDrawerState('connecting')).toBe('reconnecting')
+    expect(mapChatSessionStatusToDrawerState('closed')).toBe('reconnecting')
     expect(mapChatSessionStatusToDrawerState('error')).toBe('degraded')
-    expect(mapChatSessionStatusToDrawerState('idle')).toBe('torn-down')
-    expect(mapChatSessionStatusToDrawerState('closed')).toBe('torn-down')
   })
 
   it('maps SFU session statuses to drawer lifecycle enum strings', () => {
     expect(mapSfuMediaSessionStatusToDrawerState('open')).toBe('connected')
     expect(mapSfuMediaSessionStatusToDrawerState('connecting')).toBe('reconnecting')
     expect(mapSfuMediaSessionStatusToDrawerState('reconnecting')).toBe('reconnecting')
+    expect(mapSfuMediaSessionStatusToDrawerState('degraded')).toBe('degraded')
     expect(mapSfuMediaSessionStatusToDrawerState('error')).toBe('degraded')
     expect(mapSfuMediaSessionStatusToDrawerState('idle')).toBe('torn-down')
     expect(mapSfuMediaSessionStatusToDrawerState('closed')).toBe('torn-down')
@@ -233,6 +239,9 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
       order.push('chat-connect')
       ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+      ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+        'connected',
+      )
     })
     vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (
       this: SfuMediaSession,
@@ -550,6 +559,73 @@ describe('RoomRealtimeSdk.subscribe', () => {
 
     expect(routeSfuConsumerEvent).toHaveBeenCalledWith(event)
     expect(onConsumerTrack).toHaveBeenCalledWith(event)
+  })
+})
+
+describe('RoomRealtimeSdk drawer isolation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not disconnect SFU when chat WS enters reconnecting lifecycle', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-isolate-chat',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected'))
+
+    const chat = (sdk as unknown as { chat: ChatSession }).chat
+    ;(chat as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState('reconnecting')
+
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+  })
+
+  it('does not disconnect chat when SFU enters reconnecting lifecycle', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-isolate-sfu',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected'))
+
+    const sfu = (sdk as unknown as { sfu: SfuMediaSession }).sfu
+    ;(sfu as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState('reconnecting')
+
+    expect(chatDisconnect).not.toHaveBeenCalled()
+    expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected')
+  })
+
+  it('surfaces CHAT_SEND_DROPPED when chat send is dropped', () => {
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-send-drop',
+      wsUrl: 'wss://ws.test',
+    })
+
+    sdk.sendControl({ action: 'chat', text: 'hello', messageId: '550e8400-e29b-41d4-a716-446655440099' })
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.chat.lastErrorCode).toBe('CHAT_SEND_DROPPED')
+    expect(diag.activeErrorCodes).toContain('CHAT_SEND_DROPPED')
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -12,6 +12,24 @@ import {
   type RoomRealtimeDiagnostics,
 } from './RoomRealtimeSdk'
 
+vi.mock('../audio/theaterAudioMix', () => ({
+  THEATER_AUDIO_GAIN: 1,
+  shouldRouteConsumerAudio: (producerClass: string | undefined) =>
+    producerClass === 'host_screen' || producerClass === 'participant_av',
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn().mockReturnValue('running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
 const baseSnapshot: RoomSnapshot = {
   roomId: 'room-abc',
   hostSub: 'host-sub',
@@ -626,6 +644,92 @@ describe('RoomRealtimeSdk drawer isolation', () => {
     const diag = sdk.getDiagnostics()
     expect(diag.drawers.chat.lastErrorCode).toBe('CHAT_SEND_DROPPED')
     expect(diag.activeErrorCodes).toContain('CHAT_SEND_DROPPED')
+  })
+})
+
+describe('RoomRealtimeSdk theater playback lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('marks theater drawer degraded when AudioContext is suspended', async () => {
+    mockChatConnectOpensImmediately()
+    vi.spyOn(TheaterPlayback.prototype, 'getAudioContextState').mockReturnValue('suspended')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-theater-degraded',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.theaterPlayback.state).toBe('degraded')
+    expect(diag.drawers.theaterPlayback.lastErrorCode).toBe('THEATER_AUDIO_SUSPENDED')
+    expect(diag.drawers.theaterPlayback.audioContextState).toBe('suspended')
+  })
+
+  it('replays SFU consumers when transitioning from video chat to theater', async () => {
+    mockChatConnectOpensImmediately()
+    const replayActiveMediaSubscriptions = vi.spyOn(
+      SfuMediaSession.prototype,
+      'replayActiveMediaSubscriptions',
+    )
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: { ...baseSnapshot, roomMode: 'videoChat' },
+      sessionId: 'sess-mode-transition',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+    })
+
+    sdk.subscribe({ participantAv: { onConsumerTrack: vi.fn() } })
+
+    const chat = (sdk as unknown as { chat: ChatSession }).chat
+    const roomModeListeners = (chat as unknown as {
+      roomModeListeners: Set<(ev: { roomMode: string }) => void>
+    }).roomModeListeners
+    for (const listener of roomModeListeners) {
+      listener({ roomMode: 'theater' })
+    }
+
+    await vi.waitFor(() => expect(replayActiveMediaSubscriptions).toHaveBeenCalled())
+    expect(sdk.getDiagnostics().drawers.theaterPlayback.state).toBe('connected')
+  })
+
+  it('keeps theater drawer connected after share_state stopped', async () => {
+    mockChatConnectOpensImmediately()
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-share-stop',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      isHost: false,
+    })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+
+    const chat = (sdk as unknown as { chat: ChatSession }).chat
+    const shareListeners = (chat as unknown as {
+      shareStateListeners: Set<(ev: { roomId: string; state: unknown }) => void>
+    }).shareStateListeners
+    for (const listener of shareListeners) {
+      listener({ roomId: 'room-abc', state: 'stopped' })
+    }
+
+    expect(sdk.getDiagnostics().drawers.theaterPlayback.state).toBe('connected')
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -11,6 +11,17 @@ import {
   mapSfuMediaSessionStatusToDrawerState,
   type RoomRealtimeDiagnostics,
 } from './RoomRealtimeSdk'
+import {
+  assertDrawerReconnectCycle,
+  assertNoDrawerTornDown,
+  assertSiblingDrawerStaysConnected,
+  emitShareStateStopped,
+  joinHealthySdk,
+  mockChatConnectOpensImmediately,
+  mockSfuConnectOpensImmediately,
+  setChatLifecycle,
+  setSfuLifecycle,
+} from './roomRealtimeSdkTestHelpers'
 
 vi.mock('../audio/theaterAudioMix', () => ({
   THEATER_AUDIO_GAIN: 1,
@@ -67,24 +78,6 @@ function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
 
   expect(Array.isArray(diag.activeErrorCodes)).toBe(true)
   expect(diag.asOf).toMatch(/^\d{4}-\d{2}-\d{2}T/)
-}
-
-function mockChatConnectOpensImmediately(): void {
-  vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
-    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
-    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
-      'connected',
-    )
-  })
-}
-
-function mockSfuConnectOpensImmediately(): void {
-  vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (this: SfuMediaSession) {
-    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
-    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
-      'connected',
-    )
-  })
 }
 
 describe('RoomRealtimeSdk lifecycle mappers', () => {
@@ -580,55 +573,71 @@ describe('RoomRealtimeSdk.subscribe', () => {
   })
 })
 
-describe('RoomRealtimeSdk drawer isolation', () => {
+describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('does not disconnect SFU when chat WS enters reconnecting lifecycle', async () => {
-    mockChatConnectOpensImmediately()
-    mockSfuConnectOpensImmediately()
+  // Harness step 5: chat-only WS drop — sibling sfuSignaling stays connected.
+  it('harness step 5: chat-only forced drop reconnects without tearing down SFU', async () => {
     const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-harness-chat-drop' })
 
-    const sdk = new RoomRealtimeSdk()
-    sdk.join('room-abc', {
-      roomSnapshot: baseSnapshot,
-      sessionId: 'sess-isolate-chat',
-      wsUrl: 'wss://ws.test',
-      apiBaseUrl: 'https://api.test',
-      getIceServers: async () => [],
-    })
-
-    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected'))
-
-    const chat = (sdk as unknown as { chat: ChatSession }).chat
-    ;(chat as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState('reconnecting')
+    setChatLifecycle(sdk, 'reconnecting')
+    const duringOutage = sdk.getDiagnostics()
 
     expect(sfuDisconnect).not.toHaveBeenCalled()
-    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+    assertSiblingDrawerStaysConnected(duringOutage, 'sfuSignaling')
+    expect(duringOutage.drawers.chat.state).toBe('reconnecting')
+
+    setChatLifecycle(sdk, 'connected')
+    const afterRecovery = sdk.getDiagnostics()
+
+    assertDrawerReconnectCycle(duringOutage, afterRecovery, 'chat')
+    assertSiblingDrawerStaysConnected(afterRecovery, 'sfuSignaling')
   })
 
-  it('does not disconnect chat when SFU enters reconnecting lifecycle', async () => {
-    mockChatConnectOpensImmediately()
-    mockSfuConnectOpensImmediately()
+  // Harness step 6: SFU-only signaling drop — sibling chat stays connected.
+  it('harness step 6: SFU-only forced drop reconnects without tearing down chat', async () => {
     const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-harness-sfu-drop' })
 
-    const sdk = new RoomRealtimeSdk()
-    sdk.join('room-abc', {
-      roomSnapshot: baseSnapshot,
-      sessionId: 'sess-isolate-sfu',
-      wsUrl: 'wss://ws.test',
-      apiBaseUrl: 'https://api.test',
-      getIceServers: async () => [],
-    })
-
-    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected'))
-
-    const sfu = (sdk as unknown as { sfu: SfuMediaSession }).sfu
-    ;(sfu as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState('reconnecting')
+    setSfuLifecycle(sdk, 'reconnecting')
+    const duringOutage = sdk.getDiagnostics()
 
     expect(chatDisconnect).not.toHaveBeenCalled()
-    expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected')
+    assertSiblingDrawerStaysConnected(duringOutage, 'chat')
+    expect(duringOutage.drawers.sfuSignaling.state).toBe('reconnecting')
+
+    setSfuLifecycle(sdk, 'connected')
+    const afterRecovery = sdk.getDiagnostics()
+
+    assertDrawerReconnectCycle(duringOutage, afterRecovery, 'sfuSignaling')
+    assertSiblingDrawerStaysConnected(afterRecovery, 'chat')
+  })
+
+  it('regression: single-plane reconnecting lifecycle never calls cross-drawer disconnect', async () => {
+    const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-cross-drawer-regression' })
+
+    setChatLifecycle(sdk, 'reconnecting')
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+
+    setSfuLifecycle(sdk, 'reconnecting')
+    expect(chatDisconnect).not.toHaveBeenCalled()
+  })
+
+  it('share_state stopped leaves all drawers non-torn-down and does not disconnect chat', async () => {
+    const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const handleShareStateStopped = vi.spyOn(SfuMediaSession.prototype, 'handleShareStateStopped')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-share-stop-isolation', isHost: false })
+
+    emitShareStateStopped(sdk)
+
+    expect(handleShareStateStopped).toHaveBeenCalledWith(false)
+    expect(chatDisconnect).not.toHaveBeenCalled()
+    assertNoDrawerTornDown(sdk.getDiagnostics())
   })
 
   it('surfaces CHAT_SEND_DROPPED when chat send is dropped', () => {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -172,11 +172,11 @@ export class RoomRealtimeSdk {
 
   private chatLastErrorCode: string | undefined
   private sfuLastErrorCode: string | undefined
-  private theaterLastErrorCode: string | undefined
   private sfuRelayErrorMessage: string | null = null
   private getHostScreenStream: () => MediaStream | null = () => null
   private roomControlUnsubs: Array<() => void> = []
   private theaterSnapshotUnsub: (() => void) | null = null
+  private theaterLifecycleUnsub: (() => void) | null = null
 
   private chat: ChatSession | null = null
   private sfu: SfuMediaSession | null = null
@@ -274,16 +274,14 @@ export class RoomRealtimeSdk {
   getDiagnostics(): RoomRealtimeDiagnostics {
     const chatState = this.chat?.getLifecycleState() ?? 'torn-down'
     const sfuState = this.sfu?.getLifecycleState() ?? 'torn-down'
-    const theaterState: DrawerLifecycleState =
-      this.theaterLayoutActive && this.theaterBootstrapped && this.theater
-        ? 'connected'
-        : 'torn-down'
+    const theaterState: DrawerLifecycleState = this.theater?.getLifecycleState() ?? 'torn-down'
 
     const sfuDiag = this.sfu?.getSignalingDiagnostics() ?? {}
     const theaterAudioContextState = this.theater?.getAudioContextState()
 
     const chatLastError = this.chatLastErrorCode ?? this.chat?.getLastErrorCode()
     const sfuLastError = this.sfuLastErrorCode ?? this.sfu?.getLastErrorCode()
+    const theaterLastError = this.theater?.getLastErrorCode()
 
     const drawers: RoomRealtimeDiagnostics['drawers'] = {
       chat: {
@@ -299,7 +297,7 @@ export class RoomRealtimeSdk {
       },
       theaterPlayback: {
         state: theaterState,
-        ...(this.theaterLastErrorCode ? { lastErrorCode: this.theaterLastErrorCode } : {}),
+        ...(theaterLastError ? { lastErrorCode: theaterLastError } : {}),
         ...(theaterAudioContextState ? { audioContextState: theaterAudioContextState } : {}),
       },
     }
@@ -386,7 +384,13 @@ export class RoomRealtimeSdk {
   private wireDrawerStatusListeners(): void {
     const chat = this.chat
     const sfu = this.sfu
-    if (!chat || !sfu) return
+    const theater = this.theater
+    if (!chat || !sfu || !theater) return
+
+    this.theaterLifecycleUnsub = theater.onLifecycleChange(() => {
+      this.emitDiagnosticsChange()
+    })
+    theater.notifySignalingSiblingState(sfu.getLifecycleState())
 
     this.chatStatusUnsub = chat.onStatusChange((status) => {
       if (status === 'open') {
@@ -421,6 +425,7 @@ export class RoomRealtimeSdk {
       } else if (state === 'degraded' && sfu.getLastErrorCode()) {
         this.sfuLastErrorCode = sfu.getLastErrorCode()
       }
+      theater.notifySignalingSiblingState(state)
       this.emitDiagnosticsChange()
     })
 
@@ -557,7 +562,9 @@ export class RoomRealtimeSdk {
       avDisabled: this.avDisabled,
     })
     this.theaterBootstrapped = true
+    theater.notifySignalingSiblingState(sfu.getLifecycleState())
     this.applySubscribeHandlers()
+    sfu.replayActiveMediaSubscriptions()
   }
 
   private applySubscribeHandlers(): void {
@@ -619,6 +626,7 @@ export class RoomRealtimeSdk {
     for (const unsub of this.mediaPolicyUnsubs) unsub()
     for (const unsub of this.roomControlUnsubs) unsub()
     this.theaterSnapshotUnsub?.()
+    this.theaterLifecycleUnsub?.()
     this.hostScreenStreamUnsub?.()
     this.participantAvTrackUnsub?.()
     this.participantAvClearUnsub?.()
@@ -632,6 +640,7 @@ export class RoomRealtimeSdk {
     this.mediaPolicyUnsubs = []
     this.roomControlUnsubs = []
     this.theaterSnapshotUnsub = null
+    this.theaterLifecycleUnsub = null
     this.hostScreenStreamUnsub = null
     this.participantAvTrackUnsub = null
     this.participantAvClearUnsub = null
@@ -654,7 +663,6 @@ export class RoomRealtimeSdk {
     this.onDiagnosticsChange = undefined
     this.chatLastErrorCode = undefined
     this.sfuLastErrorCode = undefined
-    this.theaterLastErrorCode = undefined
     this.sfuRelayErrorMessage = null
 
     if (opts.intentional) {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -113,11 +113,11 @@ export function mapChatSessionStatusToDrawerState(status: ChatSessionStatus): Dr
     case 'open':
       return 'connected'
     case 'connecting':
+    case 'closed':
       return 'reconnecting'
     case 'error':
       return 'degraded'
     case 'idle':
-    case 'closed':
     default:
       return 'torn-down'
   }
@@ -132,6 +132,7 @@ export function mapSfuMediaSessionStatusToDrawerState(
     case 'connecting':
     case 'reconnecting':
       return 'reconnecting'
+    case 'degraded':
     case 'error':
       return 'degraded'
     case 'idle':
@@ -182,7 +183,10 @@ export class RoomRealtimeSdk {
   private theater: TheaterPlayback | null = null
 
   private chatStatusUnsub: (() => void) | null = null
+  private chatLifecycleUnsub: (() => void) | null = null
+  private chatSendDroppedUnsub: (() => void) | null = null
   private sfuStatusUnsub: (() => void) | null = null
+  private sfuLifecycleUnsub: (() => void) | null = null
   private sfuErrorUnsub: (() => void) | null = null
   private mediaPolicyUnsubs: Array<() => void> = []
   private hostScreenStreamUnsub: (() => void) | null = null
@@ -268,12 +272,8 @@ export class RoomRealtimeSdk {
   }
 
   getDiagnostics(): RoomRealtimeDiagnostics {
-    const chatState = this.chat
-      ? mapChatSessionStatusToDrawerState(this.chat.getStatus())
-      : 'torn-down'
-    const sfuState = this.sfu
-      ? mapSfuMediaSessionStatusToDrawerState(this.sfu.getStatus())
-      : 'torn-down'
+    const chatState = this.chat?.getLifecycleState() ?? 'torn-down'
+    const sfuState = this.sfu?.getLifecycleState() ?? 'torn-down'
     const theaterState: DrawerLifecycleState =
       this.theaterLayoutActive && this.theaterBootstrapped && this.theater
         ? 'connected'
@@ -282,14 +282,17 @@ export class RoomRealtimeSdk {
     const sfuDiag = this.sfu?.getSignalingDiagnostics() ?? {}
     const theaterAudioContextState = this.theater?.getAudioContextState()
 
+    const chatLastError = this.chatLastErrorCode ?? this.chat?.getLastErrorCode()
+    const sfuLastError = this.sfuLastErrorCode ?? this.sfu?.getLastErrorCode()
+
     const drawers: RoomRealtimeDiagnostics['drawers'] = {
       chat: {
         state: chatState,
-        ...(this.chatLastErrorCode ? { lastErrorCode: this.chatLastErrorCode } : {}),
+        ...(chatLastError ? { lastErrorCode: chatLastError } : {}),
       },
       sfuSignaling: {
         state: sfuState,
-        ...(this.sfuLastErrorCode ? { lastErrorCode: this.sfuLastErrorCode } : {}),
+        ...(sfuLastError ? { lastErrorCode: sfuLastError } : {}),
         ...(sfuDiag.role ? { role: sfuDiag.role } : {}),
         ...(sfuDiag.producerCount !== undefined ? { producerCount: sfuDiag.producerCount } : {}),
         ...(sfuDiag.consumerCount !== undefined ? { consumerCount: sfuDiag.consumerCount } : {}),
@@ -386,9 +389,6 @@ export class RoomRealtimeSdk {
     if (!chat || !sfu) return
 
     this.chatStatusUnsub = chat.onStatusChange((status) => {
-      if (status === 'error' && !this.chatLastErrorCode) {
-        this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
-      }
       if (status === 'open') {
         this.chatLastErrorCode = undefined
         void this.bootstrapMediaPlanes()
@@ -396,12 +396,30 @@ export class RoomRealtimeSdk {
       this.emitDiagnosticsChange()
     })
 
-    this.sfuStatusUnsub = sfu.onStatusChange((status) => {
-      if (status === 'error' && !this.sfuLastErrorCode) {
-        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
+    this.chatLifecycleUnsub = chat.onLifecycleChange((state) => {
+      if (state === 'connected') {
+        this.chatLastErrorCode = undefined
       }
+      this.emitDiagnosticsChange()
+    })
+
+    this.chatSendDroppedUnsub = chat.onSendDropped(() => {
+      this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuStatusUnsub = sfu.onStatusChange((status) => {
       if (status === 'open') {
         this.sfuLastErrorCode = undefined
+      }
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuLifecycleUnsub = sfu.onLifecycleChange((state) => {
+      if (state === 'connected') {
+        this.sfuLastErrorCode = undefined
+      } else if (state === 'degraded' && sfu.getLastErrorCode()) {
+        this.sfuLastErrorCode = sfu.getLastErrorCode()
       }
       this.emitDiagnosticsChange()
     })
@@ -593,7 +611,10 @@ export class RoomRealtimeSdk {
 
   private teardownModules(opts: { intentional: boolean }): void {
     this.chatStatusUnsub?.()
+    this.chatLifecycleUnsub?.()
+    this.chatSendDroppedUnsub?.()
     this.sfuStatusUnsub?.()
+    this.sfuLifecycleUnsub?.()
     this.sfuErrorUnsub?.()
     for (const unsub of this.mediaPolicyUnsubs) unsub()
     for (const unsub of this.roomControlUnsubs) unsub()
@@ -603,7 +624,10 @@ export class RoomRealtimeSdk {
     this.participantAvClearUnsub?.()
     this.participantAvStateUnsub?.()
     this.chatStatusUnsub = null
+    this.chatLifecycleUnsub = null
+    this.chatSendDroppedUnsub = null
     this.sfuStatusUnsub = null
+    this.sfuLifecycleUnsub = null
     this.sfuErrorUnsub = null
     this.mediaPolicyUnsubs = []
     this.roomControlUnsubs = []

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -4,6 +4,8 @@ import { SfuTokenHttpError } from '../av/participantAvErrors'
 import { connectSfuUnifiedSession } from '../sfu/mediasoupSharing'
 import { createParticipantAvController } from '../sfu/participantAvSession'
 import { LOCAL_SFU_UNREACHABLE_MSG } from '../sfu/sfuConfigErrors'
+import { SFU_DEGRADED_AFTER_FAILED_CYCLES, SFU_JWT_REMINT_LEAD_SECONDS, sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
+import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 import {
   formatSfuTokenError,
   isRosterConsistency403,
@@ -241,5 +243,222 @@ describe('SfuMediaSession media policy', () => {
     expect(teardown).toHaveBeenCalled()
     expect(detach).toHaveBeenCalledWith('participant_av')
     expect(clearListener).toHaveBeenCalled()
+  })
+})
+
+function base64UrlJson(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  return `header.${base64UrlJson(payload)}.sig`
+}
+
+describe('SfuMediaSession lifecycle FSM', () => {
+  it('maps failed reconnect cycles to degraded lifecycle at threshold', () => {
+    const session = new SfuMediaSession()
+    const internal = session as unknown as {
+      failedReconnectCycles: number
+      enabled: boolean
+      tokenIntentGeneration: number
+      clearJwtRemintTimer: () => void
+      sessionHandle: null
+      setStatus: (status: string) => void
+      setLifecycleState: (state: string) => void
+    }
+
+    internal.enabled = true
+    internal.tokenIntentGeneration = 0
+    internal.sessionHandle = null
+
+    for (let i = 0; i < SFU_DEGRADED_AFTER_FAILED_CYCLES - 1; i += 1) {
+      internal.failedReconnectCycles += 1
+      internal.clearJwtRemintTimer()
+      const lifecycle = sfuLifecycleAfterFailedCycle(internal.failedReconnectCycles)
+      internal.setStatus(lifecycle === 'degraded' ? 'degraded' : 'reconnecting')
+      internal.setLifecycleState(lifecycle)
+      expect(session.getLifecycleState()).toBe('reconnecting')
+    }
+
+    internal.failedReconnectCycles += 1
+    const lifecycle = sfuLifecycleAfterFailedCycle(internal.failedReconnectCycles)
+    internal.setStatus(lifecycle === 'degraded' ? 'degraded' : 'reconnecting')
+    internal.setLifecycleState(lifecycle)
+    expect(session.getLifecycleState()).toBe('degraded')
+    expect(session.getStatus()).toBe('degraded')
+  })
+})
+
+describe('SfuMediaSession JWT remint', () => {
+  const fixedNowMs = 1_700_000_000_000
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('schedules proactive remint at exp minus lead while signaling is open', async () => {
+    const exp = Math.floor(fixedNowMs / 1000) + 900
+    const token = fakeJwt({ exp })
+    vi.mocked(fetchSfuJoinToken)
+      .mockResolvedValueOnce({
+        token,
+        role: 'consumer',
+        wsUrl: 'ws://127.0.0.1:3000',
+        expiresInSeconds: 900,
+      })
+      .mockResolvedValueOnce({
+        token: fakeJwt({ exp: exp + 900 }),
+        role: 'consumer',
+        wsUrl: 'ws://127.0.0.1:3000',
+        expiresInSeconds: 900,
+      })
+
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ready: Promise.resolve(),
+      sessionEnded: new Promise(() => {}),
+      close: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      publishStream: vi.fn(),
+      supportsPublish: false,
+      tokenRole: 'consumer',
+      getProducerCount: () => 0,
+      getConsumerCount: () => 0,
+      detachConsumerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    }))
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-jwt',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => expect(session.getLifecycleState()).toBe('connected'))
+
+    const delay = resolveJwtRemintDelayMs(token, 900, fixedNowMs)!
+    expect(delay).toBe((900 - SFU_JWT_REMINT_LEAD_SECONDS) * 1000)
+
+    vi.useFakeTimers()
+    vi.setSystemTime(fixedNowMs)
+    ;(
+      session as unknown as { scheduleJwtRemint: (t: string, e?: number) => void }
+    ).scheduleJwtRemint(token, 900)
+    await vi.advanceTimersByTimeAsync(delay + 1)
+    await vi.waitFor(() => expect(fetchSfuJoinToken.mock.calls.length).toBeGreaterThanOrEqual(2))
+    expect(session.getLifecycleState()).toBe('connected')
+  })
+
+  it('enters degraded on failed remint without tearing down reconnect loop', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 120
+    const token = fakeJwt({ exp })
+    let fetchCalls = 0
+    vi.mocked(fetchSfuJoinToken).mockImplementation(async () => {
+      fetchCalls += 1
+      if (fetchCalls === 1) {
+        return {
+          token,
+          role: 'consumer' as const,
+          wsUrl: 'ws://127.0.0.1:3000',
+          expiresInSeconds: 120,
+        }
+      }
+      throw new SfuTokenHttpError(403, { code: 'av_disabled', error: 'denied' })
+    })
+
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ready: Promise.resolve(),
+      sessionEnded: new Promise(() => {}),
+      close: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      publishStream: vi.fn(),
+      supportsPublish: false,
+      tokenRole: 'consumer',
+      getProducerCount: () => 0,
+      getConsumerCount: () => 0,
+      detachConsumerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    }))
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-jwt-fail',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => expect(session.getLifecycleState()).toBe('connected'))
+
+    await (
+      session as unknown as { remintJoinToken: () => Promise<void> }
+    ).remintJoinToken()
+
+    expect(session.getLifecycleState()).toBe('degraded')
+    expect(session.getLastErrorCode()).toBe('SFU_TOKEN_DENIED')
+    expect(session.getStatus()).toBe('degraded')
+  })
+
+  it('clears JWT remint timer on disconnect', async () => {
+    const exp = Math.floor(fixedNowMs / 1000) + 900
+    const token = fakeJwt({ exp })
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token,
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+      expiresInSeconds: 900,
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ready: Promise.resolve(),
+      sessionEnded: new Promise(() => {}),
+      close: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      publishStream: vi.fn(),
+      supportsPublish: false,
+      tokenRole: 'consumer',
+      getProducerCount: () => 0,
+      getConsumerCount: () => 0,
+      detachConsumerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    }))
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-teardown',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => expect(session.getLifecycleState()).toBe('connected'))
+    const callsBefore = fetchSfuJoinToken.mock.calls.length
+    session.disconnect()
+
+    vi.useFakeTimers()
+    vi.setSystemTime(fixedNowMs)
+    ;(
+      session as unknown as { scheduleJwtRemint: (t: string, e?: number) => void }
+    ).scheduleJwtRemint(token, 900)
+    await vi.advanceTimersByTimeAsync(900_000)
+    expect(fetchSfuJoinToken.mock.calls.length).toBe(callsBefore)
+    expect(session.getLifecycleState()).toBe('torn-down')
   })
 })

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import { SfuTokenHttpError } from '../av/participantAvErrors'
-import { connectSfuUnifiedSession } from '../sfu/mediasoupSharing'
+import { connectSfuUnifiedSession, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
 import { createParticipantAvController } from '../sfu/participantAvSession'
 import { LOCAL_SFU_UNREACHABLE_MSG } from '../sfu/sfuConfigErrors'
 import { SFU_DEGRADED_AFTER_FAILED_CYCLES, SFU_JWT_REMINT_LEAD_SECONDS, sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
@@ -258,6 +258,24 @@ function fakeJwt(payload: Record<string, unknown>): string {
   return `header.${base64UrlJson(payload)}.sig`
 }
 
+function mockSfuUnifiedSessionHandle() {
+  return {
+    ready: Promise.resolve(),
+    sessionEnded: new Promise<SfuSessionEndReason>(() => {}),
+    close: vi.fn(),
+    unpublishProducerClass: vi.fn(),
+    publishStream: vi.fn(),
+    supportsPublish: false,
+    tokenRole: 'consumer' as const,
+    getProducerCount: () => 0,
+    getConsumerCount: () => 0,
+    detachConsumerClass: vi.fn(),
+    pauseProducerKind: vi.fn(),
+    resumeProducerKind: vi.fn(),
+    replayConsumerTracks: vi.fn(),
+  }
+}
+
 describe('SfuMediaSession lifecycle FSM', () => {
   it('maps failed reconnect cycles to degraded lifecycle at threshold', () => {
     const session = new SfuMediaSession()
@@ -318,20 +336,7 @@ describe('SfuMediaSession JWT remint', () => {
         expiresInSeconds: 900,
       })
 
-    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
-      ready: Promise.resolve(),
-      sessionEnded: new Promise(() => {}),
-      close: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-      publishStream: vi.fn(),
-      supportsPublish: false,
-      tokenRole: 'consumer',
-      getProducerCount: () => 0,
-      getConsumerCount: () => 0,
-      detachConsumerClass: vi.fn(),
-      pauseProducerKind: vi.fn(),
-      resumeProducerKind: vi.fn(),
-    }))
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => mockSfuUnifiedSessionHandle())
 
     const session = new SfuMediaSession()
     session.connect({
@@ -355,7 +360,7 @@ describe('SfuMediaSession JWT remint', () => {
       session as unknown as { scheduleJwtRemint: (t: string, e?: number) => void }
     ).scheduleJwtRemint(token, 900)
     await vi.advanceTimersByTimeAsync(delay + 1)
-    await vi.waitFor(() => expect(fetchSfuJoinToken.mock.calls.length).toBeGreaterThanOrEqual(2))
+    await vi.waitFor(() => expect(vi.mocked(fetchSfuJoinToken).mock.calls.length).toBeGreaterThanOrEqual(2))
     expect(session.getLifecycleState()).toBe('connected')
   })
 
@@ -376,20 +381,7 @@ describe('SfuMediaSession JWT remint', () => {
       throw new SfuTokenHttpError(403, { code: 'av_disabled', error: 'denied' })
     })
 
-    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
-      ready: Promise.resolve(),
-      sessionEnded: new Promise(() => {}),
-      close: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-      publishStream: vi.fn(),
-      supportsPublish: false,
-      tokenRole: 'consumer',
-      getProducerCount: () => 0,
-      getConsumerCount: () => 0,
-      detachConsumerClass: vi.fn(),
-      pauseProducerKind: vi.fn(),
-      resumeProducerKind: vi.fn(),
-    }))
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => mockSfuUnifiedSessionHandle())
 
     const session = new SfuMediaSession()
     session.connect({
@@ -422,20 +414,7 @@ describe('SfuMediaSession JWT remint', () => {
       wsUrl: 'ws://127.0.0.1:3000',
       expiresInSeconds: 900,
     })
-    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
-      ready: Promise.resolve(),
-      sessionEnded: new Promise(() => {}),
-      close: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-      publishStream: vi.fn(),
-      supportsPublish: false,
-      tokenRole: 'consumer',
-      getProducerCount: () => 0,
-      getConsumerCount: () => 0,
-      detachConsumerClass: vi.fn(),
-      pauseProducerKind: vi.fn(),
-      resumeProducerKind: vi.fn(),
-    }))
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => mockSfuUnifiedSessionHandle())
 
     const session = new SfuMediaSession()
     session.connect({
@@ -449,7 +428,7 @@ describe('SfuMediaSession JWT remint', () => {
     })
 
     await vi.waitFor(() => expect(session.getLifecycleState()).toBe('connected'))
-    const callsBefore = fetchSfuJoinToken.mock.calls.length
+    const callsBefore = vi.mocked(fetchSfuJoinToken).mock.calls.length
     session.disconnect()
 
     vi.useFakeTimers()
@@ -458,7 +437,7 @@ describe('SfuMediaSession JWT remint', () => {
       session as unknown as { scheduleJwtRemint: (t: string, e?: number) => void }
     ).scheduleJwtRemint(token, 900)
     await vi.advanceTimersByTimeAsync(900_000)
-    expect(fetchSfuJoinToken.mock.calls.length).toBe(callsBefore)
+    expect(vi.mocked(fetchSfuJoinToken).mock.calls.length).toBe(callsBefore)
     expect(session.getLifecycleState()).toBe('torn-down')
   })
 })

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -375,6 +375,7 @@ export class SfuMediaSession {
 
   private remoteStreamListeners = new Set<Listener<MediaStream | null>>()
   private consumerTrackListeners = new Set<Listener<SfuConsumerTrackEvent>>()
+  private lastRemoteStream: MediaStream | null = null
   private errorListeners = new Set<Listener<string | null>>()
   private statusListeners = new Set<Listener<SfuMediaSessionStatus>>()
   private lifecycleListeners = new Set<Listener<SfuMediaSessionLifecycleState>>()
@@ -520,6 +521,14 @@ export class SfuMediaSession {
 
   detachHostScreenConsumers(): void {
     this.sessionHandle?.detachConsumerClass('host_screen')
+  }
+
+  /** Re-deliver live SFU consumer attach events and last host_screen stream to subscribers. */
+  replayActiveMediaSubscriptions(): void {
+    this.sessionHandle?.replayConsumerTracks()
+    for (const listener of this.remoteStreamListeners) {
+      listener(this.lastRemoteStream)
+    }
   }
 
   /** Publish or unpublish host tab capture on the existing SFU session (no full reconnect). */
@@ -726,6 +735,7 @@ export class SfuMediaSession {
   }
 
   private emitRemoteStream(stream: MediaStream | null): void {
+    this.lastRemoteStream = stream
     for (const listener of this.remoteStreamListeners) listener(stream)
   }
 

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -27,6 +27,8 @@ import {
   messageForSfuRelayConfigError,
   type SfuRelayConfigErrorCode,
 } from '../sfu/sfuConfigErrors'
+import { sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
+import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 
 export type SfuMediaSessionStatus =
   | 'idle'
@@ -35,6 +37,14 @@ export type SfuMediaSessionStatus =
   | 'closed'
   | 'error'
   | 'reconnecting'
+  | 'degraded'
+
+/** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
+export type SfuMediaSessionLifecycleState =
+  | 'connected'
+  | 'reconnecting'
+  | 'degraded'
+  | 'torn-down'
 
 export type SfuRoomSessionHandle = SfuUnifiedSessionHandle
 
@@ -46,6 +56,7 @@ type SessionHooks = {
   onSessionClean?: () => void
   onConnecting?: () => void
   onSessionReady?: () => void
+  onTokenMinted?: (tok: import('../sfu/mediasoupSharing').SfuTokenResponse) => void
 }
 
 export type StartSfuRoomSessionOpts = SessionHooks & {
@@ -230,6 +241,8 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
 
       if (signal.aborted) break
 
+      opts.onTokenMinted?.(tok)
+
       const wantsProducer = producerClass !== undefined
       if (wantsProducer && tok.role !== 'producer') {
         await sleepBackoffMs(nextSfuReconnectDelayMs(attempt++), signal)
@@ -339,11 +352,18 @@ type Listener<T> = (event: T) => void
  */
 export class SfuMediaSession {
   private status: SfuMediaSessionStatus = 'idle'
+  private lifecycleState: SfuMediaSessionLifecycleState = 'torn-down'
+  private failedReconnectCycles = 0
+  private lastErrorCode: string | undefined
   private cancelReconnect: (() => void) | null = null
   private sessionHandle: SfuUnifiedSessionHandle | null = null
   private tokenIntentGeneration = 0
   private connectOptions: SfuMediaSessionConnectOptions | null = null
   private enabled = false
+  private jwtRemintTimer: ReturnType<typeof setTimeout> | null = null
+  private refreshedJoinToken: string | null = null
+  private lastMintedToken: string | null = null
+  private lastMintedExpiresInSeconds: number | undefined
 
   private readonly gate: ParticipantAvPublishGate = {
     wsOpen: false,
@@ -357,6 +377,7 @@ export class SfuMediaSession {
   private consumerTrackListeners = new Set<Listener<SfuConsumerTrackEvent>>()
   private errorListeners = new Set<Listener<string | null>>()
   private statusListeners = new Set<Listener<SfuMediaSessionStatus>>()
+  private lifecycleListeners = new Set<Listener<SfuMediaSessionLifecycleState>>()
   private participantAvConsumerClearListeners = new Set<Listener<void>>()
 
   constructor() {
@@ -366,6 +387,14 @@ export class SfuMediaSession {
 
   getStatus(): SfuMediaSessionStatus {
     return this.status
+  }
+
+  getLifecycleState(): SfuMediaSessionLifecycleState {
+    return this.lifecycleState
+  }
+
+  getLastErrorCode(): string | undefined {
+    return this.lastErrorCode
   }
 
   getSessionHandle(): SfuUnifiedSessionHandle | null {
@@ -406,6 +435,11 @@ export class SfuMediaSession {
     return () => this.statusListeners.delete(listener)
   }
 
+  onLifecycleChange(listener: Listener<SfuMediaSessionLifecycleState>): () => void {
+    this.lifecycleListeners.add(listener)
+    return () => this.lifecycleListeners.delete(listener)
+  }
+
   /** Fired when participant_av consumers should be cleared (kill switch). */
   onParticipantAvConsumersClear(listener: Listener<void>): () => void {
     this.participantAvConsumerClearListeners.add(listener)
@@ -429,17 +463,25 @@ export class SfuMediaSession {
     this.stopReconnectLoop()
     if (!this.enabled || !options.apiBaseUrl || !options.roomId) {
       this.setStatus('idle')
+      this.setLifecycleState('torn-down')
       return
     }
+    this.failedReconnectCycles = 0
+    this.lastErrorCode = undefined
     this.startReconnectLoop()
   }
 
   disconnect(): void {
     this.enabled = false
+    this.clearJwtRemintTimer()
+    this.refreshedJoinToken = null
     this.stopReconnectLoop()
     this.sessionHandle?.unpublishProducerClass('host_screen')
     this.emitRemoteStream(null)
+    this.failedReconnectCycles = 0
+    this.lastErrorCode = undefined
     this.setStatus('idle')
+    this.setLifecycleState('torn-down')
     this.emitError(null)
   }
 
@@ -534,6 +576,11 @@ export class SfuMediaSession {
     if (!opts || !this.enabled) return
 
     this.setStatus('connecting')
+    this.setLifecycleState(
+      this.failedReconnectCycles > 0
+        ? sfuLifecycleAfterFailedCycle(this.failedReconnectCycles)
+        : 'reconnecting',
+    )
     const generation = this.tokenIntentGeneration
 
     const { cancel } = startSfuRoomSession({
@@ -550,7 +597,10 @@ export class SfuMediaSession {
       },
       assignSession: (s) => {
         this.sessionHandle = s
-        if (s) this.setStatus('open')
+        if (s) {
+          this.setStatus('open')
+          this.setLifecycleState('connected')
+        }
       },
       onMissingWsUrl: () =>
         this.emitError(messageForSfuRelayConfigError('missing_ws_url')),
@@ -569,15 +619,34 @@ export class SfuMediaSession {
       onConnecting: () => {
         this.emitError(null)
         this.setStatus('connecting')
+        this.setLifecycleState(
+          this.failedReconnectCycles > 0
+            ? sfuLifecycleAfterFailedCycle(this.failedReconnectCycles)
+            : 'reconnecting',
+        )
       },
       onSessionReady: () => {
         this.emitError(null)
+        this.failedReconnectCycles = 0
+        this.lastErrorCode = undefined
         this.setStatus('open')
+        this.setLifecycleState('connected')
+        if (this.lastMintedToken) {
+          this.scheduleJwtRemint(this.lastMintedToken, this.lastMintedExpiresInSeconds)
+        }
+      },
+      onTokenMinted: (tok) => {
+        this.lastMintedToken = tok.token
+        this.lastMintedExpiresInSeconds = tok.expiresInSeconds
       },
       onSessionClean: () => {
+        this.clearJwtRemintTimer()
         this.sessionHandle = null
         if (this.enabled && generation === this.tokenIntentGeneration) {
-          this.setStatus('reconnecting')
+          this.failedReconnectCycles += 1
+          const lifecycle = sfuLifecycleAfterFailedCycle(this.failedReconnectCycles)
+          this.setStatus(lifecycle === 'degraded' ? 'degraded' : 'reconnecting')
+          this.setLifecycleState(lifecycle)
         }
       },
     })
@@ -589,15 +658,71 @@ export class SfuMediaSession {
   }
 
   private stopReconnectLoop(): void {
+    this.clearJwtRemintTimer()
     this.cancelReconnect?.()
     this.cancelReconnect = null
     this.sessionHandle = null
+  }
+
+  private clearJwtRemintTimer(): void {
+    if (this.jwtRemintTimer !== null) {
+      clearTimeout(this.jwtRemintTimer)
+      this.jwtRemintTimer = null
+    }
+  }
+
+  private scheduleJwtRemint(token: string, expiresInSeconds?: number): void {
+    this.clearJwtRemintTimer()
+    if (this.getStatus() !== 'open') return
+
+    const delayMs = resolveJwtRemintDelayMs(token, expiresInSeconds)
+    if (delayMs === null) return
+
+    this.jwtRemintTimer = setTimeout(() => {
+      this.jwtRemintTimer = null
+      void this.remintJoinToken()
+    }, delayMs)
+  }
+
+  private async remintJoinToken(): Promise<void> {
+    const opts = this.connectOptions
+    if (!opts || !this.enabled || this.getStatus() !== 'open') return
+
+    const producerClass = resolveSfuTokenProducerClass({
+      participantAv: this.participantAv,
+      getHostScreenStream: opts.getHostScreenStream,
+    })
+
+    try {
+      const tok = await fetchSfuJoinToken({
+        apiBaseUrl: opts.apiBaseUrl,
+        roomId: opts.roomId,
+        sessionId: opts.sessionId,
+        accessToken: opts.accessToken,
+        ...(producerClass ? { producerClass } : {}),
+      })
+      this.refreshedJoinToken = tok.token
+      this.lastErrorCode = undefined
+      if (this.getStatus() === 'open') {
+        this.scheduleJwtRemint(tok.token, tok.expiresInSeconds)
+      }
+    } catch {
+      this.lastErrorCode = 'SFU_TOKEN_DENIED'
+      this.setStatus('degraded')
+      this.setLifecycleState('degraded')
+    }
   }
 
   private setStatus(next: SfuMediaSessionStatus): void {
     if (this.status === next) return
     this.status = next
     for (const listener of this.statusListeners) listener(next)
+  }
+
+  private setLifecycleState(next: SfuMediaSessionLifecycleState): void {
+    if (this.lifecycleState === next) return
+    this.lifecycleState = next
+    for (const listener of this.lifecycleListeners) listener(next)
   }
 
   private emitRemoteStream(stream: MediaStream | null): void {

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -361,7 +361,6 @@ export class SfuMediaSession {
   private connectOptions: SfuMediaSessionConnectOptions | null = null
   private enabled = false
   private jwtRemintTimer: ReturnType<typeof setTimeout> | null = null
-  private refreshedJoinToken: string | null = null
   private lastMintedToken: string | null = null
   private lastMintedExpiresInSeconds: number | undefined
 
@@ -475,7 +474,6 @@ export class SfuMediaSession {
   disconnect(): void {
     this.enabled = false
     this.clearJwtRemintTimer()
-    this.refreshedJoinToken = null
     this.stopReconnectLoop()
     this.sessionHandle?.unpublishProducerClass('host_screen')
     this.emitRemoteStream(null)
@@ -710,7 +708,6 @@ export class SfuMediaSession {
         accessToken: opts.accessToken,
         ...(producerClass ? { producerClass } : {}),
       })
-      this.refreshedJoinToken = tok.token
       this.lastErrorCode = undefined
       if (this.getStatus() === 'open') {
         this.scheduleJwtRemint(tok.token, tok.expiresInSeconds)

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -14,15 +14,26 @@ vi.stubGlobal(
   },
 )
 
-function makeMixMock() {
-  return {
+function makeMixMock(overrides: Record<string, unknown> = {}) {
+  const contextListeners: Array<(state: AudioContextState | undefined) => void> = []
+  const mix = {
     dispose: vi.fn(),
     setAvDisabled: vi.fn(),
     setHostVideoElement: vi.fn(),
     onConsumerEvent: vi.fn(),
     resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
-    getAudioContextState: vi.fn().mockReturnValue(undefined),
+    getAudioContextState: vi.fn().mockReturnValue('running' as AudioContextState),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      contextListeners.push(listener)
+      listener('running')
+      return () => {
+        const idx = contextListeners.indexOf(listener)
+        if (idx >= 0) contextListeners.splice(idx, 1)
+      }
+    }),
+    ...overrides,
   }
+  return mix
 }
 
 function makeVideoElement(playImpl?: () => Promise<void>): HTMLVideoElement {
@@ -189,6 +200,101 @@ describe('TheaterPlayback', () => {
     playback.setYoutubeMountElement(mount as unknown as HTMLElement)
     playback.setYoutubeVideoId('abc123')
     expect(mount.dataset.riffsyncYoutubeVideoId).toBe('abc123')
+    playback.dispose()
+  })
+
+  it('reports torn-down lifecycle when theater mode is disabled', () => {
+    vi.mocked(createTheaterAudioMix).mockReturnValue(makeMixMock())
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    expect(playback.getLifecycleState()).toBe('connected')
+
+    playback.configure({ enabled: false, isPublisher: false, avDisabled: false })
+    expect(playback.getLifecycleState()).toBe('torn-down')
+    playback.dispose()
+  })
+
+  it('reports degraded lifecycle when AudioContext is suspended', () => {
+    const mix = makeMixMock({
+      getAudioContextState: vi.fn().mockReturnValue('suspended' as AudioContextState),
+    })
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+
+    expect(playback.getLifecycleState()).toBe('degraded')
+    expect(playback.getLastErrorCode()).toBe('THEATER_AUDIO_SUSPENDED')
+    playback.dispose()
+  })
+
+  it('returns to connected lifecycle after AudioContext resumes', async () => {
+    const getAudioContextState = vi.fn().mockReturnValue('suspended' as AudioContextState)
+    const resumeIfSuspended = vi.fn().mockImplementation(async () => {
+      getAudioContextState.mockReturnValue('running' as AudioContextState)
+    })
+    const mix = makeMixMock({ getAudioContextState, resumeIfSuspended })
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    expect(playback.getLifecycleState()).toBe('degraded')
+
+    playback.setGuestVideoElement(makeVideoElement())
+    await playback.playGuestVideo()
+    expect(playback.getLifecycleState()).toBe('connected')
+    playback.dispose()
+  })
+
+  it('reports degraded lifecycle when SFU signaling sibling reconnects after connect', () => {
+    vi.mocked(createTheaterAudioMix).mockReturnValue(makeMixMock())
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    expect(playback.getLifecycleState()).toBe('connected')
+
+    playback.notifySignalingSiblingState('connected')
+    playback.notifySignalingSiblingState('reconnecting')
+    expect(playback.getLifecycleState()).toBe('degraded')
+
+    playback.notifySignalingSiblingState('connected')
+    expect(playback.getLifecycleState()).toBe('connected')
+    playback.dispose()
+  })
+
+  it('ignores SFU reconnecting before signaling has connected', () => {
+    vi.mocked(createTheaterAudioMix).mockReturnValue(makeMixMock())
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+
+    playback.notifySignalingSiblingState('reconnecting')
+    expect(playback.getLifecycleState()).toBe('connected')
+    playback.dispose()
+  })
+
+  it('stays connected when only host_screen consumer detaches (share_state stopped)', () => {
+    const mix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const consumerListeners: Array<(event: unknown) => void> = []
+    const sfuSession = {
+      onConsumerTrack: (listener: (event: unknown) => void) => {
+        consumerListeners.push(listener)
+        return () => undefined
+      },
+    } as unknown as SfuMediaSession
+
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    playback.attachSfuSession(sfuSession)
+
+    consumerListeners[0]?.({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: { id: 'mic' } as MediaStreamTrack,
+    })
+    consumerListeners[0]?.({ action: 'detach', producerId: 'host-1' })
+
+    expect(playback.getLifecycleState()).toBe('connected')
+    expect(mix.onConsumerEvent).toHaveBeenCalledTimes(2)
     playback.dispose()
   })
 })

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -240,7 +240,7 @@ export class TheaterPlayback {
     this.signalingSiblingDegraded = false
     this.sfuSignalingWasConnected = false
     this.lastErrorCode = undefined
-    this.setLifecycleState('torn-down')
+    this.setLifecycleState('torn-down', undefined)
     this.snapshotListeners.clear()
     this.lifecycleListeners.clear()
   }

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -7,6 +7,9 @@ import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
 import type { GuestHostScreenFsm } from '../sfu/sfuRelayStatusCopy'
 import type { SfuMediaSession } from './SfuMediaSession'
 
+/** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
+export type TheaterPlaybackLifecycleState = 'connected' | 'degraded' | 'torn-down'
+
 export type TheaterPlaybackSnapshot = {
   guestShareFsm: GuestHostScreenFsm
   guestPlayHint: boolean
@@ -14,6 +17,7 @@ export type TheaterPlaybackSnapshot = {
 }
 
 type SnapshotListener = (snapshot: TheaterPlaybackSnapshot) => void
+type LifecycleListener = (state: TheaterPlaybackLifecycleState) => void
 
 const GUEST_INBOUND_POLL_MS = 2300
 
@@ -36,6 +40,10 @@ function mapSfuConsumerToMixEvent(event: SfuConsumerTrackEvent): TheaterAudioCon
  */
 export class TheaterPlayback {
   private enabled = false
+  private lifecycleState: TheaterPlaybackLifecycleState = 'torn-down'
+  private lastErrorCode: string | undefined
+  private signalingSiblingDegraded = false
+  private sfuSignalingWasConnected = false
   private isPublisher = false
   private avDisabled = false
   private mix: TheaterAudioMix | null = null
@@ -51,10 +59,43 @@ export class TheaterPlayback {
   private hostCapturePlayHint = false
   private pollInterval: ReturnType<typeof setInterval> | null = null
   private pollCancelled = false
+  private audioContextWatchUnsub: (() => void) | null = null
   private sfuConsumerUnsub: (() => void) | null = null
   private guestVideoPlayToken = 0
   private hostCapturePlayToken = 0
   private readonly snapshotListeners = new Set<SnapshotListener>()
+  private readonly lifecycleListeners = new Set<LifecycleListener>()
+
+  getLifecycleState(): TheaterPlaybackLifecycleState {
+    return this.lifecycleState
+  }
+
+  getLastErrorCode(): string | undefined {
+    return this.lastErrorCode
+  }
+
+  onLifecycleChange(listener: LifecycleListener): () => void {
+    this.lifecycleListeners.add(listener)
+    return () => this.lifecycleListeners.delete(listener)
+  }
+
+  /** SFU signaling sibling state while theater mix is active (`execution_model.md`). */
+  notifySignalingSiblingState(
+    state: 'connected' | 'reconnecting' | 'degraded' | 'torn-down',
+  ): void {
+    if (state === 'connected') {
+      this.sfuSignalingWasConnected = true
+      this.signalingSiblingDegraded = false
+    } else if (state === 'degraded') {
+      this.signalingSiblingDegraded = true
+    } else if (state === 'reconnecting' && this.sfuSignalingWasConnected) {
+      this.signalingSiblingDegraded = true
+    } else if (state === 'torn-down') {
+      this.sfuSignalingWasConnected = false
+      this.signalingSiblingDegraded = false
+    }
+    this.syncLifecycleState()
+  }
 
   getSnapshot(): TheaterPlaybackSnapshot {
     return {
@@ -81,6 +122,7 @@ export class TheaterPlayback {
       this.setGuestShareFsm('idle')
       this.setGuestPlayHint(false)
       this.setHostCapturePlayHint(false)
+      this.syncLifecycleState()
       return
     }
 
@@ -93,6 +135,7 @@ export class TheaterPlayback {
     this.syncHostCaptureVideoBinding()
     this.configureGuestInboundPoll()
     this.syncGuestShareFsm()
+    this.syncLifecycleState()
   }
 
   attachSfuSession(session: SfuMediaSession): void {
@@ -160,6 +203,7 @@ export class TheaterPlayback {
       await v.play()
       this.setGuestPlayHint(false)
       await this.mix?.resumeIfSuspended()
+      this.syncLifecycleState()
     } catch {
       this.setGuestPlayHint(true)
     }
@@ -173,6 +217,7 @@ export class TheaterPlayback {
       this.setHostCapturePlayHint(false)
       this.mix?.setHostVideoElement(v)
       await this.mix?.resumeIfSuspended()
+      this.syncLifecycleState()
     } catch {
       this.setHostCapturePlayHint(true)
     }
@@ -192,24 +237,66 @@ export class TheaterPlayback {
     this.guestShareFsm = 'idle'
     this.guestPlayHint = false
     this.hostCapturePlayHint = false
+    this.signalingSiblingDegraded = false
+    this.sfuSignalingWasConnected = false
+    this.lastErrorCode = undefined
+    this.setLifecycleState('torn-down')
     this.snapshotListeners.clear()
+    this.lifecycleListeners.clear()
   }
 
   private onSfuConsumerEvent(event: SfuConsumerTrackEvent): void {
     if (!this.enabled || !this.mix) return
     this.mix.onConsumerEvent(mapSfuConsumerToMixEvent(event))
-    void this.mix.resumeIfSuspended()
+    void this.mix.resumeIfSuspended().then(() => this.syncLifecycleState())
+    this.syncLifecycleState()
   }
 
   private ensureMix(): void {
     if (this.mix) return
     this.mix = createTheaterAudioMix()
     this.mix.setAvDisabled(this.avDisabled)
+    this.audioContextWatchUnsub?.()
+    this.audioContextWatchUnsub = this.mix.watchAudioContextState(() => {
+      this.syncLifecycleState()
+    })
   }
 
   private teardownMix(): void {
+    this.audioContextWatchUnsub?.()
+    this.audioContextWatchUnsub = null
     this.mix?.dispose()
     this.mix = null
+  }
+
+  private syncLifecycleState(): void {
+    if (!this.enabled || !this.mix) {
+      this.setLifecycleState('torn-down', undefined)
+      return
+    }
+
+    const audioSuspended = this.getAudioContextState() === 'suspended'
+    if (audioSuspended) {
+      this.setLifecycleState('degraded', 'THEATER_AUDIO_SUSPENDED')
+      return
+    }
+
+    if (this.signalingSiblingDegraded) {
+      this.setLifecycleState('degraded', undefined)
+      return
+    }
+
+    this.setLifecycleState('connected', undefined)
+  }
+
+  private setLifecycleState(
+    next: TheaterPlaybackLifecycleState,
+    errorCode: string | undefined,
+  ): void {
+    this.lastErrorCode = errorCode
+    if (this.lifecycleState === next) return
+    this.lifecycleState = next
+    for (const listener of this.lifecycleListeners) listener(next)
   }
 
   private syncHostVideoElement(): void {

--- a/apps/web/src/room/sessions/drawerReconnectPolicy.test.ts
+++ b/apps/web/src/room/sessions/drawerReconnectPolicy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHAT_DEGRADED_AFTER_FAILED_CYCLES,
+  CHAT_RECONNECT_BACKOFF_CAP_MS,
+  CHAT_RECONNECT_BACKOFF_INITIAL_MS,
+  CHAT_RECONNECT_BACKOFF_MULTIPLIER,
+  SFU_DEGRADED_AFTER_FAILED_CYCLES,
+  SFU_JWT_REMINT_LEAD_SECONDS,
+  chatLifecycleAfterFailedCycle,
+  nextChatReconnectBackoffMs,
+  sfuLifecycleAfterFailedCycle,
+} from './drawerReconnectPolicy'
+
+describe('drawerReconnectPolicy', () => {
+  it('exposes chat backoff constants', () => {
+    expect(CHAT_RECONNECT_BACKOFF_INITIAL_MS).toBe(1000)
+    expect(CHAT_RECONNECT_BACKOFF_MULTIPLIER).toBe(2)
+    expect(CHAT_RECONNECT_BACKOFF_CAP_MS).toBe(60_000)
+    expect(CHAT_DEGRADED_AFTER_FAILED_CYCLES).toBe(3)
+  })
+
+  it('exposes SFU degraded threshold and JWT remint lead', () => {
+    expect(SFU_DEGRADED_AFTER_FAILED_CYCLES).toBe(5)
+    expect(SFU_JWT_REMINT_LEAD_SECONDS).toBe(60)
+  })
+
+  it('doubles chat backoff until cap', () => {
+    expect(nextChatReconnectBackoffMs(1000)).toEqual({ delayMs: 1000, nextBackoffMs: 2000 })
+    expect(nextChatReconnectBackoffMs(32_000)).toEqual({ delayMs: 32_000, nextBackoffMs: 60_000 })
+    expect(nextChatReconnectBackoffMs(60_000)).toEqual({ delayMs: 60_000, nextBackoffMs: 60_000 })
+  })
+
+  it('promotes chat lifecycle to degraded after threshold failed cycles', () => {
+    expect(chatLifecycleAfterFailedCycle(2)).toBe('reconnecting')
+    expect(chatLifecycleAfterFailedCycle(3)).toBe('degraded')
+    expect(chatLifecycleAfterFailedCycle(4)).toBe('degraded')
+  })
+
+  it('promotes SFU lifecycle to degraded after threshold failed cycles', () => {
+    expect(sfuLifecycleAfterFailedCycle(4)).toBe('reconnecting')
+    expect(sfuLifecycleAfterFailedCycle(5)).toBe('degraded')
+    expect(sfuLifecycleAfterFailedCycle(6)).toBe('degraded')
+  })
+})

--- a/apps/web/src/room/sessions/drawerReconnectPolicy.ts
+++ b/apps/web/src/room/sessions/drawerReconnectPolicy.ts
@@ -1,0 +1,32 @@
+/** Shared drawer reconnect thresholds per `.ai/runtime/execution_model.md`. */
+
+export const CHAT_RECONNECT_BACKOFF_INITIAL_MS = 1000
+export const CHAT_RECONNECT_BACKOFF_MULTIPLIER = 2
+export const CHAT_RECONNECT_BACKOFF_CAP_MS = 60_000
+export const CHAT_DEGRADED_AFTER_FAILED_CYCLES = 3
+
+/** SFU signaling delay math lives in `sfuReconnectPolicy.ts`; only the degraded threshold is shared here. */
+export const SFU_DEGRADED_AFTER_FAILED_CYCLES = 5
+
+/** Proactive SFU join JWT re-mint lead time before `exp` while signaling WS is open. */
+export const SFU_JWT_REMINT_LEAD_SECONDS = 60
+
+export function nextChatReconnectBackoffMs(currentBackoffMs: number): {
+  delayMs: number
+  nextBackoffMs: number
+} {
+  const delayMs = Math.min(currentBackoffMs, CHAT_RECONNECT_BACKOFF_CAP_MS)
+  const nextBackoffMs = Math.min(
+    currentBackoffMs * CHAT_RECONNECT_BACKOFF_MULTIPLIER,
+    CHAT_RECONNECT_BACKOFF_CAP_MS,
+  )
+  return { delayMs, nextBackoffMs }
+}
+
+export function chatLifecycleAfterFailedCycle(failedCycles: number): 'reconnecting' | 'degraded' {
+  return failedCycles >= CHAT_DEGRADED_AFTER_FAILED_CYCLES ? 'degraded' : 'reconnecting'
+}
+
+export function sfuLifecycleAfterFailedCycle(failedCycles: number): 'reconnecting' | 'degraded' {
+  return failedCycles >= SFU_DEGRADED_AFTER_FAILED_CYCLES ? 'degraded' : 'reconnecting'
+}

--- a/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
+++ b/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared RoomRealtimeSdk test fixtures for unit tests and future
+ * tests/realtime-conformance harness steps 5-6 (drawer reconnect isolation).
+ *
+ * Assertion contract mirrors `.ai/runtime/lifecycle_shutdown.md` and
+ * `.ai/operations/build_packaging.md` harness steps 5-6.
+ */
+
+import { expect, vi } from 'vitest'
+import type { RoomSnapshot } from '../../api/roomsApi'
+import { ChatSession } from './ChatSession'
+import { SfuMediaSession } from './SfuMediaSession'
+import {
+  RoomRealtimeSdk,
+  type RoomRealtimeDiagnostics,
+} from './RoomRealtimeSdk'
+
+export const harnessBaseSnapshot: RoomSnapshot = {
+  roomId: 'room-abc',
+  hostSub: 'host-sub',
+  catalogEpisodeId: 'ep-1',
+  youtubeVideoId: 'yt-1',
+  playbackExpectation: 'free',
+  visibility: 'public',
+  lastActivityAt: 1,
+  version: 1,
+  roomMode: 'theater',
+  avDisabled: false,
+  broadcastCaptureActive: false,
+}
+
+export type HarnessJoinOptions = {
+  sessionId?: string
+  isHost?: boolean
+  roomMode?: RoomSnapshot['roomMode']
+}
+
+/** Bootstrap chat + SFU to connected for harness step 5/6 preconditions. */
+export async function joinHealthySdk(
+  options: HarnessJoinOptions = {},
+): Promise<RoomRealtimeSdk> {
+  mockChatConnectOpensImmediately()
+  mockSfuConnectOpensImmediately()
+
+  const sdk = new RoomRealtimeSdk()
+  sdk.join('room-abc', {
+    roomSnapshot: {
+      ...harnessBaseSnapshot,
+      ...(options.roomMode ? { roomMode: options.roomMode } : {}),
+    },
+    sessionId: options.sessionId ?? 'sess-harness',
+    wsUrl: 'wss://ws.test',
+    apiBaseUrl: 'https://api.test',
+    getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    isHost: options.isHost,
+  })
+
+  await vi.waitFor(() => {
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.chat.state).toBe('connected')
+    expect(diag.drawers.sfuSignaling.state).toBe('connected')
+  })
+
+  return sdk
+}
+
+export function mockChatConnectOpensImmediately(): void {
+  vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'connected',
+    )
+  })
+}
+
+export function mockSfuConnectOpensImmediately(): void {
+  vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (this: SfuMediaSession) {
+    ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'connected',
+    )
+  })
+}
+
+export function getChatSession(sdk: RoomRealtimeSdk): ChatSession {
+  return (sdk as unknown as { chat: ChatSession }).chat
+}
+
+export function getSfuSession(sdk: RoomRealtimeSdk): SfuMediaSession {
+  return (sdk as unknown as { sfu: SfuMediaSession }).sfu
+}
+
+export function setChatLifecycle(sdk: RoomRealtimeSdk, state: string): void {
+  const chat = getChatSession(sdk)
+  ;(chat as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState(state)
+}
+
+export function setSfuLifecycle(sdk: RoomRealtimeSdk, state: string): void {
+  const sfu = getSfuSession(sdk)
+  ;(sfu as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState(state)
+}
+
+export function emitShareStateStopped(sdk: RoomRealtimeSdk, roomId = 'room-abc'): void {
+  const chat = getChatSession(sdk)
+  const shareListeners = (chat as unknown as {
+    shareStateListeners: Set<(ev: { roomId: string; state: unknown }) => void>
+  }).shareStateListeners
+  for (const listener of shareListeners) {
+    listener({ roomId, state: 'stopped' })
+  }
+}
+
+/** Harness step 5/6: sibling drawer must stay connected while the other plane is in outage. */
+export function assertSiblingDrawerStaysConnected(
+  diag: RoomRealtimeDiagnostics,
+  siblingDrawer: 'chat' | 'sfuSignaling',
+): void {
+  expect(diag.drawers[siblingDrawer].state).toBe('connected')
+  expect(diag.drawers[siblingDrawer].state).not.toBe('torn-down')
+}
+
+/** Harness step 5/6: failed drawer reports reconnecting during outage, connected after recovery. */
+export function assertDrawerReconnectCycle(
+  duringOutage: RoomRealtimeDiagnostics,
+  afterRecovery: RoomRealtimeDiagnostics,
+  affectedDrawer: 'chat' | 'sfuSignaling',
+): void {
+  expect(duringOutage.drawers[affectedDrawer].state).toBe('reconnecting')
+  expect(afterRecovery.drawers[affectedDrawer].state).toBe('connected')
+}
+
+/** share_state stopped: no drawer may enter torn-down (partial SFU detach only). */
+export function assertNoDrawerTornDown(diag: RoomRealtimeDiagnostics): void {
+  const drawerKeys = ['chat', 'sfuSignaling', 'theaterPlayback'] as const
+  for (const key of drawerKeys) {
+    expect(diag.drawers[key].state).not.toBe('torn-down')
+  }
+}

--- a/apps/web/src/room/sessions/sfuJwtRemintSchedule.test.ts
+++ b/apps/web/src/room/sessions/sfuJwtRemintSchedule.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { SFU_JWT_REMINT_LEAD_SECONDS } from './drawerReconnectPolicy'
+import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
+
+function base64UrlJson(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  return `header.${base64UrlJson(payload)}.sig`
+}
+
+describe('resolveJwtRemintDelayMs', () => {
+  it('schedules remint at exp minus lead seconds', () => {
+    const nowMs = 1_700_000_000_000
+    const exp = Math.floor(nowMs / 1000) + 900
+    const token = fakeJwt({ exp })
+    const delay = resolveJwtRemintDelayMs(token, undefined, nowMs)
+    expect(delay).toBe((900 - SFU_JWT_REMINT_LEAD_SECONDS) * 1000)
+  })
+
+  it('falls back to expiresInSeconds when JWT exp is missing', () => {
+    const token = fakeJwt({ sub: 'sess' })
+    expect(resolveJwtRemintDelayMs(token, 900)).toBe((900 - SFU_JWT_REMINT_LEAD_SECONDS) * 1000)
+  })
+
+  it('returns null when neither exp nor expiresInSeconds is available', () => {
+    const token = fakeJwt({ sub: 'sess' })
+    expect(resolveJwtRemintDelayMs(token)).toBeNull()
+  })
+})

--- a/apps/web/src/room/sessions/sfuJwtRemintSchedule.ts
+++ b/apps/web/src/room/sessions/sfuJwtRemintSchedule.ts
@@ -1,0 +1,20 @@
+import { jwtPayload } from '../../auth/jwtDecode'
+import { SFU_JWT_REMINT_LEAD_SECONDS } from './drawerReconnectPolicy'
+
+/** Milliseconds until proactive SFU join JWT re-mint should fire, or null when unknown. */
+export function resolveJwtRemintDelayMs(
+  token: string,
+  expiresInSeconds?: number,
+  nowMs = Date.now(),
+): number | null {
+  const payload = jwtPayload<{ exp?: unknown }>(token)
+  if (typeof payload?.exp === 'number' && Number.isFinite(payload.exp)) {
+    const fireAtMs = (payload.exp - SFU_JWT_REMINT_LEAD_SECONDS) * 1000
+    return Math.max(0, fireAtMs - nowMs)
+  }
+  if (typeof expiresInSeconds === 'number' && Number.isFinite(expiresInSeconds)) {
+    const leadMs = Math.max(0, expiresInSeconds - SFU_JWT_REMINT_LEAD_SECONDS) * 1000
+    return leadMs
+  }
+  return null
+}

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -265,6 +265,8 @@ export type SfuUnifiedSessionHandle = {
   detachConsumerClass: (producerClass: SfuProducerClass) => void
   pauseProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
   resumeProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
+  /** Re-emit attach events for live mediasoup consumers (theater mode re-entry). */
+  replayConsumerTracks: () => void
 }
 
 function parseProducerClass(value: unknown): SfuProducerClass | null {
@@ -744,6 +746,17 @@ export async function connectSfuUnifiedSession(options: {
     detachConsumerClass,
     pauseProducerKind,
     resumeProducerKind,
+    replayConsumerTracks: () => {
+      for (const consumer of mediasoupConsumers) {
+        onConsumerTrack?.({
+          action: 'attach',
+          producerId: consumer.producerId,
+          producerClass: consumerProducerClassById.get(consumer.producerId),
+          kind: consumer.kind === 'audio' || consumer.kind === 'video' ? consumer.kind : 'audio',
+          track: consumer.track,
+        })
+      }
+    },
     close: (reason: SfuSessionEndReason = 'user_close') => {
       userClosed = true
       void reason


### PR DESCRIPTION
## Summary

- Add `drawerReconnectPolicy.ts` with shared chat backoff (1000ms initial, x2, 60s cap), chat degraded after 3 failed cycles, and SFU degraded after 5 failed cycles.
- Refactor `ChatSession` and `SfuMediaSession` to expose normative lifecycle states (`connected` / `reconnecting` / `degraded` / `torn-down`) for `getDiagnostics()`, with drawer-independent reconnect and no cross-drawer teardown.
- Drop outbound chat sends when the room WS is not open (no queue) and surface `CHAT_SEND_DROPPED` through `RoomRealtimeSdk`.
- Implement SFU JWT proactive re-mint at `exp - 60s` while signaling WS is open; failed re-mint enters `degraded` without tearing down the session.
- Add `TheaterPlayback` lifecycle FSM (`connected` / `degraded` / `torn-down`) mapped into `getDiagnostics().drawers.theaterPlayback`, including `THEATER_AUDIO_SUSPENDED` when `AudioContext` is suspended.
- Replay SFU consumer attach events and last host-screen stream on Video Chat → Theater via `initTheaterPlayback()` + `applySubscribeHandlers()` so mix nodes reattach without a silent black screen.
- Add drawer isolation verification tests (#184): harness step 5/6 chat-only and SFU-only reconnect cycles, `share_state: stopped` isolation, and exported `roomRealtimeSdkTestHelpers.ts` for future `realtime-conformance` reuse.

Closes #182. Closes #183. Closes #184. Parent: #140.

## Test plan

- [x] `npm test -- --run src/room/sessions/ChatSession.test.ts src/room/sessions/SfuMediaSession.test.ts src/room/sessions/RoomRealtimeSdk.test.ts src/room/sessions/TheaterPlayback.test.ts src/room/sessions/drawerReconnectPolicy.test.ts src/room/sessions/sfuJwtRemintSchedule.test.ts` (all pass)
- [x] Full web suite: `cd apps/web && npm test -- --run` (340 tests pass)
- [ ] Manual (optional): with `npm run media:local` and `npm run dev`, force chat WS drop in devtools Network tab and confirm SFU stays connected via `getDiagnostics()`
- [ ] Manual (optional): transition room mode Video Chat → Theater and confirm theater audio mix reattaches without black screen