### PR TITLE
test(room): #209 drawer status banner integration tests (#150)

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -1,0 +1,356 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomPage } from './RoomPage'
+import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import {
+  CHAT_RECONNECTING_COPY,
+  drawerDiagnostics,
+  GUEST_IDLE_VIDEO_RELAY_COPY,
+  RETIRED_COMBINED_STATUS_COPY,
+  VIDEO_RELAY_RECONNECTING_COPY,
+} from './roomPageDrawerStatusTestHelpers'
+import { RIFFSYNC_CHAT_DRAWER_STATUS_ID, RIFFSYNC_VIDEO_RELAY_STATUS_ID } from '../room/drawerErrorPresentation'
+
+const fetchRoom = vi.fn()
+const fetchRtcIceServers = vi.fn()
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    fetchRoom: (...args: unknown[]) => fetchRoom(...args),
+  }
+})
+
+vi.mock('../config/fetchRtcIceServers', () => ({
+  fetchRtcIceServers: () => fetchRtcIceServers(),
+}))
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogEpisodeQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => null,
+}))
+
+vi.mock('../config/wsUrl', () => ({
+  getPublicWsUrl: () => 'wss://ws.test.example',
+}))
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.test.example',
+}))
+
+vi.mock('../config/publicOrigin', () => ({
+  getPublicOrigin: () => 'https://www.test.example',
+}))
+
+vi.mock('../session/guestSession', () => ({
+  ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
+  setGuestDisplayName: (name: string) => name,
+  FAN_DISPLAY_NAME_MAX_LEN: 48,
+}))
+
+vi.mock('../room/audio/theaterAudioMix', () => ({
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn(() => 'running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
+const drawerStatusMockConfig = vi.hoisted(() => {
+  type MockConfig = {
+    diagnostics: {
+      roomId: string
+      sessionId: string
+      asOf: string
+      drawers: {
+        chat: { state: string; lastErrorCode?: string }
+        sfuSignaling: { state: string; lastErrorCode?: string }
+        theaterPlayback: { state: string; lastErrorCode?: string }
+      }
+      activeErrorCodes: string[]
+    }
+    guestShareFsm: 'idle' | 'verifying_media' | 'running'
+  }
+
+  let config: MockConfig = {
+    diagnostics: {
+      roomId: 'room-test-1',
+      sessionId: 'sess-test-1',
+      asOf: new Date(0).toISOString(),
+      drawers: {
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'connected' },
+        theaterPlayback: { state: 'connected' },
+      },
+      activeErrorCodes: [],
+    },
+    guestShareFsm: 'running',
+  }
+
+  class MockRoomRealtimeSdk {
+    join(_roomId: string, options: { onDiagnosticsChange?: (diagnostics: MockConfig['diagnostics']) => void }) {
+      options.onDiagnosticsChange?.(config.diagnostics)
+    }
+
+    subscribe() {}
+
+    teardown() {}
+
+    onTheaterSnapshotChange(listener: (snapshot: {
+      guestShareFsm: MockConfig['guestShareFsm']
+      guestPlayHint: boolean
+      hostCapturePlayHint: boolean
+    }) => void) {
+      listener({
+        guestShareFsm: config.guestShareFsm,
+        guestPlayHint: false,
+        hostCapturePlayHint: false,
+      })
+      return () => undefined
+    }
+
+    getTheaterSnapshot() {
+      return {
+        guestShareFsm: config.guestShareFsm,
+        guestPlayHint: false,
+        hostCapturePlayHint: false,
+      }
+    }
+
+    getDiagnostics() {
+      return config.diagnostics
+    }
+
+    getChatStatus() {
+      return 'open' as const
+    }
+
+    getParticipantAvController() {
+      return null
+    }
+
+    sendControl() {
+      return true
+    }
+
+    setCaptureStreamForTheater() {}
+    setYoutubeVideoIdForTheater() {}
+    syncHostScreenPublish() {}
+    unpublishHostScreen() {}
+    playGuestVideo() {
+      return Promise.resolve()
+    }
+    playHostCapturePreview() {
+      return Promise.resolve()
+    }
+    bindGuestVideo() {}
+    bindHostCaptureVideo() {}
+  }
+
+  return {
+    get: () => config,
+    set: (next: MockConfig) => {
+      config = next
+    },
+    MockRoomRealtimeSdk,
+  }
+})
+
+vi.mock('../room/sessions/RoomRealtimeSdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../room/sessions/RoomRealtimeSdk')>()
+  return {
+    ...actual,
+    RoomRealtimeSdk: drawerStatusMockConfig.MockRoomRealtimeSdk,
+  }
+})
+
+describe('RoomPage drawer status banner integration (#209)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({ chat: { state: 'connected' } }),
+      guestShareFsm: 'running',
+    })
+
+    fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
+    fetchRoom.mockResolvedValue({
+      roomId: 'room-test-1',
+      hostSub: 'host-sub',
+      catalogEpisodeId: 'ep-1',
+      youtubeVideoId: 'yt-1',
+      version: 1,
+      visibility: 'public',
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      roomMode: 'theater',
+      avDisabled: true,
+      broadcastCaptureActive: false,
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  function renderRoom() {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/room/room-test-1']}>
+          <RoomChromeProvider>
+            <Routes>
+              <Route path="/room/:roomId" element={<RoomPage />} />
+            </Routes>
+          </RoomChromeProvider>
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  function chatBanner() {
+    return container.querySelector(`#${RIFFSYNC_CHAT_DRAWER_STATUS_ID}`)
+  }
+
+  function videoRelayBanner() {
+    return container.querySelector(`#${RIFFSYNC_VIDEO_RELAY_STATUS_ID}`)
+  }
+
+  function assertRetiredCombinedCopyAbsent() {
+    expect(container.textContent).not.toContain(RETIRED_COMBINED_STATUS_COPY)
+  }
+
+  it('chat-only reconnecting: chat banner uses drawerErrorPresentation copy; video-relay omits chat copy', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(chatBanner()).not.toBeNull()
+    })
+
+    expect(chatBanner()?.textContent).toBe(CHAT_RECONNECTING_COPY)
+    expect(videoRelayBanner()).toBeNull()
+    assertRetiredCombinedCopyAbsent()
+  })
+
+  it('chat-only reconnecting: guest idle FSM may show host-screen idle copy without chat text on stage', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'idle',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(chatBanner()?.textContent).toBe(CHAT_RECONNECTING_COPY)
+    })
+
+    expect(videoRelayBanner()?.textContent).toBe(GUEST_IDLE_VIDEO_RELAY_COPY)
+    expect(videoRelayBanner()?.textContent).not.toBe(CHAT_RECONNECTING_COPY)
+    assertRetiredCombinedCopyAbsent()
+  })
+
+  it('SFU-only reconnecting: video-relay banner uses drawerErrorPresentation copy; chat banner absent when chat connected', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'reconnecting' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(videoRelayBanner()?.textContent).toBe(VIDEO_RELAY_RECONNECTING_COPY)
+    })
+
+    expect(chatBanner()).toBeNull()
+    assertRetiredCombinedCopyAbsent()
+  })
+
+  it('dual-outage: chat and video-relay banners render simultaneously with independent copy', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'reconnecting' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(chatBanner()?.textContent).toBe(CHAT_RECONNECTING_COPY)
+      expect(videoRelayBanner()?.textContent).toBe(VIDEO_RELAY_RECONNECTING_COPY)
+    })
+
+    assertRetiredCombinedCopyAbsent()
+  })
+
+  it('mounts stable drawer status ids when respective banners render', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'reconnecting' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(chatBanner()).not.toBeNull()
+      expect(videoRelayBanner()).not.toBeNull()
+    })
+
+    expect(chatBanner()?.id).toBe(RIFFSYNC_CHAT_DRAWER_STATUS_ID)
+    expect(videoRelayBanner()?.id).toBe(RIFFSYNC_VIDEO_RELAY_STATUS_ID)
+  })
+
+  it('places chat drawer banner above sidebar tabs per input_handling.md', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(chatBanner()).not.toBeNull()
+    })
+
+    const tabs = container.querySelector('.riffsync-room-page__tabs')
+    expect(tabs).not.toBeNull()
+    expect(
+      chatBanner()!.compareDocumentPosition(tabs!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
+++ b/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
@@ -1,0 +1,26 @@
+import type { RoomRealtimeDiagnostics } from '../room/sessions/RoomRealtimeSdk'
+
+/** Retired anti-pattern from `.ai/interface/presentation.md` (#147 / #150). */
+export const RETIRED_COMBINED_STATUS_COPY = 'Reconnecting chat… Video may pause briefly.'
+
+export const CHAT_RECONNECTING_COPY = 'Reconnecting chat…'
+export const VIDEO_RELAY_RECONNECTING_COPY = 'Video relay reconnecting…'
+export const GUEST_IDLE_VIDEO_RELAY_COPY = 'Waiting for host to share…'
+
+export function drawerDiagnostics(
+  drawers: Partial<RoomRealtimeDiagnostics['drawers']>,
+  activeErrorCodes: string[] = [],
+): RoomRealtimeDiagnostics {
+  return {
+    roomId: 'room-test-1',
+    sessionId: 'sess-test-1',
+    asOf: new Date(0).toISOString(),
+    drawers: {
+      chat: { state: 'connected' },
+      sfuSignaling: { state: 'connected' },
+      theaterPlayback: { state: 'connected' },
+      ...drawers,
+    },
+    activeErrorCodes,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds RoomPage integration tests (#209) that verify chat and video-relay status banners render independently from diagnostics-driven presentation copy.
- Covers chat-only reconnect, SFU-only reconnect, dual-outage, stable DOM ids (`#riffsync-chat-drawer-status`, `#riffsync-video-relay-status`), chat banner placement above sidebar tabs, and absence of the retired combined string.
- Uses a colocated `RoomPage.drawerStatusBanners.test.tsx` with a mocked `RoomRealtimeSdk` so existing `RoomPage.test.tsx` session lifecycle tests stay on the real SDK.

Closes #209

## Test plan

- [x] `npm test --prefix apps/web -- --run src/pages/RoomPage.drawerStatusBanners.test.tsx`
- [x] `npm test --prefix apps/web -- --run` (447 tests pass)