### PR TITLE
[M21][#157] Client drawer logs — helper (#213), ChatSession (#214), SfuMediaSession (#215), produce/consume (#216)

### DIFF
--- a/apps/web/src/room/clientDrawerLog.test.ts
+++ b/apps/web/src/room/clientDrawerLog.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clientDrawerLogForbiddenKeys,
+  emitClientDrawerLog,
+  type ClientDrawerLogPayload,
+} from './clientDrawerLog'
+
+describe('clientDrawerLog', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function lastSerialized(spy: typeof infoSpy): Record<string, string> {
+    const call = spy.mock.calls.at(-1)
+    expect(call).toBeDefined()
+    return JSON.parse(String(call![0])) as Record<string, string>
+  }
+
+  it('serializes required drawer log fields as one JSON object', () => {
+    emitClientDrawerLog({
+      drawer: 'chat',
+      event: 'ws_open',
+      outcome: 'recovered',
+    })
+
+    expect(infoSpy).toHaveBeenCalledOnce()
+    expect(lastSerialized(infoSpy)).toEqual({
+      drawer: 'chat',
+      event: 'ws_open',
+      outcome: 'recovered',
+    })
+  })
+
+  it('includes code when present', () => {
+    emitClientDrawerLog({
+      drawer: 'chat',
+      event: 'send_dropped',
+      code: 'CHAT_SEND_DROPPED',
+      outcome: 'failed',
+    })
+
+    expect(warnSpy).toHaveBeenCalledOnce()
+    expect(lastSerialized(warnSpy)).toEqual({
+      drawer: 'chat',
+      event: 'send_dropped',
+      outcome: 'failed',
+      code: 'CHAT_SEND_DROPPED',
+    })
+  })
+
+  it('routes lifecycle logs without code to console.info', () => {
+    emitClientDrawerLog({
+      drawer: 'signaling',
+      event: 'signaling_connect',
+      outcome: 'retry',
+    })
+
+    expect(infoSpy).toHaveBeenCalledOnce()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes coded failures to console.warn by default', () => {
+    emitClientDrawerLog({
+      drawer: 'connectivity',
+      event: 'ice_failed',
+      code: 'ICE_FAILED',
+      outcome: 'failed',
+    })
+
+    expect(warnSpy).toHaveBeenCalledOnce()
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes explicit error severity to console.error', () => {
+    emitClientDrawerLog({
+      drawer: 'produce_consume',
+      event: 'mix_error',
+      code: 'THEATER_AUDIO_SUSPENDED',
+      outcome: 'failed',
+      severity: 'error',
+    })
+
+    expect(errorSpy).toHaveBeenCalledOnce()
+    expect(lastSerialized(errorSpy)).toEqual({
+      drawer: 'produce_consume',
+      event: 'mix_error',
+      outcome: 'failed',
+      code: 'THEATER_AUDIO_SUSPENDED',
+    })
+    expect(infoSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('allows info severity override when code is present', () => {
+    emitClientDrawerLog({
+      drawer: 'produce_consume',
+      event: 'producer_closed',
+      code: 'PRODUCER_CLOSED',
+      outcome: 'failed',
+      severity: 'info',
+    })
+
+    expect(infoSpy).toHaveBeenCalledOnce()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('never serializes forbidden identity or media keys', () => {
+    const extras: ClientDrawerLogPayload & Record<string, unknown> = {
+      drawer: 'chat',
+      event: 'ws_close',
+      outcome: 'retry',
+      roomId: 'room-secret',
+      sessionId: 'session-secret',
+      sub: 'fan-sub',
+      jwt: 'eyJhbGciOiJIUzI1NiJ9.test',
+      accessToken: 'token-secret',
+      sdp: 'v=0\r\no=-',
+      iceCandidate: 'candidate:1 1 UDP',
+    }
+
+    emitClientDrawerLog(extras)
+
+    const serialized = lastSerialized(infoSpy)
+    for (const key of clientDrawerLogForbiddenKeys) {
+      expect(serialized).not.toHaveProperty(key)
+    }
+    expect(Object.keys(serialized).sort()).toEqual(['drawer', 'event', 'outcome'])
+  })
+})

--- a/apps/web/src/room/clientDrawerLog.ts
+++ b/apps/web/src/room/clientDrawerLog.ts
@@ -1,0 +1,57 @@
+export type ClientDrawer = 'chat' | 'signaling' | 'connectivity' | 'produce_consume'
+
+export type ClientDrawerOutcome = 'retry' | 'failed' | 'recovered'
+
+export type ClientDrawerLogSeverity = 'info' | 'warn' | 'error'
+
+export type ClientDrawerLogPayload = {
+  drawer: ClientDrawer
+  event: string
+  outcome: ClientDrawerOutcome
+  code?: string
+  /** Overrides default level selection; never serialized to the log line. */
+  severity?: ClientDrawerLogSeverity
+}
+
+const FORBIDDEN_LOG_KEYS = new Set([
+  'roomId',
+  'sessionId',
+  'sub',
+  'jwt',
+  'accessToken',
+  'idToken',
+  'token',
+  'sdp',
+  'sdpOffer',
+  'sdpAnswer',
+  'iceCandidate',
+  'candidate',
+])
+
+function selectConsoleSink(payload: ClientDrawerLogPayload): typeof console.info {
+  if (payload.severity === 'error') return console.error
+  if (payload.severity === 'warn') return console.warn
+  if (payload.severity === 'info') return console.info
+  if (payload.code !== undefined && payload.code !== '') return console.warn
+  return console.info
+}
+
+function buildSerializedBody(payload: ClientDrawerLogPayload): Record<string, string> {
+  const body: Record<string, string> = {
+    drawer: payload.drawer,
+    event: payload.event,
+    outcome: payload.outcome,
+  }
+  if (payload.code !== undefined && payload.code !== '') {
+    body.code = payload.code
+  }
+  return body
+}
+
+/** Production drawer-tagged client diagnostics — one JSON object per console line. */
+export function emitClientDrawerLog(payload: ClientDrawerLogPayload & Record<string, unknown>): void {
+  const sink = selectConsoleSink(payload)
+  sink(JSON.stringify(buildSerializedBody(payload)))
+}
+
+export const clientDrawerLogForbiddenKeys = [...FORBIDDEN_LOG_KEYS] as const

--- a/apps/web/src/room/realtimeDiagnostics.test.ts
+++ b/apps/web/src/room/realtimeDiagnostics.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as clientDrawerLog from './clientDrawerLog'
+import {
+  clearRealtimeDiag,
+  getRealtimeDiagSnapshot,
+  recordOutboundDropped,
+} from './realtimeDiagnostics'
+
+vi.mock('./clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
+}))
+
+describe('recordOutboundDropped', () => {
+  beforeEach(() => {
+    clearRealtimeDiag()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('increments diag counters and timeline without riffsync-diag warn string', () => {
+    recordOutboundDropped({ action: 'chat', text: 'hi' }, 3)
+
+    const snapshot = getRealtimeDiagSnapshot()
+    expect(snapshot.outboundDropped).toEqual({
+      ping: 0,
+      chat: 1,
+      signaling: 0,
+      other: 0,
+    })
+    const timeline = snapshot.wsTimelineRecent as Array<{ ev: string; action?: string; readyState?: number }>
+    expect(timeline.at(-1)).toMatchObject({
+      ev: 'outbound_skipped',
+      action: 'chat',
+      readyState: 3,
+    })
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('emits drawer-tagged send_dropped log', () => {
+    recordOutboundDropped({ action: 'ping' }, -1)
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'chat',
+      event: 'send_dropped',
+      code: 'CHAT_SEND_DROPPED',
+      outcome: 'failed',
+    })
+  })
+})

--- a/apps/web/src/room/realtimeDiagnostics.ts
+++ b/apps/web/src/room/realtimeDiagnostics.ts
@@ -1,5 +1,7 @@
 /** Factual realtime / WebSocket diagnostics — no JWT bodies, no full SDP/candidates. Enable UI with **`?diag=1`** or call **`window.riffsyncRealtimeDiag.print()`**. */
 
+import { emitClientDrawerLog } from './clientDrawerLog'
+
 export type RealtimeInboundKind = 'chat' | 'signaling' | 'unknown' | 'parse_error'
 
 type WsTimelineEvent =
@@ -129,9 +131,11 @@ export function recordOutboundDropped(payload: Record<string, unknown>, readySta
     action: k,
     readyState,
   })
-  console.warn('[riffsync-diag] WebSocket outbound dropped (socket not OPEN)', {
-    action: k,
-    readyState,
+  emitClientDrawerLog({
+    drawer: 'chat',
+    event: 'send_dropped',
+    code: 'CHAT_SEND_DROPPED',
+    outcome: 'failed',
   })
 }
 

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -5,17 +5,25 @@ import {
   type ChatSessionStatus,
 } from './ChatSession'
 import { SfuMediaSession } from './SfuMediaSession'
+import * as clientDrawerLog from '../clientDrawerLog'
 import * as realtimeDiagnostics from '../realtimeDiagnostics'
 
-vi.mock('../realtimeDiagnostics', () => ({
-  recordInboundWsMessage: vi.fn(),
-  recordOutboundDropped: vi.fn(),
-  recordOutboundSent: vi.fn(),
-  recordWsClose: vi.fn(),
-  recordWsConnectAttempt: vi.fn(),
-  recordWsErrorEvent: vi.fn(),
-  recordWsOpen: vi.fn(),
+vi.mock('../clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
 }))
+
+vi.mock('../realtimeDiagnostics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../realtimeDiagnostics')>()
+  return {
+    ...actual,
+    recordInboundWsMessage: vi.fn(),
+    recordOutboundSent: vi.fn(),
+    recordWsClose: vi.fn(),
+    recordWsConnectAttempt: vi.fn(),
+    recordWsErrorEvent: vi.fn(),
+    recordWsOpen: vi.fn(),
+  }
+})
 
 const ROOM = 'room-abc'
 
@@ -127,7 +135,7 @@ describe('routeInboundChatMessage', () => {
 
 describe('ChatSession send', () => {
   beforeEach(() => {
-    vi.mocked(realtimeDiagnostics.recordOutboundDropped).mockClear()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
     vi.mocked(realtimeDiagnostics.recordOutboundSent).mockClear()
   })
 
@@ -135,10 +143,12 @@ describe('ChatSession send', () => {
     const session = new ChatSession()
     const dropped = session.send({ action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440002' })
     expect(dropped).toBe(false)
-    expect(realtimeDiagnostics.recordOutboundDropped).toHaveBeenCalledWith(
-      { action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440002' },
-      -1,
-    )
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'chat',
+      event: 'send_dropped',
+      code: 'CHAT_SEND_DROPPED',
+      outcome: 'failed',
+    })
     expect(realtimeDiagnostics.recordOutboundSent).not.toHaveBeenCalled()
     expect(session.getLastErrorCode()).toBe('CHAT_SEND_DROPPED')
   })
@@ -170,7 +180,7 @@ describe('ChatSession send', () => {
     const payload = { action: 'chat', text: 'hi', messageId: '550e8400-e29b-41d4-a716-446655440004' }
     expect(session.send(payload)).toBe(true)
     expect(realtimeDiagnostics.recordOutboundSent).toHaveBeenCalledWith(payload)
-    expect(realtimeDiagnostics.recordOutboundDropped).not.toHaveBeenCalled()
+    expect(clientDrawerLog.emitClientDrawerLog).not.toHaveBeenCalled()
 
     vi.unstubAllGlobals()
   })
@@ -208,6 +218,7 @@ describe('ChatSession lifecycle FSM', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     MockWebSocket.instances = []
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
     vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
     Object.assign(MockWebSocket, { OPEN: 1, CONNECTING: 0, CLOSING: 2, CLOSED: 3 })
   })
@@ -236,6 +247,35 @@ describe('ChatSession lifecycle FSM', () => {
     }
 
     expect(session.getLifecycleState()).toBe('degraded')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith(
+      expect.objectContaining({ drawer: 'chat', event: 'degraded_threshold', severity: 'warn' }),
+    )
+  })
+
+  it('emits drawer logs on ws close and reconnect schedule', () => {
+    const session = new ChatSession()
+    session.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-close-log',
+      accessToken: null,
+      enabled: true,
+    })
+
+    const ws = MockWebSocket.instances.at(-1)!
+    ws.emit('close', { code: 1006, reason: '' })
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'chat',
+      event: 'ws_close',
+      outcome: 'retry',
+      severity: 'warn',
+    })
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'chat',
+      event: 'reconnect_scheduled',
+      outcome: 'retry',
+    })
   })
 
   it('resets failed cycles and returns to connected after a successful open', () => {
@@ -258,6 +298,11 @@ describe('ChatSession lifecycle FSM', () => {
 
     expect(session.getLifecycleState()).toBe('connected')
     expect(session.getStatus()).toBe('open')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'chat',
+      event: 'reconnect_success',
+      outcome: 'recovered',
+    })
   })
 })
 

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -1,4 +1,5 @@
 import type { RoomMode } from '../../api/roomsApi'
+import { emitClientDrawerLog } from '../clientDrawerLog'
 import { parseInboundChatGifMessage, type InboundChatGifLine } from '../chatGifMessage'
 import { parseInboundChatMessageId } from '../chatMessageId'
 import { parseInboundRoomMode } from '../roomMediaLifecycle'
@@ -344,7 +345,16 @@ export class ChatSession {
 
   private setLifecycleState(next: ChatSessionLifecycleState): void {
     if (this.lifecycleState === next) return
+    const prev = this.lifecycleState
     this.lifecycleState = next
+    if (next === 'degraded' && prev !== 'degraded') {
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'degraded_threshold',
+        outcome: 'failed',
+        severity: 'warn',
+      })
+    }
     for (const listener of this.lifecycleListeners) listener(next)
   }
 
@@ -442,6 +452,11 @@ export class ChatSession {
     }
     const wsUrlBase = `${opts.url}?${qp.toString()}`
     recordWsConnectAttempt(wsUrlBase, Boolean(opts.accessToken))
+    emitClientDrawerLog({
+      drawer: 'chat',
+      event: 'ws_connect_attempt',
+      outcome: 'retry',
+    })
     if (webrtcDebugEnabled()) {
       webrtcLog('ws opening', {
         urlChars: wsUrlBase.length,
@@ -462,12 +477,25 @@ export class ChatSession {
 
     ws.addEventListener('open', () => {
       if (this.cancelled || this.ws !== ws) return
+      const recoveredFromReconnect = this.failedReconnectCycles > 0
       this.backoffMs = CHAT_RECONNECT_BACKOFF_INITIAL_MS
       this.failedReconnectCycles = 0
       this.lastErrorCode = undefined
       this.setStatus('open')
       this.setLifecycleState('connected')
       recordWsOpen()
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'ws_open',
+        outcome: 'recovered',
+      })
+      if (recoveredFromReconnect) {
+        emitClientDrawerLog({
+          drawer: 'chat',
+          event: 'reconnect_success',
+          outcome: 'recovered',
+        })
+      }
       if (webrtcDebugEnabled()) webrtcLog('ws open')
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ action: 'presence_request' }))
@@ -497,6 +525,12 @@ export class ChatSession {
       this.clearPing()
       this.ws = null
       recordWsClose(ev.code, ev.reason !== '' ? ev.reason : undefined)
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'ws_close',
+        outcome: 'retry',
+        severity: 'warn',
+      })
       if (!this.cancelled && webrtcDebugEnabled()) {
         webrtcLog('ws close', {
           code: ev.code,
@@ -513,6 +547,11 @@ export class ChatSession {
       this.setLifecycleState(chatLifecycleAfterFailedCycle(this.failedReconnectCycles))
       const { delayMs, nextBackoffMs } = nextChatReconnectBackoffMs(this.backoffMs)
       this.backoffMs = nextBackoffMs
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'reconnect_scheduled',
+        outcome: 'retry',
+      })
       this.reconnectTimer = globalThis.setTimeout(() => {
         this.reconnectTimer = null
         this.openSocket()
@@ -522,6 +561,12 @@ export class ChatSession {
     ws.addEventListener('error', () => {
       if (this.cancelled || this.ws !== ws) return
       recordWsErrorEvent()
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'ws_error',
+        outcome: 'failed',
+        severity: 'warn',
+      })
       if (webrtcDebugEnabled()) webrtcLog('ws error event')
       this.setStatus('error')
       if (this.enabled) {

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import { SfuTokenHttpError } from '../av/participantAvErrors'
-import { connectSfuUnifiedSession, type SfuConsumerTrackEvent, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
+import { connectSfuUnifiedSession, type SfuConsumerTrackEvent, type SfuMediaErrorCode, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
 import { createParticipantAvController } from '../sfu/participantAvSession'
 import { LOCAL_SFU_UNREACHABLE_MSG } from '../sfu/sfuConfigErrors'
 import { nextSfuReconnectDelayMs } from '../sfu/sfuReconnectPolicy'
@@ -639,7 +639,7 @@ describe('SfuMediaSession signaling drawer logs', () => {
 
 describe('SfuMediaSession produce/consume drawer logs', () => {
   let capturedOnConsumerTrack: ((event: SfuConsumerTrackEvent) => void) | undefined
-  let capturedOnMediaError: ((code: string, message: string) => void) | undefined
+  let capturedOnMediaError: ((code: SfuMediaErrorCode, message: string) => void) | undefined
 
   beforeEach(() => {
     vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -14,6 +14,11 @@ import {
   SfuMediaSession,
   startSfuRoomSession,
 } from './SfuMediaSession'
+import * as clientDrawerLog from '../clientDrawerLog'
+
+vi.mock('../clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
+}))
 
 vi.mock('../../api/webrtcSfuApi', () => ({
   fetchSfuJoinToken: vi.fn(),
@@ -432,6 +437,205 @@ function attachMockSessionHandle(
     }
   ).sessionHandle = handle
 }
+
+describe('SfuMediaSession signaling drawer logs', () => {
+  beforeEach(() => {
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits signaling_connect on reconnect loop start', async () => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => mockSfuUnifiedSessionHandle())
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-log',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+        drawer: 'signaling',
+        event: 'signaling_connect',
+        outcome: 'retry',
+      })
+    })
+
+    session.disconnect()
+  })
+
+  it('emits signaling_close and signaling_reconnect_scheduled when session ends', async () => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ...mockSfuUnifiedSessionHandle(),
+      sessionEnded: Promise.resolve('signaling_close'),
+    }))
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-close-log',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+        drawer: 'signaling',
+        event: 'signaling_close',
+        outcome: 'retry',
+        severity: 'warn',
+      })
+    })
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'signaling',
+      event: 'signaling_reconnect_scheduled',
+      outcome: 'retry',
+    })
+
+    session.disconnect()
+  })
+
+  it('emits signaling_reconnect_success after a prior failed cycle', async () => {
+    let connectCall = 0
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => {
+      connectCall += 1
+      if (connectCall === 1) {
+        return {
+          ...mockSfuUnifiedSessionHandle(),
+          sessionEnded: Promise.resolve('signaling_close'),
+        }
+      }
+      return mockSfuUnifiedSessionHandle()
+    })
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-recover-log',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => connectCall >= 2)
+    await vi.waitFor(() => {
+      expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+        drawer: 'signaling',
+        event: 'signaling_reconnect_success',
+        outcome: 'recovered',
+      })
+    })
+
+    session.disconnect()
+  })
+
+  it('emits token_denied on JWT remint failure', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 120
+    const token = fakeJwt({ exp })
+    let fetchCalls = 0
+    vi.mocked(fetchSfuJoinToken).mockImplementation(async () => {
+      fetchCalls += 1
+      if (fetchCalls === 1) {
+        return {
+          token,
+          role: 'consumer' as const,
+          wsUrl: 'ws://127.0.0.1:3000',
+          expiresInSeconds: 120,
+        }
+      }
+      throw new SfuTokenHttpError(403, { code: 'av_disabled', error: 'denied' })
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => mockSfuUnifiedSessionHandle())
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-token-log',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => expect(session.getLifecycleState()).toBe('connected'))
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    await (
+      session as unknown as { remintJoinToken: () => Promise<void> }
+    ).remintJoinToken()
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'signaling',
+      event: 'token_denied',
+      code: 'SFU_TOKEN_DENIED',
+      outcome: 'failed',
+    })
+
+    session.disconnect()
+  })
+
+  it('uses signaling drawer label, not chat', async () => {
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async () => ({
+      ...mockSfuUnifiedSessionHandle(),
+      sessionEnded: Promise.resolve('signaling_close'),
+    }))
+
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-drawer-label',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalled()
+    })
+
+    for (const call of vi.mocked(clientDrawerLog.emitClientDrawerLog).mock.calls) {
+      expect(call[0]?.drawer).toBe('signaling')
+    }
+
+    session.disconnect()
+  })
+})
 
 describe('SfuMediaSession drawer errors', () => {
   it('emits typed drawer errors for config-class signaling failures', async () => {

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import { SfuTokenHttpError } from '../av/participantAvErrors'
-import { connectSfuUnifiedSession, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
+import { connectSfuUnifiedSession, type SfuConsumerTrackEvent, type SfuSessionEndReason } from '../sfu/mediasoupSharing'
 import { createParticipantAvController } from '../sfu/participantAvSession'
 import { LOCAL_SFU_UNREACHABLE_MSG } from '../sfu/sfuConfigErrors'
 import { nextSfuReconnectDelayMs } from '../sfu/sfuReconnectPolicy'
@@ -632,6 +632,139 @@ describe('SfuMediaSession signaling drawer logs', () => {
     for (const call of vi.mocked(clientDrawerLog.emitClientDrawerLog).mock.calls) {
       expect(call[0]?.drawer).toBe('signaling')
     }
+
+    session.disconnect()
+  })
+})
+
+describe('SfuMediaSession produce/consume drawer logs', () => {
+  let capturedOnConsumerTrack: ((event: SfuConsumerTrackEvent) => void) | undefined
+  let capturedOnMediaError: ((code: string, message: string) => void) | undefined
+
+  beforeEach(() => {
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+    capturedOnConsumerTrack = undefined
+    capturedOnMediaError = undefined
+    vi.mocked(fetchSfuJoinToken).mockResolvedValue({
+      token: 'tok',
+      role: 'consumer',
+      wsUrl: 'ws://127.0.0.1:3000',
+    })
+    vi.mocked(connectSfuUnifiedSession).mockImplementation(async (opts) => {
+      capturedOnConsumerTrack = opts.onConsumerTrack
+      capturedOnMediaError = opts.onMediaError
+      return mockSfuUnifiedSessionHandle()
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function connectSession(): Promise<SfuMediaSession> {
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-produce-consume',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+    await vi.waitFor(() => expect(capturedOnConsumerTrack).toBeDefined())
+    return session
+  }
+
+  it('emits producer_closed at INFO when participant_av video consumer detaches', async () => {
+    const session = await connectSession()
+    const track = { id: 'v1' } as MediaStreamTrack
+
+    capturedOnConsumerTrack?.({
+      action: 'attach',
+      producerId: 'tile-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+      track,
+    })
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+    capturedOnConsumerTrack?.({ action: 'detach', producerId: 'tile-1' })
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'producer_closed',
+      code: 'PRODUCER_CLOSED',
+      outcome: 'failed',
+      severity: 'info',
+    })
+
+    session.disconnect()
+  })
+
+  it('does not emit producer_closed for host_screen or audio-only detach', async () => {
+    const session = await connectSession()
+    const track = { id: 'a1' } as MediaStreamTrack
+
+    capturedOnConsumerTrack?.({
+      action: 'attach',
+      producerId: 'host-1',
+      producerClass: 'host_screen',
+      kind: 'video',
+      track,
+    })
+    capturedOnConsumerTrack?.({
+      action: 'attach',
+      producerId: 'mic-1',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      track,
+    })
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+    capturedOnConsumerTrack?.({ action: 'detach', producerId: 'host-1' })
+    capturedOnConsumerTrack?.({ action: 'detach', producerId: 'mic-1' })
+
+    const produceConsumeCalls = vi
+      .mocked(clientDrawerLog.emitClientDrawerLog)
+      .mock.calls.filter((call) => call[0]?.drawer === 'produce_consume')
+    expect(produceConsumeCalls).toHaveLength(0)
+
+    session.disconnect()
+  })
+
+  it('emits transport_limit and consumer_limit on cap failures', async () => {
+    const session = await connectSession()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    capturedOnMediaError?.('produce_failed', 'transport limit reached')
+    capturedOnMediaError?.('consume_failed', 'consumer limit reached')
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'transport_limit',
+      code: 'TRANSPORT_LIMIT_REACHED',
+      outcome: 'failed',
+    })
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'consumer_limit',
+      code: 'CONSUMER_LIMIT_REACHED',
+      outcome: 'failed',
+    })
+
+    session.disconnect()
+  })
+
+  it('emits consumer_attach_failed for non-limit consume errors', async () => {
+    const session = await connectSession()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    capturedOnMediaError?.('consume_failed', 'consume failed on device')
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'consumer_attach_failed',
+      outcome: 'failed',
+    })
 
     session.disconnect()
   })

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -34,6 +34,7 @@ import {
   type RealtimeDrawerError,
   type RealtimeDrawerErrorCode,
 } from '../realtimeDrawerErrors'
+import { emitClientDrawerLog } from '../clientDrawerLog'
 import { sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
 import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 
@@ -616,6 +617,11 @@ export class SfuMediaSession {
       assignSession: (s) => {
         this.sessionHandle = s
         if (s) {
+          emitClientDrawerLog({
+            drawer: 'signaling',
+            event: 'signaling_open',
+            outcome: 'recovered',
+          })
           this.setStatus('open')
           this.setLifecycleState('connected')
         }
@@ -643,6 +649,11 @@ export class SfuMediaSession {
       onConnecting: () => {
         this.emitError(null)
         this.emitDrawerError(null)
+        emitClientDrawerLog({
+          drawer: 'signaling',
+          event: 'signaling_connect',
+          outcome: 'retry',
+        })
         this.setStatus('connecting')
         this.setLifecycleState(
           this.failedReconnectCycles > 0
@@ -651,12 +662,20 @@ export class SfuMediaSession {
         )
       },
       onSessionReady: () => {
+        const recoveredFromReconnect = this.failedReconnectCycles > 0
         this.emitError(null)
         this.emitDrawerError(null)
         this.failedReconnectCycles = 0
         this.lastErrorCode = undefined
         this.setStatus('open')
         this.setLifecycleState('connected')
+        if (recoveredFromReconnect) {
+          emitClientDrawerLog({
+            drawer: 'signaling',
+            event: 'signaling_reconnect_success',
+            outcome: 'recovered',
+          })
+        }
         if (this.lastMintedToken) {
           this.scheduleJwtRemint(this.lastMintedToken, this.lastMintedExpiresInSeconds)
         }
@@ -669,6 +688,17 @@ export class SfuMediaSession {
         this.clearJwtRemintTimer()
         this.sessionHandle = null
         if (this.enabled && generation === this.tokenIntentGeneration) {
+          emitClientDrawerLog({
+            drawer: 'signaling',
+            event: 'signaling_close',
+            outcome: 'retry',
+            severity: 'warn',
+          })
+          emitClientDrawerLog({
+            drawer: 'signaling',
+            event: 'signaling_reconnect_scheduled',
+            outcome: 'retry',
+          })
           this.failedReconnectCycles += 1
           const lifecycle = sfuLifecycleAfterFailedCycle(this.failedReconnectCycles)
           this.setStatus(lifecycle === 'degraded' ? 'degraded' : 'reconnecting')
@@ -734,6 +764,12 @@ export class SfuMediaSession {
     } catch (cause) {
       const drawerError = mapSfuTokenDeniedError(cause)
       this.lastErrorCode = drawerError.code
+      emitClientDrawerLog({
+        drawer: 'signaling',
+        event: 'token_denied',
+        code: drawerError.code,
+        outcome: 'failed',
+      })
       this.emitDrawerError(drawerError)
       this.setStatus('degraded')
       this.setLifecycleState('degraded')
@@ -748,7 +784,16 @@ export class SfuMediaSession {
 
   private setLifecycleState(next: SfuMediaSessionLifecycleState): void {
     if (this.lifecycleState === next) return
+    const prev = this.lifecycleState
     this.lifecycleState = next
+    if (next === 'degraded' && prev !== 'degraded') {
+      emitClientDrawerLog({
+        drawer: 'signaling',
+        event: 'signaling_degraded',
+        outcome: 'failed',
+        severity: 'warn',
+      })
+    }
     for (const listener of this.lifecycleListeners) listener(next)
   }
 

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -15,6 +15,11 @@ import {
   type SfuProducerClass,
   type SfuUnifiedSessionHandle,
 } from '../sfu/mediasoupSharing'
+import {
+  emitPartialUnpublishDrawerLog,
+  emitProduceConsumeMediaErrorLog,
+  emitProducerClosedDrawerLog,
+} from '../sfu/produceConsumeDrawerLog'
 import { classifySignalingOpenFailure, type SfuConfigMediaErrorCode } from '../sfu/sfuConfigErrors'
 import {
   createBoundParticipantAvController,
@@ -381,6 +386,10 @@ export class SfuMediaSession {
 
   private remoteStreamListeners = new Set<Listener<MediaStream | null>>()
   private consumerTrackListeners = new Set<Listener<SfuConsumerTrackEvent>>()
+  private readonly attachedConsumerMeta = new Map<
+    string,
+    { producerClass: SfuProducerClass | undefined; kind: 'audio' | 'video' }
+  >()
   private lastRemoteStream: MediaStream | null = null
   private errorListeners = new Set<Listener<string | null>>()
   private drawerErrorListeners = new Set<Listener<RealtimeDrawerError | null>>()
@@ -389,7 +398,9 @@ export class SfuMediaSession {
   private participantAvConsumerClearListeners = new Set<Listener<void>>()
 
   constructor() {
-    this.participantAv = createBoundParticipantAvController(() => this.gate)
+    this.participantAv = createBoundParticipantAvController(() => this.gate, {
+      onPartialUnpublish: () => emitPartialUnpublishDrawerLog(),
+    })
     this.gate.onNeedsProducerTokenChange = () => this.onNeedsProducerTokenChange()
   }
 
@@ -487,6 +498,7 @@ export class SfuMediaSession {
     this.clearJwtRemintTimer()
     this.stopReconnectLoop()
     this.sessionHandle?.unpublishProducerClass('host_screen')
+    this.attachedConsumerMeta.clear()
     this.emitRemoteStream(null)
     this.failedReconnectCycles = 0
     this.lastErrorCode = undefined
@@ -578,6 +590,22 @@ export class SfuMediaSession {
     }
   }
 
+  private dispatchConsumerTrack(event: SfuConsumerTrackEvent): void {
+    if (event.action === 'attach') {
+      this.attachedConsumerMeta.set(event.producerId, {
+        producerClass: event.producerClass,
+        kind: event.kind,
+      })
+    } else {
+      const meta = this.attachedConsumerMeta.get(event.producerId)
+      this.attachedConsumerMeta.delete(event.producerId)
+      if (meta?.producerClass === 'participant_av' && meta.kind === 'video') {
+        emitProducerClosedDrawerLog()
+      }
+    }
+    for (const listener of this.consumerTrackListeners) listener(event)
+  }
+
   private onNeedsProducerTokenChange(): void {
     if (this.sessionHandle?.supportsPublish) return
     this.tokenIntentGeneration++
@@ -611,9 +639,7 @@ export class SfuMediaSession {
       getHostScreenStream: opts.getHostScreenStream,
       participantAv: this.participantAv,
       onRemoteStream: (stream) => this.emitRemoteStream(stream),
-      onConsumerTrack: (event) => {
-        for (const listener of this.consumerTrackListeners) listener(event)
-      },
+      onConsumerTrack: (event) => this.dispatchConsumerTrack(event),
       assignSession: (s) => {
         this.sessionHandle = s
         if (s) {
@@ -632,6 +658,9 @@ export class SfuMediaSession {
       },
       onTokenError: (msg) => this.emitError(msg),
       onMediaError: (code, msg) => {
+        if (code === 'consume_failed' || code === 'produce_failed') {
+          emitProduceConsumeMediaErrorLog(code, msg)
+        }
         const drawerError = mapSfuMediaCodeToDrawerError(code)
         if (isSfuRelayConfigErrorCode(code)) {
           this.emitDrawerError(drawerError)
@@ -687,6 +716,7 @@ export class SfuMediaSession {
       onSessionClean: () => {
         this.clearJwtRemintTimer()
         this.sessionHandle = null
+        this.attachedConsumerMeta.clear()
         if (this.enabled && generation === this.tokenIntentGeneration) {
           emitClientDrawerLog({
             drawer: 'signaling',

--- a/apps/web/src/room/sessions/TheaterPlayback.test.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTheaterAudioMix } from '../audio/theaterAudioMix'
 import { TheaterPlayback } from './TheaterPlayback'
 import type { SfuMediaSession } from './SfuMediaSession'
+import * as clientDrawerLog from '../clientDrawerLog'
+
+vi.mock('../clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
+}))
 
 vi.mock('../audio/theaterAudioMix', () => ({
   createTheaterAudioMix: vi.fn(),
@@ -58,6 +63,7 @@ function makeStream(tracks: MediaStreamTrack[]): MediaStream {
 describe('TheaterPlayback', () => {
   beforeEach(() => {
     vi.mocked(createTheaterAudioMix).mockReset()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
   })
 
   afterEach(() => {
@@ -239,6 +245,45 @@ describe('TheaterPlayback', () => {
 
     expect(playback.getLifecycleState()).toBe('degraded')
     expect(playback.getLastErrorCode()).toBe('THEATER_AUDIO_SUSPENDED')
+    playback.dispose()
+  })
+
+  it('emits mix_error on produce_consume drawer for theater audio graph failures', async () => {
+    const suspendedMix = makeMixMock({
+      getAudioContextState: vi.fn().mockReturnValue('suspended' as AudioContextState),
+    })
+    vi.mocked(createTheaterAudioMix).mockReturnValue(suspendedMix)
+    const suspendedPlayback = new TheaterPlayback()
+    suspendedPlayback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'mix_error',
+      code: 'THEATER_AUDIO_SUSPENDED',
+      outcome: 'failed',
+    })
+    suspendedPlayback.dispose()
+
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    const runningMix = makeMixMock()
+    vi.mocked(createTheaterAudioMix).mockReturnValue(runningMix)
+    const playback = new TheaterPlayback()
+    playback.configure({ enabled: true, isPublisher: false, avDisabled: false })
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    const video = makeVideoElement(() => Promise.reject(new Error('autoplay blocked')))
+    playback.setGuestVideoElement(video)
+    playback.setGuestRemote(makeStream([makeTrack('video')]))
+    await Promise.resolve()
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'mix_error',
+      code: 'PLAYBACK_AUDIO_BLOCKED',
+      outcome: 'failed',
+    })
+
     playback.dispose()
   })
 

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -10,6 +10,7 @@ import {
   theaterAudioSuspendedError,
   type RealtimeDrawerErrorCode,
 } from '../realtimeDrawerErrors'
+import { emitMixErrorDrawerLog } from '../sfu/produceConsumeDrawerLog'
 import type { SfuMediaSession } from './SfuMediaSession'
 
 /** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
@@ -303,7 +304,16 @@ export class TheaterPlayback {
     next: TheaterPlaybackLifecycleState,
     errorCode: RealtimeDrawerErrorCode | undefined,
   ): void {
+    const prevCode = this.lastErrorCode
     this.lastErrorCode = errorCode
+    if (
+      next === 'degraded' &&
+      errorCode &&
+      errorCode !== prevCode &&
+      (errorCode === 'THEATER_AUDIO_SUSPENDED' || errorCode === 'PLAYBACK_AUDIO_BLOCKED')
+    ) {
+      emitMixErrorDrawerLog(errorCode)
+    }
     if (this.lifecycleState === next) return
     this.lifecycleState = next
     for (const listener of this.lifecycleListeners) listener(next)

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -6,6 +6,7 @@ import type {
   RtpParameters,
 } from 'mediasoup-client/types'
 import { getPublicSfuWsUrl } from '../../config/sfuWsUrl'
+import { attachTransportConnectivityDrawerLog } from './transportConnectivityDrawerLog'
 
 export type SfuTokenResponse = {
   token: string
@@ -547,6 +548,7 @@ export async function connectSfuUnifiedSession(options: {
           finish(r)
         }),
       )
+      unwatchFns.push(attachTransportConnectivityDrawerLog(recvTransport, iceServers))
 
       recvTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
         void signaling
@@ -696,6 +698,7 @@ export async function connectSfuUnifiedSession(options: {
           finish(r)
         }),
       )
+      unwatchFns.push(attachTransportConnectivityDrawerLog(sendTransport, iceServers))
 
       sendTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
         void signaling

--- a/apps/web/src/room/sfu/participantAvSession.test.ts
+++ b/apps/web/src/room/sfu/participantAvSession.test.ts
@@ -334,6 +334,56 @@ describe('createParticipantAvController', () => {
     vi.unstubAllGlobals()
   })
 
+  it('invokes onPartialUnpublish when camera turns off while mic stays on (#216)', async () => {
+    const onPartialUnpublish = vi.fn()
+    const unpublishProducerKind = vi.fn()
+    const unpublishProducerClass = vi.fn()
+    const publishStream = vi.fn().mockResolvedValue(undefined)
+    const videoTrack = { kind: 'video', readyState: 'live', stop: vi.fn(), id: 'v1' }
+    const audioTrack = { kind: 'audio', readyState: 'live', stop: vi.fn(), id: 'a1' }
+    const stream = {
+      getVideoTracks: () => [videoTrack],
+      getAudioTracks: () => [audioTrack],
+      getTracks: () => [videoTrack, audioTrack],
+      removeTrack: vi.fn(),
+    } as unknown as MediaStream
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+    })
+
+    const controller = createParticipantAvController({
+      canPublish: () => true,
+      onPartialUnpublish,
+    })
+    const session = {
+      supportsPublish: true,
+      ready: Promise.resolve(),
+      publishStream,
+      unpublishProducerKind,
+      unpublishProducerClass,
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+    } as unknown as import('./mediasoupSharing').SfuUnifiedSessionHandle
+
+    await controller.enableCamera()
+    await controller.enableMic()
+    controller.attachSession(session)
+    await vi.waitFor(() => {
+      expect(publishStream).toHaveBeenCalled()
+    })
+
+    onPartialUnpublish.mockClear()
+    controller.disableCamera()
+
+    expect(onPartialUnpublish).toHaveBeenCalledOnce()
+    expect(unpublishProducerKind).toHaveBeenCalledWith('participant_av', 'video')
+
+    vi.unstubAllGlobals()
+  })
+
   it('disableMic with camera on unpublishes audio kind only', async () => {
     const unpublishProducerKind = vi.fn()
     const unpublishProducerClass = vi.fn()

--- a/apps/web/src/room/sfu/participantAvSession.ts
+++ b/apps/web/src/room/sfu/participantAvSession.ts
@@ -53,6 +53,8 @@ export type ParticipantAvController = {
 export function createParticipantAvController(options: {
   canPublish: () => boolean
   onNeedsProducerTokenChange?: () => void
+  /** Camera off while mic remains — partial unpublish telemetry (#216). */
+  onPartialUnpublish?: () => void
 }): ParticipantAvController {
   let cameraEnabled = false
   let micEnabled = false
@@ -263,12 +265,16 @@ export function createParticipantAvController(options: {
     },
     disableCamera: () => {
       if (!cameraEnabled) return
+      const micStaysOn = micEnabled
       cameraEnabled = false
       if (!micEnabled) {
         session?.unpublishProducerClass('participant_av')
         stopLocalTracks()
         options.onNeedsProducerTokenChange?.()
       } else if (localStream) {
+        if (micStaysOn) {
+          options.onPartialUnpublish?.()
+        }
         for (const track of localStream.getVideoTracks()) {
           try {
             track.stop()
@@ -359,6 +365,7 @@ export type ParticipantAvPublishGate = {
 
 export function createBoundParticipantAvController(
   readGate: () => ParticipantAvPublishGate,
+  hooks?: { onPartialUnpublish?: () => void },
 ): ParticipantAvController {
   return createParticipantAvController({
     canPublish: () => {
@@ -369,5 +376,6 @@ export function createBoundParticipantAvController(
       })
     },
     onNeedsProducerTokenChange: () => readGate().onNeedsProducerTokenChange?.(),
+    onPartialUnpublish: hooks?.onPartialUnpublish,
   })
 }

--- a/apps/web/src/room/sfu/produceConsumeDrawerLog.test.ts
+++ b/apps/web/src/room/sfu/produceConsumeDrawerLog.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as clientDrawerLog from '../clientDrawerLog'
+import {
+  emitConsumerAttachFailedDrawerLog,
+  emitConsumerLimitDrawerLog,
+  emitProduceConsumeMediaErrorLog,
+  emitProducerClosedDrawerLog,
+  emitTransportLimitDrawerLog,
+} from './produceConsumeDrawerLog'
+
+vi.mock('../clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
+}))
+
+describe('produceConsumeDrawerLog', () => {
+  beforeEach(() => {
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits producer_closed at INFO with PRODUCER_CLOSED', () => {
+    emitProducerClosedDrawerLog()
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'producer_closed',
+      code: 'PRODUCER_CLOSED',
+      outcome: 'failed',
+      severity: 'info',
+    })
+  })
+
+  it('maps transport limit messages to transport_limit', () => {
+    emitProduceConsumeMediaErrorLog('produce_failed', 'transport limit reached')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'transport_limit',
+      code: 'TRANSPORT_LIMIT_REACHED',
+      outcome: 'failed',
+    })
+  })
+
+  it('maps consumer limit messages to consumer_limit', () => {
+    emitProduceConsumeMediaErrorLog('consume_failed', 'consumer limit reached')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'consumer_limit',
+      code: 'CONSUMER_LIMIT_REACHED',
+      outcome: 'failed',
+    })
+  })
+
+  it('maps other consume failures to consumer_attach_failed', () => {
+    emitProduceConsumeMediaErrorLog('consume_failed', 'consume failed on device')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'produce_consume',
+      event: 'consumer_attach_failed',
+      outcome: 'failed',
+    })
+  })
+
+  it('skips benign host stream ended consume failures', () => {
+    emitProduceConsumeMediaErrorLog('consume_failed', 'Host stream ended; waiting for share.')
+    expect(clientDrawerLog.emitClientDrawerLog).not.toHaveBeenCalled()
+  })
+
+  it('emits typed codes on direct limit helpers', () => {
+    emitTransportLimitDrawerLog()
+    emitConsumerLimitDrawerLog()
+    emitConsumerAttachFailedDrawerLog('CONSUMER_LIMIT_REACHED')
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'transport_limit', code: 'TRANSPORT_LIMIT_REACHED' }),
+    )
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'consumer_limit', code: 'CONSUMER_LIMIT_REACHED' }),
+    )
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'consumer_attach_failed', code: 'CONSUMER_LIMIT_REACHED' }),
+    )
+  })
+})

--- a/apps/web/src/room/sfu/produceConsumeDrawerLog.ts
+++ b/apps/web/src/room/sfu/produceConsumeDrawerLog.ts
@@ -1,0 +1,73 @@
+import { emitClientDrawerLog } from '../clientDrawerLog'
+import type { SfuMediaErrorCode } from './mediasoupSharing'
+
+export function emitProducerClosedDrawerLog(): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'producer_closed',
+    code: 'PRODUCER_CLOSED',
+    outcome: 'failed',
+    severity: 'info',
+  })
+}
+
+export function emitPartialUnpublishDrawerLog(): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'partial_unpublish',
+    outcome: 'retry',
+    severity: 'info',
+  })
+}
+
+export function emitConsumerAttachFailedDrawerLog(code?: string): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'consumer_attach_failed',
+    outcome: 'failed',
+    ...(code ? { code } : {}),
+  })
+}
+
+export function emitTransportLimitDrawerLog(): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'transport_limit',
+    code: 'TRANSPORT_LIMIT_REACHED',
+    outcome: 'failed',
+  })
+}
+
+export function emitConsumerLimitDrawerLog(): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'consumer_limit',
+    code: 'CONSUMER_LIMIT_REACHED',
+    outcome: 'failed',
+  })
+}
+
+export function emitMixErrorDrawerLog(code: string): void {
+  emitClientDrawerLog({
+    drawer: 'produce_consume',
+    event: 'mix_error',
+    code,
+    outcome: 'failed',
+  })
+}
+
+/** Classify SFU media errors into produce/consume drawer logs (caps and attach failures). */
+export function emitProduceConsumeMediaErrorLog(code: SfuMediaErrorCode, message: string): void {
+  const lower = message.toLowerCase()
+  if (lower.includes('transport limit reached')) {
+    emitTransportLimitDrawerLog()
+    return
+  }
+  if (lower.includes('consumer limit reached')) {
+    emitConsumerLimitDrawerLog()
+    return
+  }
+  if (code !== 'consume_failed') return
+  if (lower.includes('gone') || lower.includes('host stream ended')) return
+  emitConsumerAttachFailedDrawerLog()
+}

--- a/apps/web/src/room/sfu/transportConnectivityDrawerLog.test.ts
+++ b/apps/web/src/room/sfu/transportConnectivityDrawerLog.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as clientDrawerLog from '../clientDrawerLog'
+import { ICE_DISCONNECTED_FAILURE_MS } from '../realtimeDrawerErrors'
+import {
+  attachTransportConnectivityDrawerLog,
+  iceServersRequireTurn,
+  localDescriptionHasRelayCandidate,
+} from './transportConnectivityDrawerLog'
+
+vi.mock('../clientDrawerLog', () => ({
+  emitClientDrawerLog: vi.fn(),
+}))
+
+type PcListener = () => void
+
+class MockPeerConnection {
+  iceConnectionState: RTCIceConnectionState = 'new'
+  iceGatheringState: RTCIceGatheringState = 'new'
+  connectionState: RTCPeerConnectionState = 'new'
+  signalingState: RTCSignalingState = 'stable'
+  localDescription: RTCSessionDescription | null = null
+  private listeners = new Map<string, Set<PcListener>>()
+
+  addEventListener(type: string, fn: PcListener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
+    this.listeners.get(type)!.add(fn)
+  }
+
+  removeEventListener(type: string, fn: PcListener) {
+    this.listeners.get(type)?.delete(fn)
+  }
+
+  emit(type: string) {
+    for (const fn of this.listeners.get(type) ?? []) fn()
+  }
+
+  setIceConnectionState(state: RTCIceConnectionState) {
+    this.iceConnectionState = state
+    this.emit('iceconnectionstatechange')
+  }
+
+  setIceGatheringState(state: RTCIceGatheringState) {
+    this.iceGatheringState = state
+    this.emit('icegatheringstatechange')
+  }
+}
+
+function mockTransport(pc: MockPeerConnection) {
+  return {
+    _handler: { _pc: pc as unknown as RTCPeerConnection },
+  }
+}
+
+describe('iceServersRequireTurn', () => {
+  it('detects turn and turns URLs', () => {
+    expect(iceServersRequireTurn([{ urls: 'stun:stun.test' }])).toBe(false)
+    expect(iceServersRequireTurn([{ urls: 'turn:turn.test:3478' }])).toBe(true)
+    expect(iceServersRequireTurn([{ urls: ['stun:stun.test', 'turns:turn.test:5349'] }])).toBe(true)
+  })
+})
+
+describe('localDescriptionHasRelayCandidate', () => {
+  it('matches relay typ lines in SDP', () => {
+    const pc = { localDescription: { sdp: 'a=candidate:1 1 udp typ relay raddr 1.2.3.4' } } as RTCPeerConnection
+    expect(localDescriptionHasRelayCandidate(pc)).toBe(true)
+    expect(
+      localDescriptionHasRelayCandidate({ localDescription: { sdp: 'a=candidate:1 host' } } as RTCPeerConnection),
+    ).toBe(false)
+  })
+})
+
+describe('attachTransportConnectivityDrawerLog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('emits ice_failed when ICE connection state is failed', () => {
+    const pc = new MockPeerConnection()
+    const detach = attachTransportConnectivityDrawerLog(
+      mockTransport(pc) as never,
+      [{ urls: 'stun:stun.test' }],
+    )
+
+    pc.setIceConnectionState('failed')
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'connectivity',
+      event: 'ice_failed',
+      code: 'ICE_FAILED',
+      outcome: 'failed',
+    })
+
+    detach()
+  })
+
+  it('emits ice_failed after disconnected grace elapses', () => {
+    const pc = new MockPeerConnection()
+    attachTransportConnectivityDrawerLog(mockTransport(pc) as never, [{ urls: 'stun:stun.test' }])
+
+    pc.setIceConnectionState('disconnected')
+    expect(clientDrawerLog.emitClientDrawerLog).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(ICE_DISCONNECTED_FAILURE_MS)
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'connectivity',
+      event: 'ice_failed',
+      code: 'ICE_FAILED',
+      outcome: 'failed',
+    })
+  })
+
+  it('emits ice_recovered after a prior failure clears', () => {
+    const pc = new MockPeerConnection()
+    attachTransportConnectivityDrawerLog(mockTransport(pc) as never, [{ urls: 'stun:stun.test' }])
+
+    pc.setIceConnectionState('failed')
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+
+    pc.setIceConnectionState('connected')
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'connectivity',
+      event: 'ice_recovered',
+      outcome: 'recovered',
+    })
+  })
+
+  it('emits turn_relay_required when TURN is configured but no relay candidate gathered', () => {
+    const pc = new MockPeerConnection()
+    pc.localDescription = { sdp: 'a=candidate:1 host', type: 'offer' } as RTCSessionDescription
+    attachTransportConnectivityDrawerLog(mockTransport(pc) as never, [
+      { urls: 'turn:turn.test:3478' },
+    ])
+
+    pc.setIceGatheringState('complete')
+
+    expect(clientDrawerLog.emitClientDrawerLog).toHaveBeenCalledWith({
+      drawer: 'connectivity',
+      event: 'turn_relay_required',
+      code: 'TURN_RELAY_REQUIRED',
+      outcome: 'failed',
+    })
+  })
+})

--- a/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
+++ b/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
@@ -1,16 +1,16 @@
-import type { Transport } from 'mediasoup-client/lib/types'
+import type { Transport } from 'mediasoup-client/types'
 import { emitClientDrawerLog } from '../clientDrawerLog'
 import { ICE_DISCONNECTED_FAILURE_MS } from '../realtimeDrawerErrors'
 import { webrtcDebugEnabled, webrtcLog } from '../webrtcDebug'
 
-type MediasoupTransport = Transport & {
+type TransportWithHandler = {
   _handler?: { _pc?: RTCPeerConnection }
 }
 
 export function resolvePeerConnectionFromTransport(
   transport: Transport,
 ): RTCPeerConnection | null {
-  const handler = (transport as MediasoupTransport)._handler
+  const handler = (transport as unknown as TransportWithHandler)._handler
   return handler?._pc ?? null
 }
 

--- a/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
+++ b/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
@@ -1,0 +1,143 @@
+import type { Transport } from 'mediasoup-client/lib/types'
+import { emitClientDrawerLog } from '../clientDrawerLog'
+import { ICE_DISCONNECTED_FAILURE_MS } from '../realtimeDrawerErrors'
+import { webrtcDebugEnabled, webrtcLog } from '../webrtcDebug'
+
+type MediasoupTransport = Transport & {
+  _handler?: { _pc?: RTCPeerConnection }
+}
+
+export function resolvePeerConnectionFromTransport(
+  transport: Transport,
+): RTCPeerConnection | null {
+  const handler = (transport as MediasoupTransport)._handler
+  return handler?._pc ?? null
+}
+
+export function iceServersRequireTurn(iceServers: RTCIceServer[]): boolean {
+  for (const server of iceServers) {
+    const urls = Array.isArray(server.urls) ? server.urls : [server.urls]
+    for (const url of urls) {
+      if (typeof url === 'string' && (url.startsWith('turn:') || url.startsWith('turns:'))) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export function localDescriptionHasRelayCandidate(pc: RTCPeerConnection): boolean {
+  const sdp = pc.localDescription?.sdp ?? ''
+  return /\styp relay\b/i.test(sdp)
+}
+
+/** Production connectivity drawer logs on mediasoup transport RTCPeerConnection hooks. */
+export function attachTransportConnectivityDrawerLog(
+  transport: Transport,
+  iceServers: RTCIceServer[],
+): () => void {
+  const pc = resolvePeerConnectionFromTransport(transport)
+  if (!pc) return () => undefined
+
+  const turnRequired = iceServersRequireTurn(iceServers)
+  let disconnectedTimer: ReturnType<typeof setTimeout> | null = null
+  let connectivityDegraded = false
+  let turnRelayLogged = false
+
+  const clearDisconnectedTimer = () => {
+    if (disconnectedTimer !== null) {
+      clearTimeout(disconnectedTimer)
+      disconnectedTimer = null
+    }
+  }
+
+  const emitIceFailed = () => {
+    connectivityDegraded = true
+    emitClientDrawerLog({
+      drawer: 'connectivity',
+      event: 'ice_failed',
+      code: 'ICE_FAILED',
+      outcome: 'failed',
+    })
+    if (webrtcDebugEnabled()) {
+      webrtcLog(
+        'transport',
+        'ICE failed — restrictive NAT/firewalls need TURN (`GET /v1/webrtc/ice` when API URL set, else `VITE_WEBRTC_ICE_SERVERS_JSON` — see apps/web/.env.example).',
+      )
+    }
+  }
+
+  const emitTurnRelayRequired = () => {
+    if (turnRelayLogged) return
+    turnRelayLogged = true
+    emitClientDrawerLog({
+      drawer: 'connectivity',
+      event: 'turn_relay_required',
+      code: 'TURN_RELAY_REQUIRED',
+      outcome: 'failed',
+    })
+  }
+
+  const emitIceRecovered = () => {
+    if (!connectivityDegraded) return
+    connectivityDegraded = false
+    emitClientDrawerLog({
+      drawer: 'connectivity',
+      event: 'ice_recovered',
+      outcome: 'recovered',
+    })
+  }
+
+  const onIceConnectionStateChange = () => {
+    const state = pc.iceConnectionState
+    if (state === 'connected' || state === 'completed') {
+      clearDisconnectedTimer()
+      emitIceRecovered()
+      return
+    }
+    if (state === 'failed') {
+      clearDisconnectedTimer()
+      emitIceFailed()
+      return
+    }
+    if (state === 'disconnected') {
+      clearDisconnectedTimer()
+      disconnectedTimer = setTimeout(() => {
+        disconnectedTimer = null
+        const cur = pc.iceConnectionState
+        if (cur === 'disconnected' || cur === 'failed') {
+          emitIceFailed()
+        }
+      }, ICE_DISCONNECTED_FAILURE_MS)
+    }
+  }
+
+  const onIceGatheringStateChange = () => {
+    if (pc.iceGatheringState !== 'complete' || !turnRequired) return
+    if (!localDescriptionHasRelayCandidate(pc)) {
+      emitTurnRelayRequired()
+    }
+  }
+
+  pc.addEventListener('iceconnectionstatechange', onIceConnectionStateChange)
+  pc.addEventListener('icegatheringstatechange', onIceGatheringStateChange)
+
+  if (webrtcDebugEnabled()) {
+    const logState = (ev: string) => {
+      webrtcLog('transport', ev, {
+        connectionState: pc.connectionState,
+        iceConnectionState: pc.iceConnectionState,
+        iceGatheringState: pc.iceGatheringState,
+        signalingState: pc.signalingState,
+      })
+    }
+    pc.addEventListener('connectionstatechange', () => logState('connectionstatechange'))
+    logState('connectivity hooks attached')
+  }
+
+  return () => {
+    clearDisconnectedTimer()
+    pc.removeEventListener('iceconnectionstatechange', onIceConnectionStateChange)
+    pc.removeEventListener('icegatheringstatechange', onIceGatheringStateChange)
+  }
+}

--- a/apps/web/src/room/webrtcDebug.ts
+++ b/apps/web/src/room/webrtcDebug.ts
@@ -1,4 +1,6 @@
 /** Enable with **`?webrtcDebug=1`** on the room URL (sessionStorage remembers for that tab). */
+import { emitClientDrawerLog } from './clientDrawerLog'
+
 const KEY = 'riffsync.webrtcDebug'
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -72,11 +74,19 @@ export function attachPcStateLogging(pc: RTCPeerConnection, label: string): void
   pc.addEventListener('connectionstatechange', () => log('connectionstatechange'))
   pc.addEventListener('iceconnectionstatechange', () => {
     log('iceconnectionstatechange')
-    if (webrtcDebugEnabled() && pc.iceConnectionState === 'failed') {
-      webrtcLog(
-        label,
-        'ICE failed — restrictive NAT/firewalls need TURN (`GET /v1/webrtc/ice` when API URL set, else `VITE_WEBRTC_ICE_SERVERS_JSON` — see apps/web/.env.example).',
-      )
+    if (pc.iceConnectionState === 'failed') {
+      emitClientDrawerLog({
+        drawer: 'connectivity',
+        event: 'ice_failed',
+        code: 'ICE_FAILED',
+        outcome: 'failed',
+      })
+      if (webrtcDebugEnabled()) {
+        webrtcLog(
+          label,
+          'ICE failed — restrictive NAT/firewalls need TURN (`GET /v1/webrtc/ice` when API URL set, else `VITE_WEBRTC_ICE_SERVERS_JSON` — see apps/web/.env.example).',
+        )
+      }
     }
   })
   pc.addEventListener('icegatheringstatechange', () => log('icegatheringstatechange'))


### PR DESCRIPTION
## Summary

- Add `apps/web/src/room/clientDrawerLog.ts` with `emitClientDrawerLog(payload)` for production drawer-tagged client diagnostics (#213).
- Instrument `ChatSession` with chat drawer lifecycle logs: `ws_connect_attempt`, `ws_open`, `ws_close`, `ws_error`, `reconnect_scheduled`, `reconnect_success`, `degraded_threshold`, and `send_dropped` (#214).
- Migrate `realtimeDiagnostics.recordOutboundDropped` to `emitClientDrawerLog` (removes raw `[riffsync-diag]` warn string; `?diag=1` counters unchanged).
- Instrument `SfuMediaSession` with signaling drawer logs (`signaling_connect`, `signaling_open`, `signaling_close`, `signaling_reconnect_scheduled`, `signaling_reconnect_success`, `signaling_degraded`, `token_denied`) (#215).
- Wire connectivity drawer logs on mediasoup transport PC hooks via `transportConnectivityDrawerLog.ts` (`ice_failed`, `turn_relay_required`, `ice_recovered`) (#215).
- Instrument produce/consume drawer logs in `SfuMediaSession` and `TheaterPlayback` via `produceConsumeDrawerLog.ts`: `producer_closed` (INFO/`PRODUCER_CLOSED`), `consumer_attach_failed`, `transport_limit`, `consumer_limit`, `partial_unpublish`, and `mix_error` (#216).

Closes #213
Closes #214
Closes #215
Closes #216

Part of #157 (shared branch `feature/issue-157`).

## Test plan

- [x] `npm ci --prefix apps/web`
- [x] `npm test --prefix apps/web -- --run src/room/clientDrawerLog`
- [x] `npm test --prefix apps/web -- --run src/room/sessions/ChatSession src/room/realtimeDiagnostics`
- [x] `npm test --prefix apps/web -- --run src/room/sessions/SfuMediaSession src/room/sfu/mediasoupSharing src/room/sfu/transportConnectivityDrawerLog`
- [x] `npm test --prefix apps/web -- --run src/room/sessions/SfuMediaSession src/room/sessions/TheaterPlayback src/room/sfu/produceConsumeDrawerLog`
- [ ] CI green on this PR