### PR TITLE
[M18][#146] Share-state guest media policy tests (#197, #198, #199)

### DIFF
--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -104,6 +104,12 @@ describe('routeInboundChatMessage', () => {
     ).toBeNull()
   })
 
+  it('routes share_state started per #146 api_contracts matrix', () => {
+    expect(
+      routeInboundChatMessage({ type: 'share_state', roomId: ROOM, state: 'started' }, ROOM),
+    ).toEqual({ type: 'share_state', event: { roomId: ROOM, state: 'started' } })
+  })
+
   it('routes media policy frames without SFU side effects', () => {
     expect(
       routeInboundChatMessage({ type: 'share_state', roomId: ROOM, state: 'stopped' }, ROOM),
@@ -265,6 +271,41 @@ describe('ChatSession subscriptions', () => {
     expect(chatLines).toEqual(['ping'])
     expect(shareStates).toEqual(['stopped'])
     expect(statuses).toEqual([])
+  })
+
+  it('share_state started does not invoke handleShareStateStopped or detachConsumerClass (#146 Guest theater started)', () => {
+    const session = new ChatSession()
+    const sfu = new SfuMediaSession()
+    const handleShareStateStopped = vi.spyOn(sfu, 'handleShareStateStopped')
+    const detach = vi.fn()
+    ;(
+      sfu as unknown as {
+        sessionHandle: { detachConsumerClass: ReturnType<typeof vi.fn> }
+      }
+    ).sessionHandle = { detachConsumerClass: detach }
+
+    session.onShareState((event) => {
+      if (event.state !== 'stopped') return
+      sfu.handleShareStateStopped(false)
+    })
+    ;(session as unknown as { setStatus: (status: ChatSessionStatus) => void }).setStatus('open')
+    ;(session as unknown as { setLifecycleState: (state: string) => void }).setLifecycleState(
+      'connected',
+    )
+
+    const dispatch = (
+      session as unknown as { dispatchInbound: (d: Record<string, unknown>) => void }
+    ).dispatchInbound.bind(session)
+    ;(session as unknown as { connectOptions: { roomId: string } }).connectOptions = {
+      roomId: ROOM,
+    }
+
+    dispatch({ type: 'share_state', roomId: ROOM, state: 'started' })
+
+    expect(handleShareStateStopped).not.toHaveBeenCalled()
+    expect(detach).not.toHaveBeenCalled()
+    expect(session.getStatus()).toBe('open')
+    expect(session.getLifecycleState()).toBe('connected')
   })
 
   it('keeps status open when share-stop media policy runs', () => {

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -4,6 +4,7 @@ import {
   routeInboundChatMessage,
   type ChatSessionStatus,
 } from './ChatSession'
+import { SfuMediaSession } from './SfuMediaSession'
 import * as realtimeDiagnostics from '../realtimeDiagnostics'
 
 vi.mock('../realtimeDiagnostics', () => ({
@@ -264,5 +265,30 @@ describe('ChatSession subscriptions', () => {
     expect(chatLines).toEqual(['ping'])
     expect(shareStates).toEqual(['stopped'])
     expect(statuses).toEqual([])
+  })
+
+  it('keeps status open when share-stop media policy runs', () => {
+    const session = new ChatSession()
+    const sfu = new SfuMediaSession()
+    session.onShareState((event) => {
+      if (event.state !== 'stopped') return
+      sfu.handleShareStateStopped(false)
+    })
+    ;(session as unknown as { setStatus: (status: ChatSessionStatus) => void }).setStatus('open')
+    ;(session as unknown as { setLifecycleState: (state: string) => void }).setLifecycleState(
+      'connected',
+    )
+
+    const dispatch = (
+      session as unknown as { dispatchInbound: (d: Record<string, unknown>) => void }
+    ).dispatchInbound.bind(session)
+    ;(session as unknown as { connectOptions: { roomId: string } }).connectOptions = {
+      roomId: ROOM,
+    }
+
+    dispatch({ type: 'share_state', roomId: ROOM, state: 'stopped' })
+
+    expect(session.getStatus()).toBe('open')
+    expect(session.getLifecycleState()).toBe('connected')
   })
 })

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -15,6 +15,7 @@ import {
   assertDrawerReconnectCycle,
   assertNoDrawerTornDown,
   assertSiblingDrawerStaysConnected,
+  emitShareStateStarted,
   emitShareStateStopped,
   emitSfuDrawerError,
   getChatSession,
@@ -315,6 +316,35 @@ describe('RoomRealtimeSdk media policy wiring', () => {
     }
 
     expect(handleShareStateStopped).toHaveBeenCalledWith(false)
+  })
+
+  it('share_state started does not forward to handleShareStateStopped (#146 Guest theater started)', () => {
+    const handleShareStateStopped = vi.spyOn(SfuMediaSession.prototype, 'handleShareStateStopped')
+    const detachConsumerClass = vi.fn()
+    vi.spyOn(SfuMediaSession.prototype, 'connect').mockImplementation(function (this: SfuMediaSession) {
+      ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+      ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+        'connected',
+      )
+      ;(
+        this as unknown as {
+          sessionHandle: { detachConsumerClass: ReturnType<typeof vi.fn> }
+        }
+      ).sessionHandle = { detachConsumerClass }
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-share-started',
+      wsUrl: 'wss://ws.test',
+      isHost: false,
+    })
+
+    emitShareStateStarted(sdk)
+
+    expect(handleShareStateStopped).not.toHaveBeenCalled()
+    expect(detachConsumerClass).not.toHaveBeenCalled()
   })
 
   it('forwards av_disabled kill switch to SfuMediaSession', () => {
@@ -849,6 +879,93 @@ describe('RoomRealtimeSdk theater playback lifecycle', () => {
     }
 
     expect(sdk.getDiagnostics().drawers.theaterPlayback.state).toBe('connected')
+  })
+
+  it('theater guest share_state started keeps SFU open and re-attaches on newProducer stream (#146 Guest theater started)', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    const remoteStreamListeners: Array<(stream: MediaStream | null) => void> = []
+    vi.spyOn(SfuMediaSession.prototype, 'onRemoteStream').mockImplementation(function (
+      listener: (stream: MediaStream | null) => void,
+    ) {
+      remoteStreamListeners.push(listener)
+      return () => {
+        const idx = remoteStreamListeners.indexOf(listener)
+        if (idx >= 0) remoteStreamListeners.splice(idx, 1)
+      }
+    })
+    const setGuestRemote = vi.spyOn(TheaterPlayback.prototype, 'setGuestRemote')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-share-started-theater',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      isHost: false,
+    })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+
+    sdk.subscribe({ hostScreen: { onRemoteStream: vi.fn() } })
+    setGuestRemote.mockClear()
+
+    emitShareStateStarted(sdk)
+
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(getSfuSession(sdk).getStatus()).toBe('open')
+    expect(setGuestRemote).not.toHaveBeenCalled()
+
+    const pendingStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'live' }],
+      getVideoTracks: () => [{ kind: 'video', readyState: 'live' }],
+    } as MediaStream
+    remoteStreamListeners[0]?.(pendingStream)
+
+    expect(setGuestRemote).toHaveBeenCalledWith(pendingStream)
+  })
+
+  it('videoChat guest share_state started leaves guestRemote null (#146 Guest videoChat started)', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const remoteStreamListeners: Array<(stream: MediaStream | null) => void> = []
+    vi.spyOn(SfuMediaSession.prototype, 'onRemoteStream').mockImplementation(function (
+      listener: (stream: MediaStream | null) => void,
+    ) {
+      remoteStreamListeners.push(listener)
+      return () => {
+        const idx = remoteStreamListeners.indexOf(listener)
+        if (idx >= 0) remoteStreamListeners.splice(idx, 1)
+      }
+    })
+    const setGuestRemote = vi.spyOn(TheaterPlayback.prototype, 'setGuestRemote')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: { ...baseSnapshot, roomMode: 'videoChat' },
+      sessionId: 'sess-share-started-videochat',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      isHost: false,
+    })
+
+    sdk.subscribe({ hostScreen: { onRemoteStream: vi.fn() } })
+
+    emitShareStateStarted(sdk)
+
+    const hostScreenStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'live' }],
+      getVideoTracks: () => [{ kind: 'video', readyState: 'live' }],
+    } as MediaStream
+    remoteStreamListeners[0]?.(hostScreenStream)
+
+    expect(setGuestRemote).not.toHaveBeenCalled()
+    expect((sdk as unknown as { theaterLayoutActive: boolean }).theaterLayoutActive).toBe(false)
   })
 
   it('routes emitRemoteStream(null) to TheaterPlayback.setGuestRemote for theater guests', async () => {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -18,6 +18,7 @@ import {
   emitShareStateStopped,
   emitSfuDrawerError,
   getChatSession,
+  getSfuSession,
   joinHealthySdk,
   mockChatConnectOpensImmediately,
   mockSfuConnectOpensImmediately,
@@ -848,6 +849,33 @@ describe('RoomRealtimeSdk theater playback lifecycle', () => {
     }
 
     expect(sdk.getDiagnostics().drawers.theaterPlayback.state).toBe('connected')
+  })
+
+  it('routes emitRemoteStream(null) to TheaterPlayback.setGuestRemote for theater guests', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const setGuestRemote = vi.spyOn(TheaterPlayback.prototype, 'setGuestRemote')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-guest-remote-null',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      isHost: false,
+    })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+
+    sdk.subscribe({ hostScreen: { onRemoteStream: vi.fn() } })
+    setGuestRemote.mockClear()
+
+    getSfuSession(sdk).handleShareStateStopped(false)
+
+    expect(setGuestRemote).toHaveBeenCalledWith(null)
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -17,6 +17,7 @@ import {
   assertSiblingDrawerStaysConnected,
   emitShareStateStopped,
   emitSfuDrawerError,
+  getChatSession,
   joinHealthySdk,
   mockChatConnectOpensImmediately,
   mockSfuConnectOpensImmediately,
@@ -667,6 +668,11 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
 
   it('share_state stopped leaves all drawers non-torn-down and does not disconnect chat', async () => {
     const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    const handleAvDisabledKillSwitch = vi.spyOn(
+      SfuMediaSession.prototype,
+      'handleAvDisabledKillSwitch',
+    )
     const handleShareStateStopped = vi.spyOn(SfuMediaSession.prototype, 'handleShareStateStopped')
     const sdk = await joinHealthySdk({ sessionId: 'sess-share-stop-isolation', isHost: false })
 
@@ -674,6 +680,9 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
 
     expect(handleShareStateStopped).toHaveBeenCalledWith(false)
     expect(chatDisconnect).not.toHaveBeenCalled()
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(handleAvDisabledKillSwitch).not.toHaveBeenCalled()
+    expect(getChatSession(sdk).getStatus()).toBe('open')
     assertNoDrawerTornDown(sdk.getDiagnostics())
   })
 

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -205,7 +205,11 @@ describe('startSfuRoomSession config error banner persistence', () => {
 
 function attachMockSessionHandle(
   session: SfuMediaSession,
-  handle: { detachConsumerClass: ReturnType<typeof vi.fn>; unpublishProducerClass?: ReturnType<typeof vi.fn> },
+  handle: {
+    detachConsumerClass: ReturnType<typeof vi.fn>
+    unpublishProducerClass?: ReturnType<typeof vi.fn>
+    close?: ReturnType<typeof vi.fn>
+  },
 ): void {
   ;(
     session as unknown as {
@@ -277,6 +281,26 @@ describe('SfuMediaSession media policy', () => {
     expect(detach).toHaveBeenCalledWith('host_screen')
     expect(detach).not.toHaveBeenCalledWith('participant_av')
     expect(remoteListener).toHaveBeenCalledWith(null)
+  })
+
+  it('regression: guest share-stop never tears down SFU session or participant AV', () => {
+    const session = new SfuMediaSession()
+    const detach = vi.fn()
+    const close = vi.fn()
+    attachMockSessionHandle(session, { detachConsumerClass: detach, close })
+
+    const disconnect = vi.spyOn(session, 'disconnect')
+    const killSwitch = vi.spyOn(session, 'handleAvDisabledKillSwitch')
+    const teardown = vi.spyOn(session.participantAv, 'teardownPublishing')
+
+    session.handleShareStateStopped(false)
+
+    expect(detach).toHaveBeenCalledWith('host_screen')
+    expect(detach).not.toHaveBeenCalledWith('participant_av')
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(killSwitch).not.toHaveBeenCalled()
+    expect(teardown).not.toHaveBeenCalled()
   })
 
   it('unpublishHostScreen closes host_screen producers only', () => {

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -283,6 +283,27 @@ describe('SfuMediaSession media policy', () => {
     expect(remoteListener).toHaveBeenCalledWith(null)
   })
 
+  it('share_state started has no symmetric detach — guest theater re-attaches via onRemoteStream (#146)', () => {
+    const session = new SfuMediaSession()
+    const detach = vi.fn()
+    attachMockSessionHandle(session, { detachConsumerClass: detach })
+
+    const remoteListener = vi.fn()
+    session.onRemoteStream(remoteListener)
+
+    const hostScreenStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'live' }],
+      getVideoTracks: () => [{ kind: 'video', readyState: 'live' }],
+    } as MediaStream
+    ;(
+      session as unknown as { emitRemoteStream: (stream: MediaStream | null) => void }
+    ).emitRemoteStream(hostScreenStream)
+
+    expect(detach).not.toHaveBeenCalled()
+    expect(remoteListener).toHaveBeenCalledWith(hostScreenStream)
+    expect(session.getStatus()).not.toBe('closed')
+  })
+
   it('regression: guest share-stop never tears down SFU session or participant AV', () => {
     const session = new SfuMediaSession()
     const detach = vi.fn()

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -331,6 +331,21 @@ describe('TheaterPlayback', () => {
     playback.dispose()
   })
 
+  it('theater guest FSM idle to verifying_media after share start before live track (#146 Guest theater started)', () => {
+    const mix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    playback.setGuestVideoElement(makeVideoElement())
+
+    expect(playback.getSnapshot().guestShareFsm).toBe('idle')
+
+    playback.setGuestRemote(makeStream([makeTrack('video', 'ended')]))
+
+    expect(playback.getSnapshot().guestShareFsm).toBe('verifying_media')
+    playback.dispose()
+  })
+
   it('stays connected when only host_screen consumer detaches (share_state stopped)', () => {
     const mix = makeMixMock()
     vi.mocked(createTheaterAudioMix).mockReturnValue(mix)

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -284,6 +284,53 @@ describe('TheaterPlayback', () => {
     playback.dispose()
   })
 
+  it('detaches guest host-screen playback on share stop while preserving participant mix', async () => {
+    const mix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const consumerListeners: Array<(event: unknown) => void> = []
+    const sfuSession = {
+      onConsumerTrack: (listener: (event: unknown) => void) => {
+        consumerListeners.push(listener)
+        return () => undefined
+      },
+    } as unknown as SfuMediaSession
+
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    playback.attachSfuSession(sfuSession)
+    const video = makeVideoElement()
+    playback.setGuestVideoElement(video)
+
+    playback.setGuestRemote(makeStream([makeTrack('video', 'live')]))
+    await Promise.resolve()
+    expect(playback.getSnapshot().guestShareFsm).toBe('running')
+    expect(video.srcObject).not.toBeNull()
+
+    consumerListeners[0]?.({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: { id: 'mic' } as MediaStreamTrack,
+    })
+    consumerListeners[0]?.({ action: 'detach', producerId: 'host-1' })
+    playback.setGuestRemote(null)
+    await Promise.resolve()
+
+    expect(playback.getSnapshot().guestShareFsm).toBe('idle')
+    expect(video.srcObject).toBeNull()
+    expect(mix.onConsumerEvent).toHaveBeenCalledWith({
+      action: 'attach',
+      producerId: 'fan-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track: { id: 'mic' },
+    })
+    expect(mix.onConsumerEvent).toHaveBeenCalledWith({ action: 'detach', producerId: 'host-1' })
+    expect(mix.onConsumerEvent).not.toHaveBeenCalledWith({ action: 'detach', producerId: 'fan-1' })
+    playback.dispose()
+  })
+
   it('stays connected when only host_screen consumer detaches (share_state stopped)', () => {
     const mix = makeMixMock()
     vi.mocked(createTheaterAudioMix).mockReturnValue(mix)

--- a/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
+++ b/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
@@ -110,12 +110,24 @@ export function emitSfuDrawerError(sdk: RoomRealtimeSdk, error: RealtimeDrawerEr
 }
 
 export function emitShareStateStopped(sdk: RoomRealtimeSdk, roomId = 'room-abc'): void {
+  emitShareState(sdk, 'stopped', roomId)
+}
+
+export function emitShareStateStarted(sdk: RoomRealtimeSdk, roomId = 'room-abc'): void {
+  emitShareState(sdk, 'started', roomId)
+}
+
+function emitShareState(
+  sdk: RoomRealtimeSdk,
+  state: 'started' | 'stopped',
+  roomId: string,
+): void {
   const chat = getChatSession(sdk)
   const shareListeners = (chat as unknown as {
     shareStateListeners: Set<(ev: { roomId: string; state: unknown }) => void>
   }).shareStateListeners
   for (const listener of shareListeners) {
-    listener({ roomId, state: 'stopped' })
+    listener({ roomId, state })
   }
 }
 

--- a/apps/web/src/room/useRoomSessionWiring.ts
+++ b/apps/web/src/room/useRoomSessionWiring.ts
@@ -203,6 +203,7 @@ export function useRoomSessionWiring(options: {
       }),
       chatSession.onShareState((event) => {
         if (event.state !== 'stopped') return
+        // Same host_screen-only policy as RoomRealtimeSdk.wireMediaPolicyCallbacks.
         sfuMediaSession.handleShareStateStopped(isPublisher)
       }),
       chatSession.onRoomMode((event) => {


### PR DESCRIPTION
## Summary

- Adds regression tests ensuring guest `share_state: stopped` only runs `SfuMediaSession.handleShareStateStopped` (host_screen detach), never full SFU teardown or participant AV kill switch (#197).
- Locks guest TheaterPlayback detach on share-stop: `emitRemoteStream(null)` routes to `setGuestRemote(null)`, FSM returns `idle`, guest video unbinds, and participant mix nodes stay connected (#198).
- Documents guest `share_state: started` behavior per #146 contract matrix: no detach on started, Theater re-attach via SFU `newProducer` / `onRemoteStream`, Video Chat keeps host-screen consumers idle (#199).
- Documents legacy `useRoomSessionWiring` parity with `RoomRealtimeSdk` media policy wiring.

Closes #197
Closes #198
Closes #199

Part of #146 (M18 media policy hardening).

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/sessions/TheaterPlayback.test.ts src/room/audio/theaterAudioMix.test.ts src/room/sessions/RoomRealtimeSdk.test.ts`
- [x] `npm test --prefix apps/web -- --run src/room/sessions/SfuMediaSession.test.ts src/room/sessions/ChatSession.test.ts`
- [x] `npm test --prefix apps/web -- --run` (410 tests)
- [ ] CI green on this PR