### PR TITLE
[M19] Preserve mic-only off strip/grid rule; harden tile attach/detach only (#152)

### DIFF
--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -74,34 +74,82 @@ describe('StageParticipantLayout', () => {
     expect(container.textContent).toContain('You')
   })
 
-  it('unmounts participant tiles when removed from the list', () => {
-    const stream = new MediaStream([{ kind: 'video' } as MediaStreamTrack])
-    const tile = {
+  describe('producerClosed regression (tile detach across stage surfaces)', () => {
+    const remoteTile = {
       key: 'remote-1',
       sessionId: 'remote-1',
       label: 'Alice',
       isSelf: false,
-      stream,
+      stream: new MediaStream([{ kind: 'video' } as MediaStreamTrack]),
     }
-    renderLayout({
-      roomMode: 'videoChat',
-      viewportWide: true,
-      tiles: [tile],
-    })
-    const video = container.querySelector(
-      'video.riffsync-room-page__participant-tile-video',
-    ) as HTMLVideoElement | null
-    expect(video?.srcObject).toBe(stream)
 
-    renderLayout({
-      roomMode: 'videoChat',
-      viewportWide: true,
-      tiles: [],
+    function assertTileRemoved(video: HTMLVideoElement | null) {
+      expect(container.querySelector('video.riffsync-room-page__participant-tile-video')).toBeNull()
+      expect(container.querySelector('figure[aria-label="Alice"]')).toBeNull()
+      expect(document.body.querySelector('figure[aria-label="Alice"]')).toBeNull()
+      expect(video?.srcObject).toBeNull()
+    }
+
+    it('removes remote tile from Video Chat grid when consumer detaches', () => {
+      renderLayout({
+        roomMode: 'videoChat',
+        viewportWide: true,
+        tiles: [remoteTile],
+      })
+      const video = container.querySelector(
+        'video.riffsync-room-page__participant-tile-video',
+      ) as HTMLVideoElement | null
+      expect(video?.srcObject).toBe(remoteTile.stream)
+      expect(container.querySelector('.riffsync-room-page__participant-grid')).not.toBeNull()
+
+      renderLayout({
+        roomMode: 'videoChat',
+        viewportWide: true,
+        tiles: [],
+      })
+      assertTileRemoved(video)
+      expect(container.textContent).toContain(VIDEO_CHAT_EMPTY_COPY)
     })
-    expect(container.querySelector('video.riffsync-room-page__participant-tile-video')).toBeNull()
-    expect(container.querySelector('figure[aria-label="Alice"]')).toBeNull()
-    expect(document.body.querySelector('figure[aria-label="Alice"]')).toBeNull()
-    expect(video?.srcObject).toBeNull()
+
+    it('removes remote tile from Theater desktop strip when consumer detaches', () => {
+      renderLayout({
+        roomMode: 'theater',
+        viewportWide: true,
+        tiles: [remoteTile],
+      })
+      const video = container.querySelector(
+        'video.riffsync-room-page__participant-tile-video',
+      ) as HTMLVideoElement | null
+      expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).not.toBeNull()
+
+      renderLayout({
+        roomMode: 'theater',
+        viewportWide: true,
+        tiles: [],
+      })
+      assertTileRemoved(video)
+      expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
+    })
+
+    it('removes remote tile from narrow horizontal row when consumer detaches', () => {
+      renderLayout({
+        roomMode: 'theater',
+        viewportWide: false,
+        tiles: [remoteTile],
+      })
+      const video = container.querySelector(
+        'video.riffsync-room-page__participant-tile-video',
+      ) as HTMLVideoElement | null
+      expect(container.querySelector('.riffsync-room-page__participant-row--narrow')).not.toBeNull()
+
+      renderLayout({
+        roomMode: 'theater',
+        viewportWide: false,
+        tiles: [],
+      })
+      assertTileRemoved(video)
+      expect(container.querySelector('.riffsync-room-page__participant-row--narrow')).toBeNull()
+    })
   })
 
   it('renders narrow horizontal row below primary on small viewport', () => {


### PR DESCRIPTION
## Summary

- Adds M19 ship gate regression tests in `StageParticipantLayout.test.tsx` that lock prompt tile removal and `srcObject` cleanup on consumer detach across Theater desktop strip, Video Chat grid, and narrow horizontal row.
- Verifies the #152 acceptance criteria against implementation already merged via peer **#142** (PR #223) and sub-issues **#188–#190**.
- Confirms **`PRODUCER_CLOSED`** remains tile-only UX (excluded from drawer banners and `activeErrorCodes`) per existing `realtimeDrawerErrors` and `RoomRealtimeSdk` tests.

Closes #152

## Test plan

- [x] `npm test --prefix apps/web -- --run src/room/stage/participantAvConsumers src/room/stage/stageParticipantTiles src/room/stage/ParticipantVideoTile src/room/stage/StageParticipantLayout`
- [x] `npm test --prefix apps/web -- --run src/room/realtimeDrawerErrors src/room/sessions/RoomRealtimeSdk`