### PR TITLE
[M17] Fix frozen last-frame defect on camera-off (producerClosed removes strip/grid tiles promptly)

### DIFF
--- a/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
@@ -68,6 +68,15 @@ describe('ParticipantVideoTile', () => {
     expect(video?.srcObject).toBeNull()
   })
 
+  it('removes participant figure from the DOM on unmount', () => {
+    renderTile(makeTile('Alice', false))
+    expect(container.querySelector('figure[aria-label="Alice"]')).not.toBeNull()
+
+    act(() => root.unmount())
+    expect(container.querySelector('figure[aria-label="Alice"]')).toBeNull()
+    expect(document.body.querySelector('figure[aria-label="Alice"]')).toBeNull()
+  })
+
   it('clears srcObject when stream identity changes', () => {
     const firstStream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
     const secondStream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])

--- a/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
@@ -20,31 +20,63 @@ describe('ParticipantVideoTile', () => {
     container.remove()
   })
 
-  function renderTile(label: string, isSelf: boolean) {
-    const stream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
-    const tile: StageParticipantTile = {
+  function makeTile(
+    label: string,
+    isSelf: boolean,
+    stream: MediaStream = new MediaStream([{ kind: 'video' } as MediaStreamTrack]),
+  ): StageParticipantTile {
+    return {
       key: isSelf ? 'self' : 'remote-1',
       sessionId: isSelf ? 'me' : 'remote-1',
       label,
       isSelf,
       stream,
     }
+  }
+
+  function renderTile(tile: StageParticipantTile) {
     act(() => {
       root.render(<ParticipantVideoTile tile={tile} />)
     })
   }
 
+  function videoElement(): HTMLVideoElement | null {
+    return container.querySelector('video.riffsync-room-page__participant-tile-video')
+  }
+
   it('exposes per-tile accessible name for local You tile', () => {
-    renderTile('You', true)
+    renderTile(makeTile('You', true))
     const figure = container.querySelector('figure.riffsync-room-page__participant-tile')
     expect(figure?.getAttribute('aria-label')).toBe('You')
     expect(figure?.textContent).toContain('You')
   })
 
   it('exposes per-tile accessible name for remote display name', () => {
-    renderTile('Alice', false)
+    renderTile(makeTile('Alice', false))
     const figure = container.querySelector('figure.riffsync-room-page__participant-tile')
     expect(figure?.getAttribute('aria-label')).toBe('Alice')
     expect(figure?.textContent).toContain('Alice')
+  })
+
+  it('clears srcObject on unmount', () => {
+    const stream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    renderTile(makeTile('Alice', false, stream))
+    const video = videoElement()
+    expect(video?.srcObject).toBe(stream)
+
+    act(() => root.unmount())
+    expect(video?.srcObject).toBeNull()
+  })
+
+  it('clears srcObject when stream identity changes', () => {
+    const firstStream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    const secondStream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    renderTile(makeTile('Alice', false, firstStream))
+    const video = videoElement()
+    expect(video?.srcObject).toBe(firstStream)
+
+    renderTile(makeTile('Alice', false, secondStream))
+    expect(video?.srcObject).toBe(secondStream)
+    expect(video?.srcObject).not.toBe(firstStream)
   })
 })

