### PR TITLE
[M18][#148] Participant AV publish gate and SFU reconnect intent preservation

### DIFF
--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -313,7 +313,7 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     expect(sfuConnect).toHaveBeenCalledTimes(1)
   })
 
-  it('updates publish gate wsOpen on chat flap without disconnecting SFU', async () => {
+  it('does not update publish gate on chat flap while SFU stays connected', async () => {
     const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
     const updatePublishGate = vi.spyOn(SfuMediaSession.prototype, 'updatePublishGate')
     const sdk = await joinHealthySdk({ sessionId: 'sess-publish-gate-flap' })
@@ -326,7 +326,7 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     )
 
     expect(sfuDisconnect).not.toHaveBeenCalled()
-    expect(updatePublishGate).toHaveBeenCalledWith({ wsOpen: false })
+    expect(updatePublishGate).not.toHaveBeenCalled()
     expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
 
     updatePublishGate.mockClear()
@@ -336,7 +336,7 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     )
 
     expect(sfuDisconnect).not.toHaveBeenCalled()
-    expect(updatePublishGate).toHaveBeenCalledWith({ wsOpen: true })
+    expect(updatePublishGate).not.toHaveBeenCalled()
     expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected')
     expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
   })

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -313,6 +313,50 @@ describe('RoomRealtimeSdk.join bootstrap order', () => {
     expect(sfuConnect).toHaveBeenCalledTimes(1)
   })
 
+  it('#205 regression: chat reconnecting flap preserves needsProducerToken while SFU stays connected', async () => {
+    const videoTrack = { kind: 'video', readyState: 'live', stop: vi.fn(), id: 'v1' }
+    const audioTrack = { kind: 'audio', readyState: 'live', stop: vi.fn(), id: 'a1' }
+    const stream = {
+      getVideoTracks: () => [videoTrack],
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [videoTrack, audioTrack],
+      removeTrack: vi.fn(),
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+
+    const sdk = await joinHealthySdk({ sessionId: 'sess-205-chat-flap' })
+    const av = getSfuSession(sdk).participantAv
+    getSfuSession(sdk).updatePublishGate({ fanToken: 'fan-jwt' })
+    await av.enableCamera()
+    await av.enableMic()
+
+    await vi.waitFor(() => {
+      expect(av.getState().needsProducerToken).toBe(true)
+    })
+
+    const beforeFlap = av.getState()
+    expect(beforeFlap.cameraEnabled).toBe(true)
+    expect(beforeFlap.micEnabled).toBe(true)
+
+    const chat = getChatSession(sdk)
+    ;(chat as unknown as { setStatus: (status: string) => void }).setStatus('closed')
+    setChatLifecycle(sdk, 'reconnecting')
+
+    const afterFlap = av.getState()
+    expect(afterFlap.needsProducerToken).toBe(true)
+    expect(afterFlap.cameraEnabled).toBe(true)
+    expect(afterFlap.micEnabled).toBe(true)
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+    expect(sdk.getDiagnostics().drawers.chat.state).toBe('reconnecting')
+
+    vi.unstubAllGlobals()
+  })
+
   it('does not update publish gate on chat flap while SFU stays connected', async () => {
     const sfuDisconnect = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
     const updatePublishGate = vi.spyOn(SfuMediaSession.prototype, 'updatePublishGate')

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -391,7 +391,6 @@ export class RoomRealtimeSdk {
       if (status === 'open') {
         this.chatLastErrorCode = undefined
       }
-      sfu.updatePublishGate({ wsOpen: status === 'open' })
       this.emitDiagnosticsChange()
     })
 
@@ -524,7 +523,6 @@ export class RoomRealtimeSdk {
     await getIceServers().catch(() => undefined)
 
     sfu.updatePublishGate({
-      wsOpen: chat.getStatus() === 'open',
       fanToken: options.accessToken ?? null,
       avDisabled: this.avDisabled,
     })

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -4,6 +4,7 @@ import { SfuTokenHttpError } from '../av/participantAvErrors'
 import { connectSfuUnifiedSession, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
 import { createParticipantAvController } from '../sfu/participantAvSession'
 import { LOCAL_SFU_UNREACHABLE_MSG } from '../sfu/sfuConfigErrors'
+import { nextSfuReconnectDelayMs } from '../sfu/sfuReconnectPolicy'
 import { SFU_DEGRADED_AFTER_FAILED_CYCLES, SFU_JWT_REMINT_LEAD_SECONDS, sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
 import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 import {
@@ -135,6 +136,110 @@ describe('startSfuRoomSession recoverable signaling reconnect', () => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+  })
+
+  it('#205 regression: signaling_close preserves toggles and syncPublish re-publishes after re-attach', async () => {
+    vi.useFakeTimers()
+
+    const videoTrack = { kind: 'video', readyState: 'live', stop: vi.fn(), id: 'v1' }
+    const audioTrack = { kind: 'audio', readyState: 'live', stop: vi.fn(), id: 'a1' }
+    const stream = {
+      getVideoTracks: () => [videoTrack],
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [videoTrack, audioTrack],
+      removeTrack: vi.fn(),
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+    vi.stubGlobal(
+      'MediaStream',
+      function MockMediaStream(
+        this: { tracks: MediaStreamTrack[]; getTracks: () => MediaStreamTrack[] },
+        tracks: MediaStreamTrack[] = [],
+      ) {
+        this.tracks = tracks
+        this.getTracks = () => this.tracks
+      },
+    )
+
+    const publishStreamFirst = vi.fn().mockResolvedValue(undefined)
+    const publishStreamSecond = vi.fn().mockResolvedValue(undefined)
+    let connectCall = 0
+    let resolveFirstSessionEnded: ((reason: SfuSessionEndReason) => void) | undefined
+
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'producer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => {
+      connectCall += 1
+      if (connectCall === 1) {
+        return {
+          ...mockSfuUnifiedSessionHandle(),
+          ready: Promise.resolve(),
+          sessionEnded: new Promise<SfuSessionEndReason>((resolve) => {
+            resolveFirstSessionEnded = resolve
+          }),
+          supportsPublish: true,
+          publishStream: publishStreamFirst,
+        } as Awaited<ReturnType<typeof connectSfuUnifiedSession>>
+      }
+      return {
+        ...mockSfuUnifiedSessionHandle(),
+        ready: Promise.resolve(),
+        sessionEnded: new Promise<SfuSessionEndReason>(() => {}),
+        supportsPublish: true,
+        publishStream: publishStreamSecond,
+      } as Awaited<ReturnType<typeof connectSfuUnifiedSession>>
+    })
+
+    const participantAv = createParticipantAvController({ canPublish: () => true })
+    await participantAv.enableCamera()
+    await participantAv.enableMic()
+
+    const { cancel } = startSfuRoomSession({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-205-reconnect',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      participantAv,
+      onRemoteStream: () => {},
+      assignSession: () => {},
+      onMissingWsUrl: vi.fn(),
+      onTokenError: vi.fn(),
+      onMediaError: vi.fn(),
+    })
+
+    await vi.waitFor(() => {
+      expect(publishStreamFirst).toHaveBeenCalled()
+    })
+    expect(participantAv.getState()).toMatchObject({
+      cameraEnabled: true,
+      micEnabled: true,
+      needsProducerToken: true,
+    })
+
+    resolveFirstSessionEnded?.('signaling_close')
+    await vi.advanceTimersByTimeAsync(nextSfuReconnectDelayMs(0) + 50)
+
+    await vi.waitFor(() => {
+      expect(publishStreamSecond).toHaveBeenCalled()
+    })
+    expect(participantAv.getState()).toMatchObject({
+      cameraEnabled: true,
+      micEnabled: true,
+      needsProducerToken: true,
+    })
+    expect(participantAv.getState().error).toBeNull()
+
+    cancel()
   })
 
   it('calls resetOnReconnect instead of failPublish on recoverable signaling_close', async () => {

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -130,6 +130,129 @@ describe('resolveSfuTokenProducerClass', () => {
   })
 })
 
+describe('startSfuRoomSession recoverable signaling reconnect', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('calls resetOnReconnect instead of failPublish on recoverable signaling_close', async () => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'producer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ready: Promise.resolve(),
+      sessionEnded: Promise.resolve('signaling_close'),
+      close: vi.fn(),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      publishStream: vi.fn(),
+      supportsPublish: true,
+      detachConsumerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    }))
+
+    const participantAv = {
+      getState: () => ({
+        cameraEnabled: true,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      }),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      failPublish: vi.fn(),
+    } as unknown as ReturnType<typeof createParticipantAvController>
+
+    const { cancel } = startSfuRoomSession({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      participantAv,
+      onRemoteStream: () => {},
+      assignSession: () => {},
+      onMissingWsUrl: vi.fn(),
+      onTokenError: vi.fn(),
+      onMediaError: vi.fn(),
+    })
+
+    await vi.waitFor(() => {
+      expect(participantAv.resetOnReconnect).toHaveBeenCalled()
+    })
+    expect(participantAv.failPublish).not.toHaveBeenCalled()
+    expect(participantAv.attachSession).toHaveBeenCalledWith(null)
+
+    cancel()
+  })
+
+  it('failPublish still runs on hard session end while publish intent exists', async () => {
+    const participantAv = {
+      getState: () => ({
+        cameraEnabled: true,
+        micEnabled: false,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      }),
+      attachSession: vi.fn(),
+      resetOnReconnect: vi.fn(),
+      failPublish: vi.fn(),
+    } as unknown as ReturnType<typeof createParticipantAvController>
+
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'producer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ready: Promise.resolve(),
+      sessionEnded: Promise.resolve('jwt_expired' as SfuSessionEndReason),
+      close: vi.fn(),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      publishStream: vi.fn(),
+      supportsPublish: true,
+      detachConsumerClass: vi.fn(),
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    }))
+
+    const { cancel } = startSfuRoomSession({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-1',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      participantAv,
+      onRemoteStream: () => {},
+      assignSession: () => {},
+      onMissingWsUrl: vi.fn(),
+      onTokenError: vi.fn(),
+      onMediaError: vi.fn(),
+    })
+
+    await vi.waitFor(() => {
+      expect(participantAv.failPublish).toHaveBeenCalledWith('token_expired')
+    })
+    expect(participantAv.resetOnReconnect).not.toHaveBeenCalled()
+
+    cancel()
+  })
+})
+
 describe('startSfuRoomSession config error banner persistence', () => {
   beforeEach(() => {
     vi.mocked(fetchSfuJoinToken).mockResolvedValue({

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -144,16 +144,9 @@ describe('startSfuRoomSession recoverable signaling reconnect', () => {
       wsUrl: 'ws://127.0.0.1:3000',
     })
     vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
-      ready: Promise.resolve(),
+      ...mockSfuUnifiedSessionHandle(),
       sessionEnded: Promise.resolve('signaling_close'),
-      close: vi.fn(),
-      unpublishProducerKind: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-      publishStream: vi.fn(),
       supportsPublish: true,
-      detachConsumerClass: vi.fn(),
-      pauseProducerKind: vi.fn(),
-      resumeProducerKind: vi.fn(),
     }))
 
     const participantAv = {
@@ -217,16 +210,10 @@ describe('startSfuRoomSession recoverable signaling reconnect', () => {
       wsUrl: 'ws://127.0.0.1:3000',
     })
     vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
-      ready: Promise.resolve(),
+      ...mockSfuUnifiedSessionHandle(),
       sessionEnded: Promise.resolve('jwt_expired' as SfuSessionEndReason),
-      close: vi.fn(),
-      unpublishProducerKind: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-      publishStream: vi.fn(),
       supportsPublish: true,
-      detachConsumerClass: vi.fn(),
-      pauseProducerKind: vi.fn(),
-      resumeProducerKind: vi.fn(),
+      tokenRole: 'producer',
     }))
 
     const { cancel } = startSfuRoomSession({

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -372,7 +372,6 @@ export class SfuMediaSession {
   private lastMintedExpiresInSeconds: number | undefined
 
   private readonly gate: ParticipantAvPublishGate = {
-    wsOpen: false,
     fanToken: null,
     avDisabled: true,
   }
@@ -460,11 +459,9 @@ export class SfuMediaSession {
   }
 
   updatePublishGate(partial: {
-    wsOpen?: boolean
     fanToken?: string | null
     avDisabled?: boolean
   }): void {
-    if (partial.wsOpen !== undefined) this.gate.wsOpen = partial.wsOpen
     if (partial.fanToken !== undefined) this.gate.fanToken = partial.fanToken
     if (partial.avDisabled !== undefined) this.gate.avDisabled = partial.avDisabled
     this.participantAv.refreshPublishGate()

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -20,19 +20,10 @@ vi.stubGlobal(
 )
 
 describe('canParticipantAvPublish', () => {
-  it('requires open room websocket, fan JWT, and av enabled', () => {
-    expect(
-      canParticipantAvPublish({ wsOpen: true, fanToken: 'jwt', avDisabled: false }),
-    ).toBe(true)
-    expect(
-      canParticipantAvPublish({ wsOpen: false, fanToken: 'jwt', avDisabled: false }),
-    ).toBe(false)
-    expect(
-      canParticipantAvPublish({ wsOpen: true, fanToken: null, avDisabled: false }),
-    ).toBe(false)
-    expect(
-      canParticipantAvPublish({ wsOpen: true, fanToken: 'jwt', avDisabled: true }),
-    ).toBe(false)
+  it('requires fan JWT and av enabled regardless of chat websocket', () => {
+    expect(canParticipantAvPublish({ fanToken: 'jwt', avDisabled: false })).toBe(true)
+    expect(canParticipantAvPublish({ fanToken: null, avDisabled: false })).toBe(false)
+    expect(canParticipantAvPublish({ fanToken: 'jwt', avDisabled: true })).toBe(false)
   })
 })
 

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -60,19 +60,57 @@ describe('createParticipantAvController', () => {
     })
   })
 
-  it('resetOnReconnect clears publish intent', () => {
+  it('resetOnReconnect preserves publish intent and only clears busy', async () => {
+    const videoTrack = { kind: 'video', readyState: 'live', stop: vi.fn(), id: 'v1' }
+    const stream = {
+      getVideoTracks: () => [videoTrack],
+      getAudioTracks: () => [],
+      getTracks: () => [videoTrack],
+      removeTrack: vi.fn(),
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+
+    const unpublishProducerClass = vi.fn()
     const controller = createParticipantAvController({
       canPublish: () => true,
     })
+    await controller.enableCamera()
+    const session = {
+      supportsPublish: true,
+      ready: Promise.resolve(),
+      publishStream: vi.fn().mockResolvedValue(undefined),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass,
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    } as unknown as import('./mediasoupSharing').SfuUnifiedSessionHandle
+
+    controller.attachSession(session)
+    await vi.waitFor(() => {
+      expect(session.publishStream).toHaveBeenCalled()
+    })
+
+    unpublishProducerClass.mockClear()
+    videoTrack.stop.mockClear()
+
     controller.resetOnReconnect()
+
     expect(controller.getState()).toMatchObject({
-      cameraEnabled: false,
+      cameraEnabled: true,
       micEnabled: false,
-      micMuted: false,
-      needsProducerToken: false,
-      error: null,
+      needsProducerToken: true,
       busy: false,
     })
+    expect(unpublishProducerClass).not.toHaveBeenCalled()
+    expect(videoTrack.stop).not.toHaveBeenCalled()
+    expect(controller.getLocalPreviewStream()).not.toBeNull()
+
+    vi.unstubAllGlobals()
   })
 
   it('failPublish turns toggles off and sets stable error code', () => {

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -25,6 +25,12 @@ describe('canParticipantAvPublish', () => {
     expect(canParticipantAvPublish({ fanToken: null, avDisabled: false })).toBe(false)
     expect(canParticipantAvPublish({ fanToken: 'jwt', avDisabled: true })).toBe(false)
   })
+
+  it('#205 regression: no wsOpen gate — chat websocket flap cannot block publish eligibility', () => {
+    // Pre-#148 coupling consulted chat wsOpen; drawer-independent gate is fan JWT + avDisabled only.
+    expect(canParticipantAvPublish({ fanToken: 'jwt', avDisabled: false })).toBe(true)
+    expect(canParticipantAvPublish({ fanToken: null, avDisabled: false })).toBe(false)
+  })
 })
 
 describe('createParticipantAvController', () => {
@@ -58,6 +64,62 @@ describe('createParticipantAvController', () => {
       micEnabled: false,
       needsProducerToken: false,
     })
+  })
+
+  it('#205 regression: resetOnReconnect preserves both camera and mic toggles', async () => {
+    const videoTrack = { kind: 'video', readyState: 'live', stop: vi.fn(), id: 'v1' }
+    const audioTrack = { kind: 'audio', readyState: 'live', stop: vi.fn(), id: 'a1' }
+    const stream = {
+      getVideoTracks: () => [videoTrack],
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [videoTrack, audioTrack],
+      removeTrack: vi.fn(),
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+
+    const unpublishProducerClass = vi.fn()
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+    })
+    await controller.enableCamera()
+    await controller.enableMic()
+    const session = {
+      supportsPublish: true,
+      ready: Promise.resolve(),
+      publishStream: vi.fn().mockResolvedValue(undefined),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass,
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    } as unknown as import('./mediasoupSharing').SfuUnifiedSessionHandle
+
+    controller.attachSession(session)
+    await vi.waitFor(() => {
+      expect(session.publishStream).toHaveBeenCalled()
+    })
+
+    unpublishProducerClass.mockClear()
+    videoTrack.stop.mockClear()
+    audioTrack.stop.mockClear()
+
+    controller.resetOnReconnect()
+
+    expect(controller.getState()).toMatchObject({
+      cameraEnabled: true,
+      micEnabled: true,
+      needsProducerToken: true,
+      busy: false,
+    })
+    expect(unpublishProducerClass).not.toHaveBeenCalled()
+    expect(videoTrack.stop).not.toHaveBeenCalled()
+    expect(audioTrack.stop).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
   })
 
   it('resetOnReconnect preserves publish intent and only clears busy', async () => {

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -15,11 +15,10 @@ export const PARTICIPANT_AV_MEDIA_CONSTRAINTS: MediaStreamConstraints = {
 }
 
 export function canParticipantAvPublish(opts: {
-  wsOpen: boolean
   fanToken: string | null
   avDisabled: boolean
 }): boolean {
-  return opts.wsOpen && Boolean(opts.fanToken) && !opts.avDisabled
+  return Boolean(opts.fanToken) && !opts.avDisabled
 }
 
 export type ParticipantAvPublishState = {
@@ -358,7 +357,6 @@ export function createParticipantAvController(options: {
 }
 
 export type ParticipantAvPublishGate = {
-  wsOpen: boolean
   fanToken: string | null
   avDisabled: boolean
   onNeedsProducerTokenChange?: () => void
@@ -371,7 +369,6 @@ export function createBoundParticipantAvController(
     canPublish: () => {
       const gate = readGate()
       return canParticipantAvPublish({
-        wsOpen: gate.wsOpen,
         fanToken: gate.fanToken,
         avDisabled: gate.avDisabled,
       })

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -229,13 +229,8 @@ export function createParticipantAvController(options: {
       void syncPublish()
     },
     resetOnReconnect: () => {
-      cameraEnabled = false
-      micEnabled = false
-      micMuted = false
-      error = null
       busy = false
-      stopLocalTracks()
-      session?.unpublishProducerClass('participant_av')
+      session = null
       notify()
     },
     teardownPublishing: () => {

--- a/apps/web/src/room/useRoomSessionWiring.ts
+++ b/apps/web/src/room/useRoomSessionWiring.ts
@@ -150,7 +150,6 @@ export function useRoomSessionWiring(options: {
     accessToken: fanToken,
     fanToken,
     avDisabled,
-    wsOpen: wsStatus === 'open',
     getIceServers,
     getHostScreenStream: () => captureStreamRef.current,
     captureStream,

--- a/apps/web/src/room/useSfuMediaSession.ts
+++ b/apps/web/src/room/useSfuMediaSession.ts
@@ -19,7 +19,6 @@ export function useSfuMediaSession(options: {
   accessToken: string | null
   fanToken: string | null
   avDisabled: boolean
-  wsOpen: boolean
   getIceServers: () => Promise<RTCIceServer[]>
   getHostScreenStream: () => MediaStream | null
   captureStream: MediaStream | null
@@ -43,7 +42,6 @@ export function useSfuMediaSession(options: {
     accessToken,
     fanToken,
     avDisabled,
-    wsOpen,
     getIceServers,
     getHostScreenStream,
     captureStream,
@@ -97,8 +95,8 @@ export function useSfuMediaSession(options: {
   }, [session])
 
   useEffect(() => {
-    session.updatePublishGate({ wsOpen, fanToken, avDisabled })
-  }, [session, wsOpen, fanToken, avDisabled])
+    session.updatePublishGate({ fanToken, avDisabled })
+  }, [session, fanToken, avDisabled])
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
## Summary

- **#203** — Remove `wsOpen` from `canParticipantAvPublish`, `ParticipantAvPublishGate`, and `SfuMediaSession.updatePublishGate`. Chat flap no longer gates participant A/V toggles when SFU signaling is healthy.
- **#204** — Narrow `resetOnReconnect` to session detach only (clear `busy`, detach handle). Recoverable `signaling_close` preserves camera/mic intent and local preview tracks; `syncPublish` re-runs on re-`attachSession`. `failPublish` and `teardownPublishing` unchanged for hard failures and kill switch / room leave.
- **#205** — Regression tests lock drawer-independent participant AV behavior: chat-only WS flap does not clear publish intent; SFU signaling reconnect preserves toggles and re-invokes `syncPublish` after re-attach.

Part of #148.

Closes #203
Closes #204
Closes #205

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/sfu/participantAvSession.test.ts src/room/sessions/SfuMediaSession.test.ts src/room/sessions/RoomRealtimeSdk.test.ts`
- [x] Full `npm test --prefix apps/web -- --run` (424 tests)
- [ ] Manual (#204): join with camera/mic, interrupt SFU signaling only, confirm toggles stay on and producers reattach after recovery
- [ ] Manual (#203): join with camera/mic, force chat WS drop only, confirm toggles remain enabled