### PR TITLE
M22: presence active badges and typing (epic #241)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -111,8 +111,10 @@ export function RoomPage() {
     sendJson,
     chat,
     chatReactions,
+    remoteTyping,
     chatDraft,
     setChatDraft,
+    notifyComposeBlur,
     sendChat,
     sendChatGif,
     toggleChatReaction,
@@ -389,9 +391,11 @@ export function RoomPage() {
             viewerCount={viewerCount}
             chat={chat}
             chatReactions={chatReactions}
+            remoteTyping={remoteTyping}
             chatMemberLabels={chatMemberLabels}
             chatDraft={chatDraft}
             setChatDraft={setChatDraft}
+            notifyComposeBlur={notifyComposeBlur}
             chatLogRef={chatLogRef}
             chatInputRef={chatInputRef}
             showJumpToLatest={showJumpToLatest}

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -10,7 +10,8 @@ import { isEmojiOnlyChatMessage } from './chatEmojiDisplay'
 import { isContinuedChatLine } from './chatMessageGrouping'
 import type { ReactionsByMessage } from './chatReactions'
 import type { ParticipantAvController } from './sfu/participantAvSession'
-import type { ChatLine, PresenceMember, RoomSidebarTab } from './roomPageTypes'
+import type { ChatLine, PresenceMember, RemoteTypingEntry, RoomSidebarTab } from './roomPageTypes'
+import { formatChatSystemText } from './chatSystemLine'
 import { resolveMemberAvatarUrl } from './roomPageTypes'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import {
@@ -29,9 +30,11 @@ type RoomPageSidebarProps = {
   viewerCount: number
   chat: ChatLine[]
   chatReactions: ReactionsByMessage
+  remoteTyping: RemoteTypingEntry[]
   chatMemberLabels: Map<string, string>
   chatDraft: string
   setChatDraft: (draft: string) => void
+  notifyComposeBlur: () => void
   chatLogRef: RefObject<HTMLUListElement | null>
   chatInputRef: RefObject<HTMLInputElement | null>
   showJumpToLatest: boolean
@@ -75,9 +78,11 @@ export function RoomPageSidebar({
   viewerCount,
   chat,
   chatReactions,
+  remoteTyping,
   chatMemberLabels,
   chatDraft,
   setChatDraft,
+  notifyComposeBlur,
   chatLogRef,
   chatInputRef,
   showJumpToLatest,
@@ -172,6 +177,18 @@ export function RoomPageSidebar({
           <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--chat">
             <ul ref={chatLogRef} className="riffsync-room-chat-log">
               {chat.map((m, index) => {
+                if (m.kind === 'system') {
+                  return (
+                    <li
+                      key={m.messageId}
+                      className="riffsync-room-chat-log__row riffsync-room-chat-log__row--system"
+                    >
+                      <p className="riffsync-room-chat-log__system-line" role="status">
+                        {formatChatSystemText(m.displayName, m.systemEvent)}
+                      </p>
+                    </li>
+                  )
+                }
                 const chatDisplayName =
                   (m.displayName && m.displayName.trim() !== ''
                     ? m.displayName
@@ -233,6 +250,20 @@ export function RoomPageSidebar({
                   </li>
                 )
               })}
+              {remoteTyping.map((entry) => (
+                <li
+                  key={`typing-${entry.sessionId}`}
+                  className="riffsync-room-chat-log__row riffsync-room-chat-log__row--typing"
+                >
+                  <p className="riffsync-room-chat-log__typing-line" role="status" aria-live="polite">
+                    <span className="riffsync-room-chat-log__typing-name">{entry.displayName}</span>
+                    <span aria-hidden="true"> is typing</span>
+                    <span className="riffsync-room-chat-log__typing-ellipsis" aria-hidden="true">
+                      …
+                    </span>
+                  </p>
+                </li>
+              ))}
             </ul>
           </div>
         ) : null}
@@ -266,6 +297,12 @@ export function RoomPageSidebar({
                           p.displayName
                         )}
                         {p.sessionId === sessionId ? <span className="riffsync-muted"> · you</span> : null}
+                        {p.active ? (
+                          <span className="riffsync-room-page__active-badge" aria-label="Active">
+                            <span className="riffsync-room-page__active-dot" aria-hidden="true" />
+                            Active
+                          </span>
+                        ) : null}
                       </span>
                     </span>
                   </li>
@@ -413,6 +450,9 @@ export function RoomPageSidebar({
                   disabled={!fanToken}
                   onChange={(e) => {
                     if (fanToken) setChatDraft(e.target.value)
+                  }}
+                  onBlur={() => {
+                    if (fanToken) notifyComposeBlur()
                   }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && fanToken && !chatComposeStatus.disableSubmit) sendChat()

--- a/apps/web/src/room/chatSystemLine.ts
+++ b/apps/web/src/room/chatSystemLine.ts
@@ -1,0 +1,30 @@
+export type ChatSystemKind = 'join' | 'leave'
+
+export type ChatSystemLine = {
+  kind: 'system'
+  messageId: string
+  sessionId: string
+  displayName: string
+  systemEvent: ChatSystemKind
+  ts: number
+}
+
+export function formatChatSystemText(displayName: string, systemEvent: ChatSystemKind): string {
+  return systemEvent === 'join' ? `${displayName} joined` : `${displayName} left`
+}
+
+export function buildChatSystemLine(params: {
+  sessionId: string
+  displayName: string
+  systemEvent: ChatSystemKind
+  ts: number
+}): ChatSystemLine {
+  return {
+    kind: 'system',
+    messageId: `system:${params.sessionId}:${params.ts}`,
+    sessionId: params.sessionId,
+    displayName: params.displayName,
+    systemEvent: params.systemEvent,
+    ts: params.ts,
+  }
+}

--- a/apps/web/src/room/chatTypingIndicators.test.ts
+++ b/apps/web/src/room/chatTypingIndicators.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyInboundTyping,
+  listRemoteTyping,
+  pruneExpiredTyping,
+  TYPING_INDICATOR_TTL_MS,
+} from './chatTypingIndicators'
+
+describe('chatTypingIndicators', () => {
+  it('adds typing entry on start with 5s TTL', () => {
+    const now = 1_000_000
+    const next = applyInboundTyping(
+      new Map(),
+      { sessionId: 's1', displayName: 'Alice', action: 'start' },
+      now,
+    )
+    expect(next.get('s1')).toEqual({
+      sessionId: 's1',
+      displayName: 'Alice',
+      expiresAt: now + TYPING_INDICATOR_TTL_MS,
+    })
+  })
+
+  it('removes typing entry on stop', () => {
+    const seeded = applyInboundTyping(new Map(), {
+      sessionId: 's1',
+      displayName: 'Alice',
+      action: 'start',
+    })
+    const next = applyInboundTyping(seeded, {
+      sessionId: 's1',
+      displayName: 'Alice',
+      action: 'stop',
+    })
+    expect(next.has('s1')).toBe(false)
+  })
+
+  it('prunes expired entries', () => {
+    const now = 5_000
+    const seeded = applyInboundTyping(
+      new Map(),
+      { sessionId: 's1', displayName: 'Alice', action: 'start' },
+      now,
+    )
+    const pruned = pruneExpiredTyping(seeded, now + TYPING_INDICATOR_TTL_MS + 1)
+    expect(pruned.size).toBe(0)
+  })
+
+  it('excludes own session from remote typing list', () => {
+    const now = 10_000
+    const seeded = applyInboundTyping(
+      new Map(),
+      { sessionId: 'self', displayName: 'Me', action: 'start' },
+      now,
+    )
+    const withPeer = applyInboundTyping(seeded, {
+      sessionId: 'peer',
+      displayName: 'Bob',
+      action: 'start',
+    }, now)
+    const listed = listRemoteTyping(withPeer, 'self', now)
+    expect(listed).toHaveLength(1)
+    expect(listed[0]?.sessionId).toBe('peer')
+  })
+})

--- a/apps/web/src/room/chatTypingIndicators.ts
+++ b/apps/web/src/room/chatTypingIndicators.ts
@@ -1,0 +1,57 @@
+/** Inbound typing ellipsis TTL — see `.ai/interface/interaction_flow.md`. */
+export const TYPING_INDICATOR_TTL_MS = 5_000
+
+export type RemoteTypingEntry = {
+  sessionId: string
+  displayName: string
+  expiresAt: number
+}
+
+export type InboundTypingAction = 'start' | 'stop'
+
+export function applyInboundTyping(
+  entries: ReadonlyMap<string, RemoteTypingEntry>,
+  params: {
+    sessionId: string
+    displayName: string
+    action: InboundTypingAction
+  },
+  nowMs: number = Date.now(),
+): Map<string, RemoteTypingEntry> {
+  const next = new Map(entries)
+  if (params.action === 'stop') {
+    next.delete(params.sessionId)
+    return next
+  }
+  next.set(params.sessionId, {
+    sessionId: params.sessionId,
+    displayName: params.displayName,
+    expiresAt: nowMs + TYPING_INDICATOR_TTL_MS,
+  })
+  return next
+}
+
+export function pruneExpiredTyping(
+  entries: ReadonlyMap<string, RemoteTypingEntry>,
+  nowMs: number = Date.now(),
+): Map<string, RemoteTypingEntry> {
+  const next = new Map<string, RemoteTypingEntry>()
+  for (const [key, entry] of entries) {
+    if (entry.expiresAt > nowMs) {
+      next.set(key, entry)
+    }
+  }
+  return next
+}
+
+export function listRemoteTyping(
+  entries: ReadonlyMap<string, RemoteTypingEntry>,
+  ownSessionId: string,
+  nowMs: number = Date.now(),
+): RemoteTypingEntry[] {
+  return [...pruneExpiredTyping(entries, nowMs).values()]
+    .filter((entry) => entry.sessionId !== ownSessionId)
+    .sort((a, b) =>
+      a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }),
+    )
+}

--- a/apps/web/src/room/engine/RoomMediaEngine.ts
+++ b/apps/web/src/room/engine/RoomMediaEngine.ts
@@ -9,6 +9,13 @@ import {
   type ReactionsByMessage,
 } from '../chatReactions'
 import { mergeChatHistory } from '../chatHistoryMerge'
+import { buildChatSystemLine } from '../chatSystemLine'
+import {
+  applyInboundTyping,
+  listRemoteTyping,
+  pruneExpiredTyping,
+  type RemoteTypingEntry,
+} from '../chatTypingIndicators'
 import { createChatMessageId } from '../chatMessageId'
 import { avDisabledAnnounceCopy, roomModeAnnounceCopy } from '../hostRoomControls'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
@@ -51,6 +58,7 @@ export type RoomMediaEngineSnapshot = {
   chat: ChatLine[]
   chatReactions: ReactionsByMessage
   chatDraft: string
+  remoteTyping: RemoteTypingEntry[]
   peopleShown: PresenceMember[]
   participantAvController: ParticipantAvController | null
   drawerPresentation: ReturnType<RoomMediaEngine['getDrawerPresentation']>
@@ -127,6 +135,8 @@ export class RoomMediaEngine {
   private theaterPlaybackSnapshot: TheaterPlaybackSnapshot = this.sdk.getTheaterSnapshot()
   private chat: ChatLine[] = []
   private chatReactions: ReactionsByMessage = {}
+  private remoteTypingBySession = new Map<string, RemoteTypingEntry>()
+  private typingPruneTimer: ReturnType<typeof setInterval> | null = null
   private participantAvVideoConsumers = new Map<string, ParticipantAvVideoConsumer>()
   private presenceRoster: { roomId: string; members: PresenceMember[] } = {
     roomId: '',
@@ -172,6 +182,10 @@ export class RoomMediaEngine {
       chat: this.chat,
       chatReactions: this.chatReactions,
       chatDraft: this.chatDraft,
+      remoteTyping: listRemoteTyping(
+        this.remoteTypingBySession,
+        opts?.sessionId ?? '',
+      ),
       peopleShown,
       participantAvController: participantAvController ?? null,
       drawerPresentation: this.getDrawerPresentation(opts?.isPublisher === true),
@@ -215,13 +229,45 @@ export class RoomMediaEngine {
         this.notify()
       },
       onChatHistory: (event) => {
-        const merged = mergeChatHistory(this.chat, this.chatReactions, event)
+        const durableOnly = this.chat.filter((line) => line.kind !== 'system')
+        const merged = mergeChatHistory(durableOnly, this.chatReactions, event)
         this.chat = merged.chat
         this.chatReactions = merged.chatReactions
         this.notify()
       },
       onPresence: (event) => {
-        this.presenceRoster = event
+        this.presenceRoster = {
+          roomId: event.roomId,
+          members: event.members.map((member) => ({
+            sessionId: member.sessionId,
+            displayName: member.displayName,
+            isHost: member.isHost,
+            ...(member.active === true ? { active: true } : member.active === false ? { active: false } : {}),
+            ...(member.lastActiveAt !== undefined ? { lastActiveAt: member.lastActiveAt } : {}),
+            ...(member.avatarUrl !== undefined ? { avatarUrl: member.avatarUrl } : {}),
+          })),
+        }
+        this.notify()
+      },
+      onTyping: (event) => {
+        this.remoteTypingBySession = applyInboundTyping(this.remoteTypingBySession, {
+          sessionId: event.sessionId,
+          displayName: event.displayName,
+          action: event.action,
+        })
+        this.ensureTypingPruneTimer()
+        this.notify()
+      },
+      onChatSystem: (event) => {
+        this.chat = [
+          ...this.chat,
+          buildChatSystemLine({
+            sessionId: event.sessionId,
+            displayName: event.displayName,
+            systemEvent: event.event,
+            ts: event.ts,
+          }),
+        ]
         this.notify()
       },
       onRoomModeUi: (event) => {
@@ -253,7 +299,12 @@ export class RoomMediaEngine {
       roomControlHandlers,
       onDiagnosticsChange: (next) => {
         this.diagnostics = next
-        this.wsStatus = this.sdk.getChatStatus()
+        const nextWsStatus = this.sdk.getChatStatus()
+        if (nextWsStatus !== 'open' && this.remoteTypingBySession.size > 0) {
+          this.remoteTypingBySession = new Map()
+          this.clearTypingPruneTimer()
+        }
+        this.wsStatus = nextWsStatus
         this.updateConnectionFromDiagnostics()
         this.notify()
       },
@@ -377,7 +428,12 @@ export class RoomMediaEngine {
 
   setChatDraft(draft: string): void {
     this.chatDraft = draft
+    this.sdk.notifyComposeDraftChange(draft)
     this.notify()
+  }
+
+  notifyComposeBlur(): void {
+    this.sdk.notifyComposeBlur()
   }
 
   sendControl(payload: Record<string, unknown>): boolean {
@@ -390,6 +446,7 @@ export class RoomMediaEngine {
     if (!txt) return
     const sent = this.sendControl({ action: 'chat', text: txt, messageId: createChatMessageId() })
     if (sent) {
+      this.sdk.notifyComposeSent()
       this.chatDraft = ''
       this.notify()
     }
@@ -512,6 +569,8 @@ export class RoomMediaEngine {
   }
 
   private resetSession(): void {
+    this.clearTypingPruneTimer()
+    this.remoteTypingBySession = new Map()
     this.hostScreenCleanup?.()
     this.hostScreenCleanup = null
     this.participantAvUnsub?.()
@@ -525,6 +584,27 @@ export class RoomMediaEngine {
     this.connection = transitionRoomMediaConnection(this.connection, 'tornDown')
     this.wsStatus = 'idle'
     this.diagnostics = null
+    this.chat = []
+    this.chatReactions = {}
+  }
+
+  private ensureTypingPruneTimer(): void {
+    if (this.typingPruneTimer) return
+    this.typingPruneTimer = setInterval(() => {
+      const pruned = pruneExpiredTyping(this.remoteTypingBySession)
+      if (pruned.size === this.remoteTypingBySession.size) return
+      this.remoteTypingBySession = pruned
+      if (pruned.size === 0) {
+        this.clearTypingPruneTimer()
+      }
+      this.notify()
+    }, 500)
+  }
+
+  private clearTypingPruneTimer(): void {
+    if (!this.typingPruneTimer) return
+    clearInterval(this.typingPruneTimer)
+    this.typingPruneTimer = null
   }
 
   private getIceServers(): Promise<RTCIceServer[]> {

--- a/apps/web/src/room/roomPageTypes.ts
+++ b/apps/web/src/room/roomPageTypes.ts
@@ -1,13 +1,19 @@
 import type { ChatGifLine, ChatTextLine } from './sessions/ChatSession'
+import type { ChatSystemLine } from './chatSystemLine'
+import type { RemoteTypingEntry } from './chatTypingIndicators'
 
-export type ChatLine = ChatTextLine | ChatGifLine
+export type ChatLine = ChatTextLine | ChatGifLine | ChatSystemLine
 
 export type PresenceMember = {
   sessionId: string
   displayName: string
   isHost: boolean
+  active?: boolean
+  lastActiveAt?: number
   avatarUrl?: string
 }
+
+export type { RemoteTypingEntry }
 
 export type RoomSidebarTab = 'chat' | 'people' | 'room' | 'profile'
 

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -157,6 +157,109 @@ describe('routeInboundChatMessage', () => {
     ).toBeNull()
   })
 
+  it('routes presence with active and lastActiveAt', () => {
+    const routed = routeInboundChatMessage(
+      {
+        type: 'presence',
+        roomId: ROOM,
+        members: [
+          {
+            sessionId: 'sess-a',
+            displayName: 'Alice',
+            isHost: false,
+            active: true,
+            lastActiveAt: 1_700_000_000,
+          },
+        ],
+      },
+      ROOM,
+    )
+    expect(routed).toEqual({
+      type: 'presence',
+      event: {
+        roomId: ROOM,
+        members: [
+          {
+            sessionId: 'sess-a',
+            displayName: 'Alice',
+            isHost: false,
+            active: true,
+            lastActiveAt: 1_700_000_000,
+          },
+        ],
+      },
+    })
+  })
+
+  it('routes inbound typing start/stop', () => {
+    const start = routeInboundChatMessage(
+      {
+        type: 'typing',
+        roomId: ROOM,
+        sessionId: 'sess-1',
+        displayName: 'Fan',
+        action: 'start',
+        ts: 5000,
+      },
+      ROOM,
+    )
+    expect(start).toEqual({
+      type: 'typing',
+      event: {
+        roomId: ROOM,
+        sessionId: 'sess-1',
+        displayName: 'Fan',
+        action: 'start',
+        ts: 5000,
+      },
+    })
+    const stop = routeInboundChatMessage(
+      {
+        type: 'typing',
+        roomId: ROOM,
+        sessionId: 'sess-1',
+        displayName: 'Fan',
+        action: 'stop',
+        ts: 6000,
+      },
+      ROOM,
+    )
+    expect(stop?.type).toBe('typing')
+    if (stop?.type === 'typing') {
+      expect(stop.event.action).toBe('stop')
+    }
+  })
+
+  it('routes chat_system join/leave for canonical room', () => {
+    const join = routeInboundChatMessage(
+      {
+        type: 'chat_system',
+        roomId: ROOM,
+        sessionId: 'sess-2',
+        displayName: 'Bob',
+        event: 'join',
+        ts: 7000,
+      },
+      ROOM,
+    )
+    expect(join).toEqual({
+      type: 'chat_system',
+      event: {
+        roomId: ROOM,
+        sessionId: 'sess-2',
+        displayName: 'Bob',
+        event: 'join',
+        ts: 7000,
+      },
+    })
+    expect(
+      routeInboundChatMessage(
+        { type: 'chat_system', roomId: 'other', sessionId: 's', displayName: 'X', event: 'leave' },
+        ROOM,
+      ),
+    ).toBeNull()
+  })
+
   it('routes share_state started per #146 api_contracts matrix', () => {
     expect(
       routeInboundChatMessage({ type: 'share_state', roomId: ROOM, state: 'started' }, ROOM),
@@ -403,6 +506,87 @@ describe('ChatSession lifecycle FSM', () => {
       event: 'reconnect_success',
       outcome: 'recovered',
     })
+  })
+})
+
+describe('ChatSession compose typing', () => {
+  class MockWebSocket {
+    static OPEN = 1
+    readyState = MockWebSocket.OPEN
+    send = vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(clientDrawerLog.emitClientDrawerLog).mockClear()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('debounces typing_start by 300ms and emits typing_stop on send', () => {
+    const session = new ChatSession()
+    ;(session as unknown as { connectOptions: Record<string, unknown> | null }).connectOptions = {
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-1',
+      accessToken: 'tok',
+    }
+    const ws = new WebSocket('wss://ws.test')
+    ;(session as unknown as { ws: WebSocket | null }).ws = ws
+
+    session.onComposeDraftChange('hello')
+    expect((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(300)
+    expect((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(
+      JSON.stringify({ action: 'typing_start' }),
+    )
+
+    session.onComposeSent()
+    expect((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(
+      JSON.stringify({ action: 'typing_stop' }),
+    )
+  })
+
+  it('does not emit typing_start without fan JWT', () => {
+    const session = new ChatSession()
+    ;(session as unknown as { connectOptions: Record<string, unknown> | null }).connectOptions = {
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-guest',
+      accessToken: null,
+    }
+    const ws = new WebSocket('wss://ws.test')
+    ;(session as unknown as { ws: WebSocket | null }).ws = ws
+
+    session.onComposeDraftChange('hello')
+    vi.advanceTimersByTime(300)
+    expect((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).not.toHaveBeenCalled()
+  })
+
+  it('emits typing_stop after 3s compose idle', () => {
+    const session = new ChatSession()
+    ;(session as unknown as { connectOptions: Record<string, unknown> | null }).connectOptions = {
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-1',
+      accessToken: 'tok',
+    }
+    const ws = new WebSocket('wss://ws.test')
+    ;(session as unknown as { ws: WebSocket | null }).ws = ws
+
+    session.onComposeDraftChange('typing')
+    vi.advanceTimersByTime(300)
+    vi.mocked((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).mockClear()
+
+    vi.advanceTimersByTime(3000)
+    expect((ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(
+      JSON.stringify({ action: 'typing_stop' }),
+    )
   })
 })
 

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -26,6 +26,8 @@ import {
 } from './drawerReconnectPolicy'
 
 const PING_MS = 25_000
+const TYPING_START_DEBOUNCE_MS = 300
+const TYPING_COMPOSE_IDLE_MS = 3_000
 
 export type ChatSessionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
 
@@ -59,7 +61,25 @@ export type ChatPresenceMember = {
   sessionId: string
   displayName: string
   isHost: boolean
+  active?: boolean
+  lastActiveAt?: number
   avatarUrl?: string
+}
+
+export type TypingEvent = {
+  roomId: string
+  sessionId: string
+  displayName: string
+  action: 'start' | 'stop'
+  ts: number
+}
+
+export type ChatSystemEvent = {
+  roomId: string
+  sessionId: string
+  displayName: string
+  event: 'join' | 'leave'
+  ts: number
 }
 
 export type PresenceEvent = {
@@ -90,6 +110,8 @@ export type ChatInboundRouted =
   | { type: 'chat_reaction'; event: ChatReactionEvent }
   | { type: 'chat_history'; event: ChatHistoryEvent }
   | { type: 'presence'; event: PresenceEvent }
+  | { type: 'typing'; event: TypingEvent }
+  | { type: 'chat_system'; event: ChatSystemEvent }
   | { type: 'share_state'; event: ShareStateEvent }
   | { type: 'room_mode'; event: RoomModeEvent }
   | { type: 'av_disabled'; event: AvDisabledEvent }
@@ -110,6 +132,11 @@ function parseInboundAvatarUrl(raw: unknown): string | undefined {
   if (typeof raw !== 'string') return undefined
   const trimmed = raw.trim()
   return trimmed !== '' ? trimmed : undefined
+}
+
+function parseInboundLastActiveAt(raw: unknown): number | undefined {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return undefined
+  return Math.floor(raw)
 }
 
 function parseHistoryTextLine(raw: Record<string, unknown>): ChatTextLine | null {
@@ -225,14 +252,55 @@ export function routeInboundChatMessage(
       const dn = m.displayName
       if (typeof sid !== 'string' || typeof dn !== 'string') continue
       const avatarUrl = parseInboundAvatarUrl(m.avatarUrl)
+      const lastActiveAt = parseInboundLastActiveAt(m.lastActiveAt)
       members.push({
         sessionId: sid,
         displayName: dn,
         isHost: Boolean(m.isHost),
+        ...(m.active === true ? { active: true } : m.active === false ? { active: false } : {}),
+        ...(lastActiveAt !== undefined ? { lastActiveAt } : {}),
         ...(avatarUrl !== undefined ? { avatarUrl } : {}),
       })
     }
     return { type: 'presence', event: { roomId: data.roomId, members } }
+  }
+  if (t === 'typing' && typeof data.roomId === 'string') {
+    if (data.roomId !== canonicalRoomId) return null
+    const sessionId = data.sessionId
+    const displayName = data.displayName
+    const action = data.action
+    if (typeof sessionId !== 'string' || typeof displayName !== 'string') return null
+    if (action !== 'start' && action !== 'stop') return null
+    const ts = typeof data.ts === 'number' ? data.ts : Date.now()
+    return {
+      type: 'typing',
+      event: {
+        roomId: data.roomId,
+        sessionId,
+        displayName,
+        action,
+        ts,
+      },
+    }
+  }
+  if (t === 'chat_system' && typeof data.roomId === 'string') {
+    if (data.roomId !== canonicalRoomId) return null
+    const sessionId = data.sessionId
+    const displayName = data.displayName
+    const systemEvent = data.event
+    if (typeof sessionId !== 'string' || typeof displayName !== 'string') return null
+    if (systemEvent !== 'join' && systemEvent !== 'leave') return null
+    const ts = typeof data.ts === 'number' ? data.ts : Date.now()
+    return {
+      type: 'chat_system',
+      event: {
+        roomId: data.roomId,
+        sessionId,
+        displayName,
+        event: systemEvent,
+        ts,
+      },
+    }
   }
   if (t === 'share_state' && typeof data.roomId === 'string') {
     if (data.roomId !== canonicalRoomId) return null
@@ -264,12 +332,17 @@ export class ChatSession {
   private enabled = false
   private connectOptions: ChatSessionConnectOptions | null = null
   private pageHideListener: (() => void) | null = null
+  private composeTypingStarted = false
+  private typingStartDebounceTimer: ReturnType<typeof setTimeout> | null = null
+  private typingIdleTimer: ReturnType<typeof setTimeout> | null = null
 
   private chatTextListeners = new Set<Listener<ChatTextLine>>()
   private chatGifListeners = new Set<Listener<ChatGifLine>>()
   private chatReactionListeners = new Set<Listener<ChatReactionEvent>>()
   private chatHistoryListeners = new Set<Listener<ChatHistoryEvent>>()
   private presenceListeners = new Set<Listener<PresenceEvent>>()
+  private typingListeners = new Set<Listener<TypingEvent>>()
+  private chatSystemListeners = new Set<Listener<ChatSystemEvent>>()
   private shareStateListeners = new Set<Listener<ShareStateEvent>>()
   private roomModeListeners = new Set<Listener<RoomModeEvent>>()
   private avDisabledListeners = new Set<Listener<AvDisabledEvent>>()
@@ -312,6 +385,56 @@ export class ChatSession {
   onPresence(listener: Listener<PresenceEvent>): () => void {
     this.presenceListeners.add(listener)
     return () => this.presenceListeners.delete(listener)
+  }
+
+  onTyping(listener: Listener<TypingEvent>): () => void {
+    this.typingListeners.add(listener)
+    return () => this.typingListeners.delete(listener)
+  }
+
+  onChatSystem(listener: Listener<ChatSystemEvent>): () => void {
+    this.chatSystemListeners.add(listener)
+    return () => this.chatSystemListeners.delete(listener)
+  }
+
+  /** Signed-in fans only: debounced typing_start / typing_stop on compose changes. */
+  onComposeDraftChange(draft: string): void {
+    this.clearTypingIdleTimer()
+    if (!this.connectOptions?.accessToken) return
+
+    const trimmed = draft.trim()
+    if (trimmed === '') {
+      this.clearTypingStartDebounce()
+      this.emitTypingStopIfNeeded()
+      return
+    }
+
+    this.scheduleTypingIdleStop()
+    if (this.composeTypingStarted || this.typingStartDebounceTimer) return
+
+    this.typingStartDebounceTimer = setTimeout(() => {
+      this.typingStartDebounceTimer = null
+      if (!this.connectOptions?.accessToken || this.composeTypingStarted) return
+      const sent = this.send({ action: 'typing_start' })
+      if (sent) {
+        this.composeTypingStarted = true
+        emitClientDrawerLog({
+          drawer: 'chat',
+          event: 'typing_start_sent',
+          outcome: 'retry',
+        })
+      }
+    }, TYPING_START_DEBOUNCE_MS)
+  }
+
+  onComposeBlur(): void {
+    this.clearTypingTimers()
+    this.emitTypingStopIfNeeded()
+  }
+
+  onComposeSent(): void {
+    this.clearTypingTimers()
+    this.emitTypingStopIfNeeded()
   }
 
   /** Media policy: share_state fan-out (handlers own SFU / playback reactions). */
@@ -392,6 +515,8 @@ export class ChatSession {
     this.cancelled = true
     this.enabled = false
     this.detachPageHide()
+    this.clearTypingTimers()
+    this.emitTypingStopIfNeeded()
     this.clearPing()
     this.clearReconnectTimer()
     this.ws?.close()
@@ -437,6 +562,47 @@ export class ChatSession {
       })
     }
     for (const listener of this.lifecycleListeners) listener(next)
+  }
+
+  private clearTypingStartDebounce(): void {
+    if (this.typingStartDebounceTimer) {
+      clearTimeout(this.typingStartDebounceTimer)
+      this.typingStartDebounceTimer = null
+    }
+  }
+
+  private clearTypingIdleTimer(): void {
+    if (this.typingIdleTimer) {
+      clearTimeout(this.typingIdleTimer)
+      this.typingIdleTimer = null
+    }
+  }
+
+  private clearTypingTimers(): void {
+    this.clearTypingStartDebounce()
+    this.clearTypingIdleTimer()
+  }
+
+  private scheduleTypingIdleStop(): void {
+    this.clearTypingIdleTimer()
+    this.typingIdleTimer = setTimeout(() => {
+      this.typingIdleTimer = null
+      this.emitTypingStopIfNeeded()
+    }, TYPING_COMPOSE_IDLE_MS)
+  }
+
+  private emitTypingStopIfNeeded(): void {
+    if (!this.composeTypingStarted) return
+    this.composeTypingStarted = false
+    if (!this.connectOptions?.accessToken) return
+    const sent = this.send({ action: 'typing_stop' })
+    if (sent) {
+      emitClientDrawerLog({
+        drawer: 'chat',
+        event: 'typing_stop_sent',
+        outcome: 'retry',
+      })
+    }
   }
 
   private clearPing(): void {
@@ -500,6 +666,22 @@ export class ChatSession {
         break
       case 'presence':
         for (const listener of this.presenceListeners) listener(routed.event)
+        break
+      case 'typing':
+        emitClientDrawerLog({
+          drawer: 'chat',
+          event: 'typing_fanout',
+          outcome: 'retry',
+        })
+        for (const listener of this.typingListeners) listener(routed.event)
+        break
+      case 'chat_system':
+        emitClientDrawerLog({
+          drawer: 'chat',
+          event: 'chat_system_fanout',
+          outcome: 'retry',
+        })
+        for (const listener of this.chatSystemListeners) listener(routed.event)
         break
       case 'share_state':
         for (const listener of this.shareStateListeners) listener(routed.event)

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -18,8 +18,10 @@ import {
   type ChatReactionEvent,
   type ChatSessionStatus,
   type ChatTextLine,
+  type ChatSystemEvent,
   type PresenceEvent,
   type RoomModeEvent,
+  type TypingEvent,
 } from './ChatSession'
 import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
 import { collectActiveErrorCodes } from '../realtimeDrawerErrors'
@@ -73,6 +75,8 @@ export type RoomControlHandlers = {
   onChatReaction?: (event: ChatReactionEvent) => void
   onChatHistory?: (event: ChatHistoryEvent) => void
   onPresence?: (event: PresenceEvent) => void
+  onTyping?: (event: TypingEvent) => void
+  onChatSystem?: (event: ChatSystemEvent) => void
   onRoomModeUi?: (event: RoomModeEvent) => void
   onAvDisabledUi?: (event: AvDisabledEvent) => void
 }
@@ -341,6 +345,18 @@ export class RoomRealtimeSdk {
     return sent
   }
 
+  notifyComposeDraftChange(draft: string): void {
+    this.chat?.onComposeDraftChange(draft)
+  }
+
+  notifyComposeBlur(): void {
+    this.chat?.onComposeBlur()
+  }
+
+  notifyComposeSent(): void {
+    this.chat?.onComposeSent()
+  }
+
   getChatStatus(): ChatSessionStatus {
     return this.chat?.getStatus() ?? 'idle'
   }
@@ -601,6 +617,8 @@ export class RoomRealtimeSdk {
     if (handlers.onChatReaction) maybePush(chat.onChatReaction(handlers.onChatReaction))
     if (handlers.onChatHistory) maybePush(chat.onChatHistory(handlers.onChatHistory))
     if (handlers.onPresence) maybePush(chat.onPresence(handlers.onPresence))
+    if (handlers.onTyping) maybePush(chat.onTyping(handlers.onTyping))
+    if (handlers.onChatSystem) maybePush(chat.onChatSystem(handlers.onChatSystem))
   }
 
   private async bootstrapMediaPlanes(): Promise<void> {

--- a/apps/web/src/room/useRoomMediaEngine.ts
+++ b/apps/web/src/room/useRoomMediaEngine.ts
@@ -43,8 +43,10 @@ export function useRoomMediaEngine(options: {
   sendJson: (payload: Record<string, unknown>) => boolean
   chat: ReturnType<RoomMediaEngine['getSnapshot']>['chat']
   chatReactions: ReturnType<RoomMediaEngine['getSnapshot']>['chatReactions']
+  remoteTyping: ReturnType<RoomMediaEngine['getSnapshot']>['remoteTyping']
   chatDraft: string
   setChatDraft: (draft: string) => void
+  notifyComposeBlur: () => void
   sendChat: () => void
   sendChatGif: (result: GiphySearchResult) => void
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
@@ -227,6 +229,7 @@ export function useRoomMediaEngine(options: {
   )
 
   const setChatDraft = useCallback((draft: string) => engine.setChatDraft(draft), [engine])
+  const notifyComposeBlur = useCallback(() => engine.notifyComposeBlur(), [engine])
   const sendChat = useCallback(() => engine.sendChat(fanToken), [engine, fanToken])
   const sendChatGif = useCallback(
     (result: GiphySearchResult) => engine.sendChatGif(fanToken, result),
@@ -291,8 +294,10 @@ export function useRoomMediaEngine(options: {
     sendJson,
     chat: snapshot.chat,
     chatReactions: snapshot.chatReactions,
+    remoteTyping: snapshot.remoteTyping,
     chatDraft: snapshot.chatDraft,
     setChatDraft,
+    notifyComposeBlur,
     sendChat,
     sendChatGif,
     toggleChatReaction,

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1510,6 +1510,75 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   vertical-align: middle;
 }
 
+.riffsync-room-page__active-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  margin-left: 0.4rem;
+  padding: 0.12rem 0.42rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  color: rgb(120 190 130);
+  border: 1px solid rgb(120 190 130 / 0.35);
+  vertical-align: middle;
+}
+
+.riffsync-room-page__active-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: rgb(100 175 110);
+  flex-shrink: 0;
+}
+
+.riffsync-room-chat-log__row--system {
+  justify-content: center;
+}
+
+.riffsync-room-chat-log__system-line {
+  margin: 0.15rem 0;
+  font-size: 0.78rem;
+  color: rgb(255 255 255 / 0.45);
+  text-align: center;
+}
+
+.riffsync-room-chat-log__row--typing {
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
+}
+
+.riffsync-room-chat-log__typing-line {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgb(255 255 255 / 0.55);
+}
+
+.riffsync-room-chat-log__typing-name {
+  font-weight: 600;
+}
+
+.riffsync-room-chat-log__typing-ellipsis {
+  display: inline-block;
+  margin-left: 0.15rem;
+  letter-spacing: 0.12em;
+  animation: riffsync-typing-ellipsis 1.2s steps(3, end) infinite;
+}
+
+@keyframes riffsync-typing-ellipsis {
+  0% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.35;
+  }
+}
+
 .riffsync-room-page__person-label strong {
   font-weight: 700;
 }

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -1,4 +1,6 @@
-export type WsRealtimeRoute = 'chat' | 'chat_gif' | 'react' | 'rename';
+export type WsRealtimeRoute = 'chat' | 'chat_gif' | 'react' | 'rename' | 'typing_start' | 'typing_stop';
+
+export type TypingRoute = 'typing_start' | 'typing_stop';
 
 export type WsRealtimeOutcome =
   | 'success'
@@ -145,6 +147,65 @@ export function recordWsRealtimeRoute(
     connectionIdTail: connectionId.slice(-12),
     roomIdHead: roomId.slice(0, 8),
     ...extras,
+  });
+}
+
+/** EMF counter for accepted typing routes (separate metric name per observability contract). */
+export function emitTypingRouteAccepted(route: TypingRoute): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Realtime',
+            Dimensions: [['Environment', 'Route']],
+            Metrics: [{ Name: 'TypingRouteAccepted', Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Route: route,
+      TypingRouteAccepted: 1,
+    }),
+  );
+}
+
+/** EMF counter when typing rate limit silently drops an inbound frame. */
+export function emitTypingRouteThrottled(route: TypingRoute): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Realtime',
+            Dimensions: [['Environment', 'Route']],
+            Metrics: [{ Name: 'TypingRouteThrottled', Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Route: route,
+      TypingRouteThrottled: 1,
+    }),
+  );
+}
+
+export function recordTypingRouteAccepted(route: TypingRoute, connectionId: string, roomId: string): void {
+  emitTypingRouteAccepted(route);
+  recordWsRealtimeRoute(route, 200, connectionId, roomId);
+}
+
+export function recordTypingRouteThrottled(route: TypingRoute, connectionId: string, roomId: string): void {
+  emitTypingRouteThrottled(route);
+  logWsAction({
+    route,
+    outcome: 'success',
+    connectionIdTail: connectionId.slice(-12),
+    roomIdHead: roomId.slice(0, 8),
   });
 }
 

--- a/infra/cdk/lambda/ws-chat-system-shared.ts
+++ b/infra/cdk/lambda/ws-chat-system-shared.ts
@@ -1,0 +1,82 @@
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { TextEncoder } from 'node:util';
+import {
+  postToConnections,
+  queryConnectionsForRoom,
+  wsManagementClient,
+} from './ws-shared';
+
+const encoder = new TextEncoder();
+
+export const JOIN_RECONNECT_COOLDOWN_SEC = 30;
+
+export function joinCooldownPresenceKey(fanSub: string): string {
+  return `__joinCooldown__#${fanSub}`;
+}
+
+export async function recordFanDisconnectJoinCooldown(
+  doc: DynamoDBDocumentClient,
+  presenceTable: string,
+  roomId: string,
+  fanSub: string,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): Promise<void> {
+  await doc
+    .send(
+      new PutCommand({
+        TableName: presenceTable,
+        Item: {
+          roomId,
+          presenceKey: joinCooldownPresenceKey(fanSub),
+          disconnectedAt: nowSec,
+          expiresAt: nowSec + JOIN_RECONNECT_COOLDOWN_SEC + 60,
+        },
+      }),
+    )
+    .catch(() => undefined);
+}
+
+export async function isWithinJoinReconnectCooldown(
+  doc: DynamoDBDocumentClient,
+  presenceTable: string,
+  roomId: string,
+  fanSub: string,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): Promise<boolean> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: presenceTable,
+      Key: { roomId, presenceKey: joinCooldownPresenceKey(fanSub) },
+    }),
+  );
+  const disconnectedAt = out.Item?.disconnectedAt;
+  if (typeof disconnectedAt !== 'number') {
+    return false;
+  }
+  return nowSec - disconnectedAt < JOIN_RECONNECT_COOLDOWN_SEC;
+}
+
+export async function fanOutChatSystem(params: {
+  doc: DynamoDBDocumentClient;
+  connectionsTable: string;
+  presenceTable: string;
+  roomId: string;
+  sessionId: string;
+  displayName: string;
+  event: 'join' | 'leave';
+  except?: string;
+}): Promise<void> {
+  const { doc, connectionsTable, presenceTable, roomId, sessionId, displayName, event, except } = params;
+  const mgmt = wsManagementClient();
+  const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
+  const out: Record<string, unknown> = {
+    type: 'chat_system',
+    roomId,
+    sessionId,
+    displayName,
+    event,
+    ts: Date.now(),
+  };
+  const buf = encoder.encode(JSON.stringify(out));
+  await postToConnections(mgmt, doc, connectionsTable, ids, buf, except, presenceTable);
+}

--- a/infra/cdk/lambda/ws-connect-chat-system.test.ts
+++ b/infra/cdk/lambda/ws-connect-chat-system.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  isWithinJoinReconnectCooldown: vi.fn(),
+  fanOutChatSystem: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  TransactWriteCommand: vi.fn((input: unknown) => ({ input, kind: 'TransactWrite' })),
+}));
+
+vi.mock('./cognito-jwt', () => ({
+  verifyAccessToken: vi.fn(async () => ({ sub: 'fan-sub-1' })),
+}));
+
+vi.mock('./room-lobby-cleanup', () => ({
+  clearLobbyCleanupPending: vi.fn(async () => undefined),
+}));
+
+vi.mock('./ws-chat-system-shared', () => ({
+  isWithinJoinReconnectCooldown: (...args: unknown[]) => mocks.isWithinJoinReconnectCooldown(...args),
+  fanOutChatSystem: (...args: unknown[]) => mocks.fanOutChatSystem(...args),
+}));
+
+vi.mock('./ws-shared', () => ({
+  broadcastRoomPresenceNow: vi.fn(async () => undefined),
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+}));
+
+import { handler } from './ws-connect';
+
+describe('ws-connect chat_system join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOMS_TABLE_NAME = 'rooms';
+    process.env.CONNECTIONS_TABLE_NAME = 'connections';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    mocks.docSend.mockResolvedValue({ Item: { hostSub: 'host-sub-1' } });
+    mocks.isWithinJoinReconnectCooldown.mockResolvedValue(false);
+    mocks.fanOutChatSystem.mockResolvedValue(undefined);
+  });
+
+  it('fans out join line for signed-in fans when not in reconnect cooldown', async () => {
+    await handler(
+      {
+        requestContext: { connectionId: 'conn-1' },
+        queryStringParameters: {
+          roomId: 'room-1',
+          sessionId: 'sess-fan',
+          displayName: 'Alice',
+          accessToken: 'jwt-token',
+        },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(mocks.fanOutChatSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        sessionId: 'sess-fan',
+        displayName: 'Alice',
+        event: 'join',
+        except: 'conn-1',
+      }),
+    );
+  });
+
+  it('suppresses join line for guests', async () => {
+    const { verifyAccessToken } = await import('./cognito-jwt');
+    vi.mocked(verifyAccessToken).mockResolvedValueOnce(null);
+
+    await handler(
+      {
+        requestContext: { connectionId: 'conn-guest' },
+        queryStringParameters: {
+          roomId: 'room-1',
+          sessionId: 'sess-guest',
+        },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(mocks.fanOutChatSystem).not.toHaveBeenCalled();
+  });
+
+  it('suppresses join line during reconnect cooldown', async () => {
+    mocks.isWithinJoinReconnectCooldown.mockResolvedValue(true);
+
+    await handler(
+      {
+        requestContext: { connectionId: 'conn-2' },
+        queryStringParameters: {
+          roomId: 'room-1',
+          sessionId: 'sess-fan',
+          displayName: 'Alice',
+          accessToken: 'jwt-token',
+        },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(mocks.fanOutChatSystem).not.toHaveBeenCalled();
+  });
+});

--- a/infra/cdk/lambda/ws-connect.test.ts
+++ b/infra/cdk/lambda/ws-connect.test.ts
@@ -66,6 +66,13 @@ describe('ws-connect handler', () => {
     expect(mocks.clearLobbyCleanupPending).toHaveBeenCalledWith(
       expect.objectContaining({ roomsTable: 'rooms', roomId: 'room-1' }),
     );
+
+    const transact = mocks.docSend.mock.calls.find(
+      (call) => (call[0] as { kind?: string }).kind === 'TransactWrite',
+    )?.[0] as { input?: { TransactItems?: Array<{ Put?: { Item?: Record<string, unknown> } }> } };
+    const presencePut = transact?.input?.TransactItems?.[1]?.Put?.Item;
+    expect(presencePut?.lastActiveAt).toEqual(expect.any(Number));
+    expect(presencePut?.fanSub).toBe('host-sub-1');
   });
 
   it('does not clear pending cleanup for guest connections', async () => {
@@ -87,5 +94,12 @@ describe('ws-connect handler', () => {
     );
 
     expect(mocks.clearLobbyCleanupPending).not.toHaveBeenCalled();
+
+    const transact = mocks.docSend.mock.calls.find(
+      (call) => (call[0] as { kind?: string }).kind === 'TransactWrite',
+    )?.[0] as { input?: { TransactItems?: Array<{ Put?: { Item?: Record<string, unknown> } }> } };
+    const presencePut = transact?.input?.TransactItems?.[1]?.Put?.Item;
+    expect(presencePut?.lastActiveAt).toBeUndefined();
+    expect(presencePut?.fanSub).toBeUndefined();
   });
 });

--- a/infra/cdk/lambda/ws-connect.test.ts
+++ b/infra/cdk/lambda/ws-connect.test.ts
@@ -29,6 +29,15 @@ vi.mock('./room-lobby-cleanup', () => ({
 
 vi.mock('./ws-shared', () => ({
   broadcastRoomPresenceNow: mocks.broadcastRoomPresenceNow,
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+}));
+
+vi.mock('./ws-chat-system-shared', () => ({
+  isWithinJoinReconnectCooldown: vi.fn(async () => false),
+  fanOutChatSystem: vi.fn(async () => undefined),
 }));
 
 import { handler } from './ws-connect';

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -85,7 +85,7 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
     presenceKey,
     sessionId,
     ...(displayName ? { displayName } : {}),
-    ...(fanSub ? { fanSub } : {}),
+    ...(fanSub ? { fanSub, lastActiveAt: nowSec } : {}),
     ...(hostSub ? { hostSub } : {}),
     connectedAt: nowSec,
     lastSeenAt: nowSec,

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -3,7 +3,8 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
 import { verifyAccessToken } from './cognito-jwt';
 import { clearLobbyCleanupPending } from './room-lobby-cleanup';
-import { broadcastRoomPresenceNow } from './ws-shared';
+import { fanOutChatSystem, isWithinJoinReconnectCooldown } from './ws-chat-system-shared';
+import { broadcastRoomPresenceNow, presenceDisplayNameForSession } from './ws-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -133,6 +134,25 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
   await broadcastRoomPresenceNow({ doc: client, connectionsTable: connTable, roomPresenceTable: presenceTable, roomId }).catch(
     () => undefined,
   );
+
+  if (fanSub) {
+    const inCooldown = await isWithinJoinReconnectCooldown(client, presenceTable, roomId, fanSub, nowSec).catch(
+      () => false,
+    );
+    if (!inCooldown) {
+      const rosterDisplayName = presenceDisplayNameForSession(sessionId, displayName);
+      await fanOutChatSystem({
+        doc: client,
+        connectionsTable: connTable,
+        presenceTable,
+        roomId,
+        sessionId,
+        displayName: rosterDisplayName,
+        event: 'join',
+        except: connectionId,
+      }).catch(() => undefined);
+    }
+  }
 
   return { statusCode: 200, body: 'Connected' };
 };

--- a/infra/cdk/lambda/ws-disconnect.test.ts
+++ b/infra/cdk/lambda/ws-disconnect.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   docSend: vi.fn(),
   markLobbyCleanupPendingIfLastHostGone: vi.fn(),
   broadcastRoomPresenceNow: vi.fn(),
+  recordFanDisconnectJoinCooldown: vi.fn(),
+  fanOutChatSystem: vi.fn(),
+  fanOutTyping: vi.fn(),
 }));
 
 vi.mock('@aws-sdk/client-dynamodb', () => ({
@@ -22,8 +25,21 @@ vi.mock('./room-lobby-cleanup', () => ({
   markLobbyCleanupPendingIfLastHostGone: mocks.markLobbyCleanupPendingIfLastHostGone,
 }));
 
+vi.mock('./ws-chat-system-shared', () => ({
+  recordFanDisconnectJoinCooldown: (...args: unknown[]) => mocks.recordFanDisconnectJoinCooldown(...args),
+  fanOutChatSystem: (...args: unknown[]) => mocks.fanOutChatSystem(...args),
+}));
+
+vi.mock('./ws-typing-shared', () => ({
+  fanOutTyping: (...args: unknown[]) => mocks.fanOutTyping(...args),
+}));
+
 vi.mock('./ws-shared', () => ({
   broadcastRoomPresenceNow: mocks.broadcastRoomPresenceNow,
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
 }));
 
 import { handler } from './ws-disconnect';
@@ -37,6 +53,9 @@ describe('ws-disconnect handler', () => {
     mocks.docSend.mockResolvedValue({});
     mocks.broadcastRoomPresenceNow.mockResolvedValue(undefined);
     mocks.markLobbyCleanupPendingIfLastHostGone.mockResolvedValue(undefined);
+    mocks.recordFanDisconnectJoinCooldown.mockResolvedValue(undefined);
+    mocks.fanOutChatSystem.mockResolvedValue(undefined);
+    mocks.fanOutTyping.mockResolvedValue(undefined);
   });
 
   it('marks lobby cleanup pending when the departing host socket leaves', async () => {
@@ -84,6 +103,75 @@ describe('ws-disconnect handler', () => {
 
     expect(mocks.markLobbyCleanupPendingIfLastHostGone).toHaveBeenCalledWith(
       expect.objectContaining({ departingWasHost: false }),
+    );
+  });
+
+  it('fans out leave and typing_stop for signed-in fan disconnects', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Item: {
+        roomId: 'room-1',
+        presenceKey: 'sess#conn',
+        sessionId: 'sess-fan',
+        fanSub: 'fan-sub-1',
+        displayName: 'Alice',
+      },
+    });
+
+    await handler(
+      {
+        requestContext: { connectionId: 'conn-1' },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(mocks.recordFanDisconnectJoinCooldown).toHaveBeenCalledWith(
+      expect.anything(),
+      'presence',
+      'room-1',
+      'fan-sub-1',
+    );
+    expect(mocks.fanOutChatSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        sessionId: 'sess-fan',
+        displayName: 'Alice',
+        event: 'leave',
+      }),
+    );
+    expect(mocks.fanOutTyping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        sessionId: 'sess-fan',
+        action: 'stop',
+      }),
+    );
+  });
+
+  it('does not fan out leave for guest disconnects', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Item: {
+        roomId: 'room-1',
+        presenceKey: 'sess#conn',
+        sessionId: 'sess-guest',
+      },
+    });
+
+    await handler(
+      {
+        requestContext: { connectionId: 'conn-1' },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(mocks.fanOutChatSystem).not.toHaveBeenCalled();
+    expect(mocks.recordFanDisconnectJoinCooldown).not.toHaveBeenCalled();
+    expect(mocks.fanOutTyping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-guest',
+        action: 'stop',
+      }),
     );
   });
 });

--- a/infra/cdk/lambda/ws-disconnect.ts
+++ b/infra/cdk/lambda/ws-disconnect.ts
@@ -2,7 +2,9 @@ import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, DeleteCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { markLobbyCleanupPendingIfLastHostGone } from './room-lobby-cleanup';
-import { broadcastRoomPresenceNow } from './ws-shared';
+import { fanOutChatSystem, recordFanDisconnectJoinCooldown } from './ws-chat-system-shared';
+import { fanOutTyping } from './ws-typing-shared';
+import { broadcastRoomPresenceNow, presenceDisplayNameForSession } from './ws-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -24,6 +26,9 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
   );
   const roomId = typeof prior.Item?.roomId === 'string' ? prior.Item.roomId : undefined;
   const presenceKey = typeof prior.Item?.presenceKey === 'string' ? prior.Item.presenceKey : undefined;
+  const sessionId = typeof prior.Item?.sessionId === 'string' ? prior.Item.sessionId : undefined;
+  const fanSub = typeof prior.Item?.fanSub === 'string' ? prior.Item.fanSub : undefined;
+  const displayNameAttr = prior.Item?.displayName;
   const departingWasHost =
     typeof prior.Item?.hostSub === 'string' && (prior.Item.hostSub as string).length > 0;
 
@@ -35,6 +40,34 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
   );
 
   if (roomId) {
+    if (fanSub) {
+      await recordFanDisconnectJoinCooldown(client, presenceTable, roomId, fanSub).catch(() => undefined);
+    }
+
+    if (sessionId) {
+      const displayName = presenceDisplayNameForSession(sessionId, displayNameAttr);
+      if (fanSub) {
+        await fanOutChatSystem({
+          doc: client,
+          connectionsTable: connTable,
+          presenceTable,
+          roomId,
+          sessionId,
+          displayName,
+          event: 'leave',
+        }).catch(() => undefined);
+      }
+      await fanOutTyping({
+        doc: client,
+        connectionsTable: connTable,
+        presenceTable,
+        roomId,
+        sessionId,
+        displayName,
+        action: 'stop',
+      }).catch(() => undefined);
+    }
+
     await client
       .send(
         new DeleteCommand({

--- a/infra/cdk/lambda/ws-route-chat-gif.test.ts
+++ b/infra/cdk/lambda/ws-route-chat-gif.test.ts
@@ -32,6 +32,7 @@ vi.mock('./ws-shared', () => ({
       : `Guest-${sessionId}`,
   queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
   resolveChatOutboundAvatarUrl: (...args: unknown[]) => mocks.resolveChatOutboundAvatarUrl(...args),
+  updateRoomPresenceLastActiveAt: vi.fn(async () => undefined),
   wsManagementClient: () => mocks.wsManagementClient(),
 }));
 

--- a/infra/cdk/lambda/ws-route-chat-history.test.ts
+++ b/infra/cdk/lambda/ws-route-chat-history.test.ts
@@ -62,6 +62,7 @@ vi.mock('./ws-shared', () => ({
       : `Guest-${sessionId}`,
   queryConnectionsForRoom: vi.fn(async () => ['conn-abc', 'conn-other']),
   resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
+  updateRoomPresenceLastActiveAt: vi.fn(async () => undefined),
   wsManagementClient: vi.fn(() => ({ client: true })),
 }));
 

--- a/infra/cdk/lambda/ws-route-chat.test.ts
+++ b/infra/cdk/lambda/ws-route-chat.test.ts
@@ -31,6 +31,7 @@ vi.mock('./ws-shared', () => ({
       : `Guest-${sessionId}`,
   queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
   resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
+  updateRoomPresenceLastActiveAt: vi.fn(async () => undefined),
   wsManagementClient: () => mocks.wsManagementClient(),
 }));
 

--- a/infra/cdk/lambda/ws-route-last-active-at.test.ts
+++ b/infra/cdk/lambda/ws-route-last-active-at.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   queryConnectionsForRoom: vi.fn(),
   postToConnections: vi.fn(),
   wsManagementClient: vi.fn(),
+  updateRoomPresenceLastActiveAt: vi.fn(),
 }));
 
 vi.mock('@aws-sdk/client-dynamodb', () => ({
@@ -31,7 +32,7 @@ vi.mock('./ws-shared', () => ({
       : `Guest-${sessionId}`,
   queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
   resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
-  updateRoomPresenceLastActiveAt: vi.fn(async () => undefined),
+  updateRoomPresenceLastActiveAt: (...args: unknown[]) => mocks.updateRoomPresenceLastActiveAt(...args),
   wsManagementClient: () => mocks.wsManagementClient(),
 }));
 
@@ -45,7 +46,7 @@ function baseEvent(overrides: {
   return {
     body: overrides.body,
     requestContext: {
-      routeKey: overrides.routeKey ?? 'react',
+      routeKey: overrides.routeKey ?? 'chat',
       connectionId: overrides.connectionId ?? 'conn-abc',
       requestId: 'req-1',
       apiId: 'api-1',
@@ -80,13 +81,13 @@ function stubConnectedRoom(connOverrides: Record<string, unknown> = {}) {
       };
     }
     if (table === 'rooms') {
-      return { Item: { hostSub: 'host-sub-1' } };
+      return { Item: { hostSub: 'host-sub-1', lastActivityAt: 0 } };
     }
     return {};
   });
 }
 
-describe('ws-route react', () => {
+describe('ws-route lastActiveAt updates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.ROOMS_TABLE_NAME = 'rooms';
@@ -94,91 +95,62 @@ describe('ws-route react', () => {
     process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
     process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
     mocks.wsManagementClient.mockReturnValue({ client: true });
-    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc', 'conn-other']);
+    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc']);
     mocks.postToConnections.mockResolvedValue(undefined);
+    mocks.updateRoomPresenceLastActiveAt.mockResolvedValue(undefined);
     stubConnectedRoom();
   });
 
-  it('fans out chat_reaction on valid react body', async () => {
-    const body = JSON.stringify({
-      action: 'react',
-      messageId: '11111111-1111-4111-8111-111111111111',
-      emoji: '👍',
-      reactionAction: 'add',
-    });
-    const result = await handler(baseEvent({ routeKey: 'react', body }), {} as never, () => undefined);
+  it('updates lastActiveAt on ping before returning', async () => {
+    const result = await handler(baseEvent({ routeKey: 'ping' }), {} as never, () => undefined);
     expect(result).toEqual({ statusCode: 200, body: 'OK' });
-    expect(mocks.postToConnections).toHaveBeenCalledTimes(1);
-    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
-    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
-    expect(parsed).toMatchObject({
-      type: 'chat_reaction',
-      roomId: 'room-1',
+    expect(mocks.updateRoomPresenceLastActiveAt).toHaveBeenCalledWith(
+      expect.anything(),
+      'presence',
+      'room-1',
+      'sess-1#conn-abc',
+      expect.any(Number),
+    );
+  });
+
+  it('updates lastActiveAt on chat before fan-out', async () => {
+    const body = JSON.stringify({
+      action: 'chat',
+      text: 'hi',
       messageId: '11111111-1111-4111-8111-111111111111',
-      emoji: '👍',
-      action: 'add',
-      sessionId: 'sess-1',
-      displayName: 'Fan One',
     });
-    expect(typeof parsed.ts).toBe('number');
+    await handler(baseEvent({ routeKey: 'chat', body }), {} as never, () => undefined);
+    expect(mocks.updateRoomPresenceLastActiveAt).toHaveBeenCalledWith(
+      expect.anything(),
+      'presence',
+      'room-1',
+      'sess-1#conn-abc',
+    );
+    expect(mocks.postToConnections).toHaveBeenCalled();
+    const updateOrder = mocks.updateRoomPresenceLastActiveAt.mock.invocationCallOrder[0];
+    const fanOutOrder = mocks.postToConnections.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(fanOutOrder!);
   });
 
-  it('maps $default route when body.action is react', async () => {
+  it('updates lastActiveAt on chat_gif before fan-out', async () => {
     const body = JSON.stringify({
-      action: 'react',
-      messageId: 'msg-id-1',
-      emoji: '🔥',
-      reactionAction: 'remove',
+      action: 'chat_gif',
+      messageId: '11111111-1111-4111-8111-111111111111',
+      giphyId: 'gif-1',
+      renditionUrl: 'https://media1.giphy.com/media/abc/giphy.gif',
     });
-    const result = await handler(baseEvent({ routeKey: '$default', body }), {} as never, () => undefined);
-    expect(result).toEqual({ statusCode: 200, body: 'OK' });
-    const payload = mocks.postToConnections.mock.calls[0][4] as Uint8Array;
-    const parsed = JSON.parse(new TextDecoder().decode(payload)) as Record<string, unknown>;
-    expect(parsed.action).toBe('remove');
+    await handler(baseEvent({ routeKey: 'chat_gif', body }), {} as never, () => undefined);
+    expect(mocks.updateRoomPresenceLastActiveAt).toHaveBeenCalled();
   });
 
-  it('returns 400 for missing messageId without fan-out', async () => {
-    const body = JSON.stringify({ action: 'react', emoji: '👍', reactionAction: 'add' });
-    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
-    expect(result).toEqual({ statusCode: 400, body: 'messageId required, max 64 chars' });
-    expect(mocks.postToConnections).not.toHaveBeenCalled();
-  });
-
-  it('returns 400 for invalid reactionAction without fan-out', async () => {
-    const body = JSON.stringify({
-      action: 'react',
-      messageId: 'msg-1',
-      emoji: '👍',
-      reactionAction: 'toggle',
-    });
-    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
-    expect(result).toEqual({ statusCode: 400, body: 'reactionAction must be add or remove' });
-    expect(mocks.postToConnections).not.toHaveBeenCalled();
-  });
-
-  it('returns 403 without fanSub and does not fan-out', async () => {
-    stubConnectedRoom({ fanSub: undefined });
+  it('updates lastActiveAt on react before fan-out', async () => {
     const body = JSON.stringify({
       action: 'react',
       messageId: 'msg-1',
       emoji: '👍',
       reactionAction: 'add',
     });
-    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
-    expect(result).toEqual({ statusCode: 403, body: 'Fan JWT required for react' });
-    expect(mocks.postToConnections).not.toHaveBeenCalled();
-  });
-
-  it('returns 403 for blank fanSub', async () => {
-    stubConnectedRoom({ fanSub: '   ' });
-    const body = JSON.stringify({
-      action: 'react',
-      messageId: 'msg-1',
-      emoji: '👍',
-      reactionAction: 'add',
-    });
-    const result = await handler(baseEvent({ body }), {} as never, () => undefined);
-    expect(result).toEqual({ statusCode: 403, body: 'Fan JWT required for react' });
-    expect(mocks.postToConnections).not.toHaveBeenCalled();
+    await handler(baseEvent({ routeKey: 'react', body }), {} as never, () => undefined);
+    expect(mocks.updateRoomPresenceLastActiveAt).toHaveBeenCalled();
   });
 });

--- a/infra/cdk/lambda/ws-route-typing.test.ts
+++ b/infra/cdk/lambda/ws-route-typing.test.ts
@@ -1,0 +1,185 @@
+import type { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  queryConnectionsForRoom: vi.fn(),
+  postToConnections: vi.fn(),
+  wsManagementClient: vi.fn(),
+  updateRoomPresenceLastActiveAt: vi.fn(),
+  tryConsumeTypingRateLimit: vi.fn(),
+  shouldCoalesceTypingStart: vi.fn(),
+  recordTypingStartFanOut: vi.fn(),
+  fanOutTyping: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+vi.mock('./ws-shared', () => ({
+  broadcastRoomPresence: vi.fn(),
+  broadcastRoomPresenceNow: vi.fn(),
+  postToConnections: (...args: unknown[]) => mocks.postToConnections(...args),
+  presenceDisplayNameForSession: (sessionId: string, displayNameAttr: unknown) =>
+    typeof displayNameAttr === 'string' && displayNameAttr.trim() !== ''
+      ? displayNameAttr.trim()
+      : `Guest-${sessionId}`,
+  queryConnectionsForRoom: (...args: unknown[]) => mocks.queryConnectionsForRoom(...args),
+  resolveChatOutboundAvatarUrl: vi.fn(async () => undefined),
+  updateRoomPresenceLastActiveAt: (...args: unknown[]) => mocks.updateRoomPresenceLastActiveAt(...args),
+  wsManagementClient: () => mocks.wsManagementClient(),
+}));
+
+vi.mock('./ws-typing-shared', () => ({
+  tryConsumeTypingRateLimit: (...args: unknown[]) => mocks.tryConsumeTypingRateLimit(...args),
+  shouldCoalesceTypingStart: (...args: unknown[]) => mocks.shouldCoalesceTypingStart(...args),
+  recordTypingStartFanOut: (...args: unknown[]) => mocks.recordTypingStartFanOut(...args),
+  fanOutTyping: (...args: unknown[]) => mocks.fanOutTyping(...args),
+}));
+
+import { handler } from './ws-route';
+
+function baseEvent(overrides: {
+  routeKey?: string;
+  body?: string;
+  connectionId?: string;
+}): APIGatewayProxyWebsocketEventV2 {
+  return {
+    body: overrides.body,
+    requestContext: {
+      routeKey: overrides.routeKey ?? 'typing_start',
+      connectionId: overrides.connectionId ?? 'conn-abc',
+      requestId: 'req-1',
+      apiId: 'api-1',
+      stage: 'dev',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      eventType: 'MESSAGE',
+      extendedRequestId: 'ext-1',
+      requestTime: '01/Jan/2026:00:00:00 +0000',
+      requestTimeEpoch: 0,
+      messageDirection: 'IN',
+      messageId: 'msg-1',
+      connectedAt: 0,
+    },
+    isBase64Encoded: false,
+  } as APIGatewayProxyWebsocketEventV2;
+}
+
+function stubConnectedRoom(connOverrides: Record<string, unknown> = {}) {
+  mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: { TableName?: string } }) => {
+    const table = cmd.input?.TableName;
+    if (table === 'connections') {
+      return {
+        Item: {
+          roomId: 'room-1',
+          sessionId: 'sess-1',
+          presenceKey: 'sess-1#conn-abc',
+          displayName: 'Fan One',
+          fanSub: 'fan-sub-1',
+          ...connOverrides,
+        },
+      };
+    }
+    if (table === 'rooms') {
+      return { Item: { hostSub: 'host-sub-1' } };
+    }
+    return {};
+  });
+}
+
+describe('ws-route typing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ROOMS_TABLE_NAME = 'rooms';
+    process.env.CONNECTIONS_TABLE_NAME = 'connections';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.WS_MANAGEMENT_API_ENDPOINT = 'https://mgmt.example/ws';
+    mocks.wsManagementClient.mockReturnValue({ client: true });
+    mocks.queryConnectionsForRoom.mockResolvedValue(['conn-abc', 'conn-other']);
+    mocks.postToConnections.mockResolvedValue(undefined);
+    mocks.tryConsumeTypingRateLimit.mockResolvedValue(true);
+    mocks.shouldCoalesceTypingStart.mockReturnValue(false);
+    mocks.updateRoomPresenceLastActiveAt.mockResolvedValue(undefined);
+    mocks.fanOutTyping.mockResolvedValue(undefined);
+    stubConnectedRoom();
+  });
+
+  it('rejects typing_start for guests without fan JWT', async () => {
+    stubConnectedRoom({ fanSub: undefined });
+    const result = await handler(baseEvent({ routeKey: 'typing_start' }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 403, body: 'Fan JWT required for typing_start' });
+    expect(mocks.fanOutTyping).not.toHaveBeenCalled();
+  });
+
+  it('fans out typing_start after lastActiveAt update', async () => {
+    const result = await handler(baseEvent({ routeKey: 'typing_start' }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.updateRoomPresenceLastActiveAt).toHaveBeenCalledWith(
+      expect.anything(),
+      'presence',
+      'room-1',
+      'sess-1#conn-abc',
+    );
+    expect(mocks.fanOutTyping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: 'room-1',
+        sessionId: 'sess-1',
+        displayName: 'Fan One',
+        action: 'start',
+      }),
+    );
+    const updateOrder = mocks.updateRoomPresenceLastActiveAt.mock.invocationCallOrder[0];
+    const fanOutOrder = mocks.fanOutTyping.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(fanOutOrder!);
+  });
+
+  it('silently drops typing_start when rate limit is exceeded', async () => {
+    mocks.tryConsumeTypingRateLimit.mockResolvedValue(false);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await handler(baseEvent({ routeKey: 'typing_start' }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.fanOutTyping).not.toHaveBeenCalled();
+
+    const throttledEmf = logSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .find((parsed) => parsed?.TypingRouteThrottled === 1);
+    expect(throttledEmf?.Route).toBe('typing_start');
+  });
+
+  it('coalesces duplicate typing_start within 1s without fan-out', async () => {
+    mocks.shouldCoalesceTypingStart.mockReturnValue(true);
+    const result = await handler(baseEvent({ routeKey: 'typing_start' }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.fanOutTyping).not.toHaveBeenCalled();
+    expect(mocks.updateRoomPresenceLastActiveAt).not.toHaveBeenCalled();
+  });
+
+  it('fans out typing_stop without updating lastActiveAt', async () => {
+    const result = await handler(baseEvent({ routeKey: 'typing_stop' }), {} as never, () => undefined);
+    expect(result).toEqual({ statusCode: 200, body: 'OK' });
+    expect(mocks.updateRoomPresenceLastActiveAt).not.toHaveBeenCalled();
+    expect(mocks.fanOutTyping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'stop',
+      }),
+    );
+  });
+});

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -23,7 +23,13 @@ import {
   persistReactionRemove,
   queryChatHistory,
 } from './room-chat-shared';
-import { recordWsRealtimeRoute } from './riffsync-observability';
+import { recordTypingRouteAccepted, recordTypingRouteThrottled, recordWsRealtimeRoute } from './riffsync-observability';
+import {
+  fanOutTyping,
+  recordTypingStartFanOut,
+  shouldCoalesceTypingStart,
+  tryConsumeTypingRateLimit,
+} from './ws-typing-shared';
 import {
   broadcastRoomPresence,
   broadcastRoomPresenceNow,
@@ -513,6 +519,44 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
     recordWsRealtimeRoute('react', 200, connectionId, roomId);
+    return { statusCode: 200, body: 'OK' };
+  }
+
+  if (routeKey === 'typing_start' || routeKey === 'typing_stop') {
+    const typingRoute = routeKey;
+    const action = typingRoute === 'typing_start' ? 'start' : 'stop';
+    const fanSubDenied = requireFanSub(conn, typingRoute);
+    if (fanSubDenied) {
+      recordWsRealtimeRoute(typingRoute, 403, connectionId, roomId);
+      return fanSubDenied;
+    }
+
+    const allowed = await tryConsumeTypingRateLimit(doc, connTable, connectionId).catch(() => true);
+    if (!allowed) {
+      recordTypingRouteThrottled(typingRoute, connectionId, roomId);
+      return { statusCode: 200, body: 'OK' };
+    }
+
+    const nowMs = Date.now();
+    if (typingRoute === 'typing_start') {
+      if (shouldCoalesceTypingStart(roomId, sessionId, nowMs)) {
+        return { statusCode: 200, body: 'OK' };
+      }
+      await updateRoomPresenceLastActiveAt(doc, presenceTable, roomId, presenceKey).catch(() => undefined);
+      recordTypingStartFanOut(roomId, sessionId, nowMs);
+    }
+
+    const displayName = presenceDisplayNameForSession(sessionId, conn.displayName);
+    await fanOutTyping({
+      doc,
+      connectionsTable: connTable,
+      presenceTable,
+      roomId,
+      sessionId,
+      displayName,
+      action,
+    });
+    recordTypingRouteAccepted(typingRoute, connectionId, roomId);
     return { statusCode: 200, body: 'OK' };
   }
 

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -31,6 +31,7 @@ import {
   presenceDisplayNameForSession,
   queryConnectionsForRoom,
   resolveChatOutboundAvatarUrl,
+  updateRoomPresenceLastActiveAt,
   wsManagementClient,
 } from './ws-shared';
 
@@ -181,6 +182,7 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
         }),
       )
       .catch(() => undefined);
+    await updateRoomPresenceLastActiveAt(doc, presenceTable, roomId, presenceKey, nowSec).catch(() => undefined);
 
     return { statusCode: 200, body: 'OK' };
   }
@@ -344,6 +346,8 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
       ).catch(() => undefined);
     }
 
+    await updateRoomPresenceLastActiveAt(doc, presenceTable, roomId, presenceKey).catch(() => undefined);
+
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
     recordWsRealtimeRoute('chat', 200, connectionId, roomId, { textLength: text.length });
@@ -448,6 +452,8 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
       ).catch(() => undefined);
     }
 
+    await updateRoomPresenceLastActiveAt(doc, presenceTable, roomId, presenceKey).catch(() => undefined);
+
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
     recordWsRealtimeRoute('chat_gif', 200, connectionId, roomId, { hasGiphyId: true });
@@ -501,6 +507,8 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
         await persistReactionRemove(doc, roomChatTable, roomId, messageId, emoji, sessionId).catch(() => undefined);
       }
     }
+
+    await updateRoomPresenceLastActiveAt(doc, presenceTable, roomId, presenceKey).catch(() => undefined);
 
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);

--- a/infra/cdk/lambda/ws-shared.test.ts
+++ b/infra/cdk/lambda/ws-shared.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
 import {
+  derivePresenceActive,
   enrichRosterMembersWithAvatarUrls,
+  PRESENCE_ACTIVE_WINDOW_SEC,
   rosterFromConnectionItems,
   type PresenceBroadcastMember,
 } from './ws-shared';
@@ -50,6 +52,50 @@ describe('rosterFromConnectionItems', () => {
     const guest = members.find((m) => m.sessionId === 'sess-guest');
     expect(guest?.isHost).toBe(false);
     expect(guest?.displayName).toMatch(/^Guest/);
+    expect(guest?.active).toBe(false);
+    expect(guest?.lastActiveAt).toBeUndefined();
+  });
+
+  it('uses max lastActiveAt across tabs and precomputes active', () => {
+    const nowSec = 1_700_000_000;
+    const recent = nowSec - 30;
+    const stale = nowSec - PRESENCE_ACTIVE_WINDOW_SEC;
+
+    const { members } = rosterFromConnectionItems(
+      [
+        { sessionId: 'sess-a', displayName: 'Alice', lastActiveAt: stale },
+        { sessionId: 'sess-a', displayName: 'Alice tab 2', lastActiveAt: recent },
+        { sessionId: 'sess-b', displayName: 'Bob', lastActiveAt: stale },
+      ],
+      nowSec,
+    );
+
+    const alice = members.find((m) => m.sessionId === 'sess-a');
+    expect(alice?.lastActiveAt).toBe(recent);
+    expect(alice?.active).toBe(true);
+
+    const bob = members.find((m) => m.sessionId === 'sess-b');
+    expect(bob?.lastActiveAt).toBe(stale);
+    expect(bob?.active).toBe(false);
+  });
+
+  it('treats lastActiveAt exactly at window boundary as inactive', () => {
+    const nowSec = 1_700_000_000;
+    const atBoundary = nowSec - PRESENCE_ACTIVE_WINDOW_SEC;
+    const { members } = rosterFromConnectionItems(
+      [{ sessionId: 'sess-a', displayName: 'Alice', lastActiveAt: atBoundary }],
+      nowSec,
+    );
+    expect(members[0]?.active).toBe(false);
+  });
+});
+
+describe('derivePresenceActive', () => {
+  it('returns true inside the 120s window and false at or beyond it', () => {
+    const nowSec = 1_000_000;
+    expect(derivePresenceActive(nowSec - 119, nowSec)).toBe(true);
+    expect(derivePresenceActive(nowSec - 120, nowSec)).toBe(false);
+    expect(derivePresenceActive(undefined, nowSec)).toBe(false);
   });
 });
 
@@ -58,8 +104,8 @@ describe('enrichRosterMembersWithAvatarUrls', () => {
     batchMock.mockResolvedValue(new Map([['fan-1', 'https://cdn.example/avatars/fan-1.png']]));
 
     const members: PresenceBroadcastMember[] = [
-      { sessionId: 'sess-a', displayName: 'Alice', isHost: false },
-      { sessionId: 'sess-guest', displayName: 'Guest', isHost: false },
+      { sessionId: 'sess-a', displayName: 'Alice', isHost: false, active: true },
+      { sessionId: 'sess-guest', displayName: 'Guest', isHost: false, active: false },
     ];
     const fanSubBySessionId = new Map([['sess-a', 'fan-1']]);
 

--- a/infra/cdk/lambda/ws-shared.ts
+++ b/infra/cdk/lambda/ws-shared.ts
@@ -1,5 +1,5 @@
 import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
-import { DynamoDBDocumentClient, DeleteCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand, GetCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { TextEncoder } from 'node:util';
 import { batchAvatarUrlsByFanSub } from './fan-profile-shared';
 
@@ -124,10 +124,17 @@ export async function postToConnections(
   }
 }
 
+/** Active idle window — see `.ai/data/data_model.md`. */
+export const PRESENCE_ACTIVE_WINDOW_SEC = 120;
+
 export type PresenceBroadcastMember = {
   sessionId: string;
   displayName: string;
   isHost: boolean;
+  /** Server-precomputed from roster `lastActiveAt` (max per sessionId). */
+  active: boolean;
+  /** Epoch seconds — max across tabs sharing `sessionId`; omitted when never engaged. */
+  lastActiveAt?: number;
   /** Server-trusted FanProfiles HTTPS URL; omitted when the fan has no avatar. */
   avatarUrl?: string;
 };
@@ -137,6 +144,7 @@ type RosterAccumulator = {
   displayName: string;
   isHost: boolean;
   fanSub?: string;
+  lastActiveAt?: number;
 };
 
 export type RosterFromConnectionsResult = {
@@ -156,8 +164,62 @@ export function presenceDisplayNameForSession(sessionId: string, displayNameAttr
   return guestLabelFallback(sessionId);
 }
 
+export function parseLastActiveAt(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+export function derivePresenceActive(lastActiveAt: number | undefined, nowSec: number): boolean {
+  if (lastActiveAt === undefined) {
+    return false;
+  }
+  return nowSec - lastActiveAt < PRESENCE_ACTIVE_WINDOW_SEC;
+}
+
+function maxLastActiveAt(a: number | undefined, b: number | undefined): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
+function isConditionalCheckFailed(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'ConditionalCheckFailedException';
+}
+
+/** Monotonic max write — skips when an existing row already has a newer timestamp. */
+export async function updateRoomPresenceLastActiveAt(
+  doc: DynamoDBDocumentClient,
+  presenceTable: string,
+  roomId: string,
+  presenceKey: string,
+  nowSec?: number,
+): Promise<void> {
+  const ts = nowSec ?? Math.floor(Date.now() / 1000);
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: presenceTable,
+        Key: { roomId, presenceKey },
+        UpdateExpression: 'SET lastActiveAt = :ts',
+        ExpressionAttributeValues: { ':ts': ts },
+        ConditionExpression: 'attribute_not_exists(lastActiveAt) OR lastActiveAt <= :ts',
+      }),
+    );
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      return;
+    }
+    throw err;
+  }
+}
+
 /** Collapse multiple connections that share `sessionId` (e.g. two tabs): host flag dominates; keep a stable label. */
-export function rosterFromConnectionItems(items: readonly Record<string, unknown>[]): RosterFromConnectionsResult {
+export function rosterFromConnectionItems(
+  items: readonly Record<string, unknown>[],
+  nowSec: number = Math.floor(Date.now() / 1000),
+): RosterFromConnectionsResult {
   const merged = new Map<string, RosterAccumulator>();
 
   for (const it of items) {
@@ -165,6 +227,7 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
     if (sessionId === '') continue;
     const isHostConn = typeof it.hostSub === 'string' && (it.hostSub as string).length > 0;
     const fanSubConn = typeof it.fanSub === 'string' && it.fanSub.length > 0 ? it.fanSub : undefined;
+    const lastActiveAtConn = parseLastActiveAt(it.lastActiveAt);
     let label = presenceDisplayNameForSession(sessionId, it.displayName);
 
     const cur = merged.get(sessionId);
@@ -174,6 +237,7 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
         displayName: label,
         isHost: isHostConn,
         ...(fanSubConn ? { fanSub: fanSubConn } : {}),
+        ...(lastActiveAtConn !== undefined ? { lastActiveAt: lastActiveAtConn } : {}),
       });
     } else {
       if (!isHostConn) label = cur.displayName || label;
@@ -182,6 +246,7 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
         displayName: label,
         isHost: cur.isHost || isHostConn,
         fanSub: cur.fanSub ?? fanSubConn,
+        lastActiveAt: maxLastActiveAt(cur.lastActiveAt, lastActiveAtConn),
       });
     }
   }
@@ -193,11 +258,16 @@ export function rosterFromConnectionItems(items: readonly Record<string, unknown
   });
 
   const fanSubBySessionId = new Map<string, string>();
-  const members: PresenceBroadcastMember[] = list.map(({ sessionId, displayName, isHost, fanSub }) => {
+  const members: PresenceBroadcastMember[] = list.map(({ sessionId, displayName, isHost, fanSub, lastActiveAt }) => {
     if (fanSub) {
       fanSubBySessionId.set(sessionId, fanSub);
     }
-    return { sessionId, displayName, isHost };
+    const active = derivePresenceActive(lastActiveAt, nowSec);
+    const member: PresenceBroadcastMember = { sessionId, displayName, isHost, active };
+    if (lastActiveAt !== undefined) {
+      member.lastActiveAt = lastActiveAt;
+    }
+    return member;
   });
 
   return { members, fanSubBySessionId };
@@ -255,7 +325,8 @@ export async function broadcastRoomPresence(params: {
       if (typeof cid === 'string') ids.push(cid);
     }
 
-    const { members: rosterMembers, fanSubBySessionId } = rosterFromConnectionItems(items);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const { members: rosterMembers, fanSubBySessionId } = rosterFromConnectionItems(items, nowSec);
     const profilesTable = process.env.FAN_PROFILES_TABLE_NAME;
     const members =
       profilesTable && fanSubBySessionId.size > 0

--- a/infra/cdk/lambda/ws-typing-shared.test.ts
+++ b/infra/cdk/lambda/ws-typing-shared.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+import { TYPING_PAIR_LIMIT_PER_MINUTE, tryConsumeTypingRateLimit } from './ws-typing-shared';
+
+describe('tryConsumeTypingRateLimit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows events under the per-minute pair budget', async () => {
+    mocks.docSend.mockResolvedValueOnce({});
+    const allowed = await tryConsumeTypingRateLimit(
+      { send: mocks.docSend } as never,
+      'connections',
+      'conn-1',
+      1_700_000_000_000,
+    );
+    expect(allowed).toBe(true);
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the same-minute budget is exhausted', async () => {
+    const conditionalErr = Object.assign(new Error('conditional'), { name: 'ConditionalCheckFailedException' });
+    mocks.docSend
+      .mockRejectedValueOnce(conditionalErr)
+      .mockRejectedValueOnce(conditionalErr);
+
+    const allowed = await tryConsumeTypingRateLimit(
+      { send: mocks.docSend } as never,
+      'connections',
+      'conn-1',
+      1_700_000_000_000,
+    );
+    expect(allowed).toBe(false);
+  });
+
+  it('resets the counter when the minute bucket rolls', async () => {
+    const conditionalErr = Object.assign(new Error('conditional'), { name: 'ConditionalCheckFailedException' });
+    mocks.docSend.mockRejectedValueOnce(conditionalErr).mockResolvedValueOnce({});
+
+    const allowed = await tryConsumeTypingRateLimit(
+      { send: mocks.docSend } as never,
+      'connections',
+      'conn-1',
+      1_700_000_000_000,
+    );
+    expect(allowed).toBe(true);
+    expect(mocks.docSend).toHaveBeenCalledTimes(2);
+    const resetCall = mocks.docSend.mock.calls[1][0] as {
+      input?: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+    };
+    expect(resetCall.input?.UpdateExpression).toContain('typingRateCount = :one');
+    expect(TYPING_PAIR_LIMIT_PER_MINUTE).toBe(30);
+  });
+});

--- a/infra/cdk/lambda/ws-typing-shared.ts
+++ b/infra/cdk/lambda/ws-typing-shared.ts
@@ -1,0 +1,112 @@
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { TextEncoder } from 'node:util';
+import { minuteBucketEpochMs } from './giphy-search-shared';
+import {
+  postToConnections,
+  queryConnectionsForRoom,
+  wsManagementClient,
+} from './ws-shared';
+
+const encoder = new TextEncoder();
+
+/** Pairs per minute per sessionId — each start and stop counts toward the pair budget. */
+export const TYPING_PAIR_LIMIT_PER_MINUTE = 30;
+const TYPING_EVENTS_PER_MINUTE = TYPING_PAIR_LIMIT_PER_MINUTE * 2;
+const TYPING_START_COALESCE_MS = 1000;
+
+const lastTypingStartFanOutMs = new Map<string, number>();
+
+function isConditionalCheckFailed(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'ConditionalCheckFailedException';
+}
+
+export function typingCoalesceKey(roomId: string, sessionId: string): string {
+  return `${roomId}:${sessionId}`;
+}
+
+export function shouldCoalesceTypingStart(roomId: string, sessionId: string, nowMs: number): boolean {
+  const prior = lastTypingStartFanOutMs.get(typingCoalesceKey(roomId, sessionId));
+  return prior !== undefined && nowMs - prior < TYPING_START_COALESCE_MS;
+}
+
+export function recordTypingStartFanOut(roomId: string, sessionId: string, nowMs: number): void {
+  lastTypingStartFanOutMs.set(typingCoalesceKey(roomId, sessionId), nowMs);
+}
+
+/** Returns false when the per-minute typing budget is exhausted (silent drop). */
+export async function tryConsumeTypingRateLimit(
+  doc: DynamoDBDocumentClient,
+  connectionsTable: string,
+  connectionId: string,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  const limit = TYPING_EVENTS_PER_MINUTE;
+
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: connectionsTable,
+        Key: { connectionId },
+        UpdateExpression:
+          'SET typingRateBucket = :bucket, typingRateCount = if_not_exists(typingRateCount, :zero) + :one',
+        ConditionExpression:
+          '(attribute_not_exists(typingRateBucket) OR typingRateBucket = :bucket) AND (attribute_not_exists(typingRateCount) OR typingRateCount < :limit)',
+        ExpressionAttributeValues: {
+          ':bucket': bucketMs,
+          ':one': 1,
+          ':zero': 0,
+          ':limit': limit,
+        },
+      }),
+    );
+    return true;
+  } catch (err: unknown) {
+    if (!isConditionalCheckFailed(err)) {
+      throw err;
+    }
+  }
+
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: connectionsTable,
+        Key: { connectionId },
+        UpdateExpression: 'SET typingRateBucket = :bucket, typingRateCount = :one',
+        ConditionExpression: 'attribute_not_exists(typingRateBucket) OR typingRateBucket <> :bucket',
+        ExpressionAttributeValues: { ':bucket': bucketMs, ':one': 1 },
+      }),
+    );
+    return true;
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function fanOutTyping(params: {
+  doc: DynamoDBDocumentClient;
+  connectionsTable: string;
+  presenceTable: string;
+  roomId: string;
+  sessionId: string;
+  displayName: string;
+  action: 'start' | 'stop';
+  except?: string;
+}): Promise<void> {
+  const { doc, connectionsTable, presenceTable, roomId, sessionId, displayName, action, except } = params;
+  const mgmt = wsManagementClient();
+  const ids = await queryConnectionsForRoom(doc, presenceTable, roomId);
+  const out: Record<string, unknown> = {
+    type: 'typing',
+    roomId,
+    sessionId,
+    displayName,
+    action,
+    ts: Date.now(),
+  };
+  const buf = encoder.encode(JSON.stringify(out));
+  await postToConnections(mgmt, doc, connectionsTable, ids, buf, except, presenceTable);
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -790,7 +790,7 @@ export class ApiCatalogStack extends cdk.Stack {
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
-      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, chat_gif, react, share_state, leave`,
+      description: `RiffSync WebSocket (${environment}) — ping, presence_request, chat, chat_gif, react, typing_start, typing_stop, share_state, leave`,
       routeSelectionExpression: '$request.body.action',
     });
 
@@ -838,6 +838,7 @@ export class ApiCatalogStack extends cdk.Stack {
         ROOMS_TABLE_NAME: this.roomsTable.tableName,
         CONNECTIONS_TABLE_NAME: this.connectionsTable.tableName,
         ROOM_PRESENCE_TABLE_NAME: this.roomPresenceTable.tableName,
+        WS_MANAGEMENT_API_ENDPOINT: wsMgmtEndpoint,
         HOST_DISCONNECT_GRACE_MS: String(hostDisconnectGraceMs),
         NODE_OPTIONS: '--enable-source-maps',
       },
@@ -868,6 +869,8 @@ export class ApiCatalogStack extends cdk.Stack {
     this.roomChatTable.grantReadWriteData(wsRouteFn);
     this.fanProfilesTable.grantReadData(wsRouteFn);
     this.webSocketApi.grantManageConnections(wsRouteFn);
+    this.webSocketApi.grantManageConnections(wsConnectFn);
+    this.webSocketApi.grantManageConnections(wsDisconnectFn);
 
     roomPatchFn.addEnvironment('WS_MANAGEMENT_API_ENDPOINT', wsMgmtEndpoint);
     roomPatchFn.addEnvironment('CONNECTIONS_TABLE_NAME', this.connectionsTable.tableName);
@@ -897,6 +900,8 @@ export class ApiCatalogStack extends cdk.Stack {
       'chat_gif',
       'react',
       'rename',
+      'typing_start',
+      'typing_stop',
       'share_state',
       'leave',
     ] as const) {


### PR DESCRIPTION
## Summary

M22 presence epic (#241) on `feature/issue-241`:

- **#244** (merged on branch): server `lastActiveAt` persistence and `active` roster fan-out
- **#245** (merged on branch): `typing_start` / `typing_stop` routes and ephemeral `chat_system` join/leave fan-out
- **#246** (this push): fan SPA People **Active** badges, chat typing ellipsis, and join/leave system lines

### Client (#246)

- **`ChatSession`**: parse inbound `presence.active` / `lastActiveAt`, `typing`, and `chat_system`; debounced outbound `typing_start` / `typing_stop` (300ms start, 3s idle stop, fan JWT only)
- **`RoomMediaEngine` / sidebar**: Active badge on People rows; ephemeral typing rows (5s TTL); muted system lines excluded from `chat_history` replay
- Vitest coverage for parsing, typing debounce, and indicator TTL helpers

## Test plan

- [x] `cd apps/web && npm ci && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [x] `cd infra/cdk && npm ci && npm test`
- [ ] Manual: two browsers, signed-in fan types in compose; remote sees ellipsis and Active badge
- [ ] Manual: signed-in join/leave lines appear; refresh does not replay them from history

Closes #241, #244, #245, and #246 when merged.