### PR TITLE
Complete room realtime diagnostics contract

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -15,6 +15,7 @@ import {
   VIDEO_RELAY_RECONNECTING_COPY,
 } from './roomPageDrawerStatusTestHelpers'
 import { RIFFSYNC_CHAT_DRAWER_STATUS_ID, RIFFSYNC_VIDEO_RELAY_STATUS_ID } from '../room/drawerErrorPresentation'
+import type { RoomRealtimeDiagnostics } from '../room/sessions/RoomRealtimeSdk'
 
 const fetchRoom = vi.fn()
 const fetchRtcIceServers = vi.fn()
@@ -78,17 +79,7 @@ vi.mock('../room/audio/theaterAudioMix', () => ({
 
 const drawerStatusMockConfig = vi.hoisted(() => {
   type MockConfig = {
-    diagnostics: {
-      roomId: string
-      sessionId: string
-      asOf: string
-      drawers: {
-        chat: { state: string; lastErrorCode?: string }
-        sfuSignaling: { state: string; lastErrorCode?: string }
-        theaterPlayback: { state: string; lastErrorCode?: string }
-      }
-      activeErrorCodes: string[]
-    }
+    diagnostics: RoomRealtimeDiagnostics
     guestShareFsm: 'idle' | 'verifying_media' | 'running'
   }
 
@@ -99,7 +90,19 @@ const drawerStatusMockConfig = vi.hoisted(() => {
       asOf: new Date(0).toISOString(),
       drawers: {
         chat: { state: 'connected' },
-        sfuSignaling: { state: 'connected' },
+        sfuSignaling: {
+          state: 'connected',
+          health: {
+            connectivity: { state: 'connected' },
+            produceConsume: {
+              state: 'connected',
+              producerCount: 0,
+              consumerCount: 0,
+              hostScreenAttached: false,
+              participantAvPublishActive: false,
+            },
+          },
+        },
         theaterPlayback: { state: 'connected' },
       },
       activeErrorCodes: [],

--- a/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
+++ b/apps/web/src/pages/roomPageDrawerStatusTestHelpers.ts
@@ -22,19 +22,50 @@ export const RETIRED_MESH_HOST_SCREEN_COPY = [
   'VITE_WEBRTC_USE_MEDIASOU_SFU',
 ] as const
 
+type DrawerDiagnosticsOverrides = Partial<
+  Omit<RoomRealtimeDiagnostics['drawers'], 'sfuSignaling'>
+> & {
+  sfuSignaling?: Partial<RoomRealtimeDiagnostics['drawers']['sfuSignaling']>
+}
+
 export function drawerDiagnostics(
-  drawers: Partial<RoomRealtimeDiagnostics['drawers']>,
+  drawers: DrawerDiagnosticsOverrides,
   activeErrorCodes: string[] = [],
 ): RoomRealtimeDiagnostics {
+  const defaultSfuSignaling: RoomRealtimeDiagnostics['drawers']['sfuSignaling'] = {
+    state: 'connected',
+    health: {
+      connectivity: { state: 'connected' },
+      produceConsume: {
+        state: 'connected',
+        producerCount: 0,
+        consumerCount: 0,
+        hostScreenAttached: false,
+        participantAvPublishActive: false,
+      },
+    },
+  }
+
   return {
     roomId: 'room-test-1',
     sessionId: 'sess-test-1',
     asOf: new Date(0).toISOString(),
     drawers: {
       chat: { state: 'connected' },
-      sfuSignaling: { state: 'connected' },
+      sfuSignaling: {
+        ...defaultSfuSignaling,
+        ...drawers.sfuSignaling,
+        health: {
+          connectivity:
+            drawers.sfuSignaling?.health?.connectivity ?? defaultSfuSignaling.health.connectivity,
+          produceConsume:
+            drawers.sfuSignaling?.health?.produceConsume ??
+            defaultSfuSignaling.health.produceConsume,
+        },
+      },
       theaterPlayback: { state: 'connected' },
-      ...drawers,
+      ...(drawers.chat ? { chat: drawers.chat } : {}),
+      ...(drawers.theaterPlayback ? { theaterPlayback: drawers.theaterPlayback } : {}),
     },
     activeErrorCodes,
   }

--- a/apps/web/src/room/drawerErrorPresentation.test.ts
+++ b/apps/web/src/room/drawerErrorPresentation.test.ts
@@ -15,6 +15,27 @@ import {
   resolveVideoRelayStatusLine,
   selectDrawerPresentation,
 } from './drawerErrorPresentation'
+import type { SfuSignalingDrawerDiagnostics } from './sessions/RoomRealtimeSdk'
+
+function sfuDiagnostics(
+  partial: Omit<SfuSignalingDrawerDiagnostics, 'health'> & {
+    health?: SfuSignalingDrawerDiagnostics['health']
+  },
+): SfuSignalingDrawerDiagnostics {
+  return {
+    ...partial,
+    health: partial.health ?? {
+      connectivity: { state: partial.state },
+      produceConsume: {
+        state: partial.state,
+        producerCount: 0,
+        consumerCount: 0,
+        hostScreenAttached: false,
+        participantAvPublishActive: false,
+      },
+    },
+  }
+}
 
 describe('drawerErrorPresentation', () => {
   afterEach(() => {
@@ -41,14 +62,14 @@ describe('drawerErrorPresentation', () => {
     )
     expect(
       resolveVideoRelayStatusLine({
-        sfu: { state: 'reconnecting' },
+        sfu: sfuDiagnostics({ state: 'reconnecting' }),
         isPublisher: false,
         guestShareFsm: 'running',
       }),
     ).toBe('Video relay reconnecting…')
     expect(
       resolveVideoRelayStatusLine({
-        sfu: { state: 'degraded' },
+        sfu: sfuDiagnostics({ state: 'degraded' }),
         isPublisher: false,
         guestShareFsm: 'running',
       }),
@@ -102,12 +123,12 @@ describe('drawerErrorPresentation', () => {
 
   it('surfaces config-class SFU errors on the page alert target', () => {
     expect(
-      resolveSfuConfigAlert({
+      resolveSfuConfigAlert(sfuDiagnostics({
         state: 'degraded',
         lastErrorCode: 'LOCAL_SFU_UNREACHABLE',
-      }),
+      })),
     ).toContain('Local video relay is not running')
-    expect(resolveSfuConfigAlert({ state: 'connected' })).toBeNull()
+    expect(resolveSfuConfigAlert(sfuDiagnostics({ state: 'connected' }))).toBeNull()
   })
 
   it('shows theater audio status for blocked and suspended codes', () => {
@@ -128,7 +149,7 @@ describe('drawerErrorPresentation', () => {
   it('keeps guest host-screen FSM copy on the video-relay surface when SFU drawer is healthy', () => {
     expect(
       resolveVideoRelayStatusLine({
-        sfu: { state: 'connected' },
+        sfu: sfuDiagnostics({ state: 'connected' }),
         isPublisher: false,
         guestShareFsm: 'idle',
       }),
@@ -145,7 +166,7 @@ describe('drawerErrorPresentation', () => {
         asOf: new Date(0).toISOString(),
         drawers: {
           chat: { state: 'reconnecting' },
-          sfuSignaling: { state: 'connected' },
+          sfuSignaling: sfuDiagnostics({ state: 'connected' }),
           theaterPlayback: { state: 'connected' },
         },
         activeErrorCodes: [],
@@ -166,7 +187,7 @@ describe('drawerErrorPresentation', () => {
         asOf: new Date(0).toISOString(),
         drawers: {
           chat: { state: 'reconnecting' },
-          sfuSignaling: { state: 'degraded', lastErrorCode: 'ICE_FAILED' },
+          sfuSignaling: sfuDiagnostics({ state: 'degraded', lastErrorCode: 'ICE_FAILED' }),
           theaterPlayback: { state: 'connected' },
         },
         activeErrorCodes: ['ICE_FAILED'],
@@ -223,7 +244,7 @@ describe('chat drawer banner and compose inline feedback (#207)', () => {
         asOf: new Date(0).toISOString(),
         drawers: {
           chat: { state: 'connected' },
-          sfuSignaling: { state: 'reconnecting' },
+          sfuSignaling: sfuDiagnostics({ state: 'reconnecting' }),
           theaterPlayback: { state: 'connected' },
         },
         activeErrorCodes: [],
@@ -262,7 +283,7 @@ describe('chat drawer banner and compose inline feedback (#207)', () => {
         asOf: new Date(0).toISOString(),
         drawers: {
           chat: { state: 'connected' },
-          sfuSignaling: { state: 'degraded', lastErrorCode: 'ICE_FAILED' },
+          sfuSignaling: sfuDiagnostics({ state: 'degraded', lastErrorCode: 'ICE_FAILED' }),
           theaterPlayback: { state: 'connected' },
         },
         activeErrorCodes: ['ICE_FAILED'],

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.drawerIsolationRegression.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.drawerIsolationRegression.test.ts
@@ -85,6 +85,8 @@ function mockSfuSessionWithControllableEnd(): {
     tokenRole: 'consumer',
     getProducerCount: () => 0,
     getConsumerCount: () => 0,
+    hasProducerClass: () => false,
+    hasConsumerClass: () => false,
     detachConsumerClass: vi.fn(),
     pauseProducerKind: vi.fn(),
     resumeProducerKind: vi.fn(),

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -73,6 +73,7 @@ const REQUIRED_DIAGNOSTIC_KEYS = [
 ] as const satisfies readonly (keyof RoomRealtimeDiagnostics)[]
 
 const REQUIRED_DRAWER_KEYS = ['chat', 'sfuSignaling', 'theaterPlayback'] as const
+const REQUIRED_SFU_HEALTH_KEYS = ['connectivity', 'produceConsume'] as const
 
 function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
   for (const key of REQUIRED_DIAGNOSTIC_KEYS) {
@@ -83,6 +84,13 @@ function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
     expect(diag.drawers).toHaveProperty(drawerKey)
     expect(diag.drawers[drawerKey]).toHaveProperty('state')
     expect(DRAWER_LIFECYCLE_STATES).toContain(diag.drawers[drawerKey].state)
+  }
+
+  for (const healthKey of REQUIRED_SFU_HEALTH_KEYS) {
+    expect(diag.drawers.sfuSignaling.health).toHaveProperty(healthKey)
+    expect(DRAWER_LIFECYCLE_STATES).toContain(
+      diag.drawers.sfuSignaling.health[healthKey].state,
+    )
   }
 
   expect(Array.isArray(diag.activeErrorCodes)).toBe(true)
@@ -192,13 +200,17 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
     expect({
       topLevelKeys: REQUIRED_DIAGNOSTIC_KEYS.slice().sort(),
       drawerKeys: REQUIRED_DRAWER_KEYS.slice().sort(),
+      sfuHealthKeys: REQUIRED_SFU_HEALTH_KEYS.slice().sort(),
       lifecycleStates: DRAWER_LIFECYCLE_STATES.slice(),
       sample: {
         roomId: diag.roomId,
         sessionId: diag.sessionId,
         drawers: {
           chat: { state: diag.drawers.chat.state },
-          sfuSignaling: { state: diag.drawers.sfuSignaling.state },
+          sfuSignaling: {
+            state: diag.drawers.sfuSignaling.state,
+            health: diag.drawers.sfuSignaling.health,
+          },
           theaterPlayback: { state: diag.drawers.theaterPlayback.state },
         },
         activeErrorCodes: diag.activeErrorCodes,
@@ -223,6 +235,18 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
               "state": "torn-down",
             },
             "sfuSignaling": {
+              "health": {
+                "connectivity": {
+                  "state": "torn-down",
+                },
+                "produceConsume": {
+                  "consumerCount": 0,
+                  "hostScreenAttached": false,
+                  "participantAvPublishActive": false,
+                  "producerCount": 0,
+                  "state": "torn-down",
+                },
+              },
               "state": "torn-down",
             },
             "theaterPlayback": {
@@ -232,6 +256,10 @@ describe('RoomRealtimeSdk.getDiagnostics', () => {
           "roomId": "room-abc",
           "sessionId": "sess-snapshot",
         },
+        "sfuHealthKeys": [
+          "connectivity",
+          "produceConsume",
+        ],
         "topLevelKeys": [
           "activeErrorCodes",
           "asOf",
@@ -515,6 +543,40 @@ describe('RoomRealtimeSdk public surface', () => {
       const lastCall = onDiagnosticsChange.mock.calls.at(-1)?.[0]
       expect(lastCall?.drawers.chat.state).toBe('connected')
     })
+  })
+
+  it('calls onDiagnosticsChange when SFU health changes', async () => {
+    const onDiagnosticsChange = vi.fn()
+    const sdk = await joinHealthySdk({ sessionId: 'sess-health-cb' })
+    ;(sdk as unknown as { onDiagnosticsChange: typeof onDiagnosticsChange }).onDiagnosticsChange =
+      onDiagnosticsChange
+
+    ;(
+      getSfuSession(sdk) as unknown as {
+        applyConnectivityHealth: (event: unknown) => void
+      }
+    ).applyConnectivityHealth({
+      transportId: 'recv-1',
+      direction: 'recv',
+      state: 'degraded',
+      lastErrorCode: 'ICE_FAILED',
+      iceConnectionState: 'failed',
+    })
+
+    expect(onDiagnosticsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        drawers: expect.objectContaining({
+          sfuSignaling: expect.objectContaining({
+            health: expect.objectContaining({
+              connectivity: expect.objectContaining({
+                state: 'degraded',
+                lastErrorCode: 'ICE_FAILED',
+              }),
+            }),
+          }),
+        }),
+      }),
+    )
   })
 
   it('reports connected chat and SFU drawers when modules are healthy after bootstrap', async () => {
@@ -1014,6 +1076,32 @@ describe('RoomRealtimeSdk.getDiagnostics activeErrorCodes contract', () => {
     expect(diag.activeErrorCodes).toEqual(['CHAT_SEND_DROPPED', 'SIGNALING_TIMEOUT'])
   })
 
+  it('reports ICE failures under connectivity health', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-ice-health' })
+    emitSfuDrawerError(sdk, mapSfuMediaCodeToDrawerError('transport_failed'))
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.lastErrorCode).toBeUndefined()
+    expect(diag.drawers.sfuSignaling.health.connectivity).toEqual({
+      state: 'degraded',
+      lastErrorCode: 'ICE_FAILED',
+    })
+    expect(diag.activeErrorCodes).toEqual(['ICE_FAILED'])
+  })
+
+  it('reports transport and consumer caps under produce/consume health', async () => {
+    const sdk = await joinHealthySdk({ sessionId: 'sess-produce-consume-health' })
+    emitSfuDrawerError(sdk, { code: 'TRANSPORT_LIMIT_REACHED', drawer: 'sfuSignaling' })
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.sfuSignaling.lastErrorCode).toBeUndefined()
+    expect(diag.drawers.sfuSignaling.health.produceConsume.state).toBe('degraded')
+    expect(diag.drawers.sfuSignaling.health.produceConsume.lastErrorCode).toBe(
+      'TRANSPORT_LIMIT_REACHED',
+    )
+    expect(diag.activeErrorCodes).toEqual(['TRANSPORT_LIMIT_REACHED'])
+  })
+
   it('excludes PRODUCER_CLOSED from activeErrorCodes after consumer detach simulation', async () => {
     mockChatConnectOpensImmediately()
     const consumerListeners: Array<(event: SfuConsumerTrackEvent) => void> = []
@@ -1253,13 +1341,21 @@ describe('RoomRealtimeSdk.getDiagnostics SFU counts', () => {
     vi.restoreAllMocks()
   })
 
-  it('exposes optional SFU role and producer/consumer counts when session is open', async () => {
+  it('exposes optional SFU role and health producer/consumer counts when session is open', async () => {
     mockChatConnectOpensImmediately()
     mockSfuConnectOpensImmediately()
     vi.spyOn(SfuMediaSession.prototype, 'getSignalingDiagnostics').mockReturnValue({
       role: 'consumer',
-      producerCount: 0,
-      consumerCount: 2,
+    })
+    vi.spyOn(SfuMediaSession.prototype, 'getHealthDiagnostics').mockReturnValue({
+      connectivity: { state: 'connected', iceConnectionState: 'connected' },
+      produceConsume: {
+        state: 'connected',
+        producerCount: 0,
+        consumerCount: 2,
+        hostScreenAttached: true,
+        participantAvPublishActive: false,
+      },
     })
 
     const sdk = new RoomRealtimeSdk()
@@ -1277,8 +1373,11 @@ describe('RoomRealtimeSdk.getDiagnostics SFU counts', () => {
 
     const diag = sdk.getDiagnostics()
     expect(diag.drawers.sfuSignaling.role).toBe('consumer')
-    expect(diag.drawers.sfuSignaling.producerCount).toBe(0)
-    expect(diag.drawers.sfuSignaling.consumerCount).toBe(2)
+    expect(diag.drawers.sfuSignaling).not.toHaveProperty('producerCount')
+    expect(diag.drawers.sfuSignaling).not.toHaveProperty('consumerCount')
+    expect(diag.drawers.sfuSignaling.health.produceConsume.producerCount).toBe(0)
+    expect(diag.drawers.sfuSignaling.health.produceConsume.consumerCount).toBe(2)
+    expect(diag.drawers.sfuSignaling.health.produceConsume.hostScreenAttached).toBe(true)
   })
 })
 

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.test.ts
@@ -5,12 +5,18 @@ import { ChatSession } from './ChatSession'
 import { SfuMediaSession } from './SfuMediaSession'
 import { TheaterPlayback } from './TheaterPlayback'
 import {
-  DRAWER_LIFECYCLE_STATES,
   RoomRealtimeSdk,
   mapChatSessionStatusToDrawerState,
   mapSfuMediaSessionStatusToDrawerState,
   type RoomRealtimeDiagnostics,
 } from './RoomRealtimeSdk'
+import {
+  DRAWER_LIFECYCLE_STATES,
+  REQUIRED_DIAGNOSTIC_KEYS,
+  REQUIRED_DRAWER_KEYS,
+  REQUIRED_SFU_HEALTH_KEYS,
+  assertRoomRealtimeDiagnosticsContract,
+} from './roomRealtimeDiagnosticsContract'
 import {
   assertDrawerReconnectCycle,
   assertNoDrawerTornDown,
@@ -64,18 +70,9 @@ const baseSnapshot: RoomSnapshot = {
   broadcastCaptureActive: false,
 }
 
-const REQUIRED_DIAGNOSTIC_KEYS = [
-  'roomId',
-  'sessionId',
-  'asOf',
-  'drawers',
-  'activeErrorCodes',
-] as const satisfies readonly (keyof RoomRealtimeDiagnostics)[]
-
-const REQUIRED_DRAWER_KEYS = ['chat', 'sfuSignaling', 'theaterPlayback'] as const
-const REQUIRED_SFU_HEALTH_KEYS = ['connectivity', 'produceConsume'] as const
-
 function assertStableDiagnosticsContract(diag: RoomRealtimeDiagnostics): void {
+  expect(() => assertRoomRealtimeDiagnosticsContract(diag)).not.toThrow()
+
   for (const key of REQUIRED_DIAGNOSTIC_KEYS) {
     expect(diag).toHaveProperty(key)
   }
@@ -506,6 +503,25 @@ describe('RoomRealtimeSdk public surface', () => {
     expect(typeof sdk.subscribe).toBe('function')
     expect(typeof sdk.getDiagnostics).toBe('function')
     expect(typeof sdk.teardown).toBe('function')
+  })
+
+  it('registers dev-only window.riffsyncRoomDiagnostics during a joined session', () => {
+    vi.stubGlobal('window', {})
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-dev-getter',
+    })
+
+    expect(window.riffsyncRoomDiagnostics).toBeTypeOf('function')
+    expect(window.riffsyncRoomDiagnostics?.()).toMatchObject({
+      roomId: 'room-abc',
+      sessionId: 'sess-dev-getter',
+    })
+
+    sdk.teardown()
+    expect(window.riffsyncRoomDiagnostics).toBeUndefined()
+    vi.unstubAllGlobals()
   })
 
   it('teardown resets diagnostics to torn-down drawers', () => {
@@ -1162,6 +1178,49 @@ describe('RoomRealtimeSdk theater playback lifecycle', () => {
     expect(diag.drawers.theaterPlayback.state).toBe('degraded')
     expect(diag.drawers.theaterPlayback.lastErrorCode).toBe('THEATER_AUDIO_SUSPENDED')
     expect(diag.drawers.theaterPlayback.audioContextState).toBe('suspended')
+  })
+
+  it('maps verifying guest media to reconnecting and exposes guestShareFsm', async () => {
+    mockChatConnectOpensImmediately()
+    mockSfuConnectOpensImmediately()
+    const onDiagnosticsChange = vi.fn()
+
+    const sdk = new RoomRealtimeSdk()
+    sdk.join('room-abc', {
+      roomSnapshot: baseSnapshot,
+      sessionId: 'sess-theater-verifying-media',
+      wsUrl: 'wss://ws.test',
+      apiBaseUrl: 'https://api.test',
+      getIceServers: async () => [],
+      isHost: false,
+      onDiagnosticsChange,
+    })
+
+    await vi.waitFor(() =>
+      expect((sdk as unknown as { theaterBootstrapped: boolean }).theaterBootstrapped).toBe(true),
+    )
+    onDiagnosticsChange.mockClear()
+
+    const pendingStream = {
+      getTracks: () => [{ kind: 'video', readyState: 'ended' }],
+      getVideoTracks: () => [{ kind: 'video', readyState: 'ended' }],
+      getAudioTracks: () => [],
+    } as unknown as MediaStream
+    ;(sdk as unknown as { theater: TheaterPlayback }).theater.setGuestRemote(pendingStream)
+
+    const diag = sdk.getDiagnostics()
+    expect(diag.drawers.theaterPlayback.state).toBe('reconnecting')
+    expect(diag.drawers.theaterPlayback.guestShareFsm).toBe('verifying_media')
+    expect(onDiagnosticsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        drawers: expect.objectContaining({
+          theaterPlayback: expect.objectContaining({
+            state: 'reconnecting',
+            guestShareFsm: 'verifying_media',
+          }),
+        }),
+      }),
+    )
   })
 
   it('replays SFU consumers when transitioning from video chat to theater', async () => {

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -24,7 +24,11 @@ import {
   type RoomModeEvent,
   type TypingEvent,
 } from './ChatSession'
-import { SfuMediaSession, type SfuMediaSessionStatus } from './SfuMediaSession'
+import {
+  SfuMediaSession,
+  type SfuHealthDiagnostics,
+  type SfuMediaSessionStatus,
+} from './SfuMediaSession'
 import { collectActiveErrorCodes } from '../realtimeDrawerErrors'
 import { TheaterPlayback, type TheaterPlaybackSnapshot } from './TheaterPlayback'
 
@@ -48,8 +52,7 @@ export type SfuSignalingDrawerDiagnostics = {
   state: DrawerLifecycleState
   lastErrorCode?: string
   role?: 'producer' | 'consumer'
-  producerCount?: number
-  consumerCount?: number
+  health: SfuHealthDiagnostics
 }
 
 export type TheaterPlaybackDrawerDiagnostics = {
@@ -156,6 +159,19 @@ export function mapSfuMediaSessionStatusToDrawerState(
   }
 }
 
+function defaultSfuHealthDiagnostics(): SfuHealthDiagnostics {
+  return {
+    connectivity: { state: 'torn-down' },
+    produceConsume: {
+      state: 'torn-down',
+      producerCount: 0,
+      consumerCount: 0,
+      hostScreenAttached: false,
+      participantAvPublishActive: false,
+    },
+  }
+}
+
 /**
  * Framework-agnostic facade over ChatSession, SfuMediaSession, and TheaterPlayback.
  */
@@ -196,6 +212,7 @@ export class RoomRealtimeSdk {
   private sfuLifecycleUnsub: (() => void) | null = null
   private sfuErrorUnsub: (() => void) | null = null
   private sfuDrawerErrorUnsub: (() => void) | null = null
+  private sfuHealthUnsub: (() => void) | null = null
   private mediaPolicyUnsubs: Array<() => void> = []
   private hostScreenStreamUnsub: (() => void) | null = null
   private participantAvTrackUnsub: (() => void) | null = null
@@ -292,10 +309,11 @@ export class RoomRealtimeSdk {
     const theaterState: DrawerLifecycleState = this.theater?.getLifecycleState() ?? 'torn-down'
 
     const sfuDiag = this.sfu?.getSignalingDiagnostics() ?? {}
+    const sfuHealth = this.sfu?.getHealthDiagnostics() ?? defaultSfuHealthDiagnostics()
     const theaterAudioContextState = this.theater?.getAudioContextState()
 
     const chatLastError = this.chatLastErrorCode ?? this.chat?.getLastErrorCode()
-    const sfuLastError = this.sfuLastErrorCode ?? this.sfu?.getLastErrorCode()
+    const sfuLastError = this.sfuLastErrorCode
     const theaterLastError = this.theater?.getLastErrorCode()
 
     const drawers: RoomRealtimeDiagnostics['drawers'] = {
@@ -307,8 +325,7 @@ export class RoomRealtimeSdk {
         state: sfuState,
         ...(sfuLastError ? { lastErrorCode: sfuLastError } : {}),
         ...(sfuDiag.role ? { role: sfuDiag.role } : {}),
-        ...(sfuDiag.producerCount !== undefined ? { producerCount: sfuDiag.producerCount } : {}),
-        ...(sfuDiag.consumerCount !== undefined ? { consumerCount: sfuDiag.consumerCount } : {}),
+        health: sfuHealth,
       },
       theaterPlayback: {
         state: theaterState,
@@ -325,6 +342,8 @@ export class RoomRealtimeSdk {
       activeErrorCodes: collectActiveErrorCodes([
         drawers.chat.lastErrorCode,
         drawers.sfuSignaling.lastErrorCode,
+        drawers.sfuSignaling.health.connectivity.lastErrorCode,
+        drawers.sfuSignaling.health.produceConsume.lastErrorCode,
         drawers.theaterPlayback.lastErrorCode,
       ]),
     }
@@ -535,8 +554,17 @@ export class RoomRealtimeSdk {
     this.sfuLifecycleUnsub = sfu.onLifecycleChange((state) => {
       if (state === 'connected') {
         this.sfuLastErrorCode = undefined
-      } else if (state === 'degraded' && sfu.getLastErrorCode()) {
-        this.sfuLastErrorCode = sfu.getLastErrorCode()
+      } else if (state === 'degraded') {
+        const code = sfu.getLastErrorCode()
+        this.sfuLastErrorCode =
+          code &&
+          code !== 'ICE_FAILED' &&
+          code !== 'TURN_RELAY_REQUIRED' &&
+          code !== 'TRANSPORT_LIMIT_REACHED' &&
+          code !== 'CONSUMER_LIMIT_REACHED' &&
+          code !== 'sfu_publish_rejected'
+            ? code
+            : undefined
       }
       theater.notifySignalingSiblingState(state)
       this.emitDiagnosticsChange()
@@ -548,7 +576,17 @@ export class RoomRealtimeSdk {
     })
 
     this.sfuDrawerErrorUnsub = sfu.onDrawerError((error) => {
-      this.sfuLastErrorCode = error?.code
+      this.sfuLastErrorCode =
+        error?.drawer === 'sfuSignaling' &&
+        error.code !== 'TRANSPORT_LIMIT_REACHED' &&
+        error.code !== 'CONSUMER_LIMIT_REACHED' &&
+        error.code !== 'sfu_publish_rejected'
+          ? error.code
+          : undefined
+      this.emitDiagnosticsChange()
+    })
+
+    this.sfuHealthUnsub = sfu.onHealthChange(() => {
       this.emitDiagnosticsChange()
     })
 
@@ -753,6 +791,7 @@ export class RoomRealtimeSdk {
     this.sfuLifecycleUnsub?.()
     this.sfuErrorUnsub?.()
     this.sfuDrawerErrorUnsub?.()
+    this.sfuHealthUnsub?.()
     for (const unsub of this.mediaPolicyUnsubs) unsub()
     for (const unsub of this.roomControlUnsubs) unsub()
     this.theaterSnapshotUnsub?.()
@@ -768,6 +807,7 @@ export class RoomRealtimeSdk {
     this.sfuLifecycleUnsub = null
     this.sfuErrorUnsub = null
     this.sfuDrawerErrorUnsub = null
+    this.sfuHealthUnsub = null
     this.mediaPolicyUnsubs = []
     this.roomControlUnsubs = []
     this.theaterSnapshotUnsub = null

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -31,46 +31,29 @@ import {
 } from './SfuMediaSession'
 import { collectActiveErrorCodes } from '../realtimeDrawerErrors'
 import { TheaterPlayback, type TheaterPlaybackSnapshot } from './TheaterPlayback'
+import {
+  type DrawerLifecycleState,
+  type RoomRealtimeDiagnostics,
+} from './roomRealtimeDiagnosticsContract'
 
 export type { TheaterPlaybackSnapshot }
+export {
+  DRAWER_LIFECYCLE_STATES,
+  REQUIRED_DIAGNOSTIC_KEYS,
+  REQUIRED_DRAWER_KEYS,
+  REQUIRED_SFU_HEALTH_KEYS,
+  assertRoomRealtimeDiagnosticsContract,
+  type ChatDrawerDiagnostics,
+  type DrawerLifecycleState,
+  type RoomRealtimeDiagnostics,
+  type SfuSignalingDrawerDiagnostics,
+  type TheaterPlaybackDrawerDiagnostics,
+} from './roomRealtimeDiagnosticsContract'
 
-export const DRAWER_LIFECYCLE_STATES = [
-  'connected',
-  'reconnecting',
-  'degraded',
-  'torn-down',
-] as const
-
-export type DrawerLifecycleState = (typeof DRAWER_LIFECYCLE_STATES)[number]
-
-export type ChatDrawerDiagnostics = {
-  state: DrawerLifecycleState
-  lastErrorCode?: string
-}
-
-export type SfuSignalingDrawerDiagnostics = {
-  state: DrawerLifecycleState
-  lastErrorCode?: string
-  role?: 'producer' | 'consumer'
-  health: SfuHealthDiagnostics
-}
-
-export type TheaterPlaybackDrawerDiagnostics = {
-  state: DrawerLifecycleState
-  lastErrorCode?: string
-  audioContextState?: AudioContextState
-}
-
-export type RoomRealtimeDiagnostics = {
-  roomId: string
-  sessionId: string
-  asOf: string
-  drawers: {
-    chat: ChatDrawerDiagnostics
-    sfuSignaling: SfuSignalingDrawerDiagnostics
-    theaterPlayback: TheaterPlaybackDrawerDiagnostics
+declare global {
+  interface Window {
+    riffsyncRoomDiagnostics?: () => RoomRealtimeDiagnostics
   }
-  activeErrorCodes: string[]
 }
 
 export type RoomControlHandlers = {
@@ -235,6 +218,7 @@ export class RoomRealtimeSdk {
     this.onDiagnosticsChange = options.onDiagnosticsChange
     this.getHostScreenStream = options.getHostScreenStream ?? (() => null)
     this.sfuRelayErrorMessage = null
+    this.installDevDiagnosticsGetter()
 
     this.chat = new ChatSession()
     this.sfu = new SfuMediaSession()
@@ -311,6 +295,7 @@ export class RoomRealtimeSdk {
     const sfuDiag = this.sfu?.getSignalingDiagnostics() ?? {}
     const sfuHealth = this.sfu?.getHealthDiagnostics() ?? defaultSfuHealthDiagnostics()
     const theaterAudioContextState = this.theater?.getAudioContextState()
+    const theaterGuestShareFsm = this.theater?.getSnapshot().guestShareFsm
 
     const chatLastError = this.chatLastErrorCode ?? this.chat?.getLastErrorCode()
     const sfuLastError = this.sfuLastErrorCode
@@ -331,6 +316,7 @@ export class RoomRealtimeSdk {
         state: theaterState,
         ...(theaterLastError ? { lastErrorCode: theaterLastError } : {}),
         ...(theaterAudioContextState ? { audioContextState: theaterAudioContextState } : {}),
+        ...(theaterGuestShareFsm ? { guestShareFsm: theaterGuestShareFsm } : {}),
       },
     }
 
@@ -521,6 +507,9 @@ export class RoomRealtimeSdk {
     if (!chat || !sfu || !theater) return
 
     this.theaterLifecycleUnsub = theater.onLifecycleChange(() => {
+      this.emitDiagnosticsChange()
+    })
+    this.theaterSnapshotUnsub = theater.onSnapshotChange(() => {
       this.emitDiagnosticsChange()
     })
     theater.notifySignalingSiblingState(sfu.getLifecycleState())
@@ -783,6 +772,20 @@ export class RoomRealtimeSdk {
     this.onDiagnosticsChange?.(this.getDiagnostics())
   }
 
+  private readonly devDiagnosticsGetter = (): RoomRealtimeDiagnostics => this.getDiagnostics()
+
+  private installDevDiagnosticsGetter(): void {
+    if (!import.meta.env.DEV || typeof window === 'undefined') return
+    window.riffsyncRoomDiagnostics = this.devDiagnosticsGetter
+  }
+
+  private uninstallDevDiagnosticsGetter(): void {
+    if (typeof window === 'undefined') return
+    if (window.riffsyncRoomDiagnostics === this.devDiagnosticsGetter) {
+      delete window.riffsyncRoomDiagnostics
+    }
+  }
+
   private teardownModules(opts: { intentional: boolean }): void {
     this.chatStatusUnsub?.()
     this.chatLifecycleUnsub?.()
@@ -835,6 +838,7 @@ export class RoomRealtimeSdk {
     this.chatLastErrorCode = undefined
     this.sfuLastErrorCode = undefined
     this.sfuRelayErrorMessage = null
+    this.uninstallDevDiagnosticsGetter()
 
     if (opts.intentional) {
       this.roomId = ''

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1136,6 +1136,8 @@ function mockSfuUnifiedSessionHandle() {
     tokenRole: 'consumer' as const,
     getProducerCount: () => 0,
     getConsumerCount: () => 0,
+    hasProducerClass: () => false,
+    hasConsumerClass: () => false,
     detachConsumerClass: vi.fn(),
     pauseProducerKind: vi.fn(),
     resumeProducerKind: vi.fn(),

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -12,6 +12,7 @@ import {
   type SfuConsumerTrackEvent,
   type SfuMediaErrorCode,
   type SfuProducerClass,
+  type SfuTransportConnectivityHealthEvent,
   type SfuUnifiedSessionHandle,
 } from '../sfu/mediasoupSharing'
 import {
@@ -74,6 +75,29 @@ export type SfuMediaSessionLifecycleState =
   | 'degraded'
   | 'torn-down'
 
+export type SfuConnectivityDiagnostics = {
+  state: SfuMediaSessionLifecycleState
+  lastErrorCode?: 'ICE_FAILED' | 'TURN_RELAY_REQUIRED'
+  iceConnectionState?: RTCIceConnectionState
+}
+
+export type SfuProduceConsumeDiagnostics = {
+  state: SfuMediaSessionLifecycleState
+  lastErrorCode?: Extract<
+    RealtimeDrawerErrorCode,
+    'TRANSPORT_LIMIT_REACHED' | 'CONSUMER_LIMIT_REACHED' | 'sfu_publish_rejected'
+  >
+  producerCount?: number
+  consumerCount?: number
+  hostScreenAttached?: boolean
+  participantAvPublishActive?: boolean
+}
+
+export type SfuHealthDiagnostics = {
+  connectivity: SfuConnectivityDiagnostics
+  produceConsume: SfuProduceConsumeDiagnostics
+}
+
 export type SfuRoomSessionHandle = SfuUnifiedSessionHandle
 
 type SessionHooks = {
@@ -97,6 +121,7 @@ export type StartSfuRoomSessionOpts = SessionHooks & {
   onRemoteStream: (stream: MediaStream | null) => void
   onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
   onSignalingProducerLifecycle?: (event: SignalingProducerLifecycleEvent) => void
+  onConnectivityHealth?: (event: SfuTransportConnectivityHealthEvent) => void
   getHostScreenStream: () => MediaStream | null
   participantAv: ParticipantAvController
 }
@@ -118,6 +143,38 @@ function isSfuRelayConfigErrorCode(code: string): code is SfuRelayConfigErrorCod
     code === 'local_sfu_unreachable' ||
     code === 'sfu_relay_unreachable'
   )
+}
+
+function connectivitySeverity(state: SfuMediaSessionLifecycleState): number {
+  switch (state) {
+    case 'degraded':
+      return 3
+    case 'reconnecting':
+      return 2
+    case 'connected':
+      return 1
+    case 'torn-down':
+    default:
+      return 0
+  }
+}
+
+function classifyProduceConsumeHealthError(
+  code: SfuMediaErrorCode,
+  message: string,
+): SfuProduceConsumeDiagnostics['lastErrorCode'] | undefined {
+  const lower = message.toLowerCase()
+  if (lower.includes('transport limit reached')) return 'TRANSPORT_LIMIT_REACHED'
+  if (lower.includes('consumer limit reached')) return 'CONSUMER_LIMIT_REACHED'
+  if (code === 'produce_failed' || code === 'bad_capabilities') return 'sfu_publish_rejected'
+  return undefined
+}
+
+function isProduceConsumeHealthFailure(code: SfuMediaErrorCode, message: string): boolean {
+  if (code === 'produce_failed' || code === 'bad_capabilities') return true
+  if (code !== 'consume_failed') return false
+  const lower = message.toLowerCase()
+  return !lower.includes('gone') && !lower.includes('host stream ended')
 }
 
 export function formatSfuTokenError(e: unknown): string {
@@ -295,6 +352,7 @@ export function startSfuRoomSession(opts: StartSfuRoomSessionOpts): { cancel: ()
         onRemoteStream: opts.onRemoteStream,
         onConsumerTrack: opts.onConsumerTrack,
         onSignalingProducerLifecycle: opts.onSignalingProducerLifecycle,
+        onConnectivityHealth: opts.onConnectivityHealth,
         ownSessionId: opts.sessionId,
         onMediaError: (code, message) => {
           if (code !== 'signaling_failed') {
@@ -385,6 +443,9 @@ export class SfuMediaSession {
   private lifecycleState: SfuMediaSessionLifecycleState = 'torn-down'
   private failedReconnectCycles = 0
   private lastErrorCode: RealtimeDrawerErrorCode | undefined
+  private lastConnectivityErrorCode: SfuConnectivityDiagnostics['lastErrorCode'] | undefined
+  private lastProduceConsumeErrorCode: SfuProduceConsumeDiagnostics['lastErrorCode'] | undefined
+  private produceConsumeDegraded = false
   private cancelReconnect: (() => void) | null = null
   private sessionHandle: SfuUnifiedSessionHandle | null = null
   private tokenIntentGeneration = 0
@@ -412,12 +473,14 @@ export class SfuMediaSession {
   private drawerErrorListeners = new Set<Listener<RealtimeDrawerError | null>>()
   private statusListeners = new Set<Listener<SfuMediaSessionStatus>>()
   private lifecycleListeners = new Set<Listener<SfuMediaSessionLifecycleState>>()
+  private healthListeners = new Set<Listener<SfuHealthDiagnostics>>()
   private participantAvConsumerClearListeners = new Set<Listener<void>>()
   private participantProducerRegistry: ParticipantProducerRegistryState =
     createParticipantProducerRegistryState()
   private participantProducerRegistryListeners = new Set<Listener<void>>()
   private participantAvStateUnsub: (() => void) | null = null
   private ownSessionId: string | null = null
+  private readonly connectivityByTransport = new Map<string, SfuConnectivityDiagnostics>()
 
   constructor() {
     this.participantAv = createBoundParticipantAvController(() => this.gate, {
@@ -444,16 +507,76 @@ export class SfuMediaSession {
 
   getSignalingDiagnostics(): {
     role?: 'producer' | 'consumer'
-    producerCount?: number
-    consumerCount?: number
   } {
     const handle = this.sessionHandle
     if (!handle || this.status !== 'open') return {}
     return {
       role: handle.tokenRole,
-      producerCount: handle.getProducerCount(),
-      consumerCount: handle.getConsumerCount(),
     }
+  }
+
+  getHealthDiagnostics(): SfuHealthDiagnostics {
+    const handle = this.sessionHandle
+    const participantAv = this.participantAv.getState()
+    const participantAvPublishActive = participantAv.cameraEnabled || participantAv.micEnabled
+    const hasProducerClass =
+      typeof handle?.hasProducerClass === 'function'
+        ? handle.hasProducerClass.bind(handle)
+        : () => false
+    const hasConsumerClass =
+      typeof handle?.hasConsumerClass === 'function'
+        ? handle.hasConsumerClass.bind(handle)
+        : () => false
+    const getProducerCount =
+      typeof handle?.getProducerCount === 'function' ? handle.getProducerCount.bind(handle) : () => 0
+    const getConsumerCount =
+      typeof handle?.getConsumerCount === 'function' ? handle.getConsumerCount.bind(handle) : () => 0
+    const hostScreenAttached =
+      hasProducerClass('host_screen') ||
+      hasConsumerClass('host_screen') ||
+      (this.lastRemoteStream?.getTracks().some((track) => track.readyState === 'live') ?? false)
+
+    return {
+      connectivity: this.getConnectivityDiagnostics(),
+      produceConsume: {
+        state: this.getProduceConsumeHealthState(),
+        ...(this.lastProduceConsumeErrorCode
+          ? { lastErrorCode: this.lastProduceConsumeErrorCode }
+          : {}),
+        producerCount: getProducerCount(),
+        consumerCount: getConsumerCount(),
+        hostScreenAttached,
+        participantAvPublishActive,
+      },
+    }
+  }
+
+  private getConnectivityDiagnostics(): SfuConnectivityDiagnostics {
+    if (this.lifecycleState === 'torn-down' || this.status === 'idle') {
+      return { state: 'torn-down' }
+    }
+    if (this.lastConnectivityErrorCode && this.connectivityByTransport.size === 0) {
+      return { state: 'degraded', lastErrorCode: this.lastConnectivityErrorCode }
+    }
+    if (this.connectivityByTransport.size === 0) {
+      return { state: this.lifecycleState }
+    }
+
+    let selected: SfuConnectivityDiagnostics | null = null
+    for (const health of this.connectivityByTransport.values()) {
+      if (!selected || connectivitySeverity(health.state) > connectivitySeverity(selected.state)) {
+        selected = health
+      }
+    }
+    return selected ?? { state: this.lifecycleState }
+  }
+
+  private getProduceConsumeHealthState(): SfuMediaSessionLifecycleState {
+    if (this.lifecycleState === 'torn-down' || this.status === 'idle') return 'torn-down'
+    if (this.produceConsumeDegraded) return 'degraded'
+    if (this.lifecycleState === 'degraded') return 'degraded'
+    if (this.lifecycleState === 'reconnecting') return 'reconnecting'
+    return this.status === 'open' ? 'connected' : this.lifecycleState
   }
 
   onRemoteStream(listener: Listener<MediaStream | null>): () => void {
@@ -484,6 +607,11 @@ export class SfuMediaSession {
   onLifecycleChange(listener: Listener<SfuMediaSessionLifecycleState>): () => void {
     this.lifecycleListeners.add(listener)
     return () => this.lifecycleListeners.delete(listener)
+  }
+
+  onHealthChange(listener: Listener<SfuHealthDiagnostics>): () => void {
+    this.healthListeners.add(listener)
+    return () => this.healthListeners.delete(listener)
   }
 
   /** Fired when participant_av producer registry changes (People tab cam/mic). */
@@ -536,6 +664,7 @@ export class SfuMediaSession {
     this.participantAvStateUnsub?.()
     this.participantAvStateUnsub = this.participantAv.subscribe(() => {
       this.emitParticipantProducerRegistryChange()
+      this.emitHealthChange()
     })
     this.stopReconnectLoop()
     if (!this.enabled || !options.apiBaseUrl || !options.roomId) {
@@ -545,6 +674,11 @@ export class SfuMediaSession {
     }
     this.failedReconnectCycles = 0
     this.lastErrorCode = undefined
+    this.lastConnectivityErrorCode = undefined
+    this.lastProduceConsumeErrorCode = undefined
+    this.produceConsumeDegraded = false
+    this.connectivityByTransport.clear()
+    this.emitHealthChange()
     this.startReconnectLoop()
   }
 
@@ -562,10 +696,15 @@ export class SfuMediaSession {
     this.emitRemoteStream(null)
     this.failedReconnectCycles = 0
     this.lastErrorCode = undefined
+    this.lastConnectivityErrorCode = undefined
+    this.lastProduceConsumeErrorCode = undefined
+    this.produceConsumeDegraded = false
+    this.connectivityByTransport.clear()
     this.setStatus('idle')
     this.setLifecycleState('torn-down')
     this.emitError(null)
     this.emitDrawerError(null)
+    this.emitHealthChange()
   }
 
   /** Guest: detach host_screen consumers only when share stops. */
@@ -600,10 +739,12 @@ export class SfuMediaSession {
 
   unpublishHostScreen(): void {
     this.sessionHandle?.unpublishProducerClass('host_screen')
+    this.emitHealthChange()
   }
 
   detachHostScreenConsumers(): void {
     this.sessionHandle?.detachConsumerClass('host_screen')
+    this.emitHealthChange()
   }
 
   /** Re-deliver live SFU consumer attach events and last host_screen stream to subscribers. */
@@ -700,6 +841,7 @@ export class SfuMediaSession {
       this.emitParticipantProducerRegistryChange()
     }
     for (const listener of this.consumerTrackListeners) listener(event)
+    this.emitHealthChange()
   }
 
   private applySignalingProducerLifecycle(event: SignalingProducerLifecycleEvent): void {
@@ -718,11 +860,31 @@ export class SfuMediaSession {
       )
     }
     this.emitParticipantProducerRegistryChange()
+    this.emitHealthChange()
+  }
+
+  private applyConnectivityHealth(event: SfuTransportConnectivityHealthEvent): void {
+    if (event.state === 'torn-down') {
+      this.connectivityByTransport.delete(event.transportId)
+    } else {
+      this.connectivityByTransport.set(event.transportId, {
+        state: event.state,
+        ...(event.lastErrorCode ? { lastErrorCode: event.lastErrorCode } : {}),
+        ...(event.iceConnectionState ? { iceConnectionState: event.iceConnectionState } : {}),
+      })
+    }
+    if (event.lastErrorCode) {
+      this.lastConnectivityErrorCode = event.lastErrorCode
+    } else if (event.state === 'connected') {
+      this.lastConnectivityErrorCode = undefined
+    }
+    this.emitHealthChange()
   }
 
   private resetParticipantProducerRegistry(): void {
     this.participantProducerRegistry = clearParticipantProducerRegistry()
     this.emitParticipantProducerRegistryChange()
+    this.emitHealthChange()
   }
 
   private emitParticipantProducerRegistryChange(): void {
@@ -765,6 +927,7 @@ export class SfuMediaSession {
       onRemoteStream: (stream) => this.emitRemoteStream(stream),
       onConsumerTrack: (event) => this.dispatchConsumerTrack(event),
       onSignalingProducerLifecycle: (event) => this.applySignalingProducerLifecycle(event),
+      onConnectivityHealth: (event) => this.applyConnectivityHealth(event),
       assignSession: (s) => {
         this.sessionHandle = s
         if (s) {
@@ -785,6 +948,11 @@ export class SfuMediaSession {
       onMediaError: (code, msg) => {
         if (code === 'consume_failed' || code === 'produce_failed') {
           emitProduceConsumeMediaErrorLog(code, msg)
+        }
+        if (isProduceConsumeHealthFailure(code, msg)) {
+          this.produceConsumeDegraded = true
+          this.lastProduceConsumeErrorCode = classifyProduceConsumeHealthError(code, msg)
+          this.emitHealthChange()
         }
         const drawerError = mapSfuMediaCodeToDrawerError(code)
         if (isSfuRelayConfigErrorCode(code)) {
@@ -821,8 +989,12 @@ export class SfuMediaSession {
         this.emitDrawerError(null)
         this.failedReconnectCycles = 0
         this.lastErrorCode = undefined
+        this.lastConnectivityErrorCode = undefined
+        this.lastProduceConsumeErrorCode = undefined
+        this.produceConsumeDegraded = false
         this.setStatus('open')
         this.setLifecycleState('connected')
+        this.emitHealthChange()
         if (recoveredFromReconnect) {
           emitClientDrawerLog({
             drawer: 'signaling',
@@ -842,6 +1014,7 @@ export class SfuMediaSession {
         this.clearJwtRemintTimer()
         this.sessionHandle = null
         this.attachedConsumerMeta.clear()
+        this.connectivityByTransport.clear()
         this.resetParticipantProducerRegistry()
         if (this.enabled && generation === this.tokenIntentGeneration) {
           emitClientDrawerLog({
@@ -959,6 +1132,7 @@ export class SfuMediaSession {
   private emitRemoteStream(stream: MediaStream | null): void {
     this.lastRemoteStream = stream
     for (const listener of this.remoteStreamListeners) listener(stream)
+    this.emitHealthChange()
   }
 
   private emitError(message: string | null): void {
@@ -967,6 +1141,30 @@ export class SfuMediaSession {
 
   private emitDrawerError(error: RealtimeDrawerError | null): void {
     this.lastErrorCode = error?.code
+    if (error?.drawer === 'connectivity') {
+      if (error.code === 'ICE_FAILED' || error.code === 'TURN_RELAY_REQUIRED') {
+        this.lastConnectivityErrorCode = error.code
+        this.emitHealthChange()
+      }
+    } else if (
+      error?.code === 'TRANSPORT_LIMIT_REACHED' ||
+      error?.code === 'CONSUMER_LIMIT_REACHED' ||
+      error?.code === 'sfu_publish_rejected'
+    ) {
+      this.produceConsumeDegraded = true
+      this.lastProduceConsumeErrorCode = error.code
+      this.emitHealthChange()
+    } else if (error === null) {
+      this.lastConnectivityErrorCode = undefined
+      this.lastProduceConsumeErrorCode = undefined
+      this.produceConsumeDegraded = false
+      this.emitHealthChange()
+    }
     for (const listener of this.drawerErrorListeners) listener(error)
+  }
+
+  private emitHealthChange(): void {
+    const diagnostics = this.getHealthDiagnostics()
+    for (const listener of this.healthListeners) listener(diagnostics)
   }
 }

--- a/apps/web/src/room/sessions/TheaterPlayback.ts
+++ b/apps/web/src/room/sessions/TheaterPlayback.ts
@@ -15,7 +15,11 @@ import { emitClientDrawerLog } from '../clientDrawerLog'
 import type { SfuMediaSession } from './SfuMediaSession'
 
 /** Normative drawer lifecycle for diagnostics (`execution_model.md`). */
-export type TheaterPlaybackLifecycleState = 'connected' | 'degraded' | 'torn-down'
+export type TheaterPlaybackLifecycleState =
+  | 'connected'
+  | 'reconnecting'
+  | 'degraded'
+  | 'torn-down'
 
 export type TheaterPlaybackSnapshot = {
   guestShareFsm: GuestHostScreenFsm
@@ -352,6 +356,10 @@ export class TheaterPlayback {
         this.setLifecycleState('degraded', undefined)
         return
       }
+      if (this.guestShareFsm === 'verifying_media') {
+        this.setLifecycleState('reconnecting', undefined)
+        return
+      }
       this.setLifecycleState('connected', undefined)
       return
     }
@@ -374,6 +382,11 @@ export class TheaterPlayback {
 
     if (this.signalingSiblingDegraded) {
       this.setLifecycleState('degraded', undefined)
+      return
+    }
+
+    if (this.guestShareFsm === 'verifying_media') {
+      this.setLifecycleState('reconnecting', undefined)
       return
     }
 
@@ -555,6 +568,7 @@ export class TheaterPlayback {
     if (this.guestShareFsm === next) return
     this.guestShareFsm = next
     this.emitSnapshot()
+    this.syncLifecycleState()
   }
 
   private setGuestPlayHint(next: boolean): void {

--- a/apps/web/src/room/sessions/roomRealtimeDiagnosticsContract.ts
+++ b/apps/web/src/room/sessions/roomRealtimeDiagnosticsContract.ts
@@ -1,0 +1,135 @@
+import type { GuestHostScreenFsm } from '../sfu/sfuRelayStatusCopy'
+import type { SfuHealthDiagnostics } from './SfuMediaSession'
+
+export const DRAWER_LIFECYCLE_STATES = [
+  'connected',
+  'reconnecting',
+  'degraded',
+  'torn-down',
+] as const
+
+export type DrawerLifecycleState = (typeof DRAWER_LIFECYCLE_STATES)[number]
+
+export type ChatDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+}
+
+export type SfuSignalingDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+  role?: 'producer' | 'consumer'
+  health: SfuHealthDiagnostics
+}
+
+export type TheaterPlaybackDrawerDiagnostics = {
+  state: DrawerLifecycleState
+  lastErrorCode?: string
+  audioContextState?: AudioContextState
+  guestShareFsm?: GuestHostScreenFsm
+}
+
+export type RoomRealtimeDiagnostics = {
+  roomId: string
+  sessionId: string
+  asOf: string
+  drawers: {
+    chat: ChatDrawerDiagnostics
+    sfuSignaling: SfuSignalingDrawerDiagnostics
+    theaterPlayback: TheaterPlaybackDrawerDiagnostics
+  }
+  activeErrorCodes: string[]
+}
+
+export const REQUIRED_DIAGNOSTIC_KEYS = [
+  'roomId',
+  'sessionId',
+  'asOf',
+  'drawers',
+  'activeErrorCodes',
+] as const satisfies readonly (keyof RoomRealtimeDiagnostics)[]
+
+export const REQUIRED_DRAWER_KEYS = [
+  'chat',
+  'sfuSignaling',
+  'theaterPlayback',
+] as const satisfies readonly (keyof RoomRealtimeDiagnostics['drawers'])[]
+
+export const REQUIRED_SFU_HEALTH_KEYS = [
+  'connectivity',
+  'produceConsume',
+] as const satisfies readonly (keyof SfuHealthDiagnostics)[]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function assertRecord(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new TypeError(`${path} must be an object`)
+  }
+}
+
+function assertRequiredKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  path: string,
+): void {
+  for (const key of keys) {
+    if (!(key in value)) {
+      throw new TypeError(`${path}.${key} is required`)
+    }
+  }
+}
+
+function assertDrawerLifecycleState(value: unknown, path: string): void {
+  if (!DRAWER_LIFECYCLE_STATES.includes(value as DrawerLifecycleState)) {
+    throw new TypeError(`${path} must be a known drawer lifecycle state`)
+  }
+}
+
+function assertDrawer(value: unknown, path: string): void {
+  assertRecord(value, path)
+  assertDrawerLifecycleState(value.state, `${path}.state`)
+}
+
+export function assertRoomRealtimeDiagnosticsContract(
+  diag: unknown,
+): asserts diag is RoomRealtimeDiagnostics {
+  assertRecord(diag, 'diagnostics')
+  assertRequiredKeys(diag, REQUIRED_DIAGNOSTIC_KEYS, 'diagnostics')
+
+  if (typeof diag.roomId !== 'string') throw new TypeError('diagnostics.roomId must be a string')
+  if (typeof diag.sessionId !== 'string') {
+    throw new TypeError('diagnostics.sessionId must be a string')
+  }
+  if (typeof diag.asOf !== 'string') throw new TypeError('diagnostics.asOf must be a string')
+  if (!Array.isArray(diag.activeErrorCodes)) {
+    throw new TypeError('diagnostics.activeErrorCodes must be an array')
+  }
+
+  assertRecord(diag.drawers, 'diagnostics.drawers')
+  assertRequiredKeys(diag.drawers, REQUIRED_DRAWER_KEYS, 'diagnostics.drawers')
+
+  for (const drawerKey of REQUIRED_DRAWER_KEYS) {
+    assertDrawer(diag.drawers[drawerKey], `diagnostics.drawers.${drawerKey}`)
+  }
+
+  const sfuSignaling = diag.drawers.sfuSignaling
+  assertRecord(sfuSignaling, 'diagnostics.drawers.sfuSignaling')
+  assertRecord(sfuSignaling.health, 'diagnostics.drawers.sfuSignaling.health')
+  assertRequiredKeys(
+    sfuSignaling.health,
+    REQUIRED_SFU_HEALTH_KEYS,
+    'diagnostics.drawers.sfuSignaling.health',
+  )
+
+  for (const healthKey of REQUIRED_SFU_HEALTH_KEYS) {
+    const health = sfuSignaling.health[healthKey]
+    assertRecord(health, `diagnostics.drawers.sfuSignaling.health.${healthKey}`)
+    assertDrawerLifecycleState(
+      health.state,
+      `diagnostics.drawers.sfuSignaling.health.${healthKey}.state`,
+    )
+  }
+}

--- a/apps/web/src/room/sfu/mediasoupSharing.ts
+++ b/apps/web/src/room/sfu/mediasoupSharing.ts
@@ -6,7 +6,10 @@ import type {
   RtpParameters,
 } from 'mediasoup-client/types'
 import { getPublicSfuWsUrl } from '../../config/sfuWsUrl'
-import { attachTransportConnectivityDrawerLog } from './transportConnectivityDrawerLog'
+import {
+  attachTransportConnectivityDrawerLog,
+  type TransportConnectivityHealthSnapshot,
+} from './transportConnectivityDrawerLog'
 import { emitClientDrawerLog } from '../clientDrawerLog'
 
 export type SfuTokenResponse = {
@@ -272,6 +275,12 @@ export type SignalingProducerLifecycleEvent =
       kind?: 'audio' | 'video'
     }
 
+export type SfuTransportConnectivityHealthEvent = TransportConnectivityHealthSnapshot & {
+  transportId: string
+  producerClass?: SfuProducerClass
+  direction: 'send' | 'recv'
+}
+
 export type SfuUnifiedSessionHandle = {
   close: (reason?: SfuSessionEndReason) => void
   sessionEnded: Promise<SfuSessionEndReason>
@@ -279,8 +288,10 @@ export type SfuUnifiedSessionHandle = {
   /** False for consumer-only SFU tokens (no send transport until producer reconnect). */
   supportsPublish: boolean
   tokenRole: 'producer' | 'consumer'
-  getProducerCount: () => number
-  getConsumerCount: () => number
+  getProducerCount: (producerClass?: SfuProducerClass) => number
+  getConsumerCount: (producerClass?: SfuProducerClass) => number
+  hasProducerClass: (producerClass: SfuProducerClass) => boolean
+  hasConsumerClass: (producerClass: SfuProducerClass) => boolean
   publishStream: (stream: MediaStream, producerClass: SfuProducerClass) => Promise<void>
   unpublishProducerKind: (producerClass: SfuProducerClass, kind: 'audio' | 'video') => void
   unpublishProducerClass: (producerClass: SfuProducerClass) => void
@@ -304,6 +315,7 @@ export async function connectSfuUnifiedSession(options: {
   onRemoteStream: (stream: MediaStream | null) => void
   onConsumerTrack?: (event: SfuConsumerTrackEvent) => void
   onSignalingProducerLifecycle?: (event: SignalingProducerLifecycleEvent) => void
+  onConnectivityHealth?: (event: SfuTransportConnectivityHealthEvent) => void
   ownSessionId?: string
   onMediaError?: (code: SfuMediaErrorCode, message: string) => void
 }): Promise<SfuUnifiedSessionHandle> {
@@ -315,6 +327,7 @@ export async function connectSfuUnifiedSession(options: {
     onRemoteStream,
     onConsumerTrack,
     onSignalingProducerLifecycle,
+    onConnectivityHealth,
     ownSessionId,
     onMediaError,
   } = options
@@ -506,15 +519,29 @@ export async function connectSfuUnifiedSession(options: {
       iceServers: sessionIceServers,
     })
 
-    const unwatch = watchTransportConnectionUntilUnhealthy(transport, () => {
+    const unwatchConnection = watchTransportConnectionUntilUnhealthy(transport, () => {
       onMediaError?.(
         'transport_failed',
         `Video relay send transport failed (${producerClass}).`,
       )
       teardownSendTransportClass(producerClass)
     })
+    const unwatchConnectivity = attachTransportConnectivityDrawerLog(
+      transport,
+      sessionIceServers,
+      (snapshot) =>
+        onConnectivityHealth?.({
+          ...snapshot,
+          transportId,
+          producerClass,
+          direction: 'send',
+        }),
+    )
+    const unwatch = () => {
+      unwatchConnection()
+      unwatchConnectivity()
+    }
     unwatchFns.push(unwatch)
-    unwatchFns.push(attachTransportConnectivityDrawerLog(transport, sessionIceServers))
 
     transport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
       void signaling
@@ -680,7 +707,15 @@ export async function connectSfuUnifiedSession(options: {
           finish(r)
         }),
       )
-      unwatchFns.push(attachTransportConnectivityDrawerLog(recvTransport, iceServers))
+      unwatchFns.push(
+        attachTransportConnectivityDrawerLog(recvTransport, iceServers, (snapshot) =>
+          onConnectivityHealth?.({
+            ...snapshot,
+            transportId: recvTransportId,
+            direction: 'recv',
+          }),
+        ),
+      )
 
       recvTransport.on('connect', ({ dtlsParameters: dtls }, callback, errback) => {
         void signaling
@@ -880,8 +915,22 @@ export async function connectSfuUnifiedSession(options: {
     ready,
     supportsPublish: tokenRole === 'producer',
     tokenRole,
-    getProducerCount: () => liveProducers.length,
-    getConsumerCount: () => mediasoupConsumers.length,
+    getProducerCount: (producerClass?: SfuProducerClass) =>
+      producerClass === undefined
+        ? liveProducers.length
+        : liveProducers.filter((producer) => producer.producerClass === producerClass).length,
+    getConsumerCount: (producerClass?: SfuProducerClass) =>
+      producerClass === undefined
+        ? mediasoupConsumers.length
+        : mediasoupConsumers.filter(
+            (consumer) => consumerProducerClassById.get(consumer.producerId) === producerClass,
+          ).length,
+    hasProducerClass: (producerClass: SfuProducerClass) =>
+      liveProducers.some((producer) => producer.producerClass === producerClass),
+    hasConsumerClass: (producerClass: SfuProducerClass) =>
+      mediasoupConsumers.some(
+        (consumer) => consumerProducerClassById.get(consumer.producerId) === producerClass,
+      ),
     publishStream,
     unpublishProducerKind,
     unpublishProducerClass,

--- a/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
+++ b/apps/web/src/room/sfu/transportConnectivityDrawerLog.ts
@@ -4,6 +4,18 @@ import { ICE_DISCONNECTED_FAILURE_MS } from '../realtimeDrawerErrors'
 import { webrtcDebugEnabled, webrtcLog } from '../webrtcDebug'
 import { logIceCandidateSummary, summarizeLocalIceCandidates } from './iceDiagnostics'
 
+export type TransportConnectivityHealthState =
+  | 'connected'
+  | 'reconnecting'
+  | 'degraded'
+  | 'torn-down'
+
+export type TransportConnectivityHealthSnapshot = {
+  state: TransportConnectivityHealthState
+  lastErrorCode?: 'ICE_FAILED' | 'TURN_RELAY_REQUIRED'
+  iceConnectionState?: RTCIceConnectionState
+}
+
 type TransportWithHandler = {
   _handler?: { _pc?: RTCPeerConnection }
 }
@@ -36,6 +48,7 @@ export function localDescriptionHasRelayCandidate(pc: RTCPeerConnection): boolea
 export function attachTransportConnectivityDrawerLog(
   transport: Transport,
   iceServers: RTCIceServer[],
+  onHealthChange?: (snapshot: TransportConnectivityHealthSnapshot) => void,
 ): () => void {
   const pc = resolvePeerConnectionFromTransport(transport)
   if (!pc) return () => undefined
@@ -54,8 +67,20 @@ export function attachTransportConnectivityDrawerLog(
     }
   }
 
+  const emitHealth = (
+    state: TransportConnectivityHealthState,
+    lastErrorCode?: TransportConnectivityHealthSnapshot['lastErrorCode'],
+  ) => {
+    onHealthChange?.({
+      state,
+      ...(lastErrorCode ? { lastErrorCode } : {}),
+      iceConnectionState: pc.iceConnectionState,
+    })
+  }
+
   const emitIceFailed = () => {
     connectivityDegraded = true
+    emitHealth('degraded', 'ICE_FAILED')
     emitClientDrawerLog({
       drawer: 'connectivity',
       event: 'ice_failed',
@@ -79,6 +104,7 @@ export function attachTransportConnectivityDrawerLog(
   const emitTurnRelayRequired = () => {
     if (turnRelayLogged) return
     turnRelayLogged = true
+    emitHealth('degraded', 'TURN_RELAY_REQUIRED')
     emitClientDrawerLog({
       drawer: 'connectivity',
       event: 'turn_relay_required',
@@ -90,6 +116,7 @@ export function attachTransportConnectivityDrawerLog(
   const emitIceRecovered = () => {
     if (!connectivityDegraded) return
     connectivityDegraded = false
+    emitHealth('connected')
     emitClientDrawerLog({
       drawer: 'connectivity',
       event: 'ice_recovered',
@@ -101,6 +128,7 @@ export function attachTransportConnectivityDrawerLog(
     const state = pc.iceConnectionState
     if (state === 'connected' || state === 'completed') {
       clearDisconnectedTimer()
+      emitHealth('connected')
       emitIceRecovered()
       return
     }
@@ -111,6 +139,7 @@ export function attachTransportConnectivityDrawerLog(
     }
     if (state === 'disconnected') {
       clearDisconnectedTimer()
+      emitHealth('reconnecting')
       disconnectedTimer = setTimeout(() => {
         disconnectedTimer = null
         const cur = pc.iceConnectionState
@@ -118,6 +147,14 @@ export function attachTransportConnectivityDrawerLog(
           emitIceFailed()
         }
       }, ICE_DISCONNECTED_FAILURE_MS)
+      return
+    }
+    if (state === 'checking') {
+      emitHealth('reconnecting')
+      return
+    }
+    if (state === 'closed') {
+      emitHealth('torn-down')
     }
   }
 
@@ -143,6 +180,7 @@ export function attachTransportConnectivityDrawerLog(
 
   pc.addEventListener('iceconnectionstatechange', onIceConnectionStateChange)
   pc.addEventListener('icegatheringstatechange', onIceGatheringStateChange)
+  onIceConnectionStateChange()
 
   if (webrtcDebugEnabled()) {
     const logState = (ev: string) => {
@@ -161,5 +199,6 @@ export function attachTransportConnectivityDrawerLog(
     clearDisconnectedTimer()
     pc.removeEventListener('iceconnectionstatechange', onIceConnectionStateChange)
     pc.removeEventListener('icegatheringstatechange', onIceGatheringStateChange)
+    onHealthChange?.({ state: 'torn-down', iceConnectionState: 'closed' })
   }
 }


### PR DESCRIPTION
## Summary
- Adds nested `drawers.sfuSignaling.health` diagnostics for connectivity and produce/consume health from existing mediasoup hooks.
- Exports `roomRealtimeDiagnosticsContract` as the shared required-key contract and validator for harness and unit assertions.
- Maps theater playback into the full drawer lifecycle, including `reconnecting` for `guestShareFsm: verifying_media`, and exposes dev-only `window.riffsyncRoomDiagnostics()` while joined.

Closes #217
Closes #218
Part of #158

## Test plan
- `npm test --prefix apps/web -- --run src/room/sessions/RoomRealtimeSdk.test.ts src/room/sessions/TheaterPlayback.test.ts`
- `npm test --prefix apps/web`
- `npm run build --prefix apps/web`

## Security notes
- No new secrets, network calls, or privileged browser APIs were added. The dev diagnostics getter is guarded by `import.meta.env.DEV` and removed on teardown.