### PR TITLE
[M19][#151] Guest host-screen SFU status (#210, #211, #212)

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -333,6 +333,63 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     expect(videoRelayBanner()?.id).toBe(RIFFSYNC_VIDEO_RELAY_STATUS_ID)
   })
 
+  it('guest running FSM with healthy SFU omits #riffsync-video-relay-status (#210)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+    })
+
+    expect(videoRelayBanner()).toBeNull()
+  })
+
+  it('guest idle FSM mounts #riffsync-video-relay-status with role="status" (#210)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'idle',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(videoRelayBanner()).not.toBeNull()
+    })
+
+    expect(videoRelayBanner()?.id).toBe(RIFFSYNC_VIDEO_RELAY_STATUS_ID)
+    expect(videoRelayBanner()?.getAttribute('role')).toBe('status')
+    expect(videoRelayBanner()?.textContent).toBe(GUEST_IDLE_VIDEO_RELAY_COPY)
+  })
+
+  it('config-class SFU error copy renders on #riffsync-video-relay-status (#210)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics(
+        {
+          chat: { state: 'connected' },
+          sfuSignaling: { state: 'connected', lastErrorCode: 'SFU_RELAY_UNREACHABLE' },
+        },
+        ['SFU_RELAY_UNREACHABLE'],
+      ),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(videoRelayBanner()).not.toBeNull()
+    })
+
+    expect(videoRelayBanner()?.id).toBe(RIFFSYNC_VIDEO_RELAY_STATUS_ID)
+    expect(videoRelayBanner()?.textContent).toContain('relay')
+  })
+
   it('places chat drawer banner above sidebar tabs per input_handling.md', async () => {
     drawerStatusMockConfig.set({
       diagnostics: drawerDiagnostics({

--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -9,7 +9,9 @@ import {
   CHAT_RECONNECTING_COPY,
   drawerDiagnostics,
   GUEST_IDLE_VIDEO_RELAY_COPY,
+  GUEST_VERIFYING_VIDEO_RELAY_COPY,
   RETIRED_COMBINED_STATUS_COPY,
+  RETIRED_MESH_HOST_SCREEN_COPY,
   VIDEO_RELAY_RECONNECTING_COPY,
 } from './roomPageDrawerStatusTestHelpers'
 import { RIFFSYNC_CHAT_DRAWER_STATUS_ID, RIFFSYNC_VIDEO_RELAY_STATUS_ID } from '../room/drawerErrorPresentation'
@@ -348,6 +350,26 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     })
 
     expect(videoRelayBanner()).toBeNull()
+  })
+
+  it('guest verifying_media FSM mounts normative copy on #riffsync-video-relay-status (#212)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'verifying_media',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(videoRelayBanner()).not.toBeNull()
+    })
+
+    expect(videoRelayBanner()?.textContent).toBe(GUEST_VERIFYING_VIDEO_RELAY_COPY)
+    for (const meshCopy of RETIRED_MESH_HOST_SCREEN_COPY) {
+      expect(container.textContent).not.toContain(meshCopy)
+    }
   })
 
   it('guest idle FSM mounts #riffsync-video-relay-status with role="status" (#210)', async () => {

--- a/apps/web/src/pages/RoomPage.test.tsx
+++ b/apps/web/src/pages/RoomPage.test.tsx
@@ -8,7 +8,10 @@ import { ChatSession } from '../room/sessions/ChatSession'
 import { SfuMediaSession } from '../room/sessions/SfuMediaSession'
 import { TheaterPlayback } from '../room/sessions/TheaterPlayback'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
-import { RETIRED_GUEST_NOT_SHARING_PLACEHOLDER } from './roomPageDrawerStatusTestHelpers'
+import {
+  RETIRED_GUEST_NOT_SHARING_PLACEHOLDER,
+  RETIRED_MESH_HOST_SCREEN_COPY,
+} from './roomPageDrawerStatusTestHelpers'
 
 const fetchRoom = vi.fn()
 const fetchRtcIceServers = vi.fn()
@@ -219,8 +222,14 @@ describe('RoomPage session integration', () => {
       expect(container.querySelector('#riffsync-video-relay-status')).not.toBeNull()
     })
 
+    const videoRelayStatus = container.querySelector('#riffsync-video-relay-status')
+    expect(videoRelayStatus).not.toBeNull()
+    expect(videoRelayStatus?.getAttribute('role')).toBe('status')
     expect(container.textContent).not.toContain(RETIRED_GUEST_NOT_SHARING_PLACEHOLDER)
     expect(container.querySelector('.riffsync-room-page__guest-video-placeholder')).toBeNull()
+    for (const meshCopy of RETIRED_MESH_HOST_SCREEN_COPY) {
+      expect(container.textContent).not.toContain(meshCopy)
+    }
 
     const chatDisconnectsBeforeUnmount = chatDisconnectSpy.mock.calls.length
     const sfuDisconnectsBeforeUnmount = sfuDisconnectSpy.mock.calls.length

--- a/apps/web/src/pages/RoomPage.test.tsx
+++ b/apps/web/src/pages/RoomPage.test.tsx
@@ -8,6 +8,7 @@ import { ChatSession } from '../room/sessions/ChatSession'
 import { SfuMediaSession } from '../room/sessions/SfuMediaSession'
 import { TheaterPlayback } from '../room/sessions/TheaterPlayback'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import { RETIRED_GUEST_NOT_SHARING_PLACEHOLDER } from './roomPageDrawerStatusTestHelpers'
 
 const fetchRoom = vi.fn()
 const fetchRtcIceServers = vi.fn()
@@ -217,6 +218,9 @@ describe('RoomPage session integration', () => {
     await vi.waitFor(() => {
       expect(container.querySelector('#riffsync-video-relay-status')).not.toBeNull()
     })
+
+    expect(container.textContent).not.toContain(RETIRED_GUEST_NOT_SHARING_PLACEHOLDER)
+    expect(container.querySelector('.riffsync-room-page__guest-video-placeholder')).toBeNull()
 
     const chatDisconnectsBeforeUnmount = chatDisconnectSpy.mock.calls.length
     const sfuDisconnectsBeforeUnmount = sfuDisconnectSpy.mock.calls.length

--- a/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
+++ b/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
@@ -3,6 +3,9 @@ import type { RoomRealtimeDiagnostics } from '../room/sessions/RoomRealtimeSdk'
 /** Retired anti-pattern from `.ai/interface/presentation.md` (#147 / #150). */
 export const RETIRED_COMBINED_STATUS_COPY = 'Reconnecting chat… Video may pause briefly.'
 
+/** Retired duplicate guest placeholder from **#211** / parent **#151**. */
+export const RETIRED_GUEST_NOT_SHARING_PLACEHOLDER = 'The host is not sharing video right now.'
+
 export const CHAT_RECONNECTING_COPY = 'Reconnecting chat…'
 export const VIDEO_RELAY_RECONNECTING_COPY = 'Video relay reconnecting…'
 export const GUEST_IDLE_VIDEO_RELAY_COPY = 'Waiting for host to share…'

--- a/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
+++ b/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
@@ -9,6 +9,18 @@ export const RETIRED_GUEST_NOT_SHARING_PLACEHOLDER = 'The host is not sharing vi
 export const CHAT_RECONNECTING_COPY = 'Reconnecting chat…'
 export const VIDEO_RELAY_RECONNECTING_COPY = 'Video relay reconnecting…'
 export const GUEST_IDLE_VIDEO_RELAY_COPY = 'Waiting for host to share…'
+export const GUEST_VERIFYING_VIDEO_RELAY_COPY = 'Connecting to video relay…'
+
+/** Retired mesh-era guest host-screen strings (`interaction_flow.md` / #151). */
+export const RETIRED_MESH_HOST_SCREEN_COPY = [
+  'negotiating_ice',
+  'recovering_ice',
+  'Establishing encrypted path…',
+  'Verifying video feed…',
+  'shareSessionFsm',
+  'isMeshWatchPartyMediaEnabled',
+  'VITE_WEBRTC_USE_MEDIASOU_SFU',
+] as const
 
 export function drawerDiagnostics(
   drawers: Partial<RoomRealtimeDiagnostics['drawers']>,

--- a/apps/web/src/room/RoomPlaybackPanel.test.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.test.tsx
@@ -75,6 +75,13 @@ describe('RoomPlaybackPanel guest #riffsync-video-relay-status (#210)', () => {
     expect(videoRelayStatusEl()).toBeNull()
   })
 
+  it('does not render retired guest not-sharing placeholder when idle FSM copy is shown (#211)', () => {
+    renderGuest({ videoRelayStatus: 'Waiting for host to share…', guestRemote: null })
+
+    expect(container.textContent).not.toContain('The host is not sharing video right now.')
+    expect(container.querySelector('.riffsync-room-page__guest-video-placeholder')).toBeNull()
+  })
+
   it('does not regress host captureErr alerts when guest path is inactive', () => {
     act(() => {
       root.render(

--- a/apps/web/src/room/RoomPlaybackPanel.test.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { RoomPlaybackPanel } from './RoomPlaybackPanel'
+import { RIFFSYNC_VIDEO_RELAY_STATUS_ID } from './drawerErrorPresentation'
+
+const baseProps = {
+  captureStream: null,
+  captureErr: null,
+  patchErr: null,
+  renameModalOpen: false,
+  guestRemote: null,
+  fanToken: null,
+  theaterPlaybackSnapshot: {
+    guestShareFsm: 'idle' as const,
+    guestPlayHint: false,
+    hostCapturePlayHint: false,
+  },
+  theaterAudioStatus: null,
+  bindHostCaptureVideo: () => undefined,
+  bindGuestVideo: () => undefined,
+  playHostCapturePreview: async () => undefined,
+  playGuestVideo: async () => undefined,
+  startCapture: async () => undefined,
+  openCapturePlayerTab: () => undefined,
+}
+
+describe('RoomPlaybackPanel guest #riffsync-video-relay-status (#210)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderGuest(overrides: Partial<typeof baseProps & { videoRelayStatus: string | null }> = {}) {
+    act(() => {
+      root.render(
+        <RoomPlaybackPanel
+          isPublisher={false}
+          videoRelayStatus={overrides.videoRelayStatus ?? 'Waiting for host to share…'}
+          {...baseProps}
+          {...overrides}
+        />,
+      )
+    })
+  }
+
+  function videoRelayStatusEl() {
+    return container.querySelector(`#${RIFFSYNC_VIDEO_RELAY_STATUS_ID}`)
+  }
+
+  it('guest status line exposes stable id and role="status" when copy is present', () => {
+    renderGuest({ videoRelayStatus: 'Waiting for host to share…' })
+
+    const el = videoRelayStatusEl()
+    expect(el).not.toBeNull()
+    expect(el?.id).toBe('riffsync-video-relay-status')
+    expect(el?.getAttribute('role')).toBe('status')
+    expect(el?.classList.contains('riffsync-muted')).toBe(true)
+  })
+
+  it('omits #riffsync-video-relay-status when guest copy is null', () => {
+    renderGuest({ videoRelayStatus: null })
+
+    expect(videoRelayStatusEl()).toBeNull()
+  })
+
+  it('does not regress host captureErr alerts when guest path is inactive', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPlaybackPanel
+            {...baseProps}
+            isPublisher
+            videoRelayStatus={null}
+            captureErr="Screen capture failed."
+          />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(videoRelayStatusEl()).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__host-feedback-alert')?.textContent).toBe(
+      'Screen capture failed.',
+    )
+  })
+})
+
+describe('RoomPlaybackPanel host video-relay status (#210)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('host status line uses share-status styling and stable id when copy is present', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPlaybackPanel
+            isPublisher
+            videoRelayStatus="Video relay reconnecting…"
+            {...baseProps}
+          />
+        </MemoryRouter>,
+      )
+    })
+
+    const el = container.querySelector(`#${RIFFSYNC_VIDEO_RELAY_STATUS_ID}`)
+    expect(el).not.toBeNull()
+    expect(el?.getAttribute('role')).toBe('status')
+    expect(el?.classList.contains('riffsync-room-page__share-status')).toBe(true)
+    expect(el?.classList.contains('riffsync-muted')).toBe(false)
+  })
+})

--- a/apps/web/src/room/RoomPlaybackPanel.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.tsx
@@ -93,7 +93,7 @@ export function RoomPlaybackPanel({
         {videoRelayStatus ? (
           <p
             id={RIFFSYNC_VIDEO_RELAY_STATUS_ID}
-            className="riffsync-muted"
+            className="riffsync-room-page__share-status"
             role="status"
             aria-live="polite"
           >

--- a/apps/web/src/room/RoomPlaybackPanel.tsx
+++ b/apps/web/src/room/RoomPlaybackPanel.tsx
@@ -39,8 +39,6 @@ export function RoomPlaybackPanel({
   startCapture,
   openCapturePlayerTab,
 }: RoomPlaybackPanelProps) {
-  const hideGuestPlaceholder = !guestRemote && Boolean(videoRelayStatus)
-
   if (isPublisher) {
     return (
       <section className="riffsync-room-page__playback" aria-label="Your shared stream preview">
@@ -165,11 +163,6 @@ export function RoomPlaybackPanel({
         </p>
       ) : null}
       <div className="riffsync-room-page__player-shell riffsync-room-page__player-shell--guest">
-        {!guestRemote && !hideGuestPlaceholder ? (
-          <div className="riffsync-room-page__guest-video-placeholder" role="status">
-            <p>The host is not sharing video right now.</p>
-          </div>
-        ) : null}
         <video
           ref={bindGuestVideo}
           className="riffsync-room-page__guest-video"

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -331,6 +331,20 @@ describe('TheaterPlayback', () => {
     playback.dispose()
   })
 
+  it('transitions guestShareFsm running to idle on setGuestRemote(null) share-stop (#212)', () => {
+    const mix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(mix)
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+
+    playback.setGuestRemote(makeStream([makeTrack('video', 'live')]))
+    expect(playback.getSnapshot().guestShareFsm).toBe('running')
+
+    playback.setGuestRemote(null)
+    expect(playback.getSnapshot().guestShareFsm).toBe('idle')
+    playback.dispose()
+  })
+
   it('theater guest FSM idle to verifying_media after share start before live track (#146 Guest theater started)', () => {
     const mix = makeMixMock()
     vi.mocked(createTheaterAudioMix).mockReturnValue(mix)

--- a/apps/web/src/room/sfu/guestHostScreenMeshRetirement.test.ts
+++ b/apps/web/src/room/sfu/guestHostScreenMeshRetirement.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { RETIRED_MESH_HOST_SCREEN_COPY } from '../../pages/roomPageDrawerStatusTestHelpers'
+
+const webSrcRoot = path.join(import.meta.dirname, '../..')
+
+const STAGE_PLAYBACK_PATHS = [
+  'room/sfu/sfuRelayStatusCopy.ts',
+  'room/sessions/TheaterPlayback.ts',
+  'room/RoomPlaybackPanel.tsx',
+  'room/drawerErrorPresentation.ts',
+  'pages/RoomPage.tsx',
+] as const
+
+function readWebSrc(relativePath: string): string {
+  return fs.readFileSync(path.join(webSrcRoot, relativePath), 'utf8')
+}
+
+describe('guest host-screen mesh retirement grep (#212 / #161)', () => {
+  for (const relativePath of STAGE_PLAYBACK_PATHS) {
+    it(`stage playback path ${relativePath} has no retired mesh FSM copy`, () => {
+      const src = readWebSrc(relativePath)
+      for (const banned of RETIRED_MESH_HOST_SCREEN_COPY) {
+        expect(src, `${relativePath} must not contain "${banned}"`).not.toContain(banned)
+      }
+    })
+  }
+})

--- a/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
+++ b/apps/web/src/room/sfu/sfuRelayStatusCopy.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { LOCAL_SFU_UNREACHABLE_MSG } from './sfuConfigErrors'
 import {
@@ -48,6 +50,31 @@ describe('resolveGuestVideoRelayStatusLine', () => {
         guestShareFsm: 'idle',
       }),
     ).toBe('Waiting for host to share…')
+  })
+
+  it('maps verifying_media to Connecting to video relay… (#212)', () => {
+    expect(
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: null,
+        guestShareFsm: 'verifying_media',
+      }),
+    ).toBe('Connecting to video relay…')
+  })
+
+  it('returns null for running FSM when relay is healthy (#212)', () => {
+    expect(
+      resolveGuestVideoRelayStatusLine({
+        sfuRelayError: null,
+        guestShareFsm: 'running',
+      }),
+    ).toBeNull()
+  })
+
+  it('accepts only sfuRelayError and guestShareFsm (no chat WS input) (#201 / #212)', () => {
+    const src = fs.readFileSync(path.join(import.meta.dirname, 'sfuRelayStatusCopy.ts'), 'utf8')
+    expect(src).not.toContain('chatWsDisconnected')
+    expect(src).toMatch(/resolveGuestVideoRelayStatusLine\(opts: \{\s*sfuRelayError/)
+    expect(src).toMatch(/guestShareFsm: GuestHostScreenFsm\s*\}/)
   })
 })
 


### PR DESCRIPTION
## Summary

- Wire `#riffsync-video-relay-status` on the guest video-relay status line in `RoomPlaybackPanel` with `role="status"` (stable DOM anchor for M19 ship gate #151).
- Apply `riffsync-room-page__share-status` styling on the host video-relay status line per presentation contract.
- Retire duplicate guest not-sharing placeholder so idle FSM copy (**Waiting for host to share…**) is the sole not-sharing message on the guest playback surface (#211).
- Lock guest host-screen FSM copy and transitions with unit tests so mesh-era strings cannot regress (#212):
  - `sfuRelayStatusCopy.test.ts`: all three FSM strings, no chat WS parameter
  - `TheaterPlayback.test.ts`: `verifying_media` path and `running` → `idle` on share stop
  - `RoomPage.test.tsx` / drawer banner integration: normative copy on `#riffsync-video-relay-status`, mesh copy absent
  - `guestHostScreenMeshRetirement.test.ts`: grep guard for retired mesh FSM strings

Closes #210
Closes #211
Closes #212

Part of parent #151 (M19 guest host-screen status ship gate).

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/sfu/sfuRelayStatusCopy.test.ts src/room/sfu/guestHostScreenMeshRetirement.test.ts src/room/sessions/TheaterPlayback.test.ts src/pages/RoomPage.test.tsx src/pages/RoomPage.drawerStatusBanners.test.tsx`
- [x] Guest idle FSM mounts `#riffsync-video-relay-status` with **Waiting for host to share…**
- [x] Guest `verifying_media` FSM mounts **Connecting to video relay…**
- [x] Guest running FSM + healthy SFU omits the status node
- [x] Retired placeholder and mesh FSM strings absent from stage playback surfaces
- [x] Config-class SFU errors render on `#riffsync-video-relay-status`
- [x] Host `captureErr` alerts unchanged