### PR TITLE
feat(web): M23 participant A/V reliability — SFU isolation, People state, speaking (#242)

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -149,6 +149,14 @@ const drawerStatusMockConfig = vi.hoisted(() => {
       return null
     }
 
+    buildParticipantProducerSnapshots() {
+      return new Map()
+    }
+
+    onParticipantProducerRegistryChange() {
+      return () => undefined
+    }
+
     sendControl() {
       return true
     }

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -120,6 +120,7 @@ export function RoomPage() {
     toggleChatReaction,
     peopleShown,
     participantProducerBySessionId,
+    speakingBySessionId,
     chatMemberLabels,
     sfuConfigAlert,
     chatDrawerBanner,
@@ -409,6 +410,7 @@ export function RoomPage() {
             toggleChatReaction={toggleChatReaction}
             peopleShown={peopleShown}
             participantProducerBySessionId={participantProducerBySessionId}
+            speakingBySessionId={speakingBySessionId}
             isPublisher={isPublisher}
             experimentalFeatures={experimentalFeatures}
             shareHint={shareHint}

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -119,6 +119,7 @@ export function RoomPage() {
     sendChatGif,
     toggleChatReaction,
     peopleShown,
+    participantProducerBySessionId,
     chatMemberLabels,
     sfuConfigAlert,
     chatDrawerBanner,
@@ -407,6 +408,7 @@ export function RoomPage() {
             sendChatGif={sendChatGif}
             toggleChatReaction={toggleChatReaction}
             peopleShown={peopleShown}
+            participantProducerBySessionId={participantProducerBySessionId}
             isPublisher={isPublisher}
             experimentalFeatures={experimentalFeatures}
             shareHint={shareHint}

--- a/apps/web/src/room/HostControlBar.test.tsx
+++ b/apps/web/src/room/HostControlBar.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { HostControlBar } from './HostControlBar'
+import { VIDEO_CHAT_BETA_DESCRIPTION } from './hostRoomControls'
 
 describe('HostControlBar', () => {
   let container: HTMLDivElement
@@ -83,5 +84,26 @@ describe('HostControlBar', () => {
     expect(modeButtons[0]?.getAttribute('aria-checked')).toBe('false')
     expect(modeButtons[1]?.getAttribute('aria-checked')).toBe('true')
     expect(container.querySelector('[role="radiogroup"]')).not.toBeNull()
+  })
+
+  it('renders Video Chat Beta label when room A/V is enabled', () => {
+    renderBar({ avDisabled: false })
+    const modeButtons = container.querySelectorAll('button.riffsync-room-page__host-bar-mode')
+    expect(modeButtons[1]?.querySelector('.riffsync-room-page__host-bar-beta')?.textContent).toBe('Beta')
+    expect(modeButtons[1]?.getAttribute('title')).toBe(VIDEO_CHAT_BETA_DESCRIPTION)
+    const descId = modeButtons[1]?.getAttribute('aria-describedby')
+    expect(descId).toBeTruthy()
+    expect(container.querySelector(`#${CSS.escape(descId ?? '')}`)?.textContent).toBe(
+      VIDEO_CHAT_BETA_DESCRIPTION,
+    )
+  })
+
+  it('hides Video Chat Beta label when avDisabled kill switch is on', () => {
+    renderBar({ avDisabled: true })
+    expect(container.querySelector('.riffsync-room-page__host-bar-beta')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__host-bar-beta-desc')).toBeNull()
+    const modeButtons = container.querySelectorAll('button.riffsync-room-page__host-bar-mode')
+    expect(modeButtons[1]?.getAttribute('title')).toBeNull()
+    expect(modeButtons[1]?.getAttribute('aria-describedby')).toBeNull()
   })
 })

--- a/apps/web/src/room/HostControlBar.tsx
+++ b/apps/web/src/room/HostControlBar.tsx
@@ -1,4 +1,6 @@
+import { useId } from 'react'
 import type { RoomMode } from '../api/roomsApi'
+import { VIDEO_CHAT_BETA_DESCRIPTION } from './hostRoomControls'
 
 export type HostControlBarProps = {
   roomMode: RoomMode
@@ -23,6 +25,8 @@ export function HostControlBar({
   onToggleAvDisabled,
 }: HostControlBarProps) {
   const barDisabled = busy
+  const videoChatBetaDescId = useId()
+  const showVideoChatBeta = !avDisabled
 
   return (
     <div
@@ -39,6 +43,7 @@ export function HostControlBar({
         {MODE_OPTIONS.map((opt) => {
           const videoChatInert = avDisabled && opt.value === 'videoChat'
           const optionDisabled = barDisabled || videoChatInert
+          const showBeta = showVideoChatBeta && opt.value === 'videoChat'
           return (
             <button
               key={opt.value}
@@ -47,6 +52,8 @@ export function HostControlBar({
               className={`gen-button riffsync-room-page__host-bar-mode${roomMode === opt.value ? ' riffsync-room-page__host-bar-mode--on' : ''}`}
               aria-checked={roomMode === opt.value}
               aria-disabled={optionDisabled || undefined}
+              aria-describedby={showBeta ? videoChatBetaDescId : undefined}
+              title={showBeta ? VIDEO_CHAT_BETA_DESCRIPTION : undefined}
               disabled={barDisabled}
               onClick={() => {
                 if (optionDisabled || roomMode === opt.value) return
@@ -54,10 +61,20 @@ export function HostControlBar({
               }}
             >
               {opt.label}
+              {showBeta ? (
+                <span className="riffsync-room-page__host-bar-beta" aria-hidden="true">
+                  Beta
+                </span>
+              ) : null}
             </button>
           )
         })}
       </div>
+      {showVideoChatBeta ? (
+        <p className="riffsync-room-page__host-bar-beta-desc" id={videoChatBetaDescId}>
+          {VIDEO_CHAT_BETA_DESCRIPTION}
+        </p>
+      ) : null}
       <button
         type="button"
         className={`gen-button riffsync-room-page__host-bar-kill${avDisabled ? ' riffsync-room-page__host-bar-kill--on' : ''}`}

--- a/apps/web/src/room/PeopleRowAvIndicators.tsx
+++ b/apps/web/src/room/PeopleRowAvIndicators.tsx
@@ -3,6 +3,7 @@ import { peopleAvAriaLabel } from './peoplePresentation'
 
 type PeopleRowAvIndicatorsProps = {
   snapshot: ParticipantProducerSnapshot
+  speaking?: boolean
 }
 
 function CameraOnIcon() {
@@ -61,7 +62,10 @@ function MicOffIcon() {
   )
 }
 
-export function PeopleRowAvIndicators({ snapshot }: PeopleRowAvIndicatorsProps) {
+export function PeopleRowAvIndicators({
+  snapshot,
+  speaking = false,
+}: PeopleRowAvIndicatorsProps) {
   const camClass = snapshot.hasVideoProducer
     ? 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--on'
     : 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--off'
@@ -79,7 +83,7 @@ export function PeopleRowAvIndicators({ snapshot }: PeopleRowAvIndicatorsProps) 
   return (
     <span
       className="riffsync-room-page__people-av"
-      aria-label={peopleAvAriaLabel(snapshot)}
+      aria-label={peopleAvAriaLabel(snapshot, speaking)}
     >
       <span className={camClass} title={snapshot.hasVideoProducer ? 'Camera on' : 'Camera off'}>
         {snapshot.hasVideoProducer ? <CameraOnIcon /> : <CameraOffIcon />}

--- a/apps/web/src/room/PeopleRowAvIndicators.tsx
+++ b/apps/web/src/room/PeopleRowAvIndicators.tsx
@@ -1,0 +1,101 @@
+import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
+import { peopleAvAriaLabel } from './peoplePresentation'
+
+type PeopleRowAvIndicatorsProps = {
+  snapshot: ParticipantProducerSnapshot
+}
+
+function CameraOnIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M17 10.5V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-3.5l4 3v-9l-4 3z"
+      />
+    </svg>
+  )
+}
+
+function CameraOffIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M3.27 2L2 3.27l2.76 2.76A1 1 0 0 0 5 7H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h11a1 1 0 0 0 .97-.76L20.73 22 22 20.73 3.27 2zM17 10.5V7a1 1 0 0 0-1-1h-1.18l2 2H17v2.5l2 1.5v-2.17l1.46 1.46A1 1 0 0 0 19 11h-2v-.5z"
+      />
+    </svg>
+  )
+}
+
+function MicOnIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11h-2z"
+      />
+    </svg>
+  )
+}
+
+function MicMutedIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M19 11h-1.7c0 .74-.16 1.43-.43 2.05l1.23 1.23c.56-.98.9-2.09.9-3.28zm-4.02.17c0-.06.02-.11.02-.17V5a3 3 0 0 0-5.86-1.02L7.1 8.28A3.01 3.01 0 0 0 9 11v.17l5.98 5.98zM4.27 3L3 4.27l6.01 6.01V11a3 3 0 0 0 3.18 2.99l1.66 1.66A4.98 4.98 0 0 1 7 11H5a7 7 0 0 0 6 6.92V21h2v-3.08c.91-.13 1.77-.45 2.54-.9L19.73 21 21 19.73 4.27 3z"
+      />
+    </svg>
+  )
+}
+
+function MicOffIcon() {
+  return (
+    <svg width={14} height={14} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 14a3 3 0 0 0 3-3V5a3 3 0 0 0-6 0v6a3 3 0 0 0 3 3zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11h-2z"
+        opacity="0.35"
+      />
+    </svg>
+  )
+}
+
+export function PeopleRowAvIndicators({ snapshot }: PeopleRowAvIndicatorsProps) {
+  const camClass = snapshot.hasVideoProducer
+    ? 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--on'
+    : 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--off'
+
+  let micClass = 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--off'
+  let MicIcon = MicOffIcon
+  if (snapshot.hasAudioProducer && snapshot.audioPaused) {
+    micClass = 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--muted'
+    MicIcon = MicMutedIcon
+  } else if (snapshot.hasAudioProducer) {
+    micClass = 'riffsync-room-page__people-av-icon riffsync-room-page__people-av-icon--on'
+    MicIcon = MicOnIcon
+  }
+
+  return (
+    <span
+      className="riffsync-room-page__people-av"
+      aria-label={peopleAvAriaLabel(snapshot)}
+    >
+      <span className={camClass} title={snapshot.hasVideoProducer ? 'Camera on' : 'Camera off'}>
+        {snapshot.hasVideoProducer ? <CameraOnIcon /> : <CameraOffIcon />}
+      </span>
+      <span
+        className={micClass}
+        title={
+          !snapshot.hasAudioProducer
+            ? 'Microphone off'
+            : snapshot.audioPaused
+              ? 'Microphone muted'
+              : 'Microphone on'
+        }
+      >
+        <MicIcon />
+      </span>
+    </span>
+  )
+}

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -16,7 +16,7 @@ import { resolveMemberAvatarUrl } from './roomPageTypes'
 import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
 import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from './participantProducerRegistry'
 import { PeopleRowAvIndicators } from './PeopleRowAvIndicators'
-import { shouldShowPeopleAvIndicators } from './peoplePresentation'
+import { peopleRowSpeakingClass, shouldShowPeopleAvIndicators } from './peoplePresentation'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
@@ -51,6 +51,7 @@ type RoomPageSidebarProps = {
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
   peopleShown: PresenceMember[]
   participantProducerBySessionId: Map<string, ParticipantProducerSnapshot>
+  speakingBySessionId: Map<string, boolean>
   isPublisher: boolean
   experimentalFeatures: boolean
   shareHint: string | null
@@ -100,6 +101,7 @@ export function RoomPageSidebar({
   toggleChatReaction,
   peopleShown,
   participantProducerBySessionId,
+  speakingBySessionId,
   isPublisher,
   experimentalFeatures,
   shareHint,
@@ -287,6 +289,7 @@ export function RoomPageSidebar({
                 const producerSnapshot =
                   participantProducerBySessionId.get(p.sessionId) ??
                   EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT
+                const speaking = speakingBySessionId.get(p.sessionId) ?? false
                 const showAvIndicators = shouldShowPeopleAvIndicators(
                   p.sessionId,
                   sessionId,
@@ -295,7 +298,7 @@ export function RoomPageSidebar({
                 return (
                   <li
                     key={p.sessionId}
-                    className={`riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}`}
+                    className={`riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}${peopleRowSpeakingClass(speaking)}`}
                   >
                     <span className="riffsync-room-page__person-label">
                       <FanAvatarThumb displayName={p.displayName} avatarUrl={peopleAvatarUrl} />
@@ -317,9 +320,14 @@ export function RoomPageSidebar({
                             Active
                           </span>
                         ) : null}
+                        {speaking ? (
+                          <span className="riffsync-room-page__speaking-badge" aria-hidden="true">
+                            Speaking
+                          </span>
+                        ) : null}
                       </span>
                       {showAvIndicators ? (
-                        <PeopleRowAvIndicators snapshot={producerSnapshot} />
+                        <PeopleRowAvIndicators snapshot={producerSnapshot} speaking={speaking} />
                       ) : null}
                     </span>
                   </li>

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -13,6 +13,10 @@ import type { ParticipantAvController } from './sfu/participantAvSession'
 import type { ChatLine, PresenceMember, RemoteTypingEntry, RoomSidebarTab } from './roomPageTypes'
 import { formatChatSystemText } from './chatSystemLine'
 import { resolveMemberAvatarUrl } from './roomPageTypes'
+import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
+import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from './participantProducerRegistry'
+import { PeopleRowAvIndicators } from './PeopleRowAvIndicators'
+import { shouldShowPeopleAvIndicators } from './peoplePresentation'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
@@ -46,6 +50,7 @@ type RoomPageSidebarProps = {
   sendChatGif: (result: GiphySearchResult) => void
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
   peopleShown: PresenceMember[]
+  participantProducerBySessionId: Map<string, ParticipantProducerSnapshot>
   isPublisher: boolean
   experimentalFeatures: boolean
   shareHint: string | null
@@ -94,6 +99,7 @@ export function RoomPageSidebar({
   sendChatGif,
   toggleChatReaction,
   peopleShown,
+  participantProducerBySessionId,
   isPublisher,
   experimentalFeatures,
   shareHint,
@@ -278,6 +284,14 @@ export function RoomPageSidebar({
                   sessionId,
                   myAvatarUrl,
                 )
+                const producerSnapshot =
+                  participantProducerBySessionId.get(p.sessionId) ??
+                  EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT
+                const showAvIndicators = shouldShowPeopleAvIndicators(
+                  p.sessionId,
+                  sessionId,
+                  fanToken,
+                )
                 return (
                   <li
                     key={p.sessionId}
@@ -304,6 +318,9 @@ export function RoomPageSidebar({
                           </span>
                         ) : null}
                       </span>
+                      {showAvIndicators ? (
+                        <PeopleRowAvIndicators snapshot={producerSnapshot} />
+                      ) : null}
                     </span>
                   </li>
                 )

--- a/apps/web/src/room/audio/speakingVad.test.ts
+++ b/apps/web/src/room/audio/speakingVad.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INITIAL_SPEAKING_HYSTERESIS,
+  SPEAKING_VAD_ATTACK_MS,
+  SPEAKING_VAD_HANG_MS,
+  SPEAKING_VAD_RMS_THRESHOLD,
+  computeNormalizedRms,
+  isSpeakingVadEnabled,
+  stepSpeakingHysteresis,
+  type SpeakingHysteresisState,
+} from './speakingVad'
+
+describe('speakingVad', () => {
+  describe('computeNormalizedRms', () => {
+    it('returns zero for silence', () => {
+      expect(computeNormalizedRms(new Float32Array(8))).toBe(0)
+    })
+
+    it('returns normalized RMS for non-zero samples', () => {
+      const samples = new Float32Array([0.5, -0.5, 0.5, -0.5])
+      expect(computeNormalizedRms(samples)).toBeCloseTo(0.5, 5)
+    })
+  })
+
+  describe('stepSpeakingHysteresis', () => {
+    it('requires attack duration before entering speaking', () => {
+      const t0 = 1_000
+      let state = INITIAL_SPEAKING_HYSTERESIS
+      state = stepSpeakingHysteresis(state, SPEAKING_VAD_RMS_THRESHOLD, t0)
+      expect(state.speaking).toBe(false)
+
+      state = stepSpeakingHysteresis(
+        state,
+        SPEAKING_VAD_RMS_THRESHOLD,
+        t0 + SPEAKING_VAD_ATTACK_MS - 1,
+      )
+      expect(state.speaking).toBe(false)
+
+      state = stepSpeakingHysteresis(
+        state,
+        SPEAKING_VAD_RMS_THRESHOLD,
+        t0 + SPEAKING_VAD_ATTACK_MS,
+      )
+      expect(state.speaking).toBe(true)
+    })
+
+    it('holds speaking through brief silence then clears after hang', () => {
+      const t0 = 2_000
+      let state: SpeakingHysteresisState = {
+        speaking: true,
+        aboveSinceMs: t0,
+        belowSinceMs: null,
+      }
+
+      const belowStart = t0 + 50
+      state = stepSpeakingHysteresis(state, 0, belowStart)
+      expect(state.speaking).toBe(true)
+
+      state = stepSpeakingHysteresis(state, 0, belowStart + SPEAKING_VAD_HANG_MS - 1)
+      expect(state.speaking).toBe(true)
+
+      state = stepSpeakingHysteresis(state, 0, belowStart + SPEAKING_VAD_HANG_MS)
+      expect(state.speaking).toBe(false)
+    })
+
+    it('clears immediately when not speaking and below threshold', () => {
+      const state = stepSpeakingHysteresis(INITIAL_SPEAKING_HYSTERESIS, 0, 500)
+      expect(state).toEqual(INITIAL_SPEAKING_HYSTERESIS)
+    })
+  })
+
+  describe('isSpeakingVadEnabled', () => {
+    it('is false when mic is off or muted', () => {
+      expect(
+        isSpeakingVadEnabled({ hasAudioProducer: false, audioPaused: false }),
+      ).toBe(false)
+      expect(
+        isSpeakingVadEnabled({ hasAudioProducer: true, audioPaused: true }),
+      ).toBe(false)
+      expect(
+        isSpeakingVadEnabled({ hasAudioProducer: true, audioPaused: false }),
+      ).toBe(true)
+    })
+  })
+})

--- a/apps/web/src/room/audio/speakingVad.ts
+++ b/apps/web/src/room/audio/speakingVad.ts
@@ -1,0 +1,60 @@
+export const SPEAKING_VAD_FFT_SIZE = 512
+export const SPEAKING_VAD_RMS_THRESHOLD = 0.02
+export const SPEAKING_VAD_ATTACK_MS = 150
+export const SPEAKING_VAD_HANG_MS = 300
+
+export type SpeakingHysteresisState = {
+  speaking: boolean
+  aboveSinceMs: number | null
+  belowSinceMs: number | null
+}
+
+export const INITIAL_SPEAKING_HYSTERESIS: SpeakingHysteresisState = {
+  speaking: false,
+  aboveSinceMs: null,
+  belowSinceMs: null,
+}
+
+export function computeNormalizedRms(samples: Float32Array): number {
+  if (samples.length === 0) return 0
+  let sumSq = 0
+  for (let i = 0; i < samples.length; i += 1) {
+    const sample = samples[i] ?? 0
+    sumSq += sample * sample
+  }
+  return Math.sqrt(sumSq / samples.length)
+}
+
+export function stepSpeakingHysteresis(
+  state: SpeakingHysteresisState,
+  rms: number,
+  nowMs: number,
+): SpeakingHysteresisState {
+  const above = rms >= SPEAKING_VAD_RMS_THRESHOLD
+
+  if (above) {
+    const aboveSince = state.aboveSinceMs ?? nowMs
+    if (!state.speaking && nowMs - aboveSince >= SPEAKING_VAD_ATTACK_MS) {
+      return { speaking: true, aboveSinceMs: aboveSince, belowSinceMs: null }
+    }
+    return { ...state, aboveSinceMs: aboveSince, belowSinceMs: null }
+  }
+
+  if (!state.speaking) {
+    return INITIAL_SPEAKING_HYSTERESIS
+  }
+
+  const belowSince = state.belowSinceMs ?? nowMs
+  if (nowMs - belowSince >= SPEAKING_VAD_HANG_MS) {
+    return INITIAL_SPEAKING_HYSTERESIS
+  }
+
+  return { ...state, aboveSinceMs: null, belowSinceMs: belowSince }
+}
+
+export function isSpeakingVadEnabled(snapshot: {
+  hasAudioProducer: boolean
+  audioPaused: boolean
+}): boolean {
+  return snapshot.hasAudioProducer && !snapshot.audioPaused
+}

--- a/apps/web/src/room/audio/speakingVadRegistry.test.ts
+++ b/apps/web/src/room/audio/speakingVadRegistry.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { createSpeakingVadRegistry } from './speakingVadRegistry'
+
+function mockRegistry(overrides: Parameters<typeof createSpeakingVadRegistry>[0] = {}) {
+  return createSpeakingVadRegistry({
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: vi.fn(),
+    ...overrides,
+  })
+}
+
+describe('speakingVadRegistry', () => {
+  it('clears speaking when VAD is disabled for a session', () => {
+    const mockAnalyser = {
+      fftSize: 512,
+      getFloatTimeDomainData: vi.fn(),
+      disconnect: vi.fn(),
+    }
+    const mockSource = { connect: vi.fn(), disconnect: vi.fn() }
+    const registry = mockRegistry({
+      createAudioContext: () =>
+        ({
+          createMediaStreamSource: vi.fn(() => mockSource),
+          createAnalyser: vi.fn(() => mockAnalyser),
+          close: vi.fn(),
+        }) as unknown as AudioContext,
+    })
+
+    const track = { readyState: 'live' } as MediaStreamTrack
+    registry.syncSession('s1', track, true)
+    registry.syncSession('s1', track, false)
+    expect(registry.isSpeaking('s1')).toBe(false)
+    registry.dispose()
+  })
+
+  it('clears speaking when session is removed', () => {
+    const registry = mockRegistry({
+      createAudioContext: () =>
+        ({
+          createMediaStreamSource: vi.fn(() => ({
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+          })),
+          createAnalyser: vi.fn(() => ({
+            fftSize: 512,
+            getFloatTimeDomainData: vi.fn(),
+            disconnect: vi.fn(),
+          })),
+          close: vi.fn(),
+        }) as unknown as AudioContext,
+    })
+
+    registry.syncSession('s1', { readyState: 'live' } as MediaStreamTrack, true)
+    registry.removeSession('s1')
+    expect(registry.buildSpeakingMap(['s1']).get('s1')).toBe(false)
+    registry.dispose()
+  })
+
+  it('does not enter speaking when disabled', () => {
+    const registry = mockRegistry()
+    registry.syncSession('s1', { readyState: 'live' } as MediaStreamTrack, false)
+    expect(registry.isSpeaking('s1')).toBe(false)
+    registry.dispose()
+  })
+
+  it('buildSpeakingMap returns false for unknown sessions', () => {
+    const registry = mockRegistry()
+    expect(registry.buildSpeakingMap(['unknown']).get('unknown')).toBe(false)
+    registry.dispose()
+  })
+})

--- a/apps/web/src/room/audio/speakingVadRegistry.ts
+++ b/apps/web/src/room/audio/speakingVadRegistry.ts
@@ -1,0 +1,230 @@
+import {
+  INITIAL_SPEAKING_HYSTERESIS,
+  SPEAKING_VAD_FFT_SIZE,
+  computeNormalizedRms,
+  stepSpeakingHysteresis,
+  type SpeakingHysteresisState,
+} from './speakingVad'
+
+type SessionVadRow = {
+  track: MediaStreamTrack | null
+  enabled: boolean
+  source: MediaStreamAudioSourceNode | null
+  analyser: AnalyserNode | null
+  hysteresis: SpeakingHysteresisState
+  speaking: boolean
+}
+
+export type SpeakingVadRegistry = {
+  syncSession: (
+    sessionId: string,
+    track: MediaStreamTrack | null,
+    enabled: boolean,
+  ) => void
+  removeSession: (sessionId: string) => void
+  isSpeaking: (sessionId: string) => boolean
+  buildSpeakingMap: (sessionIds: readonly string[]) => Map<string, boolean>
+  dispose: () => void
+}
+
+export type CreateSpeakingVadRegistryOptions = {
+  createAudioContext?: () => AudioContext
+  onSpeakingChange?: () => void
+  requestAnimationFrame?: (callback: FrameRequestCallback) => number
+  cancelAnimationFrame?: (handle: number) => void
+  now?: () => number
+}
+
+function createEmptyRow(): SessionVadRow {
+  return {
+    track: null,
+    enabled: false,
+    source: null,
+    analyser: null,
+    hysteresis: INITIAL_SPEAKING_HYSTERESIS,
+    speaking: false,
+  }
+}
+
+export function createSpeakingVadRegistry(
+  options: CreateSpeakingVadRegistryOptions = {},
+): SpeakingVadRegistry {
+  const createAudioContext = options.createAudioContext ?? (() => new AudioContext())
+  const raf =
+    options.requestAnimationFrame ??
+    globalThis.requestAnimationFrame?.bind(globalThis) ??
+    ((cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number)
+  const cancelRaf =
+    options.cancelAnimationFrame ??
+    globalThis.cancelAnimationFrame?.bind(globalThis) ??
+    ((handle: number) => clearTimeout(handle as unknown as ReturnType<typeof setTimeout>))
+  const now = options.now ?? (() => performance.now())
+
+  let ctx: AudioContext | null = null
+  const sessions = new Map<string, SessionVadRow>()
+  let rafId: number | null = null
+  const sampleBuffer = new Float32Array(SPEAKING_VAD_FFT_SIZE)
+
+  const ensureContext = (): AudioContext => {
+    if (!ctx) {
+      ctx = createAudioContext()
+    }
+    return ctx
+  }
+
+  const teardownGraph = (row: SessionVadRow): void => {
+    try {
+      row.source?.disconnect()
+    } catch {
+      /* ignore */
+    }
+    try {
+      row.analyser?.disconnect()
+    } catch {
+      /* ignore */
+    }
+    row.source = null
+    row.analyser = null
+  }
+
+  const clearSpeaking = (row: SessionVadRow): boolean => {
+    if (!row.speaking && row.hysteresis === INITIAL_SPEAKING_HYSTERESIS) {
+      return false
+    }
+    row.speaking = false
+    row.hysteresis = INITIAL_SPEAKING_HYSTERESIS
+    return true
+  }
+
+  const applyGraph = (row: SessionVadRow): void => {
+    teardownGraph(row)
+    if (!row.enabled || !row.track || row.track.readyState !== 'live') return
+    const audioCtx = ensureContext()
+    const stream = new MediaStream([row.track])
+    row.source = audioCtx.createMediaStreamSource(stream)
+    row.analyser = audioCtx.createAnalyser()
+    row.analyser.fftSize = SPEAKING_VAD_FFT_SIZE
+    row.source.connect(row.analyser)
+  }
+
+  const hasActiveAnalyser = (): boolean => {
+    for (const row of sessions.values()) {
+      if (row.enabled && row.analyser) return true
+    }
+    return false
+  }
+
+  const stopLoop = (): void => {
+    if (rafId === null) return
+    cancelRaf(rafId)
+    rafId = null
+  }
+
+  const tick = (): void => {
+    let changed = false
+    const t = now()
+
+    for (const row of sessions.values()) {
+      if (!row.enabled || !row.analyser) {
+        if (clearSpeaking(row)) changed = true
+        continue
+      }
+
+      row.analyser.getFloatTimeDomainData(sampleBuffer)
+      const rms = computeNormalizedRms(sampleBuffer)
+      const next = stepSpeakingHysteresis(row.hysteresis, rms, t)
+      row.hysteresis = next
+      if (next.speaking !== row.speaking) {
+        row.speaking = next.speaking
+        changed = true
+      }
+    }
+
+    if (changed) {
+      options.onSpeakingChange?.()
+    }
+
+    if (hasActiveAnalyser()) {
+      rafId = raf(tick)
+    } else {
+      stopLoop()
+    }
+  }
+
+  const ensureLoop = (): void => {
+    if (rafId !== null || !hasActiveAnalyser()) return
+    rafId = raf(tick)
+  }
+
+  const syncSession = (
+    sessionId: string,
+    track: MediaStreamTrack | null,
+    enabled: boolean,
+  ): void => {
+    let row = sessions.get(sessionId)
+    if (!row) {
+      row = createEmptyRow()
+      sessions.set(sessionId, row)
+    }
+
+    const trackChanged = row.track !== track
+    const enabledChanged = row.enabled !== enabled
+    row.track = track
+    row.enabled = enabled
+
+    if (!enabled) {
+      teardownGraph(row)
+      if (clearSpeaking(row)) {
+        options.onSpeakingChange?.()
+      }
+      return
+    }
+
+    if (trackChanged || enabledChanged) {
+      applyGraph(row)
+    }
+
+    ensureLoop()
+  }
+
+  const removeSession = (sessionId: string): void => {
+    const row = sessions.get(sessionId)
+    if (!row) return
+    teardownGraph(row)
+    sessions.delete(sessionId)
+    if (clearSpeaking(row)) {
+      options.onSpeakingChange?.()
+    }
+    if (!hasActiveAnalyser()) {
+      stopLoop()
+    }
+  }
+
+  return {
+    syncSession,
+    removeSession,
+    isSpeaking: (sessionId) => sessions.get(sessionId)?.speaking ?? false,
+    buildSpeakingMap: (sessionIds) => {
+      const out = new Map<string, boolean>()
+      for (const sessionId of sessionIds) {
+        out.set(sessionId, sessions.get(sessionId)?.speaking ?? false)
+      }
+      return out
+    },
+    dispose: () => {
+      stopLoop()
+      for (const row of sessions.values()) {
+        teardownGraph(row)
+      }
+      sessions.clear()
+      if (ctx) {
+        try {
+          void ctx.close()
+        } catch {
+          /* ignore */
+        }
+        ctx = null
+      }
+    },
+  }
+}

--- a/apps/web/src/room/engine/RoomMediaEngine.ts
+++ b/apps/web/src/room/engine/RoomMediaEngine.ts
@@ -3,6 +3,8 @@ import type { GiphySearchResult } from '../../api/giphySearchApi'
 import { getPublicApiBaseUrl } from '../../config/apiBaseUrl'
 import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
 import { probeTurnReachability } from '../sfu/iceDiagnostics'
+import { createSpeakingVadRegistry, type SpeakingVadRegistry } from '../audio/speakingVadRegistry'
+import { isSpeakingVadEnabled } from '../audio/speakingVad'
 import {
   applyChatReactionEvent,
   canAcceptReactionAdd,
@@ -24,10 +26,15 @@ import {
   applyParticipantAvConsumerEvent,
   type ParticipantAvVideoConsumer,
 } from '../stage/participantAvConsumers'
+import {
+  applyParticipantAvAudioConsumerEvent,
+  type ParticipantAvAudioConsumer,
+} from '../stage/participantAvAudioConsumers'
 import { buildStageParticipantTiles } from '../stage/stageParticipantTiles'
 import { selectDrawerPresentation } from '../drawerErrorPresentation'
 import type { ChatLine, PresenceMember } from '../roomPageTypes'
 import type { ParticipantProducerSnapshot } from '../participantProducerRegistry'
+import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from '../participantProducerRegistry'
 import {
   RoomRealtimeSdk,
   type RoomControlHandlers,
@@ -67,6 +74,7 @@ export type RoomMediaEngineSnapshot = {
   presenceRoster: { roomId: string; members: PresenceMember[] }
   participantAvPublishTick: number
   participantProducerBySessionId: Map<string, ParticipantProducerSnapshot>
+  speakingBySessionId: Map<string, boolean>
   stageParticipantTiles: ReturnType<typeof buildStageParticipantTiles>
 }
 
@@ -140,6 +148,13 @@ export class RoomMediaEngine {
   private remoteTypingBySession = new Map<string, RemoteTypingEntry>()
   private typingPruneTimer: ReturnType<typeof setInterval> | null = null
   private participantAvVideoConsumers = new Map<string, ParticipantAvVideoConsumer>()
+  private participantAvAudioConsumers = new Map<string, ParticipantAvAudioConsumer>()
+  private speakingVadRegistry: SpeakingVadRegistry = createSpeakingVadRegistry({
+    onSpeakingChange: () => {
+      this.announceSpeakingTransitions()
+      this.notify()
+    },
+  })
   private presenceRoster: { roomId: string; members: PresenceMember[] } = {
     roomId: '',
     members: [],
@@ -147,6 +162,7 @@ export class RoomMediaEngine {
   private participantAvPublishTick = 0
   private participantAvUnsub: (() => void) | null = null
   private participantProducerRegistryUnsub: (() => void) | null = null
+  private previousSpeakingBySession = new Map<string, boolean>()
   private cachedSnapshot: RoomMediaEngineSnapshot | null = null
 
   constructor(roomId: string) {
@@ -198,12 +214,18 @@ export class RoomMediaEngine {
       participantProducerBySessionId: this.sdk.buildParticipantProducerSnapshots(
         peopleShown.map((member) => member.sessionId),
       ),
+      speakingBySessionId: this.speakingVadRegistry.buildSpeakingMap(
+        peopleShown.map((member) => member.sessionId),
+      ),
       stageParticipantTiles: buildStageParticipantTiles({
         roster: peopleShown,
         videoConsumers: this.participantAvVideoConsumers,
         ownSessionId: opts?.sessionId ?? '',
         localCameraOn: participantAvPublishState.cameraEnabled,
         localPreviewStream: participantAvController?.getLocalPreviewStream() ?? null,
+        speakingBySessionId: this.speakingVadRegistry.buildSpeakingMap(
+          peopleShown.map((member) => member.sessionId),
+        ),
       }),
     }
     return this.cachedSnapshot
@@ -331,10 +353,17 @@ export class RoomMediaEngine {
             this.participantAvVideoConsumers,
             event,
           )
+          this.participantAvAudioConsumers = applyParticipantAvAudioConsumerEvent(
+            this.participantAvAudioConsumers,
+            event,
+          )
+          this.syncSpeakingVad()
           this.notify()
         },
         onConsumersClear: () => {
           this.participantAvVideoConsumers = new Map()
+          this.participantAvAudioConsumers = new Map()
+          this.syncSpeakingVad()
           this.notify()
         },
       },
@@ -350,14 +379,18 @@ export class RoomMediaEngine {
     if (controller) {
       this.participantAvUnsub = controller.subscribe(() => {
         this.participantAvPublishTick += 1
+        this.syncSpeakingVad()
         this.notify()
       })
     }
 
     this.participantProducerRegistryUnsub?.()
     this.participantProducerRegistryUnsub = this.sdk.onParticipantProducerRegistryChange(() => {
+      this.syncSpeakingVad()
       this.notify()
     })
+
+    this.syncSpeakingVad()
 
     emitClientDrawerLog({
       drawer: 'signaling',
@@ -404,6 +437,7 @@ export class RoomMediaEngine {
       this.lastMediaFields = { ...this.lastMediaFields, avDisabled }
     }
     this.sdk.setAvDisabled(avDisabled)
+    this.syncSpeakingVad()
     this.notify()
   }
 
@@ -592,6 +626,15 @@ export class RoomMediaEngine {
     this.mountOptions = null
     this.guestRemote = null
     this.participantAvVideoConsumers = new Map()
+    this.participantAvAudioConsumers = new Map()
+    this.speakingVadRegistry.dispose()
+    this.speakingVadRegistry = createSpeakingVadRegistry({
+      onSpeakingChange: () => {
+        this.announceSpeakingTransitions()
+        this.notify()
+      },
+    })
+    this.previousSpeakingBySession = new Map()
     this.connection = transitionRoomMediaConnection(this.connection, 'tornDown')
     this.wsStatus = 'idle'
     this.diagnostics = null
@@ -651,6 +694,69 @@ export class RoomMediaEngine {
     )
     const merged = mergeConnectionPhases(chatPhase, sfuPhase)
     this.connection = transitionRoomMediaConnection(this.connection, merged)
+  }
+
+  private syncSpeakingVad(): void {
+    const opts = this.mountOptions
+    if (!opts) return
+
+    const peopleShown = this.buildPeopleShown()
+    const producerSnapshots = this.sdk.buildParticipantProducerSnapshots(
+      peopleShown.map((member) => member.sessionId),
+    )
+
+    const controller = this.sdk.getParticipantAvController()
+    const localTrack = controller?.getLocalPreviewStream()?.getAudioTracks()[0] ?? null
+    const localSnapshot =
+      producerSnapshots.get(opts.sessionId) ??
+      EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT
+    const localEnabled = isSpeakingVadEnabled(localSnapshot)
+    this.speakingVadRegistry.syncSession(opts.sessionId, localTrack, localEnabled)
+
+    const remoteAudioBySession = new Map<string, MediaStreamTrack>()
+    for (const consumer of this.participantAvAudioConsumers.values()) {
+      const sessionId = consumer.sessionId?.trim()
+      if (!sessionId || sessionId === opts.sessionId) continue
+      remoteAudioBySession.set(sessionId, consumer.track)
+    }
+
+    for (const member of peopleShown) {
+      if (member.sessionId === opts.sessionId) continue
+      const snapshot =
+        producerSnapshots.get(member.sessionId) ?? EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT
+      const track = remoteAudioBySession.get(member.sessionId) ?? null
+      this.speakingVadRegistry.syncSession(
+        member.sessionId,
+        track,
+        isSpeakingVadEnabled(snapshot),
+      )
+    }
+
+    const speakingNow = this.speakingVadRegistry.buildSpeakingMap(
+      peopleShown.map((member) => member.sessionId),
+    )
+    this.announceSpeakingTransitions(speakingNow)
+  }
+
+  private announceSpeakingTransitions(
+    speakingNow = this.speakingVadRegistry.buildSpeakingMap(
+      this.buildPeopleShown().map((member) => member.sessionId),
+    ),
+  ): void {
+    const opts = this.mountOptions
+    if (!opts) return
+
+    const peopleShown = this.buildPeopleShown()
+    for (const member of peopleShown) {
+      const nowSpeaking = speakingNow.get(member.sessionId) ?? false
+      const wasSpeaking = this.previousSpeakingBySession.get(member.sessionId) ?? false
+      if (nowSpeaking && !wasSpeaking) {
+        opts.announceRoomA11y(`${member.displayName} is speaking`)
+      } else if (!nowSpeaking && wasSpeaking) {
+        opts.announceRoomA11y(`${member.displayName} stopped speaking`)
+      }
+    }
+    this.previousSpeakingBySession = speakingNow
   }
 
   private notify(): void {

--- a/apps/web/src/room/engine/RoomMediaEngine.ts
+++ b/apps/web/src/room/engine/RoomMediaEngine.ts
@@ -27,6 +27,7 @@ import {
 import { buildStageParticipantTiles } from '../stage/stageParticipantTiles'
 import { selectDrawerPresentation } from '../drawerErrorPresentation'
 import type { ChatLine, PresenceMember } from '../roomPageTypes'
+import type { ParticipantProducerSnapshot } from '../participantProducerRegistry'
 import {
   RoomRealtimeSdk,
   type RoomControlHandlers,
@@ -65,6 +66,7 @@ export type RoomMediaEngineSnapshot = {
   participantAvVideoConsumers: Map<string, ParticipantAvVideoConsumer>
   presenceRoster: { roomId: string; members: PresenceMember[] }
   participantAvPublishTick: number
+  participantProducerBySessionId: Map<string, ParticipantProducerSnapshot>
   stageParticipantTiles: ReturnType<typeof buildStageParticipantTiles>
 }
 
@@ -144,6 +146,7 @@ export class RoomMediaEngine {
   }
   private participantAvPublishTick = 0
   private participantAvUnsub: (() => void) | null = null
+  private participantProducerRegistryUnsub: (() => void) | null = null
   private cachedSnapshot: RoomMediaEngineSnapshot | null = null
 
   constructor(roomId: string) {
@@ -192,6 +195,9 @@ export class RoomMediaEngine {
       participantAvVideoConsumers: this.participantAvVideoConsumers,
       presenceRoster: this.presenceRoster,
       participantAvPublishTick: this.participantAvPublishTick,
+      participantProducerBySessionId: this.sdk.buildParticipantProducerSnapshots(
+        peopleShown.map((member) => member.sessionId),
+      ),
       stageParticipantTiles: buildStageParticipantTiles({
         roster: peopleShown,
         videoConsumers: this.participantAvVideoConsumers,
@@ -347,6 +353,11 @@ export class RoomMediaEngine {
         this.notify()
       })
     }
+
+    this.participantProducerRegistryUnsub?.()
+    this.participantProducerRegistryUnsub = this.sdk.onParticipantProducerRegistryChange(() => {
+      this.notify()
+    })
 
     emitClientDrawerLog({
       drawer: 'signaling',

--- a/apps/web/src/room/hostRoomControls.ts
+++ b/apps/web/src/room/hostRoomControls.ts
@@ -40,3 +40,6 @@ export function avDisabledAnnounceCopy(disabled: boolean): string {
     ? 'Room camera and microphone disabled by host'
     : 'Room camera and microphone enabled by host'
 }
+
+export const VIDEO_CHAT_BETA_DESCRIPTION =
+  'Video Chat layout is experimental. Participant video quality and reliability are still improving.'

--- a/apps/web/src/room/participantProducerRegistry.test.ts
+++ b/apps/web/src/room/participantProducerRegistry.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyAudioProducerPaused,
+  applyProducerClosed,
+  applyProducerOpened,
+  buildParticipantProducerSnapshots,
+  clearParticipantProducerRegistry,
+  createParticipantProducerRegistryState,
+  localSnapshotFromParticipantAv,
+  snapshotForSession,
+} from './participantProducerRegistry'
+
+describe('participantProducerRegistry', () => {
+  it('maps camera-on mic-off from remote producers', () => {
+    let state = createParticipantProducerRegistryState()
+    state = applyProducerOpened(state, 'p-v', 'fan-a', 'video')
+    expect(snapshotForSession(state, 'fan-a')).toEqual({
+      hasVideoProducer: true,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+  })
+
+  it('maps mic muted vs mic off', () => {
+    let state = createParticipantProducerRegistryState()
+    state = applyProducerOpened(state, 'p-a', 'fan-b', 'audio')
+    expect(snapshotForSession(state, 'fan-b')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: true,
+      audioPaused: false,
+    })
+
+    state = applyAudioProducerPaused(state, 'p-a', true)
+    expect(snapshotForSession(state, 'fan-b')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: true,
+      audioPaused: true,
+    })
+
+    state = applyProducerClosed(state, 'p-a')
+    expect(snapshotForSession(state, 'fan-b')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+  })
+
+  it('clears producer rows on close and registry reset', () => {
+    let state = createParticipantProducerRegistryState()
+    state = applyProducerOpened(state, 'p-v', 'fan-c', 'video')
+    state = applyProducerOpened(state, 'p-a', 'fan-c', 'audio')
+    state = applyProducerClosed(state, 'p-v')
+    expect(snapshotForSession(state, 'fan-c').hasVideoProducer).toBe(false)
+    expect(snapshotForSession(state, 'fan-c').hasAudioProducer).toBe(true)
+
+    state = clearParticipantProducerRegistry()
+    expect(snapshotForSession(state, 'fan-c')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+  })
+
+  it('prefers local participant AV state for own sessionId', () => {
+    const state = createParticipantProducerRegistryState()
+    const local = localSnapshotFromParticipantAv({
+      cameraEnabled: true,
+      micEnabled: true,
+      micMuted: true,
+      canPublish: true,
+      needsProducerToken: true,
+      error: null,
+      busy: false,
+    })
+    expect(snapshotForSession(state, 'self', local)).toEqual({
+      hasVideoProducer: true,
+      hasAudioProducer: true,
+      audioPaused: true,
+    })
+  })
+
+  it('builds snapshots for roster session ids', () => {
+    let state = createParticipantProducerRegistryState()
+    state = applyProducerOpened(state, 'p-v', 'remote-1', 'video')
+
+    const map = buildParticipantProducerSnapshots(
+      state,
+      ['remote-1', 'self'],
+      'self',
+      {
+        cameraEnabled: false,
+        micEnabled: true,
+        micMuted: false,
+        canPublish: true,
+        needsProducerToken: true,
+        error: null,
+        busy: false,
+      },
+    )
+
+    expect(map.get('remote-1')).toEqual({
+      hasVideoProducer: true,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+    expect(map.get('self')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: true,
+      audioPaused: false,
+    })
+  })
+})

--- a/apps/web/src/room/participantProducerRegistry.ts
+++ b/apps/web/src/room/participantProducerRegistry.ts
@@ -1,0 +1,112 @@
+import type { ParticipantAvPublishState } from './sfu/participantAvSession'
+
+export type ParticipantProducerSnapshot = {
+  hasVideoProducer: boolean
+  hasAudioProducer: boolean
+  audioPaused: boolean
+}
+
+export const EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT: ParticipantProducerSnapshot = {
+  hasVideoProducer: false,
+  hasAudioProducer: false,
+  audioPaused: false,
+}
+
+type ProducerRow = {
+  sessionId: string
+  kind: 'audio' | 'video'
+  audioPaused: boolean
+}
+
+export type ParticipantProducerRegistryState = {
+  byProducerId: Map<string, ProducerRow>
+}
+
+export function createParticipantProducerRegistryState(): ParticipantProducerRegistryState {
+  return { byProducerId: new Map() }
+}
+
+export function applyProducerOpened(
+  state: ParticipantProducerRegistryState,
+  producerId: string,
+  sessionId: string,
+  kind: 'audio' | 'video',
+): ParticipantProducerRegistryState {
+  const next = new Map(state.byProducerId)
+  next.set(producerId, { sessionId, kind, audioPaused: false })
+  return { byProducerId: next }
+}
+
+export function applyProducerClosed(
+  state: ParticipantProducerRegistryState,
+  producerId: string,
+): ParticipantProducerRegistryState {
+  if (!state.byProducerId.has(producerId)) return state
+  const next = new Map(state.byProducerId)
+  next.delete(producerId)
+  return { byProducerId: next }
+}
+
+export function applyAudioProducerPaused(
+  state: ParticipantProducerRegistryState,
+  producerId: string,
+  paused: boolean,
+): ParticipantProducerRegistryState {
+  const row = state.byProducerId.get(producerId)
+  if (!row || row.kind !== 'audio') return state
+  const next = new Map(state.byProducerId)
+  next.set(producerId, { ...row, audioPaused: paused })
+  return { byProducerId: next }
+}
+
+export function clearParticipantProducerRegistry(): ParticipantProducerRegistryState {
+  return createParticipantProducerRegistryState()
+}
+
+export function snapshotForSession(
+  state: ParticipantProducerRegistryState,
+  sessionId: string,
+  localOverride?: ParticipantProducerSnapshot | null,
+): ParticipantProducerSnapshot {
+  if (localOverride) return localOverride
+
+  let hasVideoProducer = false
+  let hasAudioProducer = false
+  let audioPaused = false
+
+  for (const row of state.byProducerId.values()) {
+    if (row.sessionId !== sessionId) continue
+    if (row.kind === 'video') hasVideoProducer = true
+    if (row.kind === 'audio') {
+      hasAudioProducer = true
+      if (row.audioPaused) audioPaused = true
+    }
+  }
+
+  return { hasVideoProducer, hasAudioProducer, audioPaused }
+}
+
+export function localSnapshotFromParticipantAv(
+  state: ParticipantAvPublishState,
+): ParticipantProducerSnapshot {
+  return {
+    hasVideoProducer: state.cameraEnabled,
+    hasAudioProducer: state.micEnabled,
+    audioPaused: state.micEnabled && state.micMuted,
+  }
+}
+
+export function buildParticipantProducerSnapshots(
+  state: ParticipantProducerRegistryState,
+  sessionIds: readonly string[],
+  ownSessionId: string,
+  localAvState: ParticipantAvPublishState,
+): Map<string, ParticipantProducerSnapshot> {
+  const localSnapshot = localSnapshotFromParticipantAv(localAvState)
+  const out = new Map<string, ParticipantProducerSnapshot>()
+  for (const sessionId of sessionIds) {
+    const override = sessionId === ownSessionId ? localSnapshot : null
+    out.set(sessionId, snapshotForSession(state, sessionId, override))
+  }
+  return out
+}

--- a/apps/web/src/room/peoplePresentation.test.tsx
+++ b/apps/web/src/room/peoplePresentation.test.tsx
@@ -32,6 +32,17 @@ describe('peoplePresentation', () => {
           audioPaused: false,
         }),
       ).toBe('camera off, microphone on')
+
+      expect(
+        peopleAvAriaLabel(
+          {
+            hasVideoProducer: true,
+            hasAudioProducer: true,
+            audioPaused: false,
+          },
+          true,
+        ),
+      ).toBe('camera on, microphone on, speaking')
     })
   })
 
@@ -74,6 +85,24 @@ describe('peoplePresentation', () => {
       expect(container.querySelector('.riffsync-room-page__people-av-icon--on')).not.toBeNull()
       expect(container.querySelector('.riffsync-room-page__people-av-icon--muted')).not.toBeNull()
       expect(container.querySelector('[aria-label="camera on, microphone muted"]')).not.toBeNull()
+    })
+
+    it('includes speaking in aria-label when active', () => {
+      act(() => {
+        root.render(
+          <PeopleRowAvIndicators
+            snapshot={{
+              hasVideoProducer: false,
+              hasAudioProducer: true,
+              audioPaused: false,
+            }}
+            speaking
+          />,
+        )
+      })
+      expect(
+        container.querySelector('[aria-label="camera off, microphone on, speaking"]'),
+      ).not.toBeNull()
     })
 
     it('renders cam off mic off when snapshot is empty', () => {

--- a/apps/web/src/room/peoplePresentation.test.tsx
+++ b/apps/web/src/room/peoplePresentation.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { PeopleRowAvIndicators } from './PeopleRowAvIndicators'
+import { shouldShowPeopleAvIndicators, peopleAvAriaLabel } from './peoplePresentation'
+import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from './participantProducerRegistry'
+
+describe('peoplePresentation', () => {
+  describe('peopleAvAriaLabel', () => {
+    it('distinguishes mic muted from mic off', () => {
+      expect(
+        peopleAvAriaLabel({
+          hasVideoProducer: true,
+          hasAudioProducer: false,
+          audioPaused: false,
+        }),
+      ).toBe('camera on, microphone off')
+
+      expect(
+        peopleAvAriaLabel({
+          hasVideoProducer: true,
+          hasAudioProducer: true,
+          audioPaused: true,
+        }),
+      ).toBe('camera on, microphone muted')
+
+      expect(
+        peopleAvAriaLabel({
+          hasVideoProducer: false,
+          hasAudioProducer: true,
+          audioPaused: false,
+        }),
+      ).toBe('camera off, microphone on')
+    })
+  })
+
+  describe('shouldShowPeopleAvIndicators', () => {
+    it('shows remote rows for guests and own row only when signed in', () => {
+      expect(shouldShowPeopleAvIndicators('remote', 'self', null)).toBe(true)
+      expect(shouldShowPeopleAvIndicators('self', 'self', null)).toBe(false)
+      expect(shouldShowPeopleAvIndicators('self', 'self', 'jwt')).toBe(true)
+    })
+  })
+
+  describe('PeopleRowAvIndicators', () => {
+    let container: HTMLDivElement
+    let root: Root
+
+    beforeEach(() => {
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      root = createRoot(container)
+    })
+
+    afterEach(() => {
+      act(() => root.unmount())
+      container.remove()
+    })
+
+    it('renders cam on and mic muted classes', () => {
+      act(() => {
+        root.render(
+          <PeopleRowAvIndicators
+            snapshot={{
+              hasVideoProducer: true,
+              hasAudioProducer: true,
+              audioPaused: true,
+            }}
+          />,
+        )
+      })
+
+      expect(container.querySelector('.riffsync-room-page__people-av-icon--on')).not.toBeNull()
+      expect(container.querySelector('.riffsync-room-page__people-av-icon--muted')).not.toBeNull()
+      expect(container.querySelector('[aria-label="camera on, microphone muted"]')).not.toBeNull()
+    })
+
+    it('renders cam off mic off when snapshot is empty', () => {
+      act(() => {
+        root.render(<PeopleRowAvIndicators snapshot={EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT} />)
+      })
+
+      const offIcons = container.querySelectorAll('.riffsync-room-page__people-av-icon--off')
+      expect(offIcons.length).toBe(2)
+    })
+  })
+})

--- a/apps/web/src/room/peoplePresentation.ts
+++ b/apps/web/src/room/peoplePresentation.ts
@@ -9,7 +9,10 @@ export function shouldShowPeopleAvIndicators(
   return Boolean(fanToken)
 }
 
-export function peopleAvAriaLabel(snapshot: ParticipantProducerSnapshot): string {
+export function peopleAvAriaLabel(
+  snapshot: ParticipantProducerSnapshot,
+  speaking = false,
+): string {
   const cam = snapshot.hasVideoProducer ? 'camera on' : 'camera off'
   let mic: string
   if (!snapshot.hasAudioProducer) {
@@ -19,5 +22,10 @@ export function peopleAvAriaLabel(snapshot: ParticipantProducerSnapshot): string
   } else {
     mic = 'microphone on'
   }
-  return `${cam}, ${mic}`
+  const speakingSuffix = speaking ? ', speaking' : ''
+  return `${cam}, ${mic}${speakingSuffix}`
+}
+
+export function peopleRowSpeakingClass(speaking: boolean): string {
+  return speaking ? ' riffsync-room-page__people-row--speaking' : ''
 }

--- a/apps/web/src/room/peoplePresentation.ts
+++ b/apps/web/src/room/peoplePresentation.ts
@@ -1,0 +1,23 @@
+import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
+
+export function shouldShowPeopleAvIndicators(
+  rowSessionId: string,
+  ownSessionId: string,
+  fanToken: string | null,
+): boolean {
+  if (rowSessionId !== ownSessionId) return true
+  return Boolean(fanToken)
+}
+
+export function peopleAvAriaLabel(snapshot: ParticipantProducerSnapshot): string {
+  const cam = snapshot.hasVideoProducer ? 'camera on' : 'camera off'
+  let mic: string
+  if (!snapshot.hasAudioProducer) {
+    mic = 'microphone off'
+  } else if (snapshot.audioPaused) {
+    mic = 'microphone muted'
+  } else {
+    mic = 'microphone on'
+  }
+  return `${cam}, ${mic}`
+}

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -10,6 +10,7 @@ import type { RoomMode, RoomSnapshot } from '../../api/roomsApi'
 import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
 import type { ParticipantAvController } from '../sfu/participantAvSession'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
+import type { ParticipantProducerSnapshot } from '../participantProducerRegistry'
 import {
   ChatSession,
   type AvDisabledEvent,
@@ -367,6 +368,16 @@ export class RoomRealtimeSdk {
 
   getParticipantAvController(): ParticipantAvController | null {
     return this.sfu?.participantAv ?? null
+  }
+
+  buildParticipantProducerSnapshots(
+    sessionIds: readonly string[],
+  ): Map<string, ParticipantProducerSnapshot> {
+    return this.sfu?.buildParticipantProducerSnapshots(sessionIds) ?? new Map()
+  }
+
+  onParticipantProducerRegistryChange(listener: () => void): () => void {
+    return this.sfu?.onParticipantProducerRegistryChange(listener) ?? (() => undefined)
   }
 
   unpublishHostScreen(): void {

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1308,3 +1308,175 @@ describe('SfuMediaSession JWT remint', () => {
     expect(session.getLifecycleState()).toBe('torn-down')
   })
 })
+
+describe('SfuMediaSession participant producer registry (#248)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('tracks remote participant_av producers from signaling lifecycle', () => {
+    const session = new SfuMediaSession()
+    const changes: number[] = []
+    session.onParticipantProducerRegistryChange(() => changes.push(changes.length + 1))
+
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'self',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: false,
+    })
+
+    ;(
+      session as unknown as { applySignalingProducerLifecycle: (event: unknown) => void }
+    ).applySignalingProducerLifecycle({
+      action: 'opened',
+      producerId: 'p-v',
+      sessionId: 'remote-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+    })
+
+    expect(session.getParticipantProducerSnapshot('remote-1')).toEqual({
+      hasVideoProducer: true,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+    expect(changes.length).toBe(1)
+
+    ;(
+      session as unknown as { applySignalingProducerLifecycle: (event: unknown) => void }
+    ).applySignalingProducerLifecycle({
+      action: 'closed',
+      producerId: 'p-v',
+      sessionId: 'remote-1',
+      producerClass: 'participant_av',
+      kind: 'video',
+    })
+
+    expect(session.getParticipantProducerSnapshot('remote-1')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+  })
+
+  it('uses local participant AV state for own sessionId', async () => {
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getVideoTracks: () => [],
+          getAudioTracks: () => [{ kind: 'audio', stop: vi.fn(), id: 'a1', enabled: true }],
+          getTracks: () => [{ kind: 'audio', stop: vi.fn(), id: 'a1', enabled: true }],
+          removeTrack: vi.fn(),
+        }),
+      },
+    })
+
+    const session = new SfuMediaSession()
+    session.updatePublishGate({ fanToken: 'fan-jwt', avDisabled: false })
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'self',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: false,
+    })
+
+    await session.participantAv.enableMic()
+    session.participantAv.attachSession({
+      pauseProducerKind: vi.fn(),
+      resumeProducerKind: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+      unpublishProducerKind: vi.fn(),
+    } as unknown as import('../sfu/mediasoupSharing').SfuUnifiedSessionHandle)
+    session.participantAv.toggleMicMute()
+
+    expect(session.getParticipantProducerSnapshot('self')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: true,
+      audioPaused: true,
+    })
+  })
+
+  it('clears registry on av kill switch and disconnect', () => {
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'self',
+      accessToken: 'fan-jwt',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: false,
+    })
+
+    ;(
+      session as unknown as { applySignalingProducerLifecycle: (event: unknown) => void }
+    ).applySignalingProducerLifecycle({
+      action: 'opened',
+      producerId: 'p-a',
+      sessionId: 'remote-2',
+      producerClass: 'participant_av',
+      kind: 'audio',
+    })
+
+    session.handleAvDisabledKillSwitch()
+    expect(session.getParticipantProducerSnapshot('remote-2')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+
+    session.disconnect()
+    expect(session.getParticipantProducerSnapshot('self')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: false,
+      audioPaused: false,
+    })
+  })
+
+  it('marks remote audio paused from consumer pause events', () => {
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'self',
+      accessToken: null,
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: false,
+    })
+
+    ;(
+      session as unknown as { applySignalingProducerLifecycle: (event: unknown) => void }
+    ).applySignalingProducerLifecycle({
+      action: 'opened',
+      producerId: 'p-a',
+      sessionId: 'remote-3',
+      producerClass: 'participant_av',
+      kind: 'audio',
+    })
+
+    ;(
+      session as unknown as { dispatchConsumerTrack: (event: unknown) => void }
+    ).dispatchConsumerTrack({
+      action: 'pause',
+      producerId: 'p-a',
+      sessionId: 'remote-3',
+      producerClass: 'participant_av',
+      kind: 'audio',
+    })
+
+    expect(session.getParticipantProducerSnapshot('remote-3')).toEqual({
+      hasVideoProducer: false,
+      hasAudioProducer: true,
+      audioPaused: true,
+    })
+  })
+})

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -993,6 +993,123 @@ describe('SfuMediaSession media policy', () => {
     expect(detach).toHaveBeenCalledWith('participant_av')
     expect(clearListener).toHaveBeenCalled()
   })
+
+  it('#247 regression: participant camera-off does not disconnect or touch host_screen', async () => {
+    const session = new SfuMediaSession()
+    const unpublishProducerKind = vi.fn()
+    const unpublishProducerClass = vi.fn()
+    const detachConsumerClass = vi.fn()
+    const close = vi.fn()
+    const mockHandle = {
+      ...mockSfuUnifiedSessionHandle(),
+      unpublishProducerKind,
+      unpublishProducerClass,
+      detachConsumerClass,
+      close,
+      supportsPublish: true,
+    }
+    attachMockSessionHandle(session, mockHandle)
+    session.participantAv.attachSession(mockHandle)
+
+    const disconnect = vi.spyOn(session, 'disconnect')
+    const unpublishHostScreen = vi.spyOn(session, 'unpublishHostScreen')
+    const detachHostScreen = vi.spyOn(session, 'detachHostScreenConsumers')
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getVideoTracks: () => [{ kind: 'video', stop: vi.fn(), id: 'v1' }],
+          getAudioTracks: () => [{ kind: 'audio', stop: vi.fn(), id: 'a1' }],
+          getTracks: () => [
+            { kind: 'video', stop: vi.fn(), id: 'v1' },
+            { kind: 'audio', stop: vi.fn(), id: 'a1' },
+          ],
+          removeTrack: vi.fn(),
+        }),
+      },
+    })
+    vi.stubGlobal(
+      'MediaStream',
+      function MockMediaStream(this: { tracks: MediaStreamTrack[] }, tracks: MediaStreamTrack[] = []) {
+        this.tracks = tracks
+      },
+    )
+
+    session.updatePublishGate({ fanToken: 'fan-jwt', avDisabled: false })
+    await session.participantAv.enableCamera()
+    await session.participantAv.enableMic()
+
+    unpublishProducerKind.mockClear()
+    unpublishProducerClass.mockClear()
+
+    session.participantAv.disableCamera()
+
+    expect(unpublishProducerKind).toHaveBeenCalledWith('participant_av', 'video')
+    expect(unpublishProducerClass).not.toHaveBeenCalledWith('host_screen')
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(unpublishHostScreen).not.toHaveBeenCalled()
+    expect(detachHostScreen).not.toHaveBeenCalled()
+    expect(detachConsumerClass).not.toHaveBeenCalledWith('host_screen')
+    vi.unstubAllGlobals()
+  })
+
+  it('#247 regression: participant mic-off does not disconnect or touch host_screen', async () => {
+    const session = new SfuMediaSession()
+    const unpublishProducerKind = vi.fn()
+    const unpublishProducerClass = vi.fn()
+    const detachConsumerClass = vi.fn()
+    const close = vi.fn()
+    const mockHandle = {
+      ...mockSfuUnifiedSessionHandle(),
+      unpublishProducerKind,
+      unpublishProducerClass,
+      detachConsumerClass,
+      close,
+      supportsPublish: true,
+      publishStream: vi.fn().mockResolvedValue(undefined),
+    }
+    attachMockSessionHandle(session, mockHandle)
+    session.participantAv.attachSession(mockHandle)
+
+    const disconnect = vi.spyOn(session, 'disconnect')
+    const unpublishHostScreen = vi.spyOn(session, 'unpublishHostScreen')
+
+    vi.stubGlobal('navigator', {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getVideoTracks: () => [{ kind: 'video', stop: vi.fn(), id: 'v1' }],
+          getAudioTracks: () => [{ kind: 'audio', stop: vi.fn(), id: 'a1' }],
+          getTracks: () => [
+            { kind: 'video', stop: vi.fn(), id: 'v1' },
+            { kind: 'audio', stop: vi.fn(), id: 'a1' },
+          ],
+          removeTrack: vi.fn(),
+        }),
+      },
+    })
+    vi.stubGlobal(
+      'MediaStream',
+      function MockMediaStream(this: { tracks: MediaStreamTrack[] }, tracks: MediaStreamTrack[] = []) {
+        this.tracks = tracks
+      },
+    )
+
+    session.updatePublishGate({ fanToken: 'fan-jwt', avDisabled: false })
+    await session.participantAv.enableCamera()
+    await session.participantAv.enableMic()
+
+    unpublishProducerKind.mockClear()
+
+    session.participantAv.disableMic()
+
+    expect(unpublishProducerKind).toHaveBeenCalledWith('participant_av', 'audio')
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(unpublishHostScreen).not.toHaveBeenCalled()
+    expect(detachConsumerClass).not.toHaveBeenCalledWith('host_screen')
+    vi.unstubAllGlobals()
+  })
 })
 
 function base64UrlJson(obj: unknown): string {

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -42,6 +42,19 @@ import { emitClientDrawerLog } from '../clientDrawerLog'
 import { sfuLifecycleAfterFailedCycle } from './drawerReconnectPolicy'
 import { resolveJwtRemintDelayMs } from './sfuJwtRemintSchedule'
 import { resolveSfuTokenRequest } from './sfuTokenRequest'
+import {
+  applyAudioProducerPaused,
+  applyProducerClosed,
+  applyProducerOpened,
+  buildParticipantProducerSnapshots,
+  clearParticipantProducerRegistry,
+  createParticipantProducerRegistryState,
+  type ParticipantProducerRegistryState,
+  type ParticipantProducerSnapshot,
+  snapshotForSession,
+  localSnapshotFromParticipantAv,
+} from '../participantProducerRegistry'
+import type { SignalingProducerLifecycleEvent } from '../sfu/mediasoupSharing'
 
 export { resolveSfuTokenProducerClass, resolveSfuTokenRequest } from './sfuTokenRequest'
 
@@ -83,6 +96,7 @@ export type StartSfuRoomSessionOpts = SessionHooks & {
   getIceServers: () => Promise<RTCIceServer[]>
   onRemoteStream: (stream: MediaStream | null) => void
   onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
+  onSignalingProducerLifecycle?: (event: SignalingProducerLifecycleEvent) => void
   getHostScreenStream: () => MediaStream | null
   participantAv: ParticipantAvController
 }
@@ -280,6 +294,7 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         getIceServers: opts.getIceServers,
         onRemoteStream: opts.onRemoteStream,
         onConsumerTrack: opts.onConsumerTrack,
+        onSignalingProducerLifecycle: opts.onSignalingProducerLifecycle,
         ownSessionId: opts.sessionId,
         onMediaError: (code, message) => {
           if (code !== 'signaling_failed') {
@@ -398,6 +413,11 @@ export class SfuMediaSession {
   private statusListeners = new Set<Listener<SfuMediaSessionStatus>>()
   private lifecycleListeners = new Set<Listener<SfuMediaSessionLifecycleState>>()
   private participantAvConsumerClearListeners = new Set<Listener<void>>()
+  private participantProducerRegistry: ParticipantProducerRegistryState =
+    createParticipantProducerRegistryState()
+  private participantProducerRegistryListeners = new Set<Listener<void>>()
+  private participantAvStateUnsub: (() => void) | null = null
+  private ownSessionId: string | null = null
 
   constructor() {
     this.participantAv = createBoundParticipantAvController(() => this.gate, {
@@ -466,6 +486,29 @@ export class SfuMediaSession {
     return () => this.lifecycleListeners.delete(listener)
   }
 
+  /** Fired when participant_av producer registry changes (People tab cam/mic). */
+  onParticipantProducerRegistryChange(listener: Listener<void>): () => void {
+    this.participantProducerRegistryListeners.add(listener)
+    return () => this.participantProducerRegistryListeners.delete(listener)
+  }
+
+  getParticipantProducerSnapshot(sessionId: string): ParticipantProducerSnapshot {
+    if (!this.ownSessionId || sessionId !== this.ownSessionId) {
+      return snapshotForSession(this.participantProducerRegistry, sessionId)
+    }
+    return localSnapshotFromParticipantAv(this.participantAv.getState())
+  }
+
+  buildParticipantProducerSnapshots(sessionIds: readonly string[]): Map<string, ParticipantProducerSnapshot> {
+    const ownSessionId = this.ownSessionId ?? ''
+    return buildParticipantProducerSnapshots(
+      this.participantProducerRegistry,
+      sessionIds,
+      ownSessionId,
+      this.participantAv.getState(),
+    )
+  }
+
   /** Fired when participant_av consumers should be cleared (kill switch). */
   onParticipantAvConsumersClear(listener: Listener<void>): () => void {
     this.participantAvConsumerClearListeners.add(listener)
@@ -488,7 +531,12 @@ export class SfuMediaSession {
 
   connect(options: SfuMediaSessionConnectOptions): void {
     this.connectOptions = { ...options }
+    this.ownSessionId = options.sessionId
     this.enabled = options.enabled !== false
+    this.participantAvStateUnsub?.()
+    this.participantAvStateUnsub = this.participantAv.subscribe(() => {
+      this.emitParticipantProducerRegistryChange()
+    })
     this.stopReconnectLoop()
     if (!this.enabled || !options.apiBaseUrl || !options.roomId) {
       this.setStatus('idle')
@@ -502,6 +550,10 @@ export class SfuMediaSession {
 
   disconnect(): void {
     this.enabled = false
+    this.participantAvStateUnsub?.()
+    this.participantAvStateUnsub = null
+    this.ownSessionId = null
+    this.resetParticipantProducerRegistry()
     this.clearJwtRemintTimer()
     this.stopReconnectLoop()
     this.participantAv.teardownPublishing()
@@ -542,6 +594,7 @@ export class SfuMediaSession {
   handleAvDisabledKillSwitch(): void {
     this.participantAv.teardownPublishing()
     this.sessionHandle?.detachConsumerClass('participant_av')
+    this.resetParticipantProducerRegistry()
     for (const listener of this.participantAvConsumerClearListeners) listener()
   }
 
@@ -628,14 +681,52 @@ export class SfuMediaSession {
         producerClass: event.producerClass,
         kind: event.kind,
       })
-    } else {
+    } else if (event.action === 'detach') {
       const meta = this.attachedConsumerMeta.get(event.producerId)
       this.attachedConsumerMeta.delete(event.producerId)
       if (meta?.producerClass === 'participant_av' && meta.kind === 'video') {
         emitProducerClosedDrawerLog()
       }
+    } else if (
+      (event.action === 'pause' || event.action === 'resume') &&
+      event.producerClass === 'participant_av' &&
+      event.kind === 'audio'
+    ) {
+      this.participantProducerRegistry = applyAudioProducerPaused(
+        this.participantProducerRegistry,
+        event.producerId,
+        event.action === 'pause',
+      )
+      this.emitParticipantProducerRegistryChange()
     }
     for (const listener of this.consumerTrackListeners) listener(event)
+  }
+
+  private applySignalingProducerLifecycle(event: SignalingProducerLifecycleEvent): void {
+    if (event.producerClass !== 'participant_av') return
+    if (event.action === 'opened') {
+      this.participantProducerRegistry = applyProducerOpened(
+        this.participantProducerRegistry,
+        event.producerId,
+        event.sessionId,
+        event.kind,
+      )
+    } else {
+      this.participantProducerRegistry = applyProducerClosed(
+        this.participantProducerRegistry,
+        event.producerId,
+      )
+    }
+    this.emitParticipantProducerRegistryChange()
+  }
+
+  private resetParticipantProducerRegistry(): void {
+    this.participantProducerRegistry = clearParticipantProducerRegistry()
+    this.emitParticipantProducerRegistryChange()
+  }
+
+  private emitParticipantProducerRegistryChange(): void {
+    for (const listener of this.participantProducerRegistryListeners) listener()
   }
 
   private onNeedsProducerTokenChange(): void {
@@ -673,6 +764,7 @@ export class SfuMediaSession {
       participantAv: this.participantAv,
       onRemoteStream: (stream) => this.emitRemoteStream(stream),
       onConsumerTrack: (event) => this.dispatchConsumerTrack(event),
+      onSignalingProducerLifecycle: (event) => this.applySignalingProducerLifecycle(event),
       assignSession: (s) => {
         this.sessionHandle = s
         if (s) {
@@ -750,6 +842,7 @@ export class SfuMediaSession {
         this.clearJwtRemintTimer()
         this.sessionHandle = null
         this.attachedConsumerMeta.clear()
+        this.resetParticipantProducerRegistry()
         if (this.enabled && generation === this.tokenIntentGeneration) {
           emitClientDrawerLog({
             drawer: 'signaling',

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -28,10 +28,12 @@ type LifecycleListener = (state: TheaterPlaybackLifecycleState) => void
 
 const GUEST_INBOUND_POLL_MS = 2300
 
-function mapSfuConsumerToMixEvent(event: SfuConsumerTrackEvent): TheaterAudioConsumerEvent {
+function mapSfuConsumerToMixEvent(event: SfuConsumerTrackEvent): TheaterAudioConsumerEvent | null {
+  if (event.action === 'pause' || event.action === 'resume') return null
   if (event.action === 'detach') {
     return { action: 'detach', producerId: event.producerId }
   }
+  if (event.action !== 'attach') return null
   return {
     action: 'attach',
     producerId: event.producerId,
@@ -275,7 +277,9 @@ export class TheaterPlayback {
 
   private onSfuConsumerEvent(event: SfuConsumerTrackEvent): void {
     if (!this.enabled || !this.mix) return
-    this.mix.onConsumerEvent(mapSfuConsumerToMixEvent(event))
+    const mapped = mapSfuConsumerToMixEvent(event)
+    if (!mapped) return
+    this.mix.onConsumerEvent(mapped)
     void this.mix.resumeIfSuspended().then(() => this.syncLifecycleState())
     this.syncLifecycleState()
   }

--- a/apps/web/src/room/sfu/mediasoupSharing.perClassTransport.test.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.perClassTransport.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../config/sfuWsUrl', () => ({
+  getPublicSfuWsUrl: vi.fn(() => undefined),
+}))
+
+type WsListener = (ev?: { data?: string }) => void
+
+let transportCreateCount = 0
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = 0
+  onopen: (() => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  private listeners = new Map<string, Set<WsListener>>()
+
+  constructor(_url: string) {
+    void _url
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+      this.onopen?.()
+    })
+  }
+
+  addEventListener(type: string, fn: WsListener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
+    this.listeners.get(type)!.add(fn)
+  }
+
+  send(raw: string) {
+    const msg = JSON.parse(raw) as { type?: string; id?: number; method?: string; data?: unknown }
+    const { type, id, method } = msg
+    if (type !== 'request' || id === undefined || !method) return
+    queueMicrotask(() => {
+      const data = this.responseData(method, msg.data)
+      this.onmessage?.({
+        data: JSON.stringify({ type: 'response', id, data }),
+      })
+    })
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    for (const fn of this.listeners.get('close') ?? []) fn()
+  }
+
+  private responseData(method: string, requestData?: unknown): Record<string, unknown> {
+    switch (method) {
+      case 'getRouterRtpCapabilities':
+        return { routerRtpCapabilities: { codecs: [], headerExtensions: [] } }
+      case 'createWebRtcTransport': {
+        transportCreateCount += 1
+        const isRecv =
+          typeof requestData === 'object' &&
+          requestData !== null &&
+          (requestData as { consumer?: boolean }).consumer === true
+        return {
+          transportId: isRecv ? 'recv-transport' : `send-transport-${transportCreateCount}`,
+          iceParameters: { iceLite: true },
+          iceCandidates: [],
+          dtlsParameters: { role: 'auto', fingerprints: [] },
+        }
+      }
+      case 'connectWebRtcTransport':
+        return {}
+      case 'produce':
+        return { producerId: `producer-${Date.now()}` }
+      case 'listProducers':
+        return { producers: [] }
+      default:
+        return {}
+    }
+  }
+}
+
+type MockProducer = {
+  id: string
+  kind: string
+  track: MediaStreamTrack
+  closed: boolean
+  close: ReturnType<typeof vi.fn>
+}
+
+const createdProducers: MockProducer[] = []
+const sendTransportsById = new Map<string, ReturnType<typeof createMockSendTransport>>()
+
+type ProduceHandler = (
+  args: { kind: string; rtpParameters: object; appData: object },
+  callback: (arg: { id: string }) => void,
+  errback: (e: Error) => void,
+) => void
+
+type ConnectHandler = (
+  args: { dtlsParameters: object },
+  callback: () => void,
+  errback: (e: Error) => void,
+) => void
+
+type ConnStateHandler = () => void
+
+function createMockSendTransport(id: string) {
+  const transport = {
+    id,
+    connectionState: 'connected' as string,
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    produce: vi.fn(),
+    close: vi.fn(),
+    emitConnectionState: (state: string) => {
+      transport.connectionState = state
+      for (const handler of connHandlers) handler()
+    },
+  }
+  let produceHandler: ProduceHandler | undefined
+  let connectHandler: ConnectHandler | undefined
+  const connHandlers = new Set<ConnStateHandler>()
+
+  transport.on.mockImplementation((event: string, handler: unknown) => {
+    if (event === 'produce') produceHandler = handler as ProduceHandler
+    if (event === 'connect') connectHandler = handler as ConnectHandler
+    if (event === 'connectionstatechange') connHandlers.add(handler as ConnStateHandler)
+  })
+  transport.removeListener.mockImplementation((event: string, handler: unknown) => {
+    if (event === 'connectionstatechange') connHandlers.delete(handler as ConnStateHandler)
+  })
+
+  transport.produce.mockImplementation(async (opts: { track: MediaStreamTrack; appData: object }) => {
+    const producer: MockProducer = {
+      id: `producer-${opts.track.id}`,
+      kind: opts.track.kind,
+      track: opts.track,
+      closed: false,
+      close: vi.fn(() => {
+        producer.closed = true
+      }),
+    }
+    await new Promise<void>((resolve, reject) => {
+      if (!produceHandler) {
+        reject(new Error('produce handler missing'))
+        return
+      }
+      produceHandler(
+        { kind: opts.track.kind, rtpParameters: {}, appData: opts.appData },
+        ({ id: pid }) => {
+          producer.id = pid
+          createdProducers.push(producer)
+          resolve()
+        },
+        reject,
+      )
+    })
+    if (connectHandler) {
+      connectHandler({ dtlsParameters: {} }, () => undefined, () => undefined)
+    }
+    return producer
+  })
+
+  return transport
+}
+
+const mockRecvTransport = {
+  connectionState: 'connected' as const,
+  on: vi.fn(),
+  removeListener: vi.fn(),
+  consume: vi.fn(),
+  close: vi.fn(),
+}
+
+vi.mock('mediasoup-client', () => {
+  class Device {
+    rtpCapabilities = {}
+    async load() {
+      return undefined
+    }
+    createSendTransport(opts: { id: string }) {
+      const existing = sendTransportsById.get(opts.id)
+      if (existing) return existing
+      const transport = createMockSendTransport(opts.id)
+      sendTransportsById.set(opts.id, transport)
+      return transport
+    }
+    createRecvTransport(opts: { id: string }) {
+      void opts
+      return mockRecvTransport
+    }
+  }
+  return { Device, default: { Device } }
+})
+
+import { connectSfuUnifiedSession, type SfuSessionEndReason } from './mediasoupSharing'
+
+class MockMediaStream {
+  private tracks: MediaStreamTrack[] = []
+
+  constructor(tracks?: MediaStreamTrack[]) {
+    if (tracks) this.tracks = [...tracks]
+  }
+
+  getTracks(): MediaStreamTrack[] {
+    return this.tracks
+  }
+}
+
+function mockTrack(kind: 'audio' | 'video', id: string): MediaStreamTrack {
+  return { kind, id } as MediaStreamTrack
+}
+
+function mockStream(tracks: MediaStreamTrack[]): MediaStream {
+  return new MockMediaStream(tracks) as unknown as MediaStream
+}
+
+async function connectProducerSession() {
+  const session = await connectSfuUnifiedSession({
+    wsBaseUrl: 'ws://127.0.0.1:3000',
+    token: 'tok',
+    tokenRole: 'producer',
+    getIceServers: async () => [],
+    onRemoteStream: () => undefined,
+  })
+  await session.ready
+  return session
+}
+
+describe('connectSfuUnifiedSession per-class send transport isolation (#247)', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    createdProducers.length = 0
+    sendTransportsById.clear()
+    transportCreateCount = 0
+    mockRecvTransport.on.mockReset()
+    mockRecvTransport.removeListener.mockReset()
+    mockRecvTransport.consume.mockReset()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal('MediaStream', MockMediaStream as unknown as typeof MediaStream)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('allocates distinct send transports for host_screen and participant_av', async () => {
+    const session = await connectProducerSession()
+    const screenTrack = mockTrack('video', 'screen-iso')
+    const avTrack = mockTrack('audio', 'mic-iso')
+
+    await session.publishStream(mockStream([screenTrack]), 'host_screen')
+    await session.publishStream(mockStream([avTrack]), 'participant_av')
+
+    const sendIds = [...sendTransportsById.keys()].filter((id) => id.startsWith('send-transport-'))
+    expect(sendIds).toHaveLength(2)
+    expect(session.getProducerCount()).toBe(2)
+    session.close()
+  })
+
+  it('participant_av partial unpublish leaves host_screen producers intact', async () => {
+    const session = await connectProducerSession()
+    const screenTrack = mockTrack('video', 'screen-survive')
+    const audioTrack = mockTrack('audio', 'mic-survive')
+    const videoTrack = mockTrack('video', 'cam-survive')
+
+    await session.publishStream(mockStream([screenTrack]), 'host_screen')
+    await session.publishStream(mockStream([audioTrack, videoTrack]), 'participant_av')
+
+    const screenProducer = createdProducers.find((p) => p.track.id === 'screen-survive')
+    expect(screenProducer).toBeDefined()
+    expect(session.getProducerCount()).toBe(3)
+
+    session.unpublishProducerKind('participant_av', 'video')
+
+    expect(screenProducer!.close).not.toHaveBeenCalled()
+    expect(session.getProducerCount()).toBe(2)
+    session.close()
+  })
+
+  it('class-scoped send transport failure does not end the session', async () => {
+    let sessionEndReason: SfuSessionEndReason | undefined
+    const onMediaError = vi.fn()
+
+    const session = await connectSfuUnifiedSession({
+      wsBaseUrl: 'ws://127.0.0.1:3000',
+      token: 'tok',
+      tokenRole: 'producer',
+      getIceServers: async () => [],
+      onRemoteStream: () => undefined,
+      onMediaError,
+    })
+    await session.ready
+    void session.sessionEnded.then((reason) => {
+      sessionEndReason = reason
+    })
+
+    const screenTrack = mockTrack('video', 'screen-stable')
+    const avTrack = mockTrack('audio', 'mic-fail')
+    await session.publishStream(mockStream([screenTrack]), 'host_screen')
+    await session.publishStream(mockStream([avTrack]), 'participant_av')
+
+    const avTransport = [...sendTransportsById.values()].find((t) => t.id !== 'recv-transport' && t.produce.mock.calls.some(
+      (call) => (call[0] as { track: MediaStreamTrack }).track.id === 'mic-fail',
+    ))
+    expect(avTransport).toBeDefined()
+
+    avTransport!.emitConnectionState('failed')
+    await Promise.resolve()
+
+    expect(onMediaError).toHaveBeenCalledWith(
+      'transport_failed',
+      expect.stringContaining('participant_av'),
+    )
+    expect(sessionEndReason).toBeUndefined()
+
+    const screenProducer = createdProducers.find((p) => p.track.id === 'screen-stable')
+    expect(screenProducer!.close).not.toHaveBeenCalled()
+    expect(session.getProducerCount()).toBe(1)
+
+    session.close()
+  })
+})

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -179,10 +179,11 @@ export type SfuSessionEndReason =
 
 const DISCONNECT_RECOVERY_MS = 8000
 
-function watchTransportUntilUnhealthy(
+type TransportUnhealthyReason = 'transport_failed' | 'transport_disconnected_timeout'
+
+function watchTransportConnectionUntilUnhealthy(
   transport: mediasoupClient.types.Transport,
-  signaling: SfuSignaling,
-  onEnd: (reason: SfuSessionEndReason) => void,
+  onUnhealthy: (reason: TransportUnhealthyReason) => void,
 ): () => void {
   let discTimer: ReturnType<typeof setTimeout> | null = null
   const clearDisc = () => {
@@ -196,7 +197,7 @@ function watchTransportUntilUnhealthy(
     if (s === 'failed') {
       clearDisc()
       transport.removeListener('connectionstatechange', onConn)
-      onEnd('transport_failed')
+      onUnhealthy('transport_failed')
       return
     }
     if (s === 'disconnected') {
@@ -206,7 +207,7 @@ function watchTransportUntilUnhealthy(
         const cur = transport.connectionState
         if (cur === 'disconnected' || cur === 'failed') {
           transport.removeListener('connectionstatechange', onConn)
-          onEnd('transport_disconnected_timeout')
+          onUnhealthy('transport_disconnected_timeout')
         }
       }, DISCONNECT_RECOVERY_MS)
       return
@@ -216,12 +217,6 @@ function watchTransportUntilUnhealthy(
     }
   }
   transport.on('connectionstatechange', onConn)
-  const onSigDone = () => {
-    clearDisc()
-    transport.removeListener('connectionstatechange', onConn)
-    onEnd('signaling_close')
-  }
-  signaling.onLifetimeEnded(onSigDone)
   return () => {
     clearDisc()
     transport.removeListener('connectionstatechange', onConn)
@@ -317,7 +312,14 @@ export async function connectSfuUnifiedSession(options: {
     resolveEnd(userClosed ? 'user_close' : r)
   }
 
-  let sendTransport: mediasoupClient.types.Transport | null = null
+  type SendTransportSlot = {
+    transport: mediasoupClient.types.Transport
+    transportId: string
+    unwatch: () => void
+  }
+  const sendTransportByClass: Partial<Record<SfuProducerClass, SendTransportSlot>> = {}
+  let loadedDevice: mediasoupClient.Device | null = null
+  let sessionIceServers: RTCIceServer[] = []
   let recvTransport: mediasoupClient.types.Transport | null = null
   let recvTransportId = ''
   const liveProducers: LiveProducer[] = []
@@ -426,17 +428,108 @@ export async function connectSfuUnifiedSession(options: {
     }
   }
 
-  // Serialize all produce calls on the shared send transport. Two callers publish
+  const teardownSendTransportClass = (producerClass: SfuProducerClass): void => {
+    unpublishProducerClass(producerClass)
+    const slot = sendTransportByClass[producerClass]
+    if (!slot) return
+    slot.unwatch()
+    try {
+      slot.transport.close()
+    } catch {
+      /* ignore */
+    }
+    delete sendTransportByClass[producerClass]
+  }
+
+  const ensureSendTransport = async (
+    producerClass: SfuProducerClass,
+  ): Promise<mediasoupClient.types.Transport> => {
+    const existing = sendTransportByClass[producerClass]
+    if (existing) return existing.transport
+    if (!loadedDevice) {
+      throw new Error('SFU device not ready')
+    }
+
+    let created: Record<string, unknown>
+    try {
+      created = await signaling.request('createWebRtcTransport', { producer: true, consumer: false })
+    } catch (e) {
+      onMediaError?.(
+        'produce_failed',
+        e instanceof Error ? e.message : 'createWebRtcTransport failed',
+      )
+      throw e instanceof Error ? e : new Error(String(e))
+    }
+
+    const transportId = typeof created.transportId === 'string' ? created.transportId : ''
+    if (
+      !transportId ||
+      !isRecord(created.iceParameters) ||
+      !Array.isArray(created.iceCandidates) ||
+      !isRecord(created.dtlsParameters)
+    ) {
+      const err = new Error('send_transport_invalid')
+      onMediaError?.('produce_failed', 'Invalid transport response from video relay.')
+      throw err
+    }
+
+    const transport = loadedDevice.createSendTransport({
+      id: transportId,
+      iceParameters: created.iceParameters as IceParameters,
+      iceCandidates: created.iceCandidates as IceCandidate[],
+      dtlsParameters: created.dtlsParameters as DtlsParameters,
+      iceServers: sessionIceServers,
+    })
+
+    const unwatch = watchTransportConnectionUntilUnhealthy(transport, () => {
+      onMediaError?.(
+        'transport_failed',
+        `Video relay send transport failed (${producerClass}).`,
+      )
+      teardownSendTransportClass(producerClass)
+    })
+    unwatchFns.push(unwatch)
+    unwatchFns.push(attachTransportConnectivityDrawerLog(transport, sessionIceServers))
+
+    transport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
+      void signaling
+        .request('connectWebRtcTransport', { transportId, dtlsParameters: dtls })
+        .then(() => callback())
+        .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
+    })
+
+    transport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
+      const appProducerClass = isRecord(appData) ? parseProducerClass(appData.producerClass) : null
+      if (!appProducerClass || appProducerClass !== producerClass) {
+        errback(new Error('producerClass required'))
+        return
+      }
+      void signaling
+        .request('produce', { transportId, kind, rtpParameters, producerClass })
+        .then((res) => {
+          const pid = typeof res.producerId === 'string' ? res.producerId : ''
+          if (!pid) throw new Error('no producerId')
+          callback({ id: pid })
+        })
+        .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
+    })
+
+    sendTransportByClass[producerClass] = { transport, transportId, unwatch }
+    return transport
+  }
+
+  // Serialize produce calls per producerClass send transport. Two callers publish
   // host_screen (session connect + capture-change effect); without this lock they
   // can both unpublish-then-produce the same track concurrently, which throws in
   // mediasoup-client and can trip the SFU per-session producer cap.
-  let publishChain: Promise<void> = Promise.resolve()
+  const publishChainByClass: Record<SfuProducerClass, Promise<void>> = {
+    host_screen: Promise.resolve(),
+    participant_av: Promise.resolve(),
+  }
 
   const publishStream = (stream: MediaStream, producerClass: SfuProducerClass): Promise<void> => {
     const run = async (): Promise<void> => {
-      if (!sendTransport) {
-        throw new Error('SFU send transport not ready')
-      }
+      const sendTransport = await ensureSendTransport(producerClass)
       for (const track of stream.getTracks()) {
         const kind = track.kind === 'audio' || track.kind === 'video' ? track.kind : null
         if (!kind) continue
@@ -463,8 +556,8 @@ export async function connectSfuUnifiedSession(options: {
         })
       }
     }
-    const next = publishChain.then(run, run)
-    publishChain = next.then(
+    const next = publishChainByClass[producerClass].then(run, run)
+    publishChainByClass[producerClass] = next.then(
       () => undefined,
       () => undefined,
     )
@@ -487,6 +580,11 @@ export async function connectSfuUnifiedSession(options: {
     }
 
     const iceServers = await getIceServers()
+    sessionIceServers = iceServers
+
+    signaling.onLifetimeEnded(() => {
+      finish('signaling_close')
+    })
 
     let routerRtpCapabilities: Record<string, unknown>
     try {
@@ -509,6 +607,7 @@ export async function connectSfuUnifiedSession(options: {
     }
 
     const device = new mediasoupClient.Device()
+    loadedDevice = device
     try {
       await device.load({
         routerRtpCapabilities: routerRtpCapabilities as unknown as mediasoupClient.types.RtpCapabilities,
@@ -552,7 +651,7 @@ export async function connectSfuUnifiedSession(options: {
       })
 
       unwatchFns.push(
-        watchTransportUntilUnhealthy(recvTransport, signaling, (r) => {
+        watchTransportConnectionUntilUnhealthy(recvTransport, (r) => {
           finish(r)
         }),
       )
@@ -672,72 +771,6 @@ export async function connectSfuUnifiedSession(options: {
       return
     }
 
-    if (tokenRole === 'producer') {
-      let created: Record<string, unknown>
-      try {
-        created = await signaling.request('createWebRtcTransport', { producer: true, consumer: false })
-      } catch (e) {
-        onMediaError?.(
-          'produce_failed',
-          e instanceof Error ? e.message : 'createWebRtcTransport failed',
-        )
-        finish('signaling_close')
-        rejectReady(e instanceof Error ? e : new Error(String(e)))
-        return
-      }
-
-      const transportId = typeof created.transportId === 'string' ? created.transportId : ''
-      if (
-        !transportId ||
-        !isRecord(created.iceParameters) ||
-        !Array.isArray(created.iceCandidates) ||
-        !isRecord(created.dtlsParameters)
-      ) {
-        onMediaError?.('produce_failed', 'Invalid transport response from video relay.')
-        finish('signaling_close')
-        rejectReady(new Error('send_transport_invalid'))
-        return
-      }
-
-      sendTransport = device.createSendTransport({
-        id: transportId,
-        iceParameters: created.iceParameters as IceParameters,
-        iceCandidates: created.iceCandidates as IceCandidate[],
-        dtlsParameters: created.dtlsParameters as DtlsParameters,
-        iceServers,
-      })
-
-      unwatchFns.push(
-        watchTransportUntilUnhealthy(sendTransport, signaling, (r) => {
-          finish(r)
-        }),
-      )
-      unwatchFns.push(attachTransportConnectivityDrawerLog(sendTransport, iceServers))
-
-      sendTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
-        void signaling
-          .request('connectWebRtcTransport', { transportId, dtlsParameters: dtls })
-          .then(() => callback())
-          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
-      })
-
-      sendTransport.on('produce', ({ kind, rtpParameters, appData }, callback, errback) => {
-        const producerClass = isRecord(appData) ? parseProducerClass(appData.producerClass) : null
-        if (!producerClass) {
-          errback(new Error('producerClass required'))
-          return
-        }
-        void signaling
-          .request('produce', { transportId, kind, rtpParameters, producerClass })
-          .then((res) => {
-            const pid = typeof res.producerId === 'string' ? res.producerId : ''
-            if (!pid) throw new Error('no producerId')
-            callback({ id: pid })
-          })
-          .catch((e) => errback(e instanceof Error ? e : new Error(String(e))))
-      })
-    }
-
     try {
       const listRes = await signaling.request('listProducers')
       const producersRaw = listRes.producers
@@ -819,12 +852,17 @@ export async function connectSfuUnifiedSession(options: {
       // Close the mediasoup transports so their underlying RTCPeerConnections are released.
       // Without this, every reconnect leaks a peer connection until the browser hits its cap
       // ("Cannot create so many PeerConnections"), which broke repeated host-screen publishing.
-      try {
-        sendTransport?.close()
-      } catch {
-        /* ignore */
+      // Close per-class send transports so their underlying RTCPeerConnections are released.
+      for (const producerClass of ['host_screen', 'participant_av'] as SfuProducerClass[]) {
+        const slot = sendTransportByClass[producerClass]
+        if (!slot) continue
+        try {
+          slot.transport.close()
+        } catch {
+          /* ignore */
+        }
+        delete sendTransportByClass[producerClass]
       }
-      sendTransport = null
       try {
         recvTransport?.close()
       } catch {

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -248,6 +248,29 @@ export type SfuConsumerTrackEvent =
       track: MediaStreamTrack
     }
   | { action: 'detach'; producerId: string }
+  | {
+      action: 'pause' | 'resume'
+      producerId: string
+      sessionId?: string
+      producerClass: SfuProducerClass | undefined
+      kind: 'audio' | 'video'
+    }
+
+export type SignalingProducerLifecycleEvent =
+  | {
+      action: 'opened'
+      producerId: string
+      sessionId: string
+      producerClass: SfuProducerClass
+      kind: 'audio' | 'video'
+    }
+  | {
+      action: 'closed'
+      producerId: string
+      sessionId?: string
+      producerClass?: SfuProducerClass
+      kind?: 'audio' | 'video'
+    }
 
 export type SfuUnifiedSessionHandle = {
   close: (reason?: SfuSessionEndReason) => void
@@ -280,6 +303,7 @@ export async function connectSfuUnifiedSession(options: {
   getIceServers: () => Promise<RTCIceServer[]>
   onRemoteStream: (stream: MediaStream | null) => void
   onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
+  onSignalingProducerLifecycle?: (event: SignalingProducerLifecycleEvent) => void
   ownSessionId?: string
   onMediaError?: (code: SfuMediaErrorCode, message: string) => void
 }): Promise<SfuUnifiedSessionHandle> {
@@ -290,6 +314,7 @@ export async function connectSfuUnifiedSession(options: {
     getIceServers,
     onRemoteStream,
     onConsumerTrack,
+    onSignalingProducerLifecycle,
     ownSessionId,
     onMediaError,
   } = options
@@ -720,6 +745,19 @@ export async function connectSfuUnifiedSession(options: {
         code: `${summary.producerClass ?? 'unknown'}:${kind}`,
       })
       const { track } = consumer
+      if (summary.producerClass === 'participant_av' && kind === 'audio' && track) {
+        const emitPauseResume = (action: 'pause' | 'resume') => {
+          onConsumerTrack?.({
+            action,
+            producerId,
+            sessionId: summary.sessionId,
+            producerClass: summary.producerClass,
+            kind: 'audio',
+          })
+        }
+        track.addEventListener('mute', () => emitPauseResume('pause'))
+        track.addEventListener('unmute', () => emitPauseResume('resume'))
+      }
       // The theater "view screen" stream must carry host_screen media only.
       // participant_av (camera/mic) reaches the UI exclusively via onConsumerTrack
       // (stage tiles for video, theaterAudioMix for audio); adding it here would
@@ -739,8 +777,34 @@ export async function connectSfuUnifiedSession(options: {
       })
     }
 
+    const emitSignalingProducerLifecycle = (summary: ProducerSummary, action: 'opened' | 'closed') => {
+      const producerClass = summary.producerClass
+      if (!producerClass) return
+      const kind =
+        summary.kind === 'audio' || summary.kind === 'video' ? summary.kind : undefined
+      if (action === 'opened') {
+        if (!summary.sessionId || !kind) return
+        onSignalingProducerLifecycle?.({
+          action: 'opened',
+          producerId: summary.producerId,
+          sessionId: summary.sessionId,
+          producerClass,
+          kind,
+        })
+        return
+      }
+      onSignalingProducerLifecycle?.({
+        action: 'closed',
+        producerId: summary.producerId,
+        sessionId: summary.sessionId,
+        producerClass,
+        kind,
+      })
+    }
+
     const syncFromList = async (list: ProducerSummary[]): Promise<void> => {
       for (const row of list) {
+        emitSignalingProducerLifecycle(row, 'opened')
         await consumeProducer(row)
       }
       emitRemote()
@@ -751,6 +815,15 @@ export async function connectSfuUnifiedSession(options: {
         if (!isRecord(data)) return
         const producerId = typeof data.producerId === 'string' ? data.producerId : ''
         if (!producerId) return
+        emitSignalingProducerLifecycle(
+          {
+            producerId,
+            kind: typeof data.kind === 'string' ? data.kind : '',
+            sessionId: typeof data.sessionId === 'string' ? data.sessionId : undefined,
+            producerClass: parseProducerClass(data.producerClass) ?? undefined,
+          },
+          'closed',
+        )
         detachConsumerByProducerId(producerId)
         emitRemote()
         return
@@ -762,7 +835,9 @@ export async function connectSfuUnifiedSession(options: {
       const sessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined
       const producerClass = parseProducerClass(data.producerClass) ?? undefined
       if (!producerId) return
-      void consumeProducer({ producerId, kind, sessionId, producerClass }).then(() => emitRemote())
+      const summary: ProducerSummary = { producerId, kind, sessionId, producerClass }
+      emitSignalingProducerLifecycle(summary, 'opened')
+      void consumeProducer(summary).then(() => emitRemote())
     }
 
     if (!(await setupRecvTransport())) {

--- a/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.test.tsx
@@ -31,6 +31,7 @@ describe('ParticipantVideoTile', () => {
       label,
       isSelf,
       stream,
+      speaking: false,
     }
   }
 
@@ -87,5 +88,12 @@ describe('ParticipantVideoTile', () => {
     renderTile(makeTile('Alice', false, secondStream))
     expect(video?.srcObject).toBe(secondStream)
     expect(video?.srcObject).not.toBe(firstStream)
+  })
+
+  it('applies speaking class and aria-label when tile is speaking', () => {
+    renderTile({ ...makeTile('Alice', false), speaking: true })
+    const figure = container.querySelector('figure.riffsync-room-page__participant-tile--speaking')
+    expect(figure).not.toBeNull()
+    expect(figure?.getAttribute('aria-label')).toBe('Alice, speaking')
   })
 })

--- a/apps/web/src/room/stage/ParticipantVideoTile.tsx
+++ b/apps/web/src/room/stage/ParticipantVideoTile.tsx
@@ -21,8 +21,8 @@ export function ParticipantVideoTile({ tile }: ParticipantVideoTileProps) {
 
   return (
     <figure
-      className={`riffsync-room-page__participant-tile${tile.isSelf ? ' riffsync-room-page__participant-tile--self' : ''}`}
-      aria-label={tile.label}
+      className={`riffsync-room-page__participant-tile${tile.isSelf ? ' riffsync-room-page__participant-tile--self' : ''}${tile.speaking ? ' riffsync-room-page__participant-tile--speaking' : ''}`}
+      aria-label={tile.speaking ? `${tile.label}, speaking` : tile.label}
     >
       <video
         ref={videoRef}

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -67,6 +67,7 @@ describe('StageParticipantLayout', () => {
           label: 'You',
           isSelf: true,
           stream,
+          speaking: false,
         },
       ],
     })
@@ -81,6 +82,7 @@ describe('StageParticipantLayout', () => {
       label: 'Alice',
       isSelf: false,
       stream: new MediaStream([{ kind: 'video' } as MediaStreamTrack]),
+      speaking: false,
     }
 
     function assertTileRemoved(video: HTMLVideoElement | null) {
@@ -164,6 +166,7 @@ describe('StageParticipantLayout', () => {
           label: 'You',
           isSelf: true,
           stream,
+          speaking: false,
         },
       ],
     })

--- a/apps/web/src/room/stage/participantAvAudioConsumers.test.ts
+++ b/apps/web/src/room/stage/participantAvAudioConsumers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
+import { applyParticipantAvAudioConsumerEvent } from './participantAvAudioConsumers'
+
+describe('participantAvAudioConsumers', () => {
+  it('stores participant_av audio attach events keyed by producerId', () => {
+    const track = { kind: 'audio' } as MediaStreamTrack
+    const event: SfuConsumerTrackEvent = {
+      action: 'attach',
+      producerId: 'p-a',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      sessionId: 'remote-1',
+      track,
+    }
+    const next = applyParticipantAvAudioConsumerEvent(new Map(), event)
+    expect(next.get('p-a')).toEqual({
+      producerId: 'p-a',
+      sessionId: 'remote-1',
+      track,
+    })
+  })
+
+  it('ignores non-participant_av and video attach events', () => {
+    const track = { kind: 'video' } as MediaStreamTrack
+    const event: SfuConsumerTrackEvent = {
+      action: 'attach',
+      producerId: 'p-v',
+      producerClass: 'participant_av',
+      kind: 'video',
+      sessionId: 'remote-1',
+      track,
+    }
+    expect(applyParticipantAvAudioConsumerEvent(new Map(), event).size).toBe(0)
+  })
+
+  it('removes producer on detach', () => {
+    const track = { kind: 'audio' } as MediaStreamTrack
+    const attach: SfuConsumerTrackEvent = {
+      action: 'attach',
+      producerId: 'p-a',
+      producerClass: 'participant_av',
+      kind: 'audio',
+      sessionId: 'remote-1',
+      track,
+    }
+    const state = applyParticipantAvAudioConsumerEvent(new Map(), attach)
+    const detached = applyParticipantAvAudioConsumerEvent(state, {
+      action: 'detach',
+      producerId: 'p-a',
+    })
+    expect(detached.size).toBe(0)
+  })
+})

--- a/apps/web/src/room/stage/participantAvAudioConsumers.ts
+++ b/apps/web/src/room/stage/participantAvAudioConsumers.ts
@@ -1,0 +1,30 @@
+import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
+
+export type ParticipantAvAudioConsumer = {
+  producerId: string
+  sessionId: string | undefined
+  track: MediaStreamTrack
+}
+
+export function applyParticipantAvAudioConsumerEvent(
+  state: Map<string, ParticipantAvAudioConsumer>,
+  event: SfuConsumerTrackEvent,
+): Map<string, ParticipantAvAudioConsumer> {
+  if (event.action === 'detach') {
+    if (!state.has(event.producerId)) return state
+    const next = new Map(state)
+    next.delete(event.producerId)
+    return next
+  }
+  if (event.action !== 'attach') return state
+  if (event.producerClass !== 'participant_av' || event.kind !== 'audio') {
+    return state
+  }
+  const next = new Map(state)
+  next.set(event.producerId, {
+    producerId: event.producerId,
+    sessionId: event.sessionId,
+    track: event.track,
+  })
+  return next
+}

--- a/apps/web/src/room/stage/participantAvConsumers.ts
+++ b/apps/web/src/room/stage/participantAvConsumers.ts
@@ -16,6 +16,7 @@ export function applyParticipantAvConsumerEvent(
     next.delete(event.producerId)
     return next
   }
+  if (event.action !== 'attach') return state
   if (event.producerClass !== 'participant_av' || event.kind !== 'video') {
     return state
   }

--- a/apps/web/src/room/stage/stageParticipantTiles.test.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.test.ts
@@ -137,6 +137,18 @@ describe('stageParticipantTiles', () => {
     expect(tiles.map((t) => t.sessionId)).toEqual(['host-1', 'fan-b'])
   })
 
+  it('marks tiles speaking from speakingBySessionId map', () => {
+    const tiles = buildStageParticipantTiles({
+      roster,
+      videoConsumers: new Map([['p-b', consumer('p-b', 'fan-b')]]),
+      ownSessionId: 'fan-a',
+      localCameraOn: false,
+      localPreviewStream: null,
+      speakingBySessionId: new Map([['fan-b', true]]),
+    })
+    expect(tiles[0]?.speaking).toBe(true)
+  })
+
   it('keeps a stable MediaStream identity per remote track across rebuilds', () => {
     const videoConsumers = new Map([['p1', consumer('p1', 'fan-b')]])
     const args = {

--- a/apps/web/src/room/stage/stageParticipantTiles.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.ts
@@ -12,6 +12,7 @@ export type StageParticipantTile = {
   label: string
   isSelf: boolean
   stream: MediaStream
+  speaking: boolean
 }
 
 export const VIDEO_CHAT_EMPTY_COPY =
@@ -81,7 +82,9 @@ export function buildStageParticipantTiles(opts: {
   ownSessionId: string
   localCameraOn: boolean
   localPreviewStream: MediaStream | null
+  speakingBySessionId?: ReadonlyMap<string, boolean>
 }): StageParticipantTile[] {
+  const speakingBySessionId = opts.speakingBySessionId ?? new Map<string, boolean>()
   const remoteBySession = videoConsumersBySession(opts.videoConsumers.values())
   const rosterBySession = new Map<string, RosterMember>()
   for (const member of opts.roster) rosterBySession.set(member.sessionId, member)
@@ -127,6 +130,7 @@ export function buildStageParticipantTiles(opts: {
     label: draft.label,
     isSelf: draft.isSelf,
     stream: draft.stream,
+    speaking: speakingBySessionId.get(draft.sessionId) ?? false,
   }))
 }
 

--- a/apps/web/src/room/useRoomMediaEngine.ts
+++ b/apps/web/src/room/useRoomMediaEngine.ts
@@ -51,6 +51,9 @@ export function useRoomMediaEngine(options: {
   sendChatGif: (result: GiphySearchResult) => void
   toggleChatReaction: (messageId: string, emoji: string, reactionAction: 'add' | 'remove') => void
   peopleShown: ReturnType<RoomMediaEngine['getSnapshot']>['peopleShown']
+  participantProducerBySessionId: ReturnType<
+    RoomMediaEngine['getSnapshot']
+  >['participantProducerBySessionId']
   chatMemberLabels: Map<string, string>
   sfuConfigAlert: string | null
   chatDrawerBanner: string | null
@@ -302,6 +305,7 @@ export function useRoomMediaEngine(options: {
     sendChatGif,
     toggleChatReaction,
     peopleShown: snapshot.peopleShown,
+    participantProducerBySessionId: snapshot.participantProducerBySessionId,
     chatMemberLabels,
     sfuConfigAlert: snapshot.drawerPresentation.sfuConfigAlert,
     chatDrawerBanner: snapshot.drawerPresentation.chatDrawerBanner,

--- a/apps/web/src/room/useRoomMediaEngine.ts
+++ b/apps/web/src/room/useRoomMediaEngine.ts
@@ -54,6 +54,7 @@ export function useRoomMediaEngine(options: {
   participantProducerBySessionId: ReturnType<
     RoomMediaEngine['getSnapshot']
   >['participantProducerBySessionId']
+  speakingBySessionId: ReturnType<RoomMediaEngine['getSnapshot']>['speakingBySessionId']
   chatMemberLabels: Map<string, string>
   sfuConfigAlert: string | null
   chatDrawerBanner: string | null
@@ -306,6 +307,7 @@ export function useRoomMediaEngine(options: {
     toggleChatReaction,
     peopleShown: snapshot.peopleShown,
     participantProducerBySessionId: snapshot.participantProducerBySessionId,
+    speakingBySessionId: snapshot.speakingBySessionId,
     chatMemberLabels,
     sfuConfigAlert: snapshot.drawerPresentation.sfuConfigAlert,
     chatDrawerBanner: snapshot.drawerPresentation.chatDrawerBanner,

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -978,6 +978,27 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   border: 1px solid rgb(255 255 255 / 0.1);
 }
 
+.riffsync-room-page__participant-tile--speaking {
+  border-color: rgb(100 180 255 / 0.9);
+  box-shadow: 0 0 0 2px rgb(100 180 255 / 0.55);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .riffsync-room-page__participant-tile--speaking {
+    animation: riffsync-speaking-tile-glow 1.2s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes riffsync-speaking-tile-glow {
+  from {
+    box-shadow: 0 0 0 2px rgb(100 180 255 / 0.35);
+  }
+
+  to {
+    box-shadow: 0 0 0 3px rgb(100 180 255 / 0.7);
+  }
+}
+
 @media (min-width: 992px) {
   .riffsync-room-page__participant-strip--desktop .riffsync-room-page__participant-tile {
     width: 100%;
@@ -1525,6 +1546,25 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 .riffsync-room-page__people-row--host {
   border-left: 3px solid var(--primary-color);
   background: rgb(255 255 255 / 0.07);
+}
+
+.riffsync-room-page__people-row--speaking {
+  border-color: rgb(100 180 255 / 0.55);
+  box-shadow: inset 0 0 0 1px rgb(100 180 255 / 0.35);
+}
+
+.riffsync-room-page__speaking-badge {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.1rem 0.38rem;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  color: rgb(130 195 255);
+  border: 1px solid rgb(100 180 255 / 0.45);
+  vertical-align: middle;
 }
 
 .riffsync-room-page__host-badge {

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -825,6 +825,32 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   cursor: not-allowed;
 }
 
+.riffsync-room-page__host-bar-beta {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.08rem 0.35rem;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  color: rgb(200 170 255);
+  border: 1px solid rgb(170 130 255 / 0.45);
+  vertical-align: middle;
+}
+
+.riffsync-room-page__host-bar-beta-desc {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .riffsync-room-page__host-bar-kill {
   flex: 0 1 auto;
   font-size: 0.75rem;

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1489,6 +1489,37 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
+}
+
+.riffsync-room-page__people-av {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.riffsync-room-page__people-av-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 4px;
+  color: rgb(255 255 255 / 0.35);
+}
+
+.riffsync-room-page__people-av-icon--on {
+  color: rgb(130 195 140);
+}
+
+.riffsync-room-page__people-av-icon--muted {
+  color: rgb(220 170 90);
+}
+
+.riffsync-room-page__people-av-icon--off {
+  color: rgb(255 255 255 / 0.28);
 }
 
 .riffsync-room-page__people-row--host {


### PR DESCRIPTION
## Summary

M23 epic (#242) work on shared branch `feature/issue-242`:

- **#247** — Mandatory per-`producerClass` send transport isolation in the browser SFU client. `host_screen` and `participant_av` each get a lazy-allocated mediasoup send transport on the same signaling WebSocket. Class-scoped ICE/transport failure tears down only that class's transport.
- **#248** — People tab roster rows show live camera/microphone state per `sessionId` from SFU `newProducer` / `producerClosed` lifecycle (and local participant AV for self). Mic **muted** (audio producer paused) is visually distinct from mic **off** (no audio producer).
- **#249** — Client-side VAD speaking indication on Theater strip / Video Chat tiles (video-on only) and People roster rows (including mic-only). Uses M23 params: `fftSize` 512, RMS >= 0.02, 150ms attack, 300ms hang. Clears on mic mute, producer close, and kill switch. Static border under `prefers-reduced-motion: reduce`.
- **#250** — Host control bar **Video Chat** segment shows visible **Beta** label when room A/V is enabled (`avDisabled` false). Tooltip / `aria-describedby` copy matches `.ai/interface/presentation.md`. Beta chrome hidden when kill switch disables Video Chat.

Closes #247
Closes #248
Closes #249
Closes #250

Part of #242 (M23 SFU reliability epic).

## Test plan

- [x] `cd apps/web && npm ci && npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual (#247): host shares tab + guest toggles camera/mic; host capture continues without re-prompting Share Source Tab
- [ ] Manual (#248): two browsers — fan camera-only, mic mute with camera on, camera off with mic on; People rows update without refresh
- [ ] Manual (#249): video-on fan speaks — tile border active, clears ~300ms after silence; mic-only fan speaking shows on People row only; muted mic shows no speaking affordance
- [ ] Manual (#250): host room with AV enabled — Video Chat shows Beta + tooltip; enable kill switch — Video Chat inert, no Beta chrome