### PR TITLE
[M18][#149] Chat send contract and chat drawer status UX

### DIFF
--- a/apps/web/src/room/chatDrawerUxWiring.test.ts
+++ b/apps/web/src/room/chatDrawerUxWiring.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const roomDir = path.dirname(fileURLToPath(import.meta.url))
+
+function readSrc(relativePath: string): string {
+  return fs.readFileSync(path.join(roomDir, relativePath), 'utf8')
+}
+
+describe('chat drawer UX wiring (#207)', () => {
+  it('useRoomRealtimeSdk exposes chat drawer presentation from diagnostics only', () => {
+    const src = readSrc('useRoomRealtimeSdk.ts')
+    expect(src).toContain('selectDrawerPresentation')
+    expect(src).toContain('chatDrawerBanner: drawerPresentation.chatDrawerBanner')
+    expect(src).toContain('chatComposeStatus: drawerPresentation.chatComposeStatus')
+    expect(src).not.toMatch(/chatDrawerBanner:[\s\S]*drawers\.sfuSignaling/)
+    expect(src).not.toMatch(/chatComposeStatus:[\s\S]*drawers\.sfuSignaling/)
+  })
+
+  it('RoomPage passes chat drawer props into RoomPageSidebar', () => {
+    const src = readSrc('../pages/RoomPage.tsx')
+    expect(src).toMatch(/chatDrawerBanner=\{chatDrawerBanner\}/)
+    expect(src).toMatch(/chatComposeStatus=\{chatComposeStatus\}/)
+    expect(src).toContain('useRoomRealtimeSdk')
+  })
+
+  it('RoomPageSidebar renders chat drawer banner and compose status surfaces', () => {
+    const src = readSrc('RoomPageSidebar.tsx')
+    expect(src).toContain('RIFFSYNC_CHAT_DRAWER_STATUS_ID')
+    expect(src).toContain('RIFFSYNC_CHAT_COMPOSE_STATUS_ID')
+    expect(src).toMatch(/id=\{RIFFSYNC_CHAT_DRAWER_STATUS_ID\}/)
+    expect(src).toMatch(/id=\{RIFFSYNC_CHAT_COMPOSE_STATUS_ID\}/)
+    expect(src).toMatch(/role="status"/)
+    expect(src).toContain('riffsync-room-chat-giphy-status--err')
+    expect(src).toMatch(/disabled=\{!fanToken \|\| chatComposeStatus\.disableSubmit\}/)
+    expect(src).not.toMatch(/sfuSignaling/)
+    expect(src).not.toMatch(/videoRelayStatus/)
+  })
+})

--- a/apps/web/src/room/drawerErrorPresentation.test.ts
+++ b/apps/web/src/room/drawerErrorPresentation.test.ts
@@ -185,3 +185,92 @@ describe('drawerErrorPresentation', () => {
     expect(RIFFSYNC_THEATER_AUDIO_STATUS_ID).toBe('riffsync-theater-audio-status')
   })
 })
