### PR TITLE
[M18][#147] Drawer-independent lifecycles and regression tests (#200, #201, #202)

### DIFF
--- a/apps/web/src/room/drawerErrorPresentation.test.ts
+++ b/apps/web/src/room/drawerErrorPresentation.test.ts
@@ -135,6 +135,29 @@ describe('drawerErrorPresentation', () => {
     ).toBe('Waiting for host to share…')
   })
 
+  it('keeps chat reconnect copy off the video-relay surface (#201)', () => {
+    const chatReconnecting = 'Reconnecting chat…'
+    const retiredCombinedCopy = 'Reconnecting chat… Video may pause briefly.'
+    const presentation = selectDrawerPresentation(
+      {
+        roomId: 'room-1',
+        sessionId: 'sess-1',
+        asOf: new Date(0).toISOString(),
+        drawers: {
+          chat: { state: 'reconnecting' },
+          sfuSignaling: { state: 'connected' },
+          theaterPlayback: { state: 'connected' },
+        },
+        activeErrorCodes: [],
+      },
+      { guestShareFsm: 'running', isPublisher: false },
+    )
+    expect(presentation.chatDrawerBanner).toBe(chatReconnecting)
+    expect(presentation.videoRelayStatus).toBeNull()
+    expect(presentation.videoRelayStatus).not.toBe(chatReconnecting)
+    expect(presentation.videoRelayStatus).not.toBe(retiredCombinedCopy)
+  })
+
   it('allows simultaneous chat and video-relay banners from diagnostics', () => {
     const presentation = selectDrawerPresentation(
       {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.drawerIsolationRegression.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.drawerIsolationRegression.test.ts
@@ -1,0 +1,217 @@
+/**
+ * M18 drawer isolation regressions (#202).
+ * Harness step 5/6 names cross-ref `.ai/runtime/lifecycle_shutdown.md` and parent #147.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
+import { connectSfuUnifiedSession, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
+import { ChatSession } from './ChatSession'
+import { SfuMediaSession } from './SfuMediaSession'
+import { RoomRealtimeSdk } from './RoomRealtimeSdk'
+import {
+  assertDrawerReconnectCycle,
+  assertSiblingDrawerStaysConnected,
+  emitLatestHarnessChatSocketClose,
+  harnessBaseSnapshot,
+  installHarnessChatMockWebSocket,
+  mockSfuConnectOpensImmediately,
+  openLatestHarnessChatSocket,
+} from './roomRealtimeSdkTestHelpers'
+
+vi.mock('../realtimeDiagnostics', () => ({
+  recordInboundWsMessage: vi.fn(),
+  recordOutboundDropped: vi.fn(),
+  recordOutboundSent: vi.fn(),
+  recordWsClose: vi.fn(),
+  recordWsConnectAttempt: vi.fn(),
+  recordWsErrorEvent: vi.fn(),
+  recordWsOpen: vi.fn(),
+}))
+
+vi.mock('../../api/webrtcSfuApi', () => ({
+  fetchSfuJoinToken: vi.fn(),
+}))
+
+vi.mock('../sfu/mediasoupSharing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sfu/mediasoupSharing')>()
+  return {
+    ...actual,
+    connectSfuUnifiedSession: vi.fn(),
+    resolveSfuWsBaseForToken: vi.fn((tok: { wsUrl?: string }) => tok.wsUrl ?? null),
+  }
+})
+
+vi.mock('../audio/theaterAudioMix', () => ({
+  THEATER_AUDIO_GAIN: 1,
+  shouldRouteConsumerAudio: (producerClass: string | undefined) =>
+    producerClass === 'host_screen' || producerClass === 'participant_av',
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn().mockReturnValue('running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
+function mockSfuSessionWithControllableEnd(): {
+  endSession: (reason: SfuSessionEndReason) => void
+} {
+  let resolveEnd!: (reason: SfuSessionEndReason) => void
+  const sessionEnded = new Promise<SfuSessionEndReason>((resolve) => {
+    resolveEnd = resolve
+  })
+
+  vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+    token: 'tok',
+    role: 'consumer',
+    wsUrl: 'ws://127.0.0.1:3000',
+    expiresInSeconds: 900,
+  })
+
+  vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+    ready: Promise.resolve(),
+    sessionEnded,
+    close: vi.fn(),
+    unpublishProducerKind: vi.fn(),
+    unpublishProducerClass: vi.fn(),
+    publishStream: vi.fn(),
+    supportsPublish: false,
+    tokenRole: 'consumer',
+    getProducerCount: () => 0,
+    getConsumerCount: () => 0,
+    detachConsumerClass: vi.fn(),
+    pauseProducerKind: vi.fn(),
+    resumeProducerKind: vi.fn(),
+    replayConsumerTracks: vi.fn(),
+  }))
+
+  return {
+    endSession: (reason) => resolveEnd(reason),
+  }
+}
+
+describe('RoomRealtimeSdk M18 drawer isolation regressions (#202)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  // Harness step 5 (chat-only): `harness step 5: chat-only simulated WS close`
+  it('harness step 5: chat-only simulated WS close keeps sfuSignaling connected', async () => {
+    vi.useFakeTimers()
+    installHarnessChatMockWebSocket()
+    mockSfuConnectOpensImmediately()
+
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: harnessBaseSnapshot,
+      sessionId: 'sess-m18-chat-ws-close',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    })
+
+    openLatestHarnessChatSocket()
+
+    await vi.waitFor(() => {
+      const diag = sdk.getDiagnostics()
+      expect(diag.drawers.chat.state).toBe('connected')
+      expect(diag.drawers.sfuSignaling.state).toBe('connected')
+    })
+
+    emitLatestHarnessChatSocketClose()
+    const duringOutage = sdk.getDiagnostics()
+
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(duringOutage.drawers.chat.state).toBe('reconnecting')
+    assertSiblingDrawerStaysConnected(duringOutage, 'sfuSignaling')
+
+    vi.runOnlyPendingTimers()
+    openLatestHarnessChatSocket()
+    const afterRecovery = sdk.getDiagnostics()
+
+    assertDrawerReconnectCycle(duringOutage, afterRecovery, 'chat')
+    assertSiblingDrawerStaysConnected(afterRecovery, 'sfuSignaling')
+  })
+
+  // Harness step 6 (SFU-only): `harness step 6: SFU-only simulated signaling close`
+  it('harness step 6: SFU-only simulated signaling close keeps chat connected and send path alive', async () => {
+    const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const { endSession } = mockSfuSessionWithControllableEnd()
+
+    vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+      ;(this as unknown as { setStatus: (status: string) => void }).setStatus('open')
+      ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+        'connected',
+      )
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: harnessBaseSnapshot,
+      sessionId: 'sess-m18-sfu-signaling-close',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    })
+
+    await vi.waitFor(() => {
+      const diag = sdk.getDiagnostics()
+      expect(diag.drawers.chat.state).toBe('connected')
+      expect(diag.drawers.sfuSignaling.state).toBe('connected')
+    })
+
+    endSession('signaling_close')
+
+    await vi.waitFor(() => {
+      expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('reconnecting')
+    })
+
+    const duringOutage = sdk.getDiagnostics()
+
+    expect(chatDisconnect).not.toHaveBeenCalled()
+    assertSiblingDrawerStaysConnected(duringOutage, 'chat')
+    expect(sdk.getChatStatus()).toBe('open')
+    expect(duringOutage.activeErrorCodes).not.toContain('CHAT_SEND_DROPPED')
+  })
+
+  // Cross-drawer isolation table: `regression: single-plane reconnecting lifecycle never calls cross-drawer disconnect`
+  it('regression: pre-fix SFU enabled gate on chat ws open would block bootstrap (guards #200/#202)', async () => {
+    mockSfuConnectOpensImmediately()
+    const sfuConnect = vi.mocked(SfuMediaSession.prototype.connect)
+    vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+      ;(this as unknown as { setStatus: (status: string) => void }).setStatus('connecting')
+      ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+        'reconnecting',
+      )
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: harnessBaseSnapshot,
+      sessionId: 'sess-m18-enabled-gate-regression',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    })
+
+    await vi.waitFor(() => expect(sfuConnect).toHaveBeenCalled())
+
+    expect(sdk.getDiagnostics().drawers.chat.state).toBe('reconnecting')
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).not.toBe('torn-down')
+    expect(sfuConnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -693,6 +693,7 @@ describe('RoomRealtimeSdk.subscribe', () => {
   })
 })
 
+/** M18 / #202 drawer isolation matrix; see also `RoomRealtimeSdk.drawerIsolationRegression.test.ts`. */
 describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -289,6 +289,57 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     expect(order.indexOf('ice')).toBeLessThan(order.indexOf('sfu-connect'))
     expect(order.indexOf('sfu-connect')).toBeLessThan(order.indexOf('theater-configure'))
   })
+
+  it('bootstraps SFU from room join gates without waiting for chat open', async () => {
+    const sfuConnect = vi.spyOn(SfuMediaSession.prototype, 'connect')
+    vi.spyOn(ChatSession.prototype, 'connect').mockImplementation(function (this: ChatSession) {
+      ;(this as unknown as { setStatus: (status: string) => void }).setStatus('connecting')
+      ;(this as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+        'reconnecting',
+      )
+    })
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-join-gate',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [{ urls: 'stun:stun.test' }],
+    })
+
+    await vi.waitFor(() => expect(sfuConnect).toHaveBeenCalled())
+    expect(sdk.getDiagnostics().drawers.chat.state).toBe('reconnecting')
+    expect(sfuConnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates publish gate wsOpen on chat flap without disconnecting SFU', async () => {
+    const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    const updatePublishGate = vi.spyOn(SfuMediaSession.prototype, 'updatePublishGate')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-publish-gate-flap' })
+    const chat = getChatSession(sdk)
+
+    updatePublishGate.mockClear()
+    ;(chat as unknown as { setStatus: (status: string) => void }).setStatus('closed')
+    ;(chat as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'reconnecting',
+    )
+
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(updatePublishGate).toHaveBeenCalledWith({ wsOpen: false })
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+
+    updatePublishGate.mockClear()
+    ;(chat as unknown as { setStatus: (status: string) => void }).setStatus('open')
+    ;(chat as unknown as { setLifecycleState: (status: string) => void }).setLifecycleState(
+      'connected',
+    )
+
+    expect(sfuDisconnect).not.toHaveBeenCalled()
+    expect(updatePublishGate).toHaveBeenCalledWith({ wsOpen: true })
+    expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected')
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+  })
 })
 
 describe('RoomRealtimeSdk media policy wiring', () => {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -222,6 +222,8 @@ export class RoomRealtimeSdk {
       })
     }
 
+    void this.bootstrapMediaPlanes()
+
     this.emitDiagnosticsChange()
     return this
   }
@@ -388,8 +390,8 @@ export class RoomRealtimeSdk {
     this.chatStatusUnsub = chat.onStatusChange((status) => {
       if (status === 'open') {
         this.chatLastErrorCode = undefined
-        void this.bootstrapMediaPlanes()
       }
+      sfu.updatePublishGate({ wsOpen: status === 'open' })
       this.emitDiagnosticsChange()
     })
 

--- a/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
+++ b/apps/web/src/room/sessions/roomRealtimeSdkTestHelpers.ts
@@ -157,3 +157,60 @@ export function assertNoDrawerTornDown(diag: RoomRealtimeDiagnostics): void {
     expect(diag.drawers[key].state).not.toBe('torn-down')
   }
 }
+
+/** Minimal WebSocket stub for harness step 5 chat-only outage (#202). */
+export class HarnessChatMockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: HarnessChatMockWebSocket[] = []
+
+  readyState = 0
+  private listeners = new Map<string, Array<(ev?: unknown) => void>>()
+
+  constructor(url: string) {
+    void url
+    HarnessChatMockWebSocket.instances.push(this)
+  }
+
+  send = vi.fn()
+
+  addEventListener(type: string, fn: (ev?: unknown) => void): void {
+    const list = this.listeners.get(type) ?? []
+    list.push(fn)
+    this.listeners.set(type, list)
+  }
+
+  close(): void {
+    this.readyState = HarnessChatMockWebSocket.CLOSED
+  }
+
+  emit(type: string, ev?: unknown): void {
+    for (const fn of this.listeners.get(type) ?? []) fn(ev)
+  }
+}
+
+export function installHarnessChatMockWebSocket(): void {
+  HarnessChatMockWebSocket.instances = []
+  vi.stubGlobal('WebSocket', HarnessChatMockWebSocket as unknown as typeof WebSocket)
+  Object.assign(HarnessChatMockWebSocket, {
+    OPEN: 1,
+    CONNECTING: 0,
+    CLOSING: 2,
+    CLOSED: 3,
+  })
+}
+
+export function openLatestHarnessChatSocket(): HarnessChatMockWebSocket {
+  const ws = HarnessChatMockWebSocket.instances.at(-1)!
+  ws.readyState = HarnessChatMockWebSocket.OPEN
+  ws.emit('open')
+  return ws
+}
+
+export function emitLatestHarnessChatSocketClose(code = 1006): HarnessChatMockWebSocket {
+  const ws = HarnessChatMockWebSocket.instances.at(-1)!
+  ws.emit('close', { code, reason: '' })
+  return ws
+}

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
@@ -3,7 +3,11 @@ import { LOCAL_SFU_UNREACHABLE_MSG } from './sfuConfigErrors'
 import {
   resolveGuestVideoRelayStatusLine,
   resolveHostVideoRelayStatusLine,
+  type GuestHostScreenFsm,
 } from './sfuRelayStatusCopy'
+
+/** Retired anti-pattern from presentation.md (#147 / #201). */
+const RETIRED_COMBINED_CHAT_VIDEO_COPY = 'Reconnecting chat… Video may pause briefly.'
 
 describe('resolveGuestVideoRelayStatusLine', () => {
   it('prefers configuration-class SFU errors over connecting copy', () => {
@@ -22,6 +26,19 @@ describe('resolveGuestVideoRelayStatusLine', () => {
         guestShareFsm: 'running',
       }),
     ).toBeNull()
+  })
+
+  it('never returns chat reconnect copy or the retired combined string (#201)', () => {
+    const guestFsmStates: GuestHostScreenFsm[] = ['idle', 'verifying_media', 'running']
+    const sfuErrors: Array<string | null> = [null, LOCAL_SFU_UNREACHABLE_MSG]
+
+    for (const guestShareFsm of guestFsmStates) {
+      for (const sfuRelayError of sfuErrors) {
+        const line = resolveGuestVideoRelayStatusLine({ sfuRelayError, guestShareFsm })
+        expect(line).not.toBe('Reconnecting chat…')
+        expect(line).not.toBe(RETIRED_COMBINED_CHAT_VIDEO_COPY)
+      }
+    }
   })
 
   it('shows host-screen FSM copy when relay is healthy', () => {

--- a/apps/web/src/room/useRoomSessionWiring.test.ts
+++ b/apps/web/src/room/useRoomSessionWiring.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const wiringPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'useRoomSessionWiring.ts')
+
+describe('useRoomSessionWiring SFU enabled gate (#202)', () => {
+  it('does not couple useSfuMediaSession enabled to chat wsStatus === open', () => {
+    const src = fs.readFileSync(wiringPath, 'utf8')
+    expect(src).not.toMatch(/enabled:\s*wsStatus\s*===\s*['"]open['"]/)
+    expect(src).toContain('enabled: Boolean(canonicalRoomId && sessionId && room)')
+  })
+})

--- a/apps/web/src/room/useRoomSessionWiring.ts
+++ b/apps/web/src/room/useRoomSessionWiring.ts
@@ -143,7 +143,7 @@ export function useRoomSessionWiring(options: {
     session: sfuMediaSession,
     unpublishHostScreen,
   } = useSfuMediaSession({
-    enabled: wsStatus === 'open' && Boolean(canonicalRoomId),
+    enabled: Boolean(canonicalRoomId && sessionId && room),
     apiBaseUrl: getPublicApiBaseUrl(),
     roomId: canonicalRoomId,
     sessionId,


### PR DESCRIPTION
## Summary

- Stop gating `SfuMediaSession` React `enabled` on chat WebSocket `open`; use room join gates (`canonicalRoomId`, `sessionId`, `room`) instead (#200).
- Bootstrap SFU from `RoomRealtimeSdk.join()` on room/session gates; update `ParticipantAvPublishGate.wsOpen` on chat status changes without tearing down SFU signaling (#200).
- Lock drawer-independent reconnect status surfaces: chat reconnect copy stays on the sidebar chat banner only; video-relay resolver never returns chat or retired combined copy (#201).
- Add M18 drawer isolation regression tests: simulated chat WS close and SFU signaling close keep sibling drawers `connected`; guard pre-fix `enabled: wsStatus === 'open'` coupling (#202).

Closes #200
Closes #201
Closes #202

Part of #147.

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/sessions/RoomRealtimeSdk.drawerIsolationRegression.test.ts`
- [x] `npm test --prefix apps/web -- --run src/room/sessions/RoomRealtimeSdk.test.ts`
- [x] `npm test --prefix apps/web -- --run src/room/useRoomSessionWiring.test.ts`
- [x] `npm test --prefix apps/web -- --run src/room/sfu/sfuRelayStatusCopy.test.ts src/room/drawerErrorPresentation.test.ts`
- [x] `npm test --prefix apps/web -- --run` (full suite, 418 tests)
- [ ] CI green on this PR

## Harness step 5/6 test names (#147 / #202)

| Step | Test name |
|------|-----------|
| 5 chat-only | `harness step 5: chat-only simulated WS close keeps sfuSignaling connected` |
| 5 chat-only (lifecycle) | `harness step 5: chat-only forced drop reconnects without tearing down SFU` |
| 6 SFU-only | `harness step 6: SFU-only simulated signaling close keeps chat connected and send path alive` |
| 6 SFU-only (lifecycle) | `harness step 6: SFU-only forced drop reconnects without tearing down chat` |
| Cross-drawer | `regression: single-plane reconnecting lifecycle never calls cross-drawer disconnect` |
| Enabled gate | `regression: pre-fix SFU enabled gate on chat ws open would block bootstrap (guards #200/#202)` |