### PR TITLE
[M16][#141] Typed drawer errors, status UI, and diagnostics contract (#185, #186, #187)

### DIFF
--- a/apps/web/src/pages/RoomPage.test.tsx
+++ b/apps/web/src/pages/RoomPage.test.tsx
@@ -214,7 +214,7 @@ describe('RoomPage session integration', () => {
     renderRoom()
 
     await vi.waitFor(() => {
-      expect(container.textContent).toContain('The host is not sharing video right now.')
+      expect(container.querySelector('#riffsync-video-relay-status')).not.toBeNull()
     })
 
     const chatDisconnectsBeforeUnmount = chatDisconnectSpy.mock.calls.length

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -25,6 +25,7 @@ import { useRoomProfileTab } from '../room/useRoomProfileTab'
 import { RoomPlaybackPanel } from '../room/RoomPlaybackPanel'
 import { RoomPageSidebar } from '../room/RoomPageSidebar'
 import { RoomRenameModal } from '../room/RoomRenameModal'
+import { RIFFSYNC_SFU_CONFIG_ALERT_ID } from '../room/drawerErrorPresentation'
 import type { RoomSidebarTab } from '../room/roomPageTypes'
 
 export function RoomPage() {
@@ -114,7 +115,11 @@ export function RoomPage() {
     toggleChatReaction,
     peopleShown,
     chatMemberLabels,
-    sfuRoomErr,
+    sfuConfigAlert,
+    chatDrawerBanner,
+    chatComposeStatus,
+    videoRelayStatus,
+    theaterAudioStatus,
     guestRemote,
     participantAvController,
     unpublishHostScreen,
@@ -125,8 +130,6 @@ export function RoomPage() {
     bindHostCaptureVideo,
     stageParticipantTiles,
     stageLayoutUpdating,
-    guestVideoStatusSentence,
-    hostVideoRelayStatusSentence,
   } = useRoomRealtimeSdk({
     wsBase,
     canonicalRoomId,
@@ -331,9 +334,13 @@ export function RoomPage() {
       ) : null}
 
       <div className="container riffsync-room-page">
-        {sfuRoomErr ? (
-          <p className="riffsync-room-page__host-feedback-alert" role="alert">
-            {sfuRoomErr}
+        {sfuConfigAlert ? (
+          <p
+            id={RIFFSYNC_SFU_CONFIG_ALERT_ID}
+            className="riffsync-room-page__host-feedback-alert"
+            role="alert"
+          >
+            {sfuConfigAlert}
           </p>
         ) : null}
         <div className="riffsync-room-page__stage">
@@ -354,8 +361,8 @@ export function RoomPage() {
                   guestRemote={guestRemote}
                   fanToken={fanToken}
                   theaterPlaybackSnapshot={theaterPlaybackSnapshot}
-                  hostVideoRelayStatusSentence={hostVideoRelayStatusSentence}
-                  guestVideoStatusSentence={guestVideoStatusSentence}
+                  videoRelayStatus={videoRelayStatus}
+                  theaterAudioStatus={theaterAudioStatus}
                   bindHostCaptureVideo={bindHostCaptureVideo}
                   bindGuestVideo={bindGuestVideo}
                   playHostCapturePreview={playHostCapturePreview}
@@ -386,6 +393,8 @@ export function RoomPage() {
             showJumpToLatest={showJumpToLatest}
             jumpToLatestLabel={jumpToLatestLabel}
             jumpToLatest={jumpToLatest}
+            chatDrawerBanner={chatDrawerBanner}
+            chatComposeStatus={chatComposeStatus}
             sendChat={sendChat}
             sendChatGif={sendChatGif}
             toggleChatReaction={toggleChatReaction}

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ParticipantAvToggles } from './ParticipantAvToggles'
+import { RIFFSYNC_AV_TOGGLE_STATUS_ID } from './drawerErrorPresentation'
 import { PARTICIPANT_AV_DISABLED_COPY } from './participantAvErrorCopy'
 import { createParticipantAvController } from './sfu/participantAvSession'
 
@@ -108,11 +109,11 @@ describe('ParticipantAvToggles', () => {
         />,
       )
     })
-    const err = container.querySelector('.riffsync-room-av__err')
+    const err = container.querySelector(`#${RIFFSYNC_AV_TOGGLE_STATUS_ID}`)
     expect(err?.getAttribute('role')).toBe('status')
     expect(err?.textContent).toContain('maximum number of live')
     const camera = container.querySelector('button.riffsync-room-av-toggle') as HTMLButtonElement
-    expect(camera.getAttribute('aria-describedby')).toContain(err?.id ?? '')
+    expect(camera.getAttribute('aria-describedby')).toContain(RIFFSYNC_AV_TOGGLE_STATUS_ID)
   })
 
   it('announces local camera toggle via callback', () => {

--- a/apps/web/src/room/ParticipantAvToggles.test.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.test.tsx
@@ -73,6 +73,7 @@ describe('ParticipantAvToggles', () => {
     ) as HTMLButtonElement
     expect(camera.getAttribute('aria-disabled')).toBe('true')
     expect(camera.getAttribute('aria-describedby')).toBe(killSwitch?.id)
+    expect(killSwitch?.getAttribute('aria-live')).toBeNull()
   })
 
   it('shows inline error copy with aria-describedby on toggles', () => {
@@ -111,6 +112,7 @@ describe('ParticipantAvToggles', () => {
     })
     const err = container.querySelector(`#${RIFFSYNC_AV_TOGGLE_STATUS_ID}`)
     expect(err?.getAttribute('role')).toBe('status')
+    expect(err?.getAttribute('aria-live')).toBe('polite')
     expect(err?.textContent).toContain('maximum number of live')
     const camera = container.querySelector('button.riffsync-room-av-toggle') as HTMLButtonElement
     expect(camera.getAttribute('aria-describedby')).toContain(RIFFSYNC_AV_TOGGLE_STATUS_ID)

--- a/apps/web/src/room/ParticipantAvToggles.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.tsx
@@ -131,7 +131,12 @@ export function ParticipantAvToggles({
         </button>
       </div>
       {inlineErr ? (
-        <p className="riffsync-room-av__err" id={RIFFSYNC_AV_TOGGLE_STATUS_ID} role="status">
+        <p
+          className="riffsync-room-av__err"
+          id={RIFFSYNC_AV_TOGGLE_STATUS_ID}
+          role="status"
+          aria-live="polite"
+        >
           {inlineErr}
         </p>
       ) : null}

--- a/apps/web/src/room/ParticipantAvToggles.tsx
+++ b/apps/web/src/room/ParticipantAvToggles.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useId, useState } from 'react'
 import type { ParticipantAvController } from './sfu/participantAvSession'
 import {
   PARTICIPANT_AV_DISABLED_COPY,
-  participantAvErrorMessage,
 } from './participantAvErrorCopy'
+import { messageForParticipantAvError, RIFFSYNC_AV_TOGGLE_STATUS_ID } from './drawerErrorPresentation'
 
 export type ParticipantAvTogglesProps = {
   controller: ParticipantAvController
@@ -53,8 +53,6 @@ export function ParticipantAvToggles({
   onLocalToggleAnnounce,
 }: ParticipantAvTogglesProps) {
   const killSwitchId = useId()
-  const cameraErrId = useId()
-  const micErrId = useId()
   const [state, setState] = useState(() => controller.getState())
 
   useEffect(() => controller.subscribe(() => setState(controller.getState())), [controller])
@@ -62,20 +60,11 @@ export function ParticipantAvToggles({
   const killSwitchActive = avDisabled
   const activationBlocked = killSwitchActive || !state.canPublish || state.busy
 
-  const inlineErr = state.error ? participantAvErrorMessage(state.error) : null
-  const cameraErr = inlineErr
-  const micErr = inlineErr
+  const inlineErr = state.error ? messageForParticipantAvError(state.error) : null
 
-  const cameraDescribedBy = [
+  const toggleDescribedBy = [
     killSwitchActive ? killSwitchId : null,
-    cameraErr ? cameraErrId : null,
-  ]
-    .filter(Boolean)
-    .join(' ') || undefined
-
-  const micDescribedBy = [
-    killSwitchActive ? killSwitchId : null,
-    micErr ? micErrId : null,
+    inlineErr ? RIFFSYNC_AV_TOGGLE_STATUS_ID : null,
   ]
     .filter(Boolean)
     .join(' ') || undefined
@@ -121,7 +110,7 @@ export function ParticipantAvToggles({
           className={`gen-button riffsync-room-av-toggle${state.cameraEnabled ? ' riffsync-room-av-toggle--on' : ''}`}
           aria-pressed={state.cameraEnabled}
           aria-disabled={activationBlocked || undefined}
-          aria-describedby={cameraDescribedBy}
+          aria-describedby={toggleDescribedBy}
           disabled={state.busy}
           onClick={toggleCamera}
         >
@@ -133,7 +122,7 @@ export function ParticipantAvToggles({
           className={`gen-button riffsync-room-av-toggle${state.micEnabled ? ' riffsync-room-av-toggle--on' : ''}`}
           aria-pressed={state.micEnabled}
           aria-disabled={activationBlocked || undefined}
-          aria-describedby={micDescribedBy}
+          aria-describedby={toggleDescribedBy}
           disabled={state.busy}
           onClick={toggleMic}
         >
@@ -141,14 +130,9 @@ export function ParticipantAvToggles({
           <span className="riffsync-room-av-toggle__label">Microphone</span>
         </button>
       </div>
-      {cameraErr ? (
-        <p className="riffsync-room-av__err" id={cameraErrId} role="status">
-          {cameraErr}
-        </p>
-      ) : null}
-      {micErr && micErr !== cameraErr ? (
-        <p className="riffsync-room-av__err" id={micErrId} role="status">
-          {micErr}
+      {inlineErr ? (
+        <p className="riffsync-room-av__err" id={RIFFSYNC_AV_TOGGLE_STATUS_ID} role="status">
+          {inlineErr}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -13,6 +13,10 @@ import type { ParticipantAvController } from './sfu/participantAvSession'
 import type { ChatLine, PresenceMember, RoomSidebarTab } from './roomPageTypes'
 import { resolveMemberAvatarUrl } from './roomPageTypes'
 import type { GiphySearchResult } from '../api/giphySearchApi'
+import {
+  RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
+  RIFFSYNC_CHAT_DRAWER_STATUS_ID,
+} from './drawerErrorPresentation'
 
 type RoomPageSidebarProps = {
   wsBase: string | undefined
@@ -33,6 +37,8 @@ type RoomPageSidebarProps = {
   showJumpToLatest: boolean
   jumpToLatestLabel: string
   jumpToLatest: () => void
+  chatDrawerBanner: string | null
+  chatComposeStatus: { message: string | null; disableSubmit: boolean }
   sendChat: () => void
   sendChatGif: (result: GiphySearchResult) => void
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
@@ -76,6 +82,8 @@ export function RoomPageSidebar({
   showJumpToLatest,
   jumpToLatestLabel,
   jumpToLatest,
+  chatDrawerBanner,
+  chatComposeStatus,
   sendChat,
   sendChatGif,
   toggleChatReaction,
@@ -105,6 +113,16 @@ export function RoomPageSidebar({
         {!wsBase ? (
           <p className="riffsync-room-page__ws-banner riffsync-muted" role="status">
             Chat and viewer list require <code>VITE_PUBLIC_WS_URL</code> on this deployment.
+          </p>
+        ) : null}
+
+        {chatDrawerBanner ? (
+          <p
+            id={RIFFSYNC_CHAT_DRAWER_STATUS_ID}
+            className="riffsync-room-page__ws-banner riffsync-muted"
+            role="status"
+          >
+            {chatDrawerBanner}
           </p>
         ) : null}
 
@@ -391,18 +409,27 @@ export function RoomPageSidebar({
                     if (fanToken) setChatDraft(e.target.value)
                   }}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' && fanToken) sendChat()
+                    if (e.key === 'Enter' && fanToken && !chatComposeStatus.disableSubmit) sendChat()
                   }}
                 />
                 <button
                   type="button"
                   className="riffsync-room-chat-compose-send gen-button"
-                  disabled={!fanToken}
+                  disabled={!fanToken || chatComposeStatus.disableSubmit}
                   onClick={sendChat}
                 >
                   Send
                 </button>
               </div>
+              {chatComposeStatus.message ? (
+                <p
+                  id={RIFFSYNC_CHAT_COMPOSE_STATUS_ID}
+                  className="riffsync-room-chat-giphy-status riffsync-room-chat-giphy-status--err"
+                  role="status"
+                >
+                  {chatComposeStatus.message}
+                </p>
+              ) : null}
               {!fanToken ? (
                 <div className="riffsync-room-chat-signin-overlay" role="region" aria-label="Sign in to participate in chat">
                   <button

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -121,6 +121,7 @@ export function RoomPageSidebar({
             id={RIFFSYNC_CHAT_DRAWER_STATUS_ID}
             className="riffsync-room-page__ws-banner riffsync-muted"
             role="status"
+            aria-live="polite"
           >
             {chatDrawerBanner}
           </p>
@@ -426,6 +427,7 @@ export function RoomPageSidebar({
                   id={RIFFSYNC_CHAT_COMPOSE_STATUS_ID}
                   className="riffsync-room-chat-giphy-status riffsync-room-chat-giphy-status--err"
                   role="status"
+                  aria-live="polite"
                 >
                   {chatComposeStatus.message}
                 </p>

--- a/apps/web/src/room/RoomPlaybackPanel.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { TheaterPlaybackSnapshot } from './sessions/TheaterPlayback'
+import { RIFFSYNC_THEATER_AUDIO_STATUS_ID, RIFFSYNC_VIDEO_RELAY_STATUS_ID } from './drawerErrorPresentation'
 
 type RoomPlaybackPanelProps = {
   isPublisher: boolean
@@ -10,8 +11,8 @@ type RoomPlaybackPanelProps = {
   guestRemote: MediaStream | null
   fanToken: string | null
   theaterPlaybackSnapshot: TheaterPlaybackSnapshot
-  hostVideoRelayStatusSentence: string | null
-  guestVideoStatusSentence: string | null
+  videoRelayStatus: string | null
+  theaterAudioStatus: string | null
   bindHostCaptureVideo: (element: HTMLVideoElement | null) => void
   bindGuestVideo: (element: HTMLVideoElement | null) => void
   playHostCapturePreview: () => Promise<void>
@@ -29,8 +30,8 @@ export function RoomPlaybackPanel({
   guestRemote,
   fanToken,
   theaterPlaybackSnapshot,
-  hostVideoRelayStatusSentence,
-  guestVideoStatusSentence,
+  videoRelayStatus,
+  theaterAudioStatus,
   bindHostCaptureVideo,
   bindGuestVideo,
   playHostCapturePreview,
@@ -38,6 +39,8 @@ export function RoomPlaybackPanel({
   startCapture,
   openCapturePlayerTab,
 }: RoomPlaybackPanelProps) {
+  const hideGuestPlaceholder = !guestRemote && Boolean(videoRelayStatus)
+
   if (isPublisher) {
     return (
       <section className="riffsync-room-page__playback" aria-label="Your shared stream preview">
@@ -87,9 +90,15 @@ export function RoomPlaybackPanel({
           )}
         </div>
 
-        {hostVideoRelayStatusSentence ? (
-          <p className="riffsync-muted" role="status">
-            {hostVideoRelayStatusSentence}
+        {videoRelayStatus ? (
+          <p id={RIFFSYNC_VIDEO_RELAY_STATUS_ID} className="riffsync-muted" role="status">
+            {videoRelayStatus}
+          </p>
+        ) : null}
+
+        {theaterAudioStatus ? (
+          <p id={RIFFSYNC_THEATER_AUDIO_STATUS_ID} className="riffsync-muted" role="status">
+            {theaterAudioStatus}
           </p>
         ) : null}
 
@@ -118,9 +127,14 @@ export function RoomPlaybackPanel({
         in another browser; use Play if prompted. If you hear no audio, check that the video is not muted in the player
         controls.
       </span>
-      {guestVideoStatusSentence ? (
-        <p className="riffsync-muted" role="status">
-          {guestVideoStatusSentence}
+      {videoRelayStatus ? (
+        <p id={RIFFSYNC_VIDEO_RELAY_STATUS_ID} className="riffsync-muted" role="status">
+          {videoRelayStatus}
+        </p>
+      ) : null}
+      {theaterAudioStatus ? (
+        <p id={RIFFSYNC_THEATER_AUDIO_STATUS_ID} className="riffsync-muted" role="status">
+          {theaterAudioStatus}
         </p>
       ) : null}
       {theaterPlaybackSnapshot.guestPlayHint ? (
@@ -131,7 +145,7 @@ export function RoomPlaybackPanel({
         </p>
       ) : null}
       <div className="riffsync-room-page__player-shell riffsync-room-page__player-shell--guest">
-        {!guestRemote ? (
+        {!guestRemote && !hideGuestPlaceholder ? (
           <div className="riffsync-room-page__guest-video-placeholder" role="status">
             <p>The host is not sharing video right now.</p>
           </div>

--- a/apps/web/src/room/RoomPlaybackPanel.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.tsx
@@ -91,13 +91,23 @@ export function RoomPlaybackPanel({
         </div>
 
         {videoRelayStatus ? (
-          <p id={RIFFSYNC_VIDEO_RELAY_STATUS_ID} className="riffsync-muted" role="status">
+          <p
+            id={RIFFSYNC_VIDEO_RELAY_STATUS_ID}
+            className="riffsync-muted"
+            role="status"
+            aria-live="polite"
+          >
             {videoRelayStatus}
           </p>
         ) : null}
 
         {theaterAudioStatus ? (
-          <p id={RIFFSYNC_THEATER_AUDIO_STATUS_ID} className="riffsync-muted" role="status">
+          <p
+            id={RIFFSYNC_THEATER_AUDIO_STATUS_ID}
+            className="riffsync-muted"
+            role="status"
+            aria-live="polite"
+          >
             {theaterAudioStatus}
           </p>
         ) : null}
@@ -128,12 +138,22 @@ export function RoomPlaybackPanel({
         controls.
       </span>
       {videoRelayStatus ? (
-        <p id={RIFFSYNC_VIDEO_RELAY_STATUS_ID} className="riffsync-muted" role="status">
+        <p
+          id={RIFFSYNC_VIDEO_RELAY_STATUS_ID}
+          className="riffsync-muted"
+          role="status"
+          aria-live="polite"
+        >
           {videoRelayStatus}
         </p>
       ) : null}
       {theaterAudioStatus ? (
-        <p id={RIFFSYNC_THEATER_AUDIO_STATUS_ID} className="riffsync-muted" role="status">
+        <p
+          id={RIFFSYNC_THEATER_AUDIO_STATUS_ID}
+          className="riffsync-muted"
+          role="status"
+          aria-live="polite"
+        >
           {theaterAudioStatus}
         </p>
       ) : null}

--- a/apps/web/src/room/drawerErrorPresentation.test.ts
+++ b/apps/web/src/room/drawerErrorPresentation.test.ts
@@ -153,4 +153,12 @@ describe('drawerErrorPresentation', () => {
     expect(presentation.chatDrawerBanner).toBe('Reconnecting chat…')
     expect(presentation.videoRelayStatus).toContain('Network connection failed')
   })
+
+  it('maps drawer status surfaces to stable ids for aria-describedby wiring', () => {
+    expect(RIFFSYNC_AV_TOGGLE_STATUS_ID).toBe('riffsync-av-toggle-status')
+    expect(RIFFSYNC_CHAT_DRAWER_STATUS_ID).toBe('riffsync-chat-drawer-status')
+    expect(RIFFSYNC_VIDEO_RELAY_STATUS_ID).toBe('riffsync-video-relay-status')
+    expect(RIFFSYNC_CHAT_COMPOSE_STATUS_ID).toBe('riffsync-chat-compose-status')
+    expect(RIFFSYNC_THEATER_AUDIO_STATUS_ID).toBe('riffsync-theater-audio-status')
+  })
 })

--- a/apps/web/src/room/drawerErrorPresentation.test.ts
+++ b/apps/web/src/room/drawerErrorPresentation.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  RIFFSYNC_AV_TOGGLE_STATUS_ID,
+  RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
+  RIFFSYNC_CHAT_DRAWER_STATUS_ID,
+  RIFFSYNC_SFU_CONFIG_ALERT_ID,
+  RIFFSYNC_THEATER_AUDIO_STATUS_ID,
+  RIFFSYNC_VIDEO_RELAY_STATUS_ID,
+  messageForDrawerError,
+  messageForParticipantAvError,
+  resolveChatComposeStatus,
+  resolveChatDrawerBanner,
+  resolveSfuConfigAlert,
+  resolveTheaterAudioStatus,
+  resolveVideoRelayStatusLine,
+  selectDrawerPresentation,
+} from './drawerErrorPresentation'
+
+describe('drawerErrorPresentation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  beforeEach(() => {
+    vi.stubEnv('DEV', false)
+  })
+
+  it('exports stable surface id constants', () => {
+    expect(RIFFSYNC_CHAT_DRAWER_STATUS_ID).toBe('riffsync-chat-drawer-status')
+    expect(RIFFSYNC_VIDEO_RELAY_STATUS_ID).toBe('riffsync-video-relay-status')
+    expect(RIFFSYNC_CHAT_COMPOSE_STATUS_ID).toBe('riffsync-chat-compose-status')
+    expect(RIFFSYNC_AV_TOGGLE_STATUS_ID).toBe('riffsync-av-toggle-status')
+    expect(RIFFSYNC_THEATER_AUDIO_STATUS_ID).toBe('riffsync-theater-audio-status')
+    expect(RIFFSYNC_SFU_CONFIG_ALERT_ID).toBe('riffsync-sfu-config-alert')
+  })
+
+  it('maps drawer lifecycle copy from presentation.md', () => {
+    expect(resolveChatDrawerBanner({ state: 'reconnecting' })).toBe('Reconnecting chat…')
+    expect(resolveChatDrawerBanner({ state: 'degraded' })).toBe(
+      'Chat unavailable. Try refreshing the page.',
+    )
+    expect(
+      resolveVideoRelayStatusLine({
+        sfu: { state: 'reconnecting' },
+        isPublisher: false,
+        guestShareFsm: 'running',
+      }),
+    ).toBe('Video relay reconnecting…')
+    expect(
+      resolveVideoRelayStatusLine({
+        sfu: { state: 'degraded' },
+        isPublisher: false,
+        guestShareFsm: 'running',
+      }),
+    ).toBe('Video relay unavailable. Try refreshing the page.')
+  })
+
+  it('maps error codes from error_state.md', () => {
+    expect(messageForDrawerError('CHAT_SEND_DROPPED')).toBe(
+      'Message could not be sent. Check chat connection and try again.',
+    )
+    expect(messageForDrawerError('ICE_FAILED')).toBe(
+      'Network connection failed. Check your network or VPN and try again.',
+    )
+    expect(messageForDrawerError('PLAYBACK_AUDIO_BLOCKED')).toContain('Party audio is blocked')
+  })
+
+  it('appends dev code suffix when import.meta.env.DEV is true', () => {
+    vi.stubEnv('DEV', true)
+    expect(messageForDrawerError('CHAT_SEND_DROPPED')).toContain('(code: CHAT_SEND_DROPPED)')
+    expect(messageForParticipantAvError('permission_denied')).toContain('(code: permission_denied)')
+  })
+
+  it('omits dev code suffix in production builds', () => {
+    vi.stubEnv('DEV', false)
+    expect(messageForDrawerError('CHAT_SEND_DROPPED')).not.toContain('(code:')
+  })
+
+  it('shows independent chat compose status without SFU input', () => {
+    expect(
+      resolveChatComposeStatus({
+        state: 'reconnecting',
+      }),
+    ).toEqual({
+      message: 'Reconnecting chat…',
+      disableSubmit: true,
+    })
+    expect(
+      resolveChatComposeStatus({
+        state: 'connected',
+        lastErrorCode: 'CHAT_SEND_DROPPED',
+      }),
+    ).toEqual({
+      message: 'Message could not be sent. Check chat connection and try again.',
+      disableSubmit: true,
+    })
+    expect(resolveChatComposeStatus({ state: 'connected' })).toEqual({
+      message: null,
+      disableSubmit: false,
+    })
+  })
+
+  it('surfaces config-class SFU errors on the page alert target', () => {
+    expect(
+      resolveSfuConfigAlert({
+        state: 'degraded',
+        lastErrorCode: 'LOCAL_SFU_UNREACHABLE',
+      }),
+    ).toContain('Local video relay is not running')
+    expect(resolveSfuConfigAlert({ state: 'connected' })).toBeNull()
+  })
+
+  it('shows theater audio status for blocked and suspended codes', () => {
+    expect(
+      resolveTheaterAudioStatus({
+        state: 'connected',
+        lastErrorCode: 'PLAYBACK_AUDIO_BLOCKED',
+      }),
+    ).toContain('Party audio is blocked')
+    expect(
+      resolveTheaterAudioStatus({
+        state: 'connected',
+        lastErrorCode: 'THEATER_AUDIO_SUSPENDED',
+      }),
+    ).toContain('Party audio is paused')
+  })
+
+  it('keeps guest host-screen FSM copy on the video-relay surface when SFU drawer is healthy', () => {
+    expect(
+      resolveVideoRelayStatusLine({
+        sfu: { state: 'connected' },
+        isPublisher: false,
+        guestShareFsm: 'idle',
+      }),
+    ).toBe('Waiting for host to share…')
+  })
+
+  it('allows simultaneous chat and video-relay banners from diagnostics', () => {
+    const presentation = selectDrawerPresentation(
+      {
+        roomId: 'room-1',
+        sessionId: 'sess-1',
+        asOf: new Date(0).toISOString(),
+        drawers: {
+          chat: { state: 'reconnecting' },
+          sfuSignaling: { state: 'degraded', lastErrorCode: 'ICE_FAILED' },
+          theaterPlayback: { state: 'connected' },
+        },
+        activeErrorCodes: ['ICE_FAILED'],
+      },
+      { guestShareFsm: 'running', isPublisher: false },
+    )
+    expect(presentation.chatDrawerBanner).toBe('Reconnecting chat…')
+    expect(presentation.videoRelayStatus).toContain('Network connection failed')
+  })
+})

--- a/apps/web/src/room/drawerErrorPresentation.ts
+++ b/apps/web/src/room/drawerErrorPresentation.ts
@@ -1,0 +1,204 @@
+import {
+  participantAvErrorMessage,
+  type ParticipantAvErrorCode,
+} from './av/participantAvErrors'
+import type { DrawerLifecycleState } from './sessions/RoomRealtimeSdk'
+import type {
+  ChatDrawerDiagnostics,
+  RoomRealtimeDiagnostics,
+  SfuSignalingDrawerDiagnostics,
+  TheaterPlaybackDrawerDiagnostics,
+} from './sessions/RoomRealtimeSdk'
+import {
+  isRealtimeDrawerErrorCode,
+  type RealtimeDrawerErrorCode,
+} from './realtimeDrawerErrors'
+import {
+  resolveGuestVideoRelayStatusLine,
+  resolveHostVideoRelayStatusLine,
+  type GuestHostScreenFsm,
+} from './sfu/sfuRelayStatusCopy'
+
+/** Stable DOM anchors from `.ai/business_logic/error_state.md` Surface mapping (#141). */
+export const RIFFSYNC_CHAT_DRAWER_STATUS_ID = 'riffsync-chat-drawer-status'
+export const RIFFSYNC_VIDEO_RELAY_STATUS_ID = 'riffsync-video-relay-status'
+export const RIFFSYNC_CHAT_COMPOSE_STATUS_ID = 'riffsync-chat-compose-status'
+export const RIFFSYNC_AV_TOGGLE_STATUS_ID = 'riffsync-av-toggle-status'
+export const RIFFSYNC_THEATER_AUDIO_STATUS_ID = 'riffsync-theater-audio-status'
+export const RIFFSYNC_SFU_CONFIG_ALERT_ID = 'riffsync-sfu-config-alert'
+
+const CONFIG_CLASS_SFU_CODES = new Set<RealtimeDrawerErrorCode>([
+  'SFU_RELAY_URL_MISSING',
+  'LOCAL_SFU_UNREACHABLE',
+  'SFU_RELAY_UNREACHABLE',
+])
+
+const DRAWER_ERROR_COPY: Record<RealtimeDrawerErrorCode, string> = {
+  CHAT_SEND_DROPPED: 'Message could not be sent. Check chat connection and try again.',
+  CHAT_RECONNECTING: 'Reconnecting chat…',
+  SIGNALING_TIMEOUT: 'Video relay is slow to connect. Waiting…',
+  sfu_signaling_failed:
+    'Video relay connection lost. Refresh or wait for automatic reconnect.',
+  ICE_FAILED: 'Network connection failed. Check your network or VPN and try again.',
+  TURN_RELAY_REQUIRED:
+    'A relay connection is required but could not be established. Try again or check network settings.',
+  PRODUCER_CLOSED: 'Remote video ended.',
+  sfu_publish_rejected: 'Could not publish your camera/microphone. Try again in a moment.',
+  PLAYBACK_AUDIO_BLOCKED:
+    'Party audio is blocked. Tap to enable sound or check browser autoplay settings.',
+  THEATER_AUDIO_SUSPENDED:
+    'Party audio is paused. Interact with the page to resume sound.',
+  SFU_RELAY_URL_MISSING:
+    'Video relay URL is missing. Set VITE_PUBLIC_SFU_WS_URL at build time or redeploy API so POST /v1/webrtc/sfu-token returns wsUrl.',
+  LOCAL_SFU_UNREACHABLE:
+    'Local video relay is not running. Run npm run media:local, then confirm curl -sSf http://127.0.0.1:3000/healthz.',
+  SFU_RELAY_UNREACHABLE:
+    'Video relay is unreachable. Check docs/sfu-deploy-checklist.md and /healthz on the signaling host.',
+  SFU_TOKEN_DENIED: 'Video relay access was denied. Try again or refresh the page.',
+  TRANSPORT_LIMIT_REACHED:
+    'This session reached the video relay connection limit. Refresh the page or wait for others to leave.',
+  CONSUMER_LIMIT_REACHED:
+    'This session reached the video relay viewer limit. Refresh the page or wait for others to leave.',
+}
+
+const CHAT_DRAWER_LIFECYCLE_COPY: Partial<Record<DrawerLifecycleState, string>> = {
+  reconnecting: 'Reconnecting chat…',
+  degraded: 'Chat unavailable. Try refreshing the page.',
+}
+
+const SFU_DRAWER_LIFECYCLE_COPY: Partial<Record<DrawerLifecycleState, string>> = {
+  reconnecting: 'Video relay reconnecting…',
+  degraded: 'Video relay unavailable. Try refreshing the page.',
+}
+
+function appendDevCodeSuffix(message: string, code: string): string {
+  if (import.meta.env.DEV) {
+    return `${message} (code: ${code})`
+  }
+  return message
+}
+
+export function messageForDrawerError(code: RealtimeDrawerErrorCode): string {
+  return appendDevCodeSuffix(DRAWER_ERROR_COPY[code], code)
+}
+
+export function messageForParticipantAvError(code: ParticipantAvErrorCode): string {
+  return appendDevCodeSuffix(participantAvErrorMessage(code), code)
+}
+
+export function isConfigClassSfuDrawerError(code: string | undefined): code is RealtimeDrawerErrorCode {
+  return code !== undefined && CONFIG_CLASS_SFU_CODES.has(code as RealtimeDrawerErrorCode)
+}
+
+export function resolveChatDrawerBanner(chat: ChatDrawerDiagnostics): string | null {
+  if (chat.lastErrorCode && isRealtimeDrawerErrorCode(chat.lastErrorCode)) {
+    if (chat.lastErrorCode === 'CHAT_SEND_DROPPED' || chat.lastErrorCode === 'CHAT_RECONNECTING') {
+      return messageForDrawerError(chat.lastErrorCode)
+    }
+  }
+  const lifecycleCopy = CHAT_DRAWER_LIFECYCLE_COPY[chat.state]
+  if (lifecycleCopy) return lifecycleCopy
+  return null
+}
+
+export function resolveChatComposeStatus(chat: ChatDrawerDiagnostics): {
+  message: string | null
+  disableSubmit: boolean
+} {
+  const unhealthy =
+    chat.state === 'reconnecting' ||
+    chat.state === 'degraded' ||
+    chat.lastErrorCode === 'CHAT_SEND_DROPPED'
+
+  if (chat.lastErrorCode === 'CHAT_SEND_DROPPED') {
+    return {
+      message: messageForDrawerError('CHAT_SEND_DROPPED'),
+      disableSubmit: true,
+    }
+  }
+
+  if (chat.state === 'reconnecting' || chat.state === 'degraded') {
+    const lifecycleCopy = CHAT_DRAWER_LIFECYCLE_COPY[chat.state]
+    return {
+      message: lifecycleCopy ?? null,
+      disableSubmit: true,
+    }
+  }
+
+  return { message: null, disableSubmit: unhealthy }
+}
+
+function resolveSfuDrawerErrorLine(
+  sfu: SfuSignalingDrawerDiagnostics,
+): string | null {
+  if (sfu.lastErrorCode && isRealtimeDrawerErrorCode(sfu.lastErrorCode)) {
+    if (sfu.lastErrorCode === 'sfu_publish_rejected') {
+      return null
+    }
+    return messageForDrawerError(sfu.lastErrorCode)
+  }
+  return SFU_DRAWER_LIFECYCLE_COPY[sfu.state] ?? null
+}
+
+export function resolveVideoRelayStatusLine(opts: {
+  sfu: SfuSignalingDrawerDiagnostics
+  guestShareFsm?: GuestHostScreenFsm
+  isPublisher: boolean
+}): string | null {
+  const drawerLine = resolveSfuDrawerErrorLine(opts.sfu)
+  if (drawerLine) return drawerLine
+
+  if (opts.isPublisher) {
+    return resolveHostVideoRelayStatusLine(null)
+  }
+
+  return resolveGuestVideoRelayStatusLine({
+    sfuRelayError: null,
+    guestShareFsm: opts.guestShareFsm ?? 'idle',
+  })
+}
+
+export function resolveSfuConfigAlert(sfu: SfuSignalingDrawerDiagnostics): string | null {
+  if (!sfu.lastErrorCode || !isConfigClassSfuDrawerError(sfu.lastErrorCode)) {
+    return null
+  }
+  return messageForDrawerError(sfu.lastErrorCode)
+}
+
+export function resolveTheaterAudioStatus(
+  theater: TheaterPlaybackDrawerDiagnostics,
+): string | null {
+  if (!theater.lastErrorCode || !isRealtimeDrawerErrorCode(theater.lastErrorCode)) {
+    return null
+  }
+  if (
+    theater.lastErrorCode !== 'PLAYBACK_AUDIO_BLOCKED' &&
+    theater.lastErrorCode !== 'THEATER_AUDIO_SUSPENDED'
+  ) {
+    return null
+  }
+  return messageForDrawerError(theater.lastErrorCode)
+}
+
+export function selectDrawerPresentation(diagnostics: RoomRealtimeDiagnostics, opts: {
+  guestShareFsm: GuestHostScreenFsm
+  isPublisher: boolean
+}): {
+  chatDrawerBanner: string | null
+  chatComposeStatus: { message: string | null; disableSubmit: boolean }
+  videoRelayStatus: string | null
+  sfuConfigAlert: string | null
+  theaterAudioStatus: string | null
+} {
+  return {
+    chatDrawerBanner: resolveChatDrawerBanner(diagnostics.drawers.chat),
+    chatComposeStatus: resolveChatComposeStatus(diagnostics.drawers.chat),
+    videoRelayStatus: resolveVideoRelayStatusLine({
+      sfu: diagnostics.drawers.sfuSignaling,
+      guestShareFsm: opts.guestShareFsm,
+      isPublisher: opts.isPublisher,
+    }),
+    sfuConfigAlert: resolveSfuConfigAlert(diagnostics.drawers.sfuSignaling),
+    theaterAudioStatus: resolveTheaterAudioStatus(diagnostics.drawers.theaterPlayback),
+  }
+}

--- a/apps/web/src/room/realtimeDrawerErrors.test.ts
+++ b/apps/web/src/room/realtimeDrawerErrors.test.ts
@@ -146,6 +146,34 @@ describe('realtimeDrawerErrors', () => {
     ).toEqual(['CHAT_SEND_DROPPED', 'ICE_FAILED'])
   })
 
+  it('dedupes active codes and ignores unknown or inactive drawer codes', () => {
+    expect(
+      collectActiveErrorCodes([
+        undefined,
+        'not-a-real-code',
+        'CHAT_RECONNECTING',
+        'CHAT_SEND_DROPPED',
+        'SIGNALING_TIMEOUT',
+        'CHAT_SEND_DROPPED',
+        'THEATER_AUDIO_SUSPENDED',
+      ]),
+    ).toEqual(['CHAT_SEND_DROPPED', 'SIGNALING_TIMEOUT', 'THEATER_AUDIO_SUSPENDED'])
+  })
+
+  it('scopes drawer membership for collected active codes', () => {
+    const codes = collectActiveErrorCodes([
+      'CHAT_SEND_DROPPED',
+      'SIGNALING_TIMEOUT',
+      'THEATER_AUDIO_SUSPENDED',
+    ])
+    for (const code of codes) {
+      expect(drawerForErrorCode(code as (typeof codes)[number])).toBeTruthy()
+    }
+    expect(drawerForErrorCode('CHAT_SEND_DROPPED')).toBe('chat')
+    expect(drawerForErrorCode('SIGNALING_TIMEOUT')).toBe('sfuSignaling')
+    expect(drawerForErrorCode('THEATER_AUDIO_SUSPENDED')).toBe('theaterPlayback')
+  })
+
   it('treats producerClosedError as informational at diagnostics boundary', () => {
     const err = producerClosedError('producer-1')
     expect(err.code).toBe('PRODUCER_CLOSED')

--- a/apps/web/src/room/realtimeDrawerErrors.test.ts
+++ b/apps/web/src/room/realtimeDrawerErrors.test.ts
@@ -161,14 +161,13 @@ describe('realtimeDrawerErrors', () => {
   })
 
   it('scopes drawer membership for collected active codes', () => {
-    const codes = collectActiveErrorCodes([
-      'CHAT_SEND_DROPPED',
-      'SIGNALING_TIMEOUT',
-      'THEATER_AUDIO_SUSPENDED',
-    ])
-    for (const code of codes) {
-      expect(drawerForErrorCode(code as (typeof codes)[number])).toBeTruthy()
-    }
+    expect(
+      collectActiveErrorCodes([
+        'CHAT_SEND_DROPPED',
+        'SIGNALING_TIMEOUT',
+        'THEATER_AUDIO_SUSPENDED',
+      ]),
+    ).toEqual(['CHAT_SEND_DROPPED', 'SIGNALING_TIMEOUT', 'THEATER_AUDIO_SUSPENDED'])
     expect(drawerForErrorCode('CHAT_SEND_DROPPED')).toBe('chat')
     expect(drawerForErrorCode('SIGNALING_TIMEOUT')).toBe('sfuSignaling')
     expect(drawerForErrorCode('THEATER_AUDIO_SUSPENDED')).toBe('theaterPlayback')

--- a/apps/web/src/room/realtimeDrawerErrors.test.ts
+++ b/apps/web/src/room/realtimeDrawerErrors.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REALTIME_DRAWER_ERROR_CODES,
+  SIGNALING_TIMEOUT_MS,
+  ICE_DISCONNECTED_FAILURE_MS,
+  chatSendDroppedError,
+  collectActiveErrorCodes,
+  drawerForErrorCode,
+  isActiveErrorCode,
+  mapIceConnectionStateToDrawerError,
+  mapSfuConfigMediaCodeToDrawerError,
+  mapSfuMediaCodeToDrawerError,
+  mapTurnRelayRequiredFailure,
+  playbackAudioBlockedError,
+  producerClosedError,
+  theaterAudioSuspendedError,
+} from './realtimeDrawerErrors'
+
+describe('realtimeDrawerErrors', () => {
+  it('lists every code from the execution_model boundary table', () => {
+    const executionModelCodes = [
+      'CHAT_SEND_DROPPED',
+      'SIGNALING_TIMEOUT',
+      'ICE_FAILED',
+      'TURN_RELAY_REQUIRED',
+      'PRODUCER_CLOSED',
+      'SFU_TOKEN_DENIED',
+      'TRANSPORT_LIMIT_REACHED',
+      'CONSUMER_LIMIT_REACHED',
+      'THEATER_AUDIO_SUSPENDED',
+      'SFU_RELAY_URL_MISSING',
+      'LOCAL_SFU_UNREACHABLE',
+      'SFU_RELAY_UNREACHABLE',
+    ]
+    for (const code of executionModelCodes) {
+      expect(REALTIME_DRAWER_ERROR_CODES).toContain(code)
+    }
+  })
+
+  it('lists surface-mapping codes from error_state.md', () => {
+    expect(REALTIME_DRAWER_ERROR_CODES).toContain('PLAYBACK_AUDIO_BLOCKED')
+    expect(REALTIME_DRAWER_ERROR_CODES).toContain('sfu_signaling_failed')
+    expect(REALTIME_DRAWER_ERROR_CODES).toContain('sfu_publish_rejected')
+    expect(REALTIME_DRAWER_ERROR_CODES).toContain('CHAT_RECONNECTING')
+  })
+
+  it('exposes normative timing constants', () => {
+    expect(SIGNALING_TIMEOUT_MS).toBe(15_000)
+    expect(ICE_DISCONNECTED_FAILURE_MS).toBe(10_000)
+  })
+
+  it('maps chat send drops to the chat drawer', () => {
+    const err = chatSendDroppedError({ readyState: 3 })
+    expect(err).toEqual({
+      code: 'CHAT_SEND_DROPPED',
+      drawer: 'chat',
+      cause: { readyState: 3 },
+    })
+    expect(drawerForErrorCode(err.code)).toBe('chat')
+  })
+
+  it('maps SFU config-class media codes to drawer errors', () => {
+    expect(mapSfuConfigMediaCodeToDrawerError('missing_ws_url')).toEqual({
+      code: 'SFU_RELAY_URL_MISSING',
+      drawer: 'sfuSignaling',
+    })
+    expect(mapSfuConfigMediaCodeToDrawerError('local_sfu_unreachable')).toEqual({
+      code: 'LOCAL_SFU_UNREACHABLE',
+      drawer: 'sfuSignaling',
+    })
+    expect(mapSfuConfigMediaCodeToDrawerError('sfu_relay_unreachable')).toEqual({
+      code: 'SFU_RELAY_UNREACHABLE',
+      drawer: 'sfuSignaling',
+    })
+  })
+
+  it('maps SFU media codes to signaling and connectivity drawer errors', () => {
+    expect(mapSfuMediaCodeToDrawerError('signaling_failed')).toEqual({
+      code: 'SIGNALING_TIMEOUT',
+      drawer: 'sfuSignaling',
+    })
+    expect(mapSfuMediaCodeToDrawerError('signaling_closed')).toEqual({
+      code: 'sfu_signaling_failed',
+      drawer: 'sfuSignaling',
+    })
+    expect(mapSfuMediaCodeToDrawerError('transport_failed')).toEqual({
+      code: 'ICE_FAILED',
+      drawer: 'connectivity',
+    })
+    expect(mapSfuMediaCodeToDrawerError('transport_stalled')).toEqual({
+      code: 'ICE_FAILED',
+      drawer: 'connectivity',
+    })
+    expect(mapSfuMediaCodeToDrawerError('consume_failed')).toEqual({
+      code: 'CONSUMER_LIMIT_REACHED',
+      drawer: 'sfuSignaling',
+    })
+    expect(mapSfuMediaCodeToDrawerError('produce_failed')).toEqual({
+      code: 'sfu_publish_rejected',
+      drawer: 'sfuSignaling',
+    })
+  })
+
+  it('maps ICE failed state immediately', () => {
+    expect(mapIceConnectionStateToDrawerError('failed')).toEqual({
+      code: 'ICE_FAILED',
+      drawer: 'connectivity',
+    })
+    expect(mapIceConnectionStateToDrawerError('disconnected')).toBeNull()
+    expect(mapIceConnectionStateToDrawerError('connected')).toBeNull()
+  })
+
+  it('maps theater playback boundary errors', () => {
+    expect(theaterAudioSuspendedError()).toEqual({
+      code: 'THEATER_AUDIO_SUSPENDED',
+      drawer: 'theaterPlayback',
+    })
+    expect(playbackAudioBlockedError()).toEqual({
+      code: 'PLAYBACK_AUDIO_BLOCKED',
+      drawer: 'theaterPlayback',
+    })
+  })
+
+  it('maps TURN relay requirement to connectivity drawer', () => {
+    expect(mapTurnRelayRequiredFailure('no relay')).toEqual({
+      code: 'TURN_RELAY_REQUIRED',
+      drawer: 'connectivity',
+      cause: 'no relay',
+    })
+  })
+
+  it('excludes PRODUCER_CLOSED and CHAT_RECONNECTING from activeErrorCodes', () => {
+    expect(isActiveErrorCode('PRODUCER_CLOSED')).toBe(false)
+    expect(isActiveErrorCode('CHAT_RECONNECTING')).toBe(false)
+    expect(isActiveErrorCode('CHAT_SEND_DROPPED')).toBe(true)
+    expect(isActiveErrorCode('ICE_FAILED')).toBe(true)
+
+    expect(
+      collectActiveErrorCodes([
+        'CHAT_SEND_DROPPED',
+        'PRODUCER_CLOSED',
+        'CHAT_RECONNECTING',
+        'ICE_FAILED',
+        'PRODUCER_CLOSED',
+      ]),
+    ).toEqual(['CHAT_SEND_DROPPED', 'ICE_FAILED'])
+  })
+
+  it('treats producerClosedError as informational at diagnostics boundary', () => {
+    const err = producerClosedError('producer-1')
+    expect(err.code).toBe('PRODUCER_CLOSED')
+    expect(collectActiveErrorCodes([err.code])).toEqual([])
+  })
+})

--- a/apps/web/src/room/realtimeDrawerErrors.ts
+++ b/apps/web/src/room/realtimeDrawerErrors.ts
@@ -1,0 +1,196 @@
+import type { SfuMediaErrorCode } from './sfu/mediasoupSharing'
+import type { SfuRelayConfigErrorCode } from './sfu/sfuConfigErrors'
+
+/** Normative drawer keys (`execution_model.md`, `api_contracts.md`). */
+export const REALTIME_DRAWERS = [
+  'chat',
+  'sfuSignaling',
+  'theaterPlayback',
+  'connectivity',
+] as const
+
+export type RealtimeDrawer = (typeof REALTIME_DRAWERS)[number]
+
+/**
+ * Canonical drawer error codes from `.ai/business_logic/error_state.md` boundary table
+ * and `.ai/runtime/execution_model.md` typed runtime errors.
+ */
+export const REALTIME_DRAWER_ERROR_CODES = [
+  'CHAT_SEND_DROPPED',
+  'CHAT_RECONNECTING',
+  'SIGNALING_TIMEOUT',
+  'sfu_signaling_failed',
+  'ICE_FAILED',
+  'TURN_RELAY_REQUIRED',
+  'PRODUCER_CLOSED',
+  'sfu_publish_rejected',
+  'PLAYBACK_AUDIO_BLOCKED',
+  'THEATER_AUDIO_SUSPENDED',
+  'SFU_RELAY_URL_MISSING',
+  'LOCAL_SFU_UNREACHABLE',
+  'SFU_RELAY_UNREACHABLE',
+  'SFU_TOKEN_DENIED',
+  'TRANSPORT_LIMIT_REACHED',
+  'CONSUMER_LIMIT_REACHED',
+] as const
+
+export type RealtimeDrawerErrorCode = (typeof REALTIME_DRAWER_ERROR_CODES)[number]
+
+export type RealtimeDrawerError = {
+  code: RealtimeDrawerErrorCode
+  drawer: RealtimeDrawer
+  cause?: unknown
+}
+
+/** SFU signaling connect / per-RPC request-ack deadline (`api_contracts.md` #141). */
+export const SIGNALING_TIMEOUT_MS = 15_000
+
+/** ICE `disconnected` grace before surfacing `ICE_FAILED` (`api_contracts.md` #141). */
+export const ICE_DISCONNECTED_FAILURE_MS = 10_000
+
+const INACTIVE_ACTIVE_ERROR_CODES = new Set<RealtimeDrawerErrorCode>([
+  'PRODUCER_CLOSED',
+  'CHAT_RECONNECTING',
+])
+
+const ERROR_CODE_DRAWER: Record<RealtimeDrawerErrorCode, RealtimeDrawer> = {
+  CHAT_SEND_DROPPED: 'chat',
+  CHAT_RECONNECTING: 'chat',
+  SIGNALING_TIMEOUT: 'sfuSignaling',
+  sfu_signaling_failed: 'sfuSignaling',
+  ICE_FAILED: 'connectivity',
+  TURN_RELAY_REQUIRED: 'connectivity',
+  PRODUCER_CLOSED: 'sfuSignaling',
+  sfu_publish_rejected: 'sfuSignaling',
+  PLAYBACK_AUDIO_BLOCKED: 'theaterPlayback',
+  THEATER_AUDIO_SUSPENDED: 'theaterPlayback',
+  SFU_RELAY_URL_MISSING: 'sfuSignaling',
+  LOCAL_SFU_UNREACHABLE: 'sfuSignaling',
+  SFU_RELAY_UNREACHABLE: 'sfuSignaling',
+  SFU_TOKEN_DENIED: 'sfuSignaling',
+  TRANSPORT_LIMIT_REACHED: 'sfuSignaling',
+  CONSUMER_LIMIT_REACHED: 'sfuSignaling',
+}
+
+export function drawerForErrorCode(code: RealtimeDrawerErrorCode): RealtimeDrawer {
+  return ERROR_CODE_DRAWER[code]
+}
+
+export function isRealtimeDrawerErrorCode(value: string): value is RealtimeDrawerErrorCode {
+  return (REALTIME_DRAWER_ERROR_CODES as readonly string[]).includes(value)
+}
+
+export function isActiveErrorCode(code: RealtimeDrawerErrorCode): boolean {
+  return !INACTIVE_ACTIVE_ERROR_CODES.has(code)
+}
+
+/** Collect user-visible blocking codes for `getDiagnostics().activeErrorCodes`. */
+export function collectActiveErrorCodes(codes: Iterable<string | undefined>): string[] {
+  const active: string[] = []
+  for (const code of codes) {
+    if (!code || !isRealtimeDrawerErrorCode(code)) continue
+    if (!isActiveErrorCode(code)) continue
+    if (!active.includes(code)) active.push(code)
+  }
+  return active
+}
+
+export function chatSendDroppedError(cause?: unknown): RealtimeDrawerError {
+  return { code: 'CHAT_SEND_DROPPED', drawer: 'chat', ...(cause !== undefined ? { cause } : {}) }
+}
+
+export function theaterAudioSuspendedError(cause?: unknown): RealtimeDrawerError {
+  return {
+    code: 'THEATER_AUDIO_SUSPENDED',
+    drawer: 'theaterPlayback',
+    ...(cause !== undefined ? { cause } : {}),
+  }
+}
+
+export function playbackAudioBlockedError(cause?: unknown): RealtimeDrawerError {
+  return {
+    code: 'PLAYBACK_AUDIO_BLOCKED',
+    drawer: 'theaterPlayback',
+    ...(cause !== undefined ? { cause } : {}),
+  }
+}
+
+export function producerClosedError(cause?: unknown): RealtimeDrawerError {
+  return { code: 'PRODUCER_CLOSED', drawer: 'sfuSignaling', ...(cause !== undefined ? { cause } : {}) }
+}
+
+export function mapSfuConfigMediaCodeToDrawerError(
+  code: SfuRelayConfigErrorCode,
+): RealtimeDrawerError {
+  switch (code) {
+    case 'missing_ws_url':
+      return { code: 'SFU_RELAY_URL_MISSING', drawer: 'sfuSignaling' }
+    case 'local_sfu_unreachable':
+      return { code: 'LOCAL_SFU_UNREACHABLE', drawer: 'sfuSignaling' }
+    case 'sfu_relay_unreachable':
+      return { code: 'SFU_RELAY_UNREACHABLE', drawer: 'sfuSignaling' }
+    default: {
+      const _exhaustive: never = code
+      return _exhaustive
+    }
+  }
+}
+
+export function mapSfuMediaCodeToDrawerError(code: SfuMediaErrorCode): RealtimeDrawerError {
+  if (code === 'missing_ws_url') {
+    return mapSfuConfigMediaCodeToDrawerError('missing_ws_url')
+  }
+  if (code === 'local_sfu_unreachable') {
+    return mapSfuConfigMediaCodeToDrawerError('local_sfu_unreachable')
+  }
+  if (code === 'sfu_relay_unreachable') {
+    return mapSfuConfigMediaCodeToDrawerError('sfu_relay_unreachable')
+  }
+  if (code === 'signaling_failed') {
+    return { code: 'SIGNALING_TIMEOUT', drawer: 'sfuSignaling' }
+  }
+  if (code === 'signaling_closed') {
+    return { code: 'sfu_signaling_failed', drawer: 'sfuSignaling' }
+  }
+  if (code === 'transport_failed' || code === 'transport_stalled') {
+    return { code: 'ICE_FAILED', drawer: 'connectivity' }
+  }
+  if (code === 'consume_failed') {
+    return { code: 'CONSUMER_LIMIT_REACHED', drawer: 'sfuSignaling' }
+  }
+  if (code === 'produce_failed' || code === 'bad_capabilities') {
+    return { code: 'sfu_publish_rejected', drawer: 'sfuSignaling' }
+  }
+  return { code: 'sfu_signaling_failed', drawer: 'sfuSignaling' }
+}
+
+export function mapIceConnectionStateToDrawerError(
+  state: RTCIceConnectionState,
+): RealtimeDrawerError | null {
+  if (state === 'failed') {
+    return { code: 'ICE_FAILED', drawer: 'connectivity' }
+  }
+  return null
+}
+
+export function mapTurnRelayRequiredFailure(cause?: unknown): RealtimeDrawerError {
+  return { code: 'TURN_RELAY_REQUIRED', drawer: 'connectivity', ...(cause !== undefined ? { cause } : {}) }
+}
+
+export function mapDomExceptionToDrawerError(error: unknown): RealtimeDrawerError | null {
+  if (!(error instanceof DOMException)) return null
+  if (error.name === 'NotAllowedError' || error.name === 'PermissionDeniedError') {
+    return null
+  }
+  return null
+}
+
+export function mapChatWsCloseToDrawerError(code: number, reason?: string): RealtimeDrawerError | null {
+  void code
+  void reason
+  return null
+}
+
+export function mapSfuTokenDeniedError(cause?: unknown): RealtimeDrawerError {
+  return { code: 'SFU_TOKEN_DENIED', drawer: 'sfuSignaling', ...(cause !== undefined ? { cause } : {}) }
+}

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -136,12 +136,17 @@ describe('ChatSession send', () => {
     expect(session.getLastErrorCode()).toBe('CHAT_SEND_DROPPED')
   })
 
-  it('notifies send-dropped listeners without queueing', () => {
+  it('notifies send-dropped listeners with typed drawer errors without queueing', () => {
     const session = new ChatSession()
     const dropped = vi.fn()
     session.onSendDropped(dropped)
     session.send({ action: 'ping' })
     expect(dropped).toHaveBeenCalledTimes(1)
+    expect(dropped).toHaveBeenCalledWith({
+      code: 'CHAT_SEND_DROPPED',
+      drawer: 'chat',
+      cause: { readyState: -1 },
+    })
   })
 })
 

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -3,6 +3,11 @@ import { parseInboundChatGifMessage, type InboundChatGifLine } from '../chatGifM
 import { parseInboundChatMessageId } from '../chatMessageId'
 import { parseInboundRoomMode } from '../roomMediaLifecycle'
 import {
+  chatSendDroppedError,
+  type RealtimeDrawerError,
+  type RealtimeDrawerErrorCode,
+} from '../realtimeDrawerErrors'
+import {
   recordInboundWsMessage,
   recordOutboundDropped,
   recordOutboundSent,
@@ -191,7 +196,7 @@ export class ChatSession {
   private status: ChatSessionStatus = 'idle'
   private lifecycleState: ChatSessionLifecycleState = 'torn-down'
   private failedReconnectCycles = 0
-  private lastErrorCode: string | undefined
+  private lastErrorCode: RealtimeDrawerErrorCode | undefined
   private ws: WebSocket | null = null
   private pingTimer: ReturnType<typeof setInterval> | null = null
   private reconnectTimer: number | null = null
@@ -210,7 +215,7 @@ export class ChatSession {
   private avDisabledListeners = new Set<Listener<AvDisabledEvent>>()
   private statusListeners = new Set<Listener<ChatSessionStatus>>()
   private lifecycleListeners = new Set<Listener<ChatSessionLifecycleState>>()
-  private sendDroppedListeners = new Set<Listener<void>>()
+  private sendDroppedListeners = new Set<Listener<RealtimeDrawerError>>()
 
   getStatus(): ChatSessionStatus {
     return this.status
@@ -220,7 +225,7 @@ export class ChatSession {
     return this.lifecycleState
   }
 
-  getLastErrorCode(): string | undefined {
+  getLastErrorCode(): RealtimeDrawerErrorCode | undefined {
     return this.lastErrorCode
   }
 
@@ -273,7 +278,7 @@ export class ChatSession {
   }
 
   /** Fired when outbound send is dropped because room WS is not open. */
-  onSendDropped(listener: Listener<void>): () => void {
+  onSendDropped(listener: Listener<RealtimeDrawerError>): () => void {
     this.sendDroppedListeners.add(listener)
     return () => this.sendDroppedListeners.delete(listener)
   }
@@ -319,9 +324,11 @@ export class ChatSession {
   send(payload: Record<string, unknown>): boolean {
     const ws = this.ws
     if (!ws || ws.readyState !== WebSocket.OPEN) {
-      recordOutboundDropped(payload, ws?.readyState ?? -1)
-      this.lastErrorCode = 'CHAT_SEND_DROPPED'
-      for (const listener of this.sendDroppedListeners) listener()
+      const readyState = ws?.readyState ?? -1
+      recordOutboundDropped(payload, readyState)
+      const drawerError = chatSendDroppedError({ readyState })
+      this.lastErrorCode = drawerError.code
+      for (const listener of this.sendDroppedListeners) listener(drawerError)
       return false
     }
     recordOutboundSent(payload)

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -16,12 +16,18 @@ import {
   assertNoDrawerTornDown,
   assertSiblingDrawerStaysConnected,
   emitShareStateStopped,
+  emitSfuDrawerError,
   joinHealthySdk,
   mockChatConnectOpensImmediately,
   mockSfuConnectOpensImmediately,
   setChatLifecycle,
   setSfuLifecycle,
 } from './roomRealtimeSdkTestHelpers'
+import {
+  mapSfuConfigMediaCodeToDrawerError,
+  mapSfuMediaCodeToDrawerError,
+  producerClosedError,
+} from '../realtimeDrawerErrors'
 
 vi.mock('../audio/theaterAudioMix', () => ({
   THEATER_AUDIO_GAIN: 1,
@@ -653,6 +659,71 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
     const diag = sdk.getDiagnostics()
     expect(diag.drawers.chat.lastErrorCode).toBe('CHAT_SEND_DROPPED')
     expect(diag.activeErrorCodes).toContain('CHAT_SEND_DROPPED')
+  })
+})
+
+describe('RoomRealtimeSdk.getDiagnostics activeErrorCodes contract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('includes SIGNALING_TIMEOUT from SFU drawer errors', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-signaling-timeout' })
+    emitSfuDrawerError(sdk, mapSfuMediaCodeToDrawerError('signaling_failed'))
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.lastErrorCode).toBe('SIGNALING_TIMEOUT')
+    expect(diag.activeErrorCodes).toEqual(['SIGNALING_TIMEOUT'])
+  })
+
+  it('includes config-class LOCAL_SFU_UNREACHABLE from SFU drawer errors', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-config-error' })
+    emitSfuDrawerError(sdk, mapSfuConfigMediaCodeToDrawerError('local_sfu_unreachable'))
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.lastErrorCode).toBe('LOCAL_SFU_UNREACHABLE')
+    expect(diag.activeErrorCodes).toEqual(['LOCAL_SFU_UNREACHABLE'])
+  })
+
+  it('collects activeErrorCodes from multiple drawers without duplicates', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-multi-drawer' })
+    sdk.sendControl({ action: 'chat', text: 'hello', messageId: '550e8400-e29b-41d4-a716-446655440099' })
+    emitSfuDrawerError(sdk, mapSfuMediaCodeToDrawerError('signaling_failed'))
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.activeErrorCodes).toEqual(['CHAT_SEND_DROPPED', 'SIGNALING_TIMEOUT'])
+  })
+
+  it('excludes PRODUCER_CLOSED from activeErrorCodes after consumer detach simulation', async () => {
+    mockChatConnectOpensImmediately()
+    const consumerListeners: Array<(event: SfuConsumerTrackEvent) => void> = []
+    vi.spyOn(SfuMediaSession.prototype, 'onConsumerTrack').mockImplementation(function (
+      listener: (event: SfuConsumerTrackEvent) => void,
+    ) {
+      consumerListeners.push(listener)
+      return () => {
+        const idx = consumerListeners.indexOf(listener)
+        if (idx >= 0) consumerListeners.splice(idx, 1)
+      }
+    })
+
+    const sdk = await joinHealthySdk({ sessionId: 'sess-producer-closed' })
+    sdk.subscribe({ participantAv: { onConsumerTrack: vi.fn() } })
+    await vi.waitFor(() => expect(consumerListeners.length).toBeGreaterThan(0))
+
+    consumerListeners[0]?.({
+      action: 'detach',
+      producerId: 'p-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+    })
+
+    emitSfuDrawerError(sdk, producerClosedError('p-1'))
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.lastErrorCode).toBe('PRODUCER_CLOSED')
+    expect(diag.activeErrorCodes).not.toContain('PRODUCER_CLOSED')
+    expect(diag.activeErrorCodes).toEqual([])
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -714,8 +714,6 @@ describe('RoomRealtimeSdk.getDiagnostics activeErrorCodes contract', () => {
     consumerListeners[0]?.({
       action: 'detach',
       producerId: 'p-1',
-      producerClass: 'participant_av',
-      kind: 'video',
     })
 
     emitSfuDrawerError(sdk, producerClosedError('p-1'))

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -21,6 +21,7 @@ import {
   type RoomModeEvent,
 } from './ChatSession'
 import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
+import { collectActiveErrorCodes } from '../realtimeDrawerErrors'
 import { TheaterPlayback, type TheaterPlaybackSnapshot } from './TheaterPlayback'
 
 export type { TheaterPlaybackSnapshot }
@@ -142,19 +143,6 @@ export function mapSfuMediaSessionStatusToDrawerState(
   }
 }
 
-function collectActiveErrorCodes(
-  drawers: RoomRealtimeDiagnostics['drawers'],
-): string[] {
-  const codes: string[] = []
-  const maybePush = (code: string | undefined) => {
-    if (code && !codes.includes(code)) codes.push(code)
-  }
-  maybePush(drawers.chat.lastErrorCode)
-  maybePush(drawers.sfuSignaling.lastErrorCode)
-  maybePush(drawers.theaterPlayback.lastErrorCode)
-  return codes
-}
-
 /**
  * Framework-agnostic facade over ChatSession, SfuMediaSession, and TheaterPlayback.
  */
@@ -188,6 +176,7 @@ export class RoomRealtimeSdk {
   private sfuStatusUnsub: (() => void) | null = null
   private sfuLifecycleUnsub: (() => void) | null = null
   private sfuErrorUnsub: (() => void) | null = null
+  private sfuDrawerErrorUnsub: (() => void) | null = null
   private mediaPolicyUnsubs: Array<() => void> = []
   private hostScreenStreamUnsub: (() => void) | null = null
   private participantAvTrackUnsub: (() => void) | null = null
@@ -307,7 +296,11 @@ export class RoomRealtimeSdk {
       sessionId: this.sessionId,
       asOf: new Date().toISOString(),
       drawers,
-      activeErrorCodes: collectActiveErrorCodes(drawers),
+      activeErrorCodes: collectActiveErrorCodes([
+        drawers.chat.lastErrorCode,
+        drawers.sfuSignaling.lastErrorCode,
+        drawers.theaterPlayback.lastErrorCode,
+      ]),
     }
   }
 
@@ -407,8 +400,8 @@ export class RoomRealtimeSdk {
       this.emitDiagnosticsChange()
     })
 
-    this.chatSendDroppedUnsub = chat.onSendDropped(() => {
-      this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
+    this.chatSendDroppedUnsub = chat.onSendDropped((error) => {
+      this.chatLastErrorCode = error.code
       this.emitDiagnosticsChange()
     })
 
@@ -431,9 +424,11 @@ export class RoomRealtimeSdk {
 
     this.sfuErrorUnsub = sfu.onError((message) => {
       this.sfuRelayErrorMessage = message
-      if (message) {
-        this.sfuLastErrorCode = 'SIGNALING_TIMEOUT'
-      }
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuDrawerErrorUnsub = sfu.onDrawerError((error) => {
+      this.sfuLastErrorCode = error?.code
       this.emitDiagnosticsChange()
     })
 
@@ -623,6 +618,7 @@ export class RoomRealtimeSdk {
     this.sfuStatusUnsub?.()
     this.sfuLifecycleUnsub?.()
     this.sfuErrorUnsub?.()
+    this.sfuDrawerErrorUnsub?.()
     for (const unsub of this.mediaPolicyUnsubs) unsub()
     for (const unsub of this.roomControlUnsubs) unsub()
     this.theaterSnapshotUnsub?.()
@@ -637,6 +633,7 @@ export class RoomRealtimeSdk {
     this.sfuStatusUnsub = null
     this.sfuLifecycleUnsub = null
     this.sfuErrorUnsub = null
+    this.sfuDrawerErrorUnsub = null
     this.mediaPolicyUnsubs = []
     this.roomControlUnsubs = []
     this.theaterSnapshotUnsub = null

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -213,6 +213,52 @@ function attachMockSessionHandle(
   ).sessionHandle = handle
 }
 
+describe('SfuMediaSession drawer errors', () => {
+  it('emits typed drawer errors for config-class signaling failures', async () => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async (opts) => {
+      opts.onMediaError?.('signaling_failed', 'Could not connect to video relay (signaling).')
+      return {
+        ready: Promise.reject(new Error('signaling failed')),
+        sessionEnded: Promise.resolve('signaling_close'),
+        close: vi.fn(),
+        unpublishProducerClass: vi.fn(),
+        publishStream: vi.fn(),
+        supportsPublish: false,
+        detachConsumerClass: vi.fn(),
+        pauseProducerKind: vi.fn(),
+        resumeProducerKind: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof connectSfuUnifiedSession>>
+    })
+
+    const session = new SfuMediaSession()
+    const drawerErrors: Array<{ code: string; drawer: string } | null> = []
+    session.onDrawerError((error) => drawerErrors.push(error))
+
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(drawerErrors.some((error) => error?.code === 'LOCAL_SFU_UNREACHABLE')).toBe(true)
+    })
+
+    session.disconnect()
+    vi.unstubAllGlobals()
+  })
+})
+
 describe('SfuMediaSession media policy', () => {
   it('handleShareStateStopped detaches host_screen for guests only', () => {
     const session = new SfuMediaSession()

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -27,6 +27,13 @@ import {
   messageForSfuRelayConfigError,
   type SfuRelayConfigErrorCode,
 } from '../sfu/sfuConfigErrors'
+import {
+  mapSfuConfigMediaCodeToDrawerError,
+  mapSfuMediaCodeToDrawerError,
+  mapSfuTokenDeniedError,
+  type RealtimeDrawerError,
+  type RealtimeDrawerErrorCode,
+} from '../realtimeDrawerErrors'
 import { sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
 import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 
@@ -354,7 +361,7 @@ export class SfuMediaSession {
   private status: SfuMediaSessionStatus = 'idle'
   private lifecycleState: SfuMediaSessionLifecycleState = 'torn-down'
   private failedReconnectCycles = 0
-  private lastErrorCode: string | undefined
+  private lastErrorCode: RealtimeDrawerErrorCode | undefined
   private cancelReconnect: (() => void) | null = null
   private sessionHandle: SfuUnifiedSessionHandle | null = null
   private tokenIntentGeneration = 0
@@ -376,6 +383,7 @@ export class SfuMediaSession {
   private consumerTrackListeners = new Set<Listener<SfuConsumerTrackEvent>>()
   private lastRemoteStream: MediaStream | null = null
   private errorListeners = new Set<Listener<string | null>>()
+  private drawerErrorListeners = new Set<Listener<RealtimeDrawerError | null>>()
   private statusListeners = new Set<Listener<SfuMediaSessionStatus>>()
   private lifecycleListeners = new Set<Listener<SfuMediaSessionLifecycleState>>()
   private participantAvConsumerClearListeners = new Set<Listener<void>>()
@@ -393,7 +401,7 @@ export class SfuMediaSession {
     return this.lifecycleState
   }
 
-  getLastErrorCode(): string | undefined {
+  getLastErrorCode(): RealtimeDrawerErrorCode | undefined {
     return this.lastErrorCode
   }
 
@@ -428,6 +436,11 @@ export class SfuMediaSession {
   onError(listener: Listener<string | null>): () => void {
     this.errorListeners.add(listener)
     return () => this.errorListeners.delete(listener)
+  }
+
+  onDrawerError(listener: Listener<RealtimeDrawerError | null>): () => void {
+    this.drawerErrorListeners.add(listener)
+    return () => this.drawerErrorListeners.delete(listener)
   }
 
   onStatusChange(listener: Listener<SfuMediaSessionStatus>): () => void {
@@ -482,6 +495,7 @@ export class SfuMediaSession {
     this.setStatus('idle')
     this.setLifecycleState('torn-down')
     this.emitError(null)
+    this.emitDrawerError(null)
   }
 
   /** Guest: detach host_screen consumers only when share stops. */
@@ -609,22 +623,29 @@ export class SfuMediaSession {
           this.setLifecycleState('connected')
         }
       },
-      onMissingWsUrl: () =>
-        this.emitError(messageForSfuRelayConfigError('missing_ws_url')),
+      onMissingWsUrl: () => {
+        this.emitDrawerError(mapSfuConfigMediaCodeToDrawerError('missing_ws_url'))
+        this.emitError(messageForSfuRelayConfigError('missing_ws_url'))
+      },
       onTokenError: (msg) => this.emitError(msg),
       onMediaError: (code, msg) => {
+        const drawerError = mapSfuMediaCodeToDrawerError(code)
         if (isSfuRelayConfigErrorCode(code)) {
+          this.emitDrawerError(drawerError)
           this.emitError(messageForSfuRelayConfigError(code))
           return
         }
         if (this.participantAv.getState().needsProducerToken) {
           this.participantAv.failPublish(participantAvErrorFromSfuMediaCode(code))
+          this.emitDrawerError(drawerError)
           return
         }
+        this.emitDrawerError(drawerError)
         this.emitError(msg)
       },
       onConnecting: () => {
         this.emitError(null)
+        this.emitDrawerError(null)
         this.setStatus('connecting')
         this.setLifecycleState(
           this.failedReconnectCycles > 0
@@ -634,6 +655,7 @@ export class SfuMediaSession {
       },
       onSessionReady: () => {
         this.emitError(null)
+        this.emitDrawerError(null)
         this.failedReconnectCycles = 0
         this.lastErrorCode = undefined
         this.setStatus('open')
@@ -712,8 +734,10 @@ export class SfuMediaSession {
       if (this.getStatus() === 'open') {
         this.scheduleJwtRemint(tok.token, tok.expiresInSeconds)
       }
-    } catch {
-      this.lastErrorCode = 'SFU_TOKEN_DENIED'
+    } catch (cause) {
+      const drawerError = mapSfuTokenDeniedError(cause)
+      this.lastErrorCode = drawerError.code
+      this.emitDrawerError(drawerError)
       this.setStatus('degraded')
       this.setLifecycleState('degraded')
     }
@@ -738,5 +762,10 @@ export class SfuMediaSession {
 
   private emitError(message: string | null): void {
     for (const listener of this.errorListeners) listener(message)
+  }
+
+  private emitDrawerError(error: RealtimeDrawerError | null): void {
+    this.lastErrorCode = error?.code
+    for (const listener of this.drawerErrorListeners) listener(error)
   }
 }

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -214,6 +214,21 @@ describe('TheaterPlayback', () => {
     playback.dispose()
   })
 
+  it('reports PLAYBACK_AUDIO_BLOCKED when guest video autoplay is blocked', async () => {
+    const mix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const video = makeVideoElement(() => Promise.reject(new Error('autoplay blocked')))
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    playback.setGuestVideoElement(video)
+    playback.setGuestRemote(makeStream([makeTrack('video')]))
+
+    await Promise.resolve()
+    expect(playback.getLifecycleState()).toBe('degraded')
+    expect(playback.getLastErrorCode()).toBe('PLAYBACK_AUDIO_BLOCKED')
+    playback.dispose()
+  })
+
   it('reports degraded lifecycle when AudioContext is suspended', () => {
     const mix = makeMixMock({
       getAudioContextState: vi.fn().mockReturnValue('suspended' as AudioContextState),

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -5,6 +5,11 @@ import {
 } from '../audio/theaterAudioMix'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
 import type { GuestHostScreenFsm } from '../sfu/sfuRelayStatusCopy'
+import {
+  playbackAudioBlockedError,
+  theaterAudioSuspendedError,
+  type RealtimeDrawerErrorCode,
+} from '../realtimeDrawerErrors'
 import type { SfuMediaSession } from './SfuMediaSession'
 
 /** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
@@ -41,7 +46,7 @@ function mapSfuConsumerToMixEvent(event: SfuConsumerTrackEvent): TheaterAudioCon
 export class TheaterPlayback {
   private enabled = false
   private lifecycleState: TheaterPlaybackLifecycleState = 'torn-down'
-  private lastErrorCode: string | undefined
+  private lastErrorCode: RealtimeDrawerErrorCode | undefined
   private signalingSiblingDegraded = false
   private sfuSignalingWasConnected = false
   private isPublisher = false
@@ -70,7 +75,7 @@ export class TheaterPlayback {
     return this.lifecycleState
   }
 
-  getLastErrorCode(): string | undefined {
+  getLastErrorCode(): RealtimeDrawerErrorCode | undefined {
     return this.lastErrorCode
   }
 
@@ -277,7 +282,12 @@ export class TheaterPlayback {
 
     const audioSuspended = this.getAudioContextState() === 'suspended'
     if (audioSuspended) {
-      this.setLifecycleState('degraded', 'THEATER_AUDIO_SUSPENDED')
+      this.setLifecycleState('degraded', theaterAudioSuspendedError().code)
+      return
+    }
+
+    if (this.guestPlayHint || this.hostCapturePlayHint) {
+      this.setLifecycleState('degraded', playbackAudioBlockedError().code)
       return
     }
 
@@ -291,7 +301,7 @@ export class TheaterPlayback {
 
   private setLifecycleState(
     next: TheaterPlaybackLifecycleState,
-    errorCode: string | undefined,
+    errorCode: RealtimeDrawerErrorCode | undefined,
   ): void {
     this.lastErrorCode = errorCode
     if (this.lifecycleState === next) return
@@ -428,12 +438,14 @@ export class TheaterPlayback {
     if (this.guestPlayHint === next) return
     this.guestPlayHint = next
     this.emitSnapshot()
+    this.syncLifecycleState()
   }
 
   private setHostCapturePlayHint(next: boolean): void {
     if (this.hostCapturePlayHint === next) return
     this.hostCapturePlayHint = next
     this.emitSnapshot()
+    this.syncLifecycleState()
   }
 
   private emitSnapshot(): void {

--- a/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
+++ b/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
@@ -8,6 +8,7 @@
 
 import { expect, vi } from 'vitest'
 import type { RoomSnapshot } from '../../api/roomsApi'
+import type { RealtimeDrawerError } from '../realtimeDrawerErrors'
 import { ChatSession } from './ChatSession'
 import { SfuMediaSession } from './SfuMediaSession'
 import {
@@ -98,6 +99,14 @@ export function setChatLifecycle(sdk: RoomRealtimeSdk, state: string): void {
 export function setSfuLifecycle(sdk: RoomRealtimeSdk, state: string): void {
   const sfu = getSfuSession(sdk)
   ;(sfu as unknown as { setLifecycleState: (s: string) => void }).setLifecycleState(state)
+}
+
+/** Drive SFU drawer error wiring the same path production uses via `onDrawerError`. */
+export function emitSfuDrawerError(sdk: RoomRealtimeSdk, error: RealtimeDrawerError): void {
+  const sfu = getSfuSession(sdk)
+  ;(sfu as unknown as { emitDrawerError: (e: RealtimeDrawerError | null) => void }).emitDrawerError(
+    error,
+  )
 }
 
 export function emitShareStateStopped(sdk: RoomRealtimeSdk, roomId = 'room-abc'): void {

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
@@ -11,19 +11,17 @@ describe('resolveGuestVideoRelayStatusLine', () => {
       resolveGuestVideoRelayStatusLine({
         sfuRelayError: LOCAL_SFU_UNREACHABLE_MSG,
         guestShareFsm: 'verifying_media',
-        chatWsDisconnected: false,
       }),
     ).toBe(LOCAL_SFU_UNREACHABLE_MSG)
   })
 
-  it('shows chat reconnect copy only when no SFU config error is active', () => {
+  it('does not branch on chat WS state (drawer-independent banners)', () => {
     expect(
       resolveGuestVideoRelayStatusLine({
         sfuRelayError: null,
         guestShareFsm: 'running',
-        chatWsDisconnected: true,
       }),
-    ).toBe('Reconnecting chat… Video may pause briefly.')
+    ).toBeNull()
   })
 
   it('shows host-screen FSM copy when relay is healthy', () => {
@@ -31,7 +29,6 @@ describe('resolveGuestVideoRelayStatusLine', () => {
       resolveGuestVideoRelayStatusLine({
         sfuRelayError: null,
         guestShareFsm: 'idle',
-        chatWsDisconnected: false,
       }),
     ).toBe('Waiting for host to share…')
   })

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.ts
@@ -8,10 +8,8 @@ export type GuestHostScreenFsm = 'idle' | 'verifying_media' | 'running'
 export function resolveGuestVideoRelayStatusLine(opts: {
   sfuRelayError: string | null
   guestShareFsm: GuestHostScreenFsm
-  chatWsDisconnected: boolean
 }): string | null {
   if (opts.sfuRelayError) return opts.sfuRelayError
-  if (opts.chatWsDisconnected) return 'Reconnecting chat… Video may pause briefly.'
   switch (opts.guestShareFsm) {
     case 'idle':
       return 'Waiting for host to share…'

--- a/apps/web/src/room/useRoomRealtimeSdk.ts
+++ b/apps/web/src/room/useRoomRealtimeSdk.ts
@@ -20,10 +20,7 @@ import { createChatMessageId } from './chatMessageId'
 import { avDisabledAnnounceCopy, roomModeAnnounceCopy } from './hostRoomControls'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import type { SfuConsumerTrackEvent } from './sfu/mediasoupSharing'
-import {
-  resolveGuestVideoRelayStatusLine,
-  resolveHostVideoRelayStatusLine,
-} from './sfu/sfuRelayStatusCopy'
+import { selectDrawerPresentation } from './drawerErrorPresentation'
 import {
   applyParticipantAvConsumerEvent,
   type ParticipantAvVideoConsumer,
@@ -33,6 +30,7 @@ import { useStageLayoutTransition } from './stage/useStageLayoutTransition'
 import type { ChatLine, PresenceMember } from './roomPageTypes'
 import {
   RoomRealtimeSdk,
+  type RoomRealtimeDiagnostics,
   type TheaterPlaybackSnapshot,
 } from './sessions/RoomRealtimeSdk'
 import type { ChatSessionStatus } from './sessions/ChatSession'
@@ -66,7 +64,11 @@ export function useRoomRealtimeSdk(options: {
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
   peopleShown: PresenceMember[]
   chatMemberLabels: Map<string, string>
-  sfuRoomErr: string | null
+  sfuConfigAlert: string | null
+  chatDrawerBanner: string | null
+  chatComposeStatus: { message: string | null; disableSubmit: boolean }
+  videoRelayStatus: string | null
+  theaterAudioStatus: string | null
   guestRemote: MediaStream | null
   participantAvController: ParticipantAvController
   unpublishHostScreen: () => void
@@ -77,8 +79,6 @@ export function useRoomRealtimeSdk(options: {
   bindHostCaptureVideo: (element: HTMLVideoElement | null) => void
   stageParticipantTiles: ReturnType<typeof buildStageParticipantTiles>
   stageLayoutUpdating: boolean
-  guestVideoStatusSentence: string | null
-  hostVideoRelayStatusSentence: string | null
 } {
   const {
     wsBase,
@@ -100,7 +100,9 @@ export function useRoomRealtimeSdk(options: {
 
   const [sdk] = useState(() => new RoomRealtimeSdk())
   const [wsStatus, setWsStatus] = useState<ChatSessionStatus>('idle')
-  const [sfuRoomErr, setSfuRoomErr] = useState<string | null>(null)
+  const [realtimeDiagnostics, setRealtimeDiagnostics] = useState<RoomRealtimeDiagnostics | null>(
+    null,
+  )
   const [guestRemote, setGuestRemote] = useState<MediaStream | null>(null)
   const [theaterPlaybackSnapshot, setTheaterPlaybackSnapshot] = useState<TheaterPlaybackSnapshot>(
     () => sdk.getTheaterSnapshot(),
@@ -199,13 +201,15 @@ export function useRoomRealtimeSdk(options: {
           }
         },
       },
-      onDiagnosticsChange: () => {
+      onDiagnosticsChange: (diagnostics) => {
         queueMicrotask(() => {
           setWsStatus(sdk.getChatStatus())
-          setSfuRoomErr(sdk.getSfuRelayError())
+          setRealtimeDiagnostics(diagnostics)
         })
       },
     })
+
+    setRealtimeDiagnostics(sdk.getDiagnostics())
 
     sdk.subscribe({
       hostScreen: {
@@ -226,6 +230,7 @@ export function useRoomRealtimeSdk(options: {
     const theaterUnsub = sdk.onTheaterSnapshotChange(setTheaterPlaybackSnapshot)
     queueMicrotask(() => {
       setTheaterPlaybackSnapshot(sdk.getTheaterSnapshot())
+      setRealtimeDiagnostics(sdk.getDiagnostics())
     })
     const chatPoll = window.setInterval(() => {
       setWsStatus(sdk.getChatStatus())
@@ -237,7 +242,7 @@ export function useRoomRealtimeSdk(options: {
       sdk.teardown()
       setGuestRemote(null)
       setWsStatus('idle')
-      setSfuRoomErr(null)
+      setRealtimeDiagnostics(null)
     }
   }, [
     canonicalRoomId,
@@ -400,15 +405,19 @@ export function useRoomRealtimeSdk(options: {
     [sendChatReaction],
   )
 
-  const guestVideoStatusSentence = !isPublisher
-    ? resolveGuestVideoRelayStatusLine({
-        sfuRelayError: sfuRoomErr,
-        guestShareFsm: theaterPlaybackSnapshot.guestShareFsm,
-        chatWsDisconnected: Boolean(wsBase) && wsStatus !== 'open',
-      })
-    : null
-
-  const hostVideoRelayStatusSentence = isPublisher ? resolveHostVideoRelayStatusLine(sfuRoomErr) : null
+  const drawerPresentation =
+    realtimeDiagnostics !== null
+      ? selectDrawerPresentation(realtimeDiagnostics, {
+          guestShareFsm: theaterPlaybackSnapshot.guestShareFsm,
+          isPublisher,
+        })
+      : {
+          chatDrawerBanner: null,
+          chatComposeStatus: { message: null, disableSubmit: false },
+          videoRelayStatus: null,
+          sfuConfigAlert: null,
+          theaterAudioStatus: null,
+        }
 
   const noopParticipantAvController: ParticipantAvController = {
     getState: () => participantAvPublishState,
@@ -439,7 +448,11 @@ export function useRoomRealtimeSdk(options: {
     toggleChatReaction,
     peopleShown,
     chatMemberLabels,
-    sfuRoomErr,
+    sfuConfigAlert: drawerPresentation.sfuConfigAlert,
+    chatDrawerBanner: drawerPresentation.chatDrawerBanner,
+    chatComposeStatus: drawerPresentation.chatComposeStatus,
+    videoRelayStatus: drawerPresentation.videoRelayStatus,
+    theaterAudioStatus: drawerPresentation.theaterAudioStatus,
     guestRemote: isPublisher ? null : guestRemote,
     participantAvController: participantAvController ?? noopParticipantAvController,
     unpublishHostScreen,
@@ -450,7 +463,5 @@ export function useRoomRealtimeSdk(options: {
     bindHostCaptureVideo,
     stageParticipantTiles,
     stageLayoutUpdating,
-    guestVideoStatusSentence,
-    hostVideoRelayStatusSentence,
   }
 }

--- a/apps/web/src/room/useRoomRealtimeSdk.ts
+++ b/apps/web/src/room/useRoomRealtimeSdk.ts
@@ -209,8 +209,6 @@ export function useRoomRealtimeSdk(options: {
       },
     })
 
-    setRealtimeDiagnostics(sdk.getDiagnostics())
-
     sdk.subscribe({
       hostScreen: {
         onRemoteStream: (stream) => {


### PR DESCRIPTION
## Summary

- Adds `realtimeDrawerErrors.ts` with canonical drawer codes and boundary mappers (#185).
- Adds `drawerErrorPresentation.ts` with normative copy, stable DOM surface ids, and dev `(code: …)` suffix (#186).
- Wires room shell UI from `RoomRealtimeSdk.getDiagnostics()`: independent chat drawer banner, video-relay status, chat compose inline status, AV toggle status, theater audio status, and SFU config page alert (#186).
- Locks `getDiagnostics().activeErrorCodes` contract with multi-drawer tests, SFU error surfaces, and `PRODUCER_CLOSED` exclusion (#187).
- Adds `aria-live="polite"` on mounted drawer `role="status"` regions and asserts AV toggle `aria-describedby` wiring (#187).

Closes #185
Closes #186
Closes #187

Part of #141 (shared parent branch `feature/issue-141`).

## Test plan

- [x] `npm test --prefix apps/web -- --run`
- [x] `RoomRealtimeSdk` contract tests cover `activeErrorCodes` for chat send drop, signaling timeout, config error, multi-drawer dedupe, and consumer detach / `PRODUCER_CLOSED` exclusion
- [x] `realtimeDrawerErrors` tests cover `collectActiveErrorCodes` dedupe and drawer scoping
- [x] `drawerErrorPresentation` unit tests cover lifecycle copy, error codes, dev suffix, and simultaneous banners
- [x] `ParticipantAvToggles` asserts `#riffsync-av-toggle-status` with `aria-describedby` and `aria-live="polite"`
- [x] RoomPage integration asserts `#riffsync-video-relay-status` renders from diagnostics