+
+describe('chat drawer banner and compose inline feedback (#207)', () => {
+  beforeEach(() => {
+    vi.stubEnv('DEV', false)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('renders chat drawer banner from chat lifecycle state only', () => {
+    expect(resolveChatDrawerBanner({ state: 'reconnecting' })).toBe('Reconnecting chat…')
+    expect(resolveChatDrawerBanner({ state: 'degraded' })).toBe(
+      'Chat unavailable. Try refreshing the page.',
+    )
+    expect(resolveChatDrawerBanner({ state: 'connected' })).toBeNull()
+  })
+
+  it('shows CHAT_SEND_DROPPED inline compose copy without SFU input', () => {
+    expect(
+      resolveChatComposeStatus({
+        state: 'connected',
+        lastErrorCode: 'CHAT_SEND_DROPPED',
+      }),
+    ).toEqual({
+      message: 'Message could not be sent. Check chat connection and try again.',
+      disableSubmit: true,
+    })
+  })
+
+  it('keeps compose enabled when chat is connected and SFU video relay is unhealthy', () => {
+    const presentation = selectDrawerPresentation(
+      {
+        roomId: 'room-1',
+        sessionId: 'sess-1',
+        asOf: new Date(0).toISOString(),
+        drawers: {
+          chat: { state: 'connected' },
+          sfuSignaling: { state: 'reconnecting' },
+          theaterPlayback: { state: 'connected' },
+        },
+        activeErrorCodes: [],
+      },
+      { guestShareFsm: 'running', isPublisher: false },
+    )
+
+    expect(presentation.chatComposeStatus).toEqual({
+      message: null,
+      disableSubmit: false,
+    })
+    expect(presentation.chatDrawerBanner).toBeNull()
+    expect(presentation.videoRelayStatus).toBe('Video relay reconnecting…')
+  })
+
+  it('clears inline compose feedback when chat recovers to connected without lastErrorCode', () => {
+    const afterDrop = resolveChatComposeStatus({
+      state: 'connected',
+      lastErrorCode: 'CHAT_SEND_DROPPED',
+    })
+    const afterRecovery = resolveChatComposeStatus({ state: 'connected' })
+
+    expect(afterDrop.message).not.toBeNull()
+    expect(afterRecovery).toEqual({
+      message: null,
+      disableSubmit: false,
+    })
+    expect(resolveChatDrawerBanner({ state: 'connected' })).toBeNull()
+  })
+
+  it('does not derive chat drawer banner from SFU diagnostics', () => {
+    const presentation = selectDrawerPresentation(
+      {
+        roomId: 'room-1',
+        sessionId: 'sess-1',
+        asOf: new Date(0).toISOString(),
+        drawers: {
+          chat: { state: 'connected' },
+          sfuSignaling: { state: 'degraded', lastErrorCode: 'ICE_FAILED' },
+          theaterPlayback: { state: 'connected' },
+        },
+        activeErrorCodes: ['ICE_FAILED'],
+      },
+      { guestShareFsm: 'running', isPublisher: false },
+    )
+
+    expect(presentation.chatDrawerBanner).toBeNull()
+    expect(presentation.videoRelayStatus).toContain('Network connection failed')
+  })
+})

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -155,6 +155,25 @@ describe('ChatSession send', () => {
       cause: { readyState: -1 },
     })
   })
+
+  it('returns true and records outbound sent when socket is open', () => {
+    class MockWebSocket {
+      static OPEN = 1
+      readyState = MockWebSocket.OPEN
+      send = vi.fn()
+    }
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+
+    const session = new ChatSession()
+    ;(session as unknown as { ws: WebSocket | null }).ws = new WebSocket('wss://ws.test')
+
+    const payload = { action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440004' }
+    expect(session.send(payload)).toBe(true)
+    expect(realtimeDiagnostics.recordOutboundSent).toHaveBeenCalledWith(payload)
+    expect(realtimeDiagnostics.recordOutboundDropped).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
 })
 
 describe('ChatSession lifecycle FSM', () => {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -854,6 +854,9 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
 describe('RoomRealtimeSdk #208 chat send survives SFU-only outage', () => {
   class MockOpenWebSocket {
     static OPEN = 1
+    static CONNECTING = 0
+    static CLOSING = 2
+    static CLOSED = 3
     readyState = MockOpenWebSocket.OPEN
     send = vi.fn()
   }
@@ -865,12 +868,14 @@ describe('RoomRealtimeSdk #208 chat send survives SFU-only outage', () => {
   }
 
   function attachOpenChatSocket(sdk: RoomRealtimeSdk): void {
+    vi.stubGlobal('WebSocket', MockOpenWebSocket as unknown as typeof WebSocket)
     const chat = getChatSession(sdk)
     ;(chat as unknown as { ws: WebSocket | null }).ws =
       new MockOpenWebSocket() as unknown as WebSocket
   }
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -850,6 +850,100 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
   })
 })
 
+/** M18 / #208 send-path regressions; names cross-ref parent #149 AC and execution_model.md cross-drawer table. */
+describe('RoomRealtimeSdk #208 chat send survives SFU-only outage', () => {
+  class MockOpenWebSocket {
+    static OPEN = 1
+    readyState = MockOpenWebSocket.OPEN
+    send = vi.fn()
+  }
+
+  const chatPayload = {
+    action: 'chat',
+    text: 'hello',
+    messageId: '550e8400-e29b-41d4-a716-446655440208',
+  }
+
+  function attachOpenChatSocket(sdk: RoomRealtimeSdk): void {
+    const chat = getChatSession(sdk)
+    ;(chat as unknown as { ws: WebSocket | null }).ws =
+      new MockOpenWebSocket() as unknown as WebSocket
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('#208 SFU reconnecting: sendControl succeeds without CHAT_SEND_DROPPED', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-208-sfu-reconnecting' })
+    attachOpenChatSocket(sdk)
+
+    const sfu = getSfuSession(sdk)
+    ;(sfu as unknown as { setStatus: (status: string) => void }).setStatus('reconnecting')
+    setSfuLifecycle(sdk, 'reconnecting')
+
+    expect(getChatSession(sdk).getStatus()).toBe('open')
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('reconnecting')
+
+    expect(sdk.sendControl(chatPayload)).toBe(true)
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.activeErrorCodes).not.toContain('CHAT_SEND_DROPPED')
+    expect(diag.drawers.chat.lastErrorCode).toBeUndefined()
+  })
+
+  it('#208 SFU error/degraded: sendControl succeeds without CHAT_SEND_DROPPED', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-208-sfu-degraded' })
+    attachOpenChatSocket(sdk)
+
+    const sfu = getSfuSession(sdk)
+    ;(sfu as unknown as { setStatus: (status: string) => void }).setStatus('error')
+    setSfuLifecycle(sdk, 'degraded')
+
+    expect(getChatSession(sdk).getStatus()).toBe('open')
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('degraded')
+
+    expect(sdk.sendControl(chatPayload)).toBe(true)
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.activeErrorCodes).not.toContain('CHAT_SEND_DROPPED')
+    expect(diag.drawers.chat.lastErrorCode).toBeUndefined()
+  })
+
+  it('#208 chat WS not open: sendControl fails with CHAT_SEND_DROPPED while SFU stays connected', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-208-chat-send-drop' })
+
+    const chat = getChatSession(sdk)
+    ;(chat as unknown as { setStatus: (status: string) => void }).setStatus('closed')
+    ;(chat as unknown as { ws: WebSocket | null }).ws = null
+
+    expect(sdk.getDiagnostics().drawers.sfuSignaling.state).toBe('connected')
+
+    expect(sdk.sendControl(chatPayload)).toBe(false)
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.chat.lastErrorCode).toBe('CHAT_SEND_DROPPED')
+    expect(diag.activeErrorCodes).toContain('CHAT_SEND_DROPPED')
+    expect(diag.drawers.sfuSignaling.state).toBe('connected')
+  })
+
+  it('#208 cross-drawer table: SFU reconnect does not disconnect chat or block sendControl', async () => {
+    const chatDisconnect = vi.spyOn(ChatSession.prototype, 'disconnect')
+    const sdk = await joinHealthySdk({ sessionId: 'sess-208-sfu-no-chat-block' })
+    attachOpenChatSocket(sdk)
+
+    setSfuLifecycle(sdk, 'reconnecting')
+    ;(getSfuSession(sdk) as unknown as { setStatus: (status: string) => void }).setStatus(
+      'reconnecting',
+    )
+
+    expect(chatDisconnect).not.toHaveBeenCalled()
+    expect(getChatSession(sdk).getStatus()).toBe('open')
+    expect(sdk.sendControl(chatPayload)).toBe(true)
+    expect(sdk.getDiagnostics().activeErrorCodes).not.toContain('CHAT_SEND_DROPPED')
+  })
+})
+
 describe('RoomRealtimeSdk.getDiagnostics activeErrorCodes contract', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -821,11 +821,32 @@ describe('RoomRealtimeSdk drawer isolation (harness steps 5-6)', () => {
       wsUrl: 'wss://ws.test',
     })
 
-    sdk.sendControl({ action: 'chat', text: 'hello', messageId: '550e8400-e29b-41d4-a716-446655440099' })
+    expect(
+      sdk.sendControl({ action: 'chat', text: 'hello', messageId: '550e8400-e29b-41d4-a716-446655440099' }),
+    ).toBe(false)
 
     const diag = sdk.getDiagnostics()
     expect(diag.drawers.chat.lastErrorCode).toBe('CHAT_SEND_DROPPED')
     expect(diag.activeErrorCodes).toContain('CHAT_SEND_DROPPED')
+  })
+
+  it('returns true from sendControl when chat session accepts outbound', async () => {
+    mockChatConnectOpensImmediately()
+    vi.spyOn(ChatSession.prototype, 'send').mockReturnValue(true)
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-send-ok',
+      wsUrl: 'wss://ws.test',
+    })
+
+    await vi.waitFor(() => expect(sdk.getDiagnostics().drawers.chat.state).toBe('connected'))
+
+    expect(
+      sdk.sendControl({ action: 'chat', text: 'hello', messageId: '550e8400-e29b-41d4-a716-446655440100' }),
+    ).toBe(true)
+    expect(sdk.getDiagnostics().drawers.chat.lastErrorCode).toBeUndefined()
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -310,8 +310,16 @@ export class RoomRealtimeSdk {
     this.teardownModules({ intentional: true })
   }
 
-  sendControl(payload: Record<string, unknown>): void {
-    this.chat?.send(payload)
+  /** Returns false when chat outbound is dropped (socket not open). */
+  sendControl(payload: Record<string, unknown>): boolean {
+    const chat = this.chat
+    if (!chat) return false
+    const sent = chat.send(payload)
+    if (!sent) {
+      this.chatLastErrorCode = 'CHAT_SEND_DROPPED'
+      this.emitDiagnosticsChange()
+    }
+    return sent
   }
 
   getChatStatus(): ChatSessionStatus {

--- a/apps/web/src/room/useChatSession.ts
+++ b/apps/web/src/room/useChatSession.ts
@@ -16,7 +16,7 @@ export function useChatSession(options: {
   enabled: boolean
 }): {
   status: ChatSessionStatus
-  sendJson: (payload: Record<string, unknown>) => void
+  sendJson: (payload: Record<string, unknown>) => boolean
   session: ChatSession
 } {
   const { url, roomId, sessionId, displayName, accessToken, enabled } = options
@@ -44,9 +44,7 @@ export function useChatSession(options: {
   }, [accessToken, displayName, enabled, roomId, session, sessionId, url])
 
   const sendJson = useCallback(
-    (payload: Record<string, unknown>) => {
-      session.send(payload)
-    },
+    (payload: Record<string, unknown>) => session.send(payload),
     [session],
   )
 

--- a/apps/web/src/room/useRoomRealtimeSdk.ts
+++ b/apps/web/src/room/useRoomRealtimeSdk.ts
@@ -54,7 +54,7 @@ export function useRoomRealtimeSdk(options: {
   setRoom: Dispatch<SetStateAction<RoomSnapshot | null | undefined>>
 }): {
   wsStatus: ChatSessionStatus
-  sendJson: (payload: Record<string, unknown>) => void
+  sendJson: (payload: Record<string, unknown>) => boolean
   chat: ChatLine[]
   chatReactions: ReactionsByMessage
   chatDraft: string
@@ -290,9 +290,7 @@ export function useRoomRealtimeSdk(options: {
   }, [sdk])
 
   const sendJson = useCallback(
-    (payload: Record<string, unknown>) => {
-      sdk.sendControl(payload)
-    },
+    (payload: Record<string, unknown>) => sdk.sendControl(payload),
     [sdk],
   )
 
@@ -357,8 +355,8 @@ export function useRoomRealtimeSdk(options: {
     if (!fanToken) return
     const txt = chatDraft.trim()
     if (!txt) return
-    sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
-    setChatDraft('')
+    const sent = sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
+    if (sent) setChatDraft('')
   }, [chatDraft, fanToken, sendJson])
 
   const sendChatGif = useCallback(
@@ -386,12 +384,14 @@ export function useRoomRealtimeSdk(options: {
         const chips = chatReactions[messageId] ?? {}
         if (!canAcceptReactionAdd(chips, trimmedEmoji)) return
       }
-      sendJson({
+      if (!sendJson({
         action: 'react',
         messageId,
         emoji: trimmedEmoji,
         reactionAction,
-      })
+      })) {
+        return
+      }
     },
     [chatReactions, fanToken, sendJson],
   )

--- a/apps/web/src/room/useRoomSessionWiring.test.ts
+++ b/apps/web/src/room/useRoomSessionWiring.test.ts
@@ -4,11 +4,37 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const wiringPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'useRoomSessionWiring.ts')
+const realtimeSdkPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'useRoomRealtimeSdk.ts')
 
 describe('useRoomSessionWiring SFU enabled gate (#202)', () => {
   it('does not couple useSfuMediaSession enabled to chat wsStatus === open', () => {
     const src = fs.readFileSync(wiringPath, 'utf8')
     expect(src).not.toMatch(/enabled:\s*wsStatus\s*===\s*['"]open['"]/)
     expect(src).toContain('enabled: Boolean(canonicalRoomId && sessionId && room)')
+  })
+})
+
+describe('chat compose send success contract (#206)', () => {
+  it('retains chat draft in useRoomSessionWiring when sendJson returns false', () => {
+    const src = fs.readFileSync(wiringPath, 'utf8')
+    expect(src).toMatch(/const sent = sendJson\(\{ action: 'chat'/)
+    expect(src).toMatch(/if \(sent\) setChatDraft\(''\)/)
+  })
+
+  it('retains chat draft in useRoomRealtimeSdk when sendJson returns false', () => {
+    const src = fs.readFileSync(realtimeSdkPath, 'utf8')
+    expect(src).toMatch(/const sent = sendJson\(\{ action: 'chat'/)
+    expect(src).toMatch(/if \(sent\) setChatDraft\(''\)/)
+  })
+
+  it('does not gate sendControl on SFU status in RoomRealtimeSdk', () => {
+    const sdkPath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      'sessions',
+      'RoomRealtimeSdk.ts',
+    )
+    const src = fs.readFileSync(sdkPath, 'utf8')
+    const sendControlBlock = src.slice(src.indexOf('sendControl('), src.indexOf('getChatStatus()'))
+    expect(sendControlBlock).not.toMatch(/sfu|getSfu|sfuLastError/)
   })
 })

--- a/apps/web/src/room/useRoomSessionWiring.ts
+++ b/apps/web/src/room/useRoomSessionWiring.ts
@@ -50,7 +50,7 @@ export function useRoomSessionWiring(options: {
   setRoom: Dispatch<SetStateAction<RoomSnapshot | null | undefined>>
 }): {
   wsStatus: ReturnType<typeof useChatSession>['status']
-  sendJson: (payload: Record<string, unknown>) => void
+  sendJson: (payload: Record<string, unknown>) => boolean
   chat: ChatLine[]
   chatReactions: ReactionsByMessage
   chatDraft: string
@@ -244,9 +244,7 @@ export function useRoomSessionWiring(options: {
   }, [roomId, room, wsStatus, getIceServers])
 
   const sendJson = useCallback(
-    (payload: Record<string, unknown>) => {
-      wsSendJson(payload)
-    },
+    (payload: Record<string, unknown>) => wsSendJson(payload),
     [wsSendJson],
   )
 
@@ -301,8 +299,8 @@ export function useRoomSessionWiring(options: {
     if (!fanToken) return
     const txt = chatDraft.trim()
     if (!txt) return
-    sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
-    setChatDraft('')
+    const sent = sendJson({ action: 'chat', text: txt, messageId: createChatMessageId() })
+    if (sent) setChatDraft('')
   }, [chatDraft, fanToken, sendJson])
 
   const sendChatGif = useCallback(
@@ -330,12 +328,14 @@ export function useRoomSessionWiring(options: {
         const chips = chatReactions[messageId] ?? {}
         if (!canAcceptReactionAdd(chips, trimmedEmoji)) return
       }
-      sendJson({
+      if (!sendJson({
         action: 'react',
         messageId,
         emoji: trimmedEmoji,
         reactionAction,
-      })
+      })) {
+        return
+      }
     },
     [chatReactions, fanToken, sendJson],
   )

--- a/apps/web/src/room/useRoomWebSocket.ts
+++ b/apps/web/src/room/useRoomWebSocket.ts
@@ -18,7 +18,7 @@ export function useRoomWebSocket(options: {
   onMessage?: (data: Record<string, unknown>) => void
 }): {
   status: WsStatus
-  sendJson: (payload: Record<string, unknown>) => void
+  sendJson: (payload: Record<string, unknown>) => boolean
 } {
   const { url, roomId, sessionId, displayName, accessToken, enabled } = options
   const { status, sendJson } = useChatSession({


### PR DESCRIPTION
## Summary

- **#206:** `ChatSession.send` boolean contract flows through `RoomRealtimeSdk.sendControl` and compose hooks; failed sends set `CHAT_SEND_DROPPED` in diagnostics and retain chat draft.
- **#207:** Chat drawer status banner and compose inline feedback ship via `useRoomRealtimeSdk` → `drawerErrorPresentation` → `RoomPageSidebar`; chat-plane surfaces are independent of SFU diagnostics. Regression tests lock acceptance criteria.
- **#208:** `RoomRealtimeSdk.test.ts` regressions lock chat send path during SFU-only `reconnecting` / `degraded` outage (send succeeds, no `CHAT_SEND_DROPPED`), chat-only WS drop (send fails with `CHAT_SEND_DROPPED` while SFU stays connected), and cross-drawer isolation (SFU reconnect does not disconnect chat or block send).
- `useRoomRealtimeSdk` and `useRoomSessionWiring` clear compose draft only when outbound send succeeds; reaction sends bail on drop.

## Scope note

Shared `feature/issue-149` branch for M18 chat send / drawer UX epic.

## Test plan

- [x] `npm test --prefix apps/web -- --run` (441 tests)
- [x] `npm run build --prefix apps/web`
- [x] Targeted: `ChatSession.test.ts`, `RoomRealtimeSdk.test.ts`, `drawerErrorPresentation.test.ts`, `chatDrawerUxWiring.test.ts`

Closes #206, #207, and #208 when merged (part of #149 epic).