--- a/apps/web/src/room/stage/ParticipantVideoTile.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.tsx
@@ -11,6 +11,7 @@ export function ParticipantVideoTile({ tile }: ParticipantVideoTileProps) {
   useEffect(() => {
     const el = videoRef.current
     if (!el) return
+    el.srcObject = null
     el.srcObject = tile.stream
     void el.play().catch(() => undefined)
     return () => {

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -74,6 +74,32 @@ describe('StageParticipantLayout', () => {
     expect(container.textContent).toContain('You')
   })
 
+  it('unmounts participant tiles when removed from the list', () => {
+    const stream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+    const tile = {
+      key: 'remote-1',
+      sessionId: 'remote-1',
+      label: 'Alice',
+      isSelf: false,
+      stream,
+    }
+    renderLayout({
+      roomMode: 'videoChat',
+      viewportWide: true,
+      tiles: [tile],
+    })
+    const video = container.querySelector('video.riffsync-room-page__participant-tile-video')
+    expect(video?.srcObject).toBe(stream)
+
+    renderLayout({
+      roomMode: 'videoChat',
+      viewportWide: true,
+      tiles: [],
+    })
+    expect(container.querySelector('video.riffsync-room-page__participant-tile-video')).toBeNull()
+    expect(video?.srcObject).toBeNull()
+  })
+
   it('renders narrow horizontal row below primary on small viewport', () => {
     const stream = new MediaStream()
     renderLayout({

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -99,6 +99,8 @@ describe('StageParticipantLayout', () => {
       tiles: [],
     })
     expect(container.querySelector('video.riffsync-room-page__participant-tile-video')).toBeNull()
+    expect(container.querySelector('figure[aria-label="Alice"]')).toBeNull()
+    expect(document.body.querySelector('figure[aria-label="Alice"]')).toBeNull()
     expect(video?.srcObject).toBeNull()
   })
 

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -88,7 +88,9 @@ describe('StageParticipantLayout', () => {
       viewportWide: true,
       tiles: [tile],
     })
-    const video = container.querySelector('video.riffsync-room-page__participant-tile-video')
+    const video = container.querySelector(
+      'video.riffsync-room-page__participant-tile-video',
+    ) as HTMLVideoElement | null
     expect(video?.srcObject).toBe(stream)
 
     renderLayout({

--- a/apps/web/src/room/stage/participantAvConsumers.test.ts
+++ b/apps/web/src/room/stage/participantAvConsumers.test.ts
@@ -52,4 +52,24 @@ describe('participantAvConsumers', () => {
     })
     expect(next.size).toBe(0)
   })
+
+  it('wires attach then detach to an empty videoConsumers map', () => {
+    const track = { kind: 'video' } as MediaStreamTrack
+    const attached = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p1',
+      sessionId: 'fan-b',
+      producerClass: 'participant_av',
+      kind: 'video',
+      track,
+    })
+    expect(attached.size).toBe(1)
+
+    const detached = applyParticipantAvConsumerEvent(attached, {
+      action: 'detach',
+      producerId: 'p1',
+    })
+    expect(detached.size).toBe(0)
+    expect(detached.has('p1')).toBe(false)
+  })
 })

--- a/apps/web/src/room/stage/stageParticipantTiles.test.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.test.ts
@@ -60,32 +60,55 @@ describe('stageParticipantTiles', () => {
     expect(tiles.map((t) => t.sessionId)).toEqual(['fan-b'])
   })
 
-  it('removes remote participant tile after video consumer detach', () => {
-    const track = { kind: 'video' } as MediaStreamTrack
-    let videoConsumers = applyParticipantAvConsumerEvent(new Map(), {
-      action: 'attach',
-      producerId: 'p1',
-      sessionId: 'fan-b',
-      producerClass: 'participant_av',
-      kind: 'video',
-      track,
-    })
-    const tileArgs = {
-      roster,
-      videoConsumers,
-      ownSessionId: 'fan-a',
-      localCameraOn: false,
-      localPreviewStream: null,
-    }
-    expect(buildStageParticipantTiles(tileArgs).map((t) => t.sessionId)).toEqual(['fan-b'])
+  describe('producerClosed regression (consumer detach → empty tile list)', () => {
+    it('removes remote fan-b tile after video consumer detach', () => {
+      const track = { kind: 'video' } as MediaStreamTrack
+      let videoConsumers = applyParticipantAvConsumerEvent(new Map(), {
+        action: 'attach',
+        producerId: 'p1',
+        sessionId: 'fan-b',
+        producerClass: 'participant_av',
+        kind: 'video',
+        track,
+      })
+      const tileArgs = {
+        roster,
+        videoConsumers,
+        ownSessionId: 'fan-a',
+        localCameraOn: false,
+        localPreviewStream: null,
+      }
+      expect(buildStageParticipantTiles(tileArgs).map((t) => t.sessionId)).toEqual(['fan-b'])
 
-    videoConsumers = applyParticipantAvConsumerEvent(videoConsumers, {
-      action: 'detach',
-      producerId: 'p1',
+      videoConsumers = applyParticipantAvConsumerEvent(videoConsumers, {
+        action: 'detach',
+        producerId: 'p1',
+      })
+      expect(
+        buildStageParticipantTiles({ ...tileArgs, videoConsumers }).map((t) => t.sessionId),
+      ).toEqual([])
     })
-    expect(
-      buildStageParticipantTiles({ ...tileArgs, videoConsumers }).map((t) => t.sessionId),
-    ).toEqual([])
+
+    it('removes local You tile when camera turns off', () => {
+      const local = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
+      const withCamera = buildStageParticipantTiles({
+        roster,
+        videoConsumers: new Map(),
+        ownSessionId: 'fan-a',
+        localCameraOn: true,
+        localPreviewStream: local,
+      })
+      expect(withCamera.map((t) => t.label)).toEqual(['You'])
+
+      const cameraOff = buildStageParticipantTiles({
+        roster,
+        videoConsumers: new Map(),
+        ownSessionId: 'fan-a',
+        localCameraOn: false,
+        localPreviewStream: local,
+      })
+      expect(cameraOff).toEqual([])
+    })
   })
 
   it('orders tiles by roster join order', () => {

--- a/apps/web/src/room/stage/stageParticipantTiles.test.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
+import { applyParticipantAvConsumerEvent } from './participantAvConsumers'
 import type { ParticipantAvVideoConsumer } from './participantAvConsumers'
 import {
   VIDEO_CHAT_EMPTY_COPY,
@@ -57,6 +58,34 @@ describe('stageParticipantTiles', () => {
       localPreviewStream: null,
     })
     expect(tiles.map((t) => t.sessionId)).toEqual(['fan-b'])
+  })
+
+  it('removes remote participant tile after video consumer detach', () => {
+    const track = { kind: 'video' } as MediaStreamTrack
+    let videoConsumers = applyParticipantAvConsumerEvent(new Map(), {
+      action: 'attach',
+      producerId: 'p1',
+      sessionId: 'fan-b',
+      producerClass: 'participant_av',
+      kind: 'video',
+      track,
+    })
+    const tileArgs = {
+      roster,
+      videoConsumers,
+      ownSessionId: 'fan-a',
+      localCameraOn: false,
+      localPreviewStream: null,
+    }
+    expect(buildStageParticipantTiles(tileArgs).map((t) => t.sessionId)).toEqual(['fan-b'])
+
+    videoConsumers = applyParticipantAvConsumerEvent(videoConsumers, {
+      action: 'detach',
+      producerId: 'p1',
+    })
+    expect(
+      buildStageParticipantTiles({ ...tileArgs, videoConsumers }).map((t) => t.sessionId),
+    ).toEqual([])
   })
 
   it('orders tiles by roster join order', () => {


### PR DESCRIPTION
## Summary

- Parent epic #142: participant video tiles must vanish when camera-off triggers video `producerClosed`, not linger as frozen frames.
- **#188**: verifies existing `detachConsumerByProducerId` → `onConsumerTrack({ action: 'detach' })` → `applyParticipantAvConsumerEvent` → `buildStageParticipantTiles` chain and adds a unit test that attach then detach yields an empty tile list for the remote `sessionId`.
- **#189**: clears `<video>` `srcObject` before stream re-attach and on unmount in `ParticipantVideoTile`; adds unit tests for unmount and stream-identity change, plus a layout test that removed tiles unmount cleanly via stable `tile.key`.
- **#190**: frozen-frame regression tests — `producerClosed` detach → empty tile list (remote + local You), `ParticipantVideoTile` DOM/a11y cleanup (`figure`/`aria-label` absent, `srcObject` null), and layout unmount when tile list clears.

## Linked issues

- Part of #142
- Closes #188
- Closes #189
- Closes #190

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/stage/participantAvConsumers src/room/stage/stageParticipantTiles`
- [x] `npm test --prefix apps/web -- --run src/room/stage/ParticipantVideoTile src/room/stage/StageParticipantLayout`
- [x] Full `apps/web` test suite