### PR TITLE
[M17] Preserve theater mic mix when host_screen producer closes (#145)

### DIFF
--- a/apps/web/src/room/audio/theaterAudioMix.test.ts
+++ b/apps/web/src/room/audio/theaterAudioMix.test.ts
@@ -197,6 +197,36 @@ describe('createTheaterAudioMix', () => {
     mix.dispose()
   })
 
+  it('keeps participant audio nodes connected when host_screen detaches', () => {
+    const { ctx, gainNodes } = makeMockAudioContext()
+    const mix = createTheaterAudioMix({ createContext: () => ctx })
+
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'audio',
+      track: makeTrack('host-audio'),
+    })
+    mix.onConsumerEvent({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: makeTrack('fan-audio'),
+    })
+
+    const participantGain = gainNodes[1]
+    expect(participantGain?.gain.value).toBe(THEATER_AUDIO_GAIN)
+
+    mix.onConsumerEvent({ action: 'detach', producerId: 'host-1' })
+
+    expect(participantGain?.disconnect).not.toHaveBeenCalled()
+    expect(participantGain?.gain.value).toBe(THEATER_AUDIO_GAIN)
+    expect(ctx.close).not.toHaveBeenCalled()
+    mix.dispose()
+  })
+
   it('resumes a suspended AudioContext', async () => {
     const { ctx } = makeMockAudioContext()
     const mix = createTheaterAudioMix({ createContext: () => ctx })

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -275,7 +275,19 @@ describe('SfuMediaSession media policy', () => {
 
     session.handleShareStateStopped(false)
     expect(detach).toHaveBeenCalledWith('host_screen')
+    expect(detach).not.toHaveBeenCalledWith('participant_av')
     expect(remoteListener).toHaveBeenCalledWith(null)
+  })
+
+  it('unpublishHostScreen closes host_screen producers only', () => {
+    const session = new SfuMediaSession()
+    const unpublish = vi.fn()
+    attachMockSessionHandle(session, { detachConsumerClass: vi.fn(), unpublishProducerClass: unpublish })
+
+    session.unpublishHostScreen()
+
+    expect(unpublish).toHaveBeenCalledWith('host_screen')
+    expect(unpublish).not.toHaveBeenCalledWith('participant_av')
   })
 
   it('handleAvDisabledKillSwitch tears down participant AV', () => {


### PR DESCRIPTION
## Summary

Locks acceptance criteria for #145 with focused unit tests. Runtime behavior for partial `host_screen` teardown (guest `share_state: stopped`, SFU consumer detach, host `unpublishHostScreen`) was already delivered via M17 drawer work (#142-#144); this PR adds the missing regression coverage called out in the issue.

- `theaterAudioMix.test.ts`: participant gain nodes and `AudioContext` stay alive when `host_screen` detaches
- `SfuMediaSession.test.ts`: `handleShareStateStopped` never detaches `participant_av`; `unpublishHostScreen` only unpublishes `host_screen`

Closes #145

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/audio/theaterAudioMix.test.ts src/room/sessions/TheaterPlayback.test.ts src/room/sessions/SfuMediaSession.test.ts src/room/sessions/RoomRealtimeSdk.test.ts` (74 passed)
- [ ] CI green on this PR