### PR TITLE
Fix iOS keyboard pushing room video player off-screen (#240)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/design/images/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>RiffSync</title>
     <meta
       name="description"

--- a/apps/web/src/layouts/SiteLayout.tsx
+++ b/apps/web/src/layouts/SiteLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet, useMatch, useSearchParams } from 'react-router-dom'
 import { SiteHeader } from '../components/site/SiteHeader'
 import { SiteFooter } from '../components/site/SiteFooter'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import { useVisualViewportRoomShell } from '../room/useVisualViewportRoomShell'
 
 export function SiteLayout() {
   const roomMatch = useMatch({ path: '/room/:roomId', end: true })
@@ -10,6 +11,7 @@ export function SiteLayout() {
   const partyCaptureBare = Boolean(watchMatch && searchParams.get('partyCapture') === '1')
 
   const compactChrome = Boolean(roomMatch)
+  const viewportShell = useVisualViewportRoomShell(compactChrome)
 
   if (partyCaptureBare) {
     return (
@@ -23,7 +25,10 @@ export function SiteLayout() {
 
   return (
     <RoomChromeProvider>
-      <div className={`riffsync-site${compactChrome ? ' riffsync-site--room' : ''}`}>
+      <div
+        className={`riffsync-site${compactChrome ? ` riffsync-site--room${viewportShell.className}` : ''}`}
+        style={compactChrome ? viewportShell.style : undefined}
+      >
         <SiteHeader compact={compactChrome} />
         <main id="riffsync-main" className={`riffsync-main${compactChrome ? ' riffsync-main--room' : ''}`}>
           <Outlet />

--- a/apps/web/src/room/useVisualViewportRoomShell.test.ts
+++ b/apps/web/src/room/useVisualViewportRoomShell.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import {
+  KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX,
+  buildVisualViewportShellStyle,
+  computeVisualViewportShellState,
+  containRoomTextInputFocus,
+  isRoomTextInput,
+} from './useVisualViewportRoomShell'
+
+describe('computeVisualViewportShellState', () => {
+  it('returns empty vars when visualViewport is unavailable', () => {
+    expect(computeVisualViewportShellState(null, 800, true)).toEqual({
+      keyboardOpen: false,
+      cssVars: {},
+    })
+  })
+
+  it('returns empty vars when narrow fix is disabled', () => {
+    expect(
+      computeVisualViewportShellState({ height: 400, width: 390, offsetTop: 120, offsetLeft: 0 }, 800, false),
+    ).toEqual({
+      keyboardOpen: false,
+      cssVars: {},
+    })
+  })
+
+  it('detects keyboard open when visual viewport height shrinks', () => {
+    const state = computeVisualViewportShellState(
+      { height: 420, width: 390, offsetTop: 80, offsetLeft: 0 },
+      800,
+      true,
+    )
+    expect(state.keyboardOpen).toBe(true)
+    expect(state.cssVars['--riffsync-vv-height']).toBe('420px')
+    expect(state.cssVars['--riffsync-vv-offset-top']).toBe('80px')
+    expect(state.cssVars['--riffsync-room-stage-max-height']).toBe(
+      'calc(420px - var(--riffsync-room-chrome-height))',
+    )
+  })
+
+  it('treats small layout deltas as keyboard closed', () => {
+    const layoutHeight = 800
+    const state = computeVisualViewportShellState(
+      {
+        height: layoutHeight - KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX,
+        width: 390,
+        offsetTop: 0,
+        offsetLeft: 0,
+      },
+      layoutHeight,
+      true,
+    )
+    expect(state.keyboardOpen).toBe(false)
+    expect(state.cssVars['--riffsync-vv-height']).toBe(`${layoutHeight - KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX}px`)
+  })
+})
+
+describe('buildVisualViewportShellStyle', () => {
+  it('maps css vars to style object', () => {
+    expect(
+      buildVisualViewportShellStyle({
+        keyboardOpen: true,
+        cssVars: { '--riffsync-vv-height': '420px' },
+      }),
+    ).toEqual({ '--riffsync-vv-height': '420px' })
+  })
+})
+
+describe('isRoomTextInput', () => {
+  it('matches native text controls used on the room page', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    expect(isRoomTextInput(input)).toBe(true)
+
+    const textarea = document.createElement('textarea')
+    expect(isRoomTextInput(textarea)).toBe(true)
+
+    const button = document.createElement('button')
+    expect(isRoomTextInput(button)).toBe(false)
+
+    input.type = 'checkbox'
+    expect(isRoomTextInput(input)).toBe(false)
+  })
+})
+
+describe('containRoomTextInputFocus', () => {
+  it('resets document scroll offsets', () => {
+    const scrollTo = vi.fn()
+    vi.stubGlobal('scrollTo', scrollTo)
+    document.documentElement.scrollTop = 40
+    document.body.scrollTop = 40
+
+    containRoomTextInputFocus()
+
+    expect(scrollTo).toHaveBeenCalledWith(0, 0)
+    expect(document.documentElement.scrollTop).toBe(0)
+    expect(document.body.scrollTop).toBe(0)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/web/src/room/useVisualViewportRoomShell.ts
+++ b/apps/web/src/room/useVisualViewportRoomShell.ts
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react'
+
+export const NARROW_ROOM_LAYOUT_MQ = '(max-width: 991px)'
+export const KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX = 50
+
+export type VisualViewportLike = {
+  height: number
+  width: number
+  offsetTop: number
+  offsetLeft: number
+}
+
+export type VisualViewportShellState = {
+  keyboardOpen: boolean
+  cssVars: Record<string, string>
+}
+
+export function computeVisualViewportShellState(
+  vv: VisualViewportLike | null | undefined,
+  layoutHeight: number,
+  applyNarrowFix: boolean,
+): VisualViewportShellState {
+  if (!vv || !applyNarrowFix) {
+    return {
+      keyboardOpen: false,
+      cssVars: {},
+    }
+  }
+
+  const heightPx = `${Math.round(vv.height)}px`
+  const offsetTopPx = `${Math.round(vv.offsetTop)}px`
+  const keyboardOpen = vv.height < layoutHeight - KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX
+
+  return {
+    keyboardOpen,
+    cssVars: {
+      '--riffsync-vv-height': heightPx,
+      '--riffsync-vv-offset-top': offsetTopPx,
+      '--riffsync-room-stage-max-height': `calc(${heightPx} - var(--riffsync-room-chrome-height))`,
+    },
+  }
+}
+
+export function buildVisualViewportShellStyle(state: VisualViewportShellState): CSSProperties {
+  return state.cssVars as CSSProperties
+}
+
+export function isRoomTextInput(el: HTMLElement): boolean {
+  if (el instanceof HTMLTextAreaElement) return true
+  if (el instanceof HTMLInputElement) {
+    const type = el.type
+    return (
+      type === 'text' ||
+      type === 'search' ||
+      type === 'email' ||
+      type === 'url' ||
+      type === 'tel' ||
+      type === 'password' ||
+      type === 'number'
+    )
+  }
+  return false
+}
+
+export function containRoomTextInputFocus(): void {
+  window.scrollTo(0, 0)
+  document.documentElement.scrollTop = 0
+  document.body.scrollTop = 0
+}
+
+function readVisualViewportSnapshot(): VisualViewportLike | null {
+  const vv = window.visualViewport
+  if (!vv) return null
+  return {
+    height: vv.height,
+    width: vv.width,
+    offsetTop: vv.offsetTop,
+    offsetLeft: vv.offsetLeft,
+  }
+}
+
+export function useVisualViewportRoomShell(enabled: boolean): {
+  style: CSSProperties
+  className: string
+} {
+  const [narrow, setNarrow] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false
+    return window.matchMedia(NARROW_ROOM_LAYOUT_MQ).matches
+  })
+  const [layoutHeight, setLayoutHeight] = useState(() =>
+    typeof window !== 'undefined' ? window.innerHeight : 0,
+  )
+  const [vvSnapshot, setVvSnapshot] = useState<VisualViewportLike | null>(() =>
+    typeof window !== 'undefined' ? readVisualViewportSnapshot() : null,
+  )
+
+  useEffect(() => {
+    if (!enabled) return
+    const mq = window.matchMedia(NARROW_ROOM_LAYOUT_MQ)
+    const onMq = () => setNarrow(mq.matches)
+    mq.addEventListener('change', onMq)
+    return () => mq.removeEventListener('change', onMq)
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+    const vv = window.visualViewport
+    if (!vv) return
+
+    const sync = () => {
+      const nextLayoutHeight = window.innerHeight
+      const nextSnapshot = readVisualViewportSnapshot()
+      setLayoutHeight(nextLayoutHeight)
+      setVvSnapshot(nextSnapshot)
+      if (
+        narrow &&
+        nextSnapshot &&
+        nextSnapshot.height < nextLayoutHeight - KEYBOARD_HEIGHT_DELTA_THRESHOLD_PX
+      ) {
+        containRoomTextInputFocus()
+      }
+    }
+
+    vv.addEventListener('resize', sync)
+    vv.addEventListener('scroll', sync)
+    window.addEventListener('resize', sync)
+    sync()
+    return () => {
+      vv.removeEventListener('resize', sync)
+      vv.removeEventListener('scroll', sync)
+      window.removeEventListener('resize', sync)
+    }
+  }, [enabled, narrow])
+
+  useEffect(() => {
+    if (!enabled || !narrow) return
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target
+      if (!(target instanceof HTMLElement)) return
+      if (!target.closest('.riffsync-site--room')) return
+      if (!isRoomTextInput(target)) return
+      containRoomTextInputFocus()
+    }
+    document.addEventListener('focusin', onFocusIn, true)
+    return () => document.removeEventListener('focusin', onFocusIn, true)
+  }, [enabled, narrow])
+
+  const state = useMemo(
+    () => computeVisualViewportShellState(vvSnapshot, layoutHeight, enabled && narrow),
+    [vvSnapshot, layoutHeight, enabled, narrow],
+  )
+
+  return {
+    style: buildVisualViewportShellStyle(state),
+    className: state.keyboardOpen ? ' riffsync-site--room-vv-keyboard' : '',
+  }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -553,7 +553,62 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   max-height: 100dvh;
   overflow: hidden;
   --riffsync-room-chrome-height: 4.5rem;
+  --riffsync-vv-height: 100dvh;
+  --riffsync-vv-offset-top: 0px;
   --riffsync-room-stage-max-height: calc(100dvh - var(--riffsync-room-chrome-height));
+}
+
+@media (max-width: 991px) {
+  .riffsync-site--room.riffsync-site--room-vv-keyboard {
+    position: fixed;
+    top: var(--riffsync-vv-offset-top);
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: var(--riffsync-vv-height);
+    max-height: var(--riffsync-vv-height);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .riffsync-site--room.riffsync-site--room-vv-keyboard {
+      transition:
+        height 200ms ease,
+        max-height 200ms ease,
+        top 200ms ease;
+    }
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__stage {
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: 100%;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__theater {
+    flex-shrink: 0;
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__player-shell--guest {
+    max-height: min(
+      calc(var(--riffsync-vv-height) - var(--riffsync-room-chrome-height) - 6rem),
+      calc((100vw - 2.5rem) * 9 / 16)
+    );
+    width: 100%;
+    height: auto;
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__chat-column {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__chat {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
 }
 
 .riffsync-room-shell {
@@ -1323,6 +1378,10 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   .riffsync-room-page__chat {
     /* Stacked below the player — approximate 16:9 min height at full content width */
     min-height: min(420px, calc((100vw - 2.5rem) * 9 / 16));
+  }
+
+  .riffsync-site--room-vv-keyboard .riffsync-room-page__chat {
+    min-height: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `useVisualViewportRoomShell` to drive room shell CSS variables from `window.visualViewport` on narrow stacked layouts (< 992px).
- Pin the room shell to the visible viewport when the iOS software keyboard opens so the 16:9 player stays on screen; chat column compresses and scrolls internally.
- Add `interactive-widget=resizes-content` to the document viewport meta and reset document scroll on room text input focus (chat compose, Profile fields, rename modal).

## Test plan

- [x] `npm test`, `npm run lint`, and `npm run build` pass under `apps/web`
- [ ] Manual iOS Safari QA on iPhone/iPad portrait: chat compose, Profile display name, room rename modal keep full player visible
- [ ] Keyboard dismiss restores layout (brief transition; instant with reduced motion)
- [ ] Desktop and Android regression check

Closes #240