### PR TITLE
Fix compose media picker height jitter

### DIFF
--- a/apps/web/src/room/ChatComposeMediaPicker.test.tsx
+++ b/apps/web/src/room/ChatComposeMediaPicker.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -12,6 +14,11 @@ vi.mock('../api/giphySearchApi', () => ({
 vi.mock('emoji-picker-element', () => ({}))
 
 const searchGiphyMock = vi.mocked(giphySearchApi.searchGiphy)
+
+function cssRule(selector: string): string {
+  const css = readFileSync(join(process.cwd(), 'src/styles/riffsync-app.css'), 'utf8')
+  return css.match(new RegExp(`${selector.replaceAll('.', '\\.')}\\s*\\{[^}]+\\}`))?.[0] ?? ''
+}
 
 function setInputValue(input: HTMLInputElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
@@ -74,8 +81,26 @@ describe('ChatComposeMediaPicker', () => {
     const emojiTab = container.querySelector('.riffsync-room-chat-media-tab') as HTMLButtonElement
     expect(emojiTab.textContent).toBe('Emojis')
     expect(emojiTab.getAttribute('aria-selected')).toBe('true')
+    const body = container.querySelector('.riffsync-room-chat-media-body')
+    expect(body?.querySelector('.riffsync-room-chat-media-panel--emoji')).not.toBeNull()
+    expect(body?.querySelector('.riffsync-room-chat-media-panel--giphy')).not.toBeNull()
     expect(container.querySelector('.riffsync-room-chat-emoji-picker')).not.toBeNull()
     expect(container.querySelector('.riffsync-room-chat-media-panel--giphy')?.hasAttribute('hidden')).toBe(true)
+  })
+
+  it('keeps picker tab body fixed while Giphy results scroll internally', () => {
+    const bodyRule = cssRule('.riffsync-room-chat-media-body')
+    const panelRule = cssRule('.riffsync-room-chat-media-panel')
+    const giphyPanelRule = cssRule('.riffsync-room-chat-media-panel--giphy')
+    const resultsRule = cssRule('.riffsync-room-chat-giphy-results')
+
+    expect(bodyRule).toContain('height: 16.5rem;')
+    expect(bodyRule).toContain('flex: 0 0 16.5rem;')
+    expect(bodyRule).toContain('overflow: hidden;')
+    expect(panelRule).toContain('height: 100%;')
+    expect(giphyPanelRule).toContain('overflow: hidden;')
+    expect(resultsRule).toContain('overflow: auto;')
+    expect(resultsRule).toContain('min-height: 0;')
   })
 
   it('switches to GIF tab and runs debounced search', async () => {

--- a/apps/web/src/room/ChatComposeMediaPicker.tsx
+++ b/apps/web/src/room/ChatComposeMediaPicker.tsx
@@ -117,32 +117,34 @@ export function ChatComposeMediaPicker({
               GIF
             </button>
           </div>
-          <div
-            id={emojiPanelId}
-            role="tabpanel"
-            className="riffsync-room-chat-media-panel riffsync-room-chat-media-panel--emoji"
-            aria-labelledby={emojiTabId}
-            hidden={tab !== 'emoji'}
-          >
-            <ChatEmojiPickerPanel
-              draft={draft}
-              onDraftChange={onDraftChange}
-              inputRef={inputRef}
-              active={tab === 'emoji'}
-            />
-          </div>
-          <div
-            id={giphyPanelId}
-            role="tabpanel"
-            className="riffsync-room-chat-media-panel riffsync-room-chat-media-panel--giphy"
-            aria-labelledby={giphyTabId}
-            hidden={tab !== 'giphy'}
-          >
-            <ChatGiphyPickerPanel
-              accessToken={accessToken}
-              onSelect={handleGifSelect}
-              active={tab === 'giphy'}
-            />
+          <div className="riffsync-room-chat-media-body">
+            <div
+              id={emojiPanelId}
+              role="tabpanel"
+              className="riffsync-room-chat-media-panel riffsync-room-chat-media-panel--emoji"
+              aria-labelledby={emojiTabId}
+              hidden={tab !== 'emoji'}
+            >
+              <ChatEmojiPickerPanel
+                draft={draft}
+                onDraftChange={onDraftChange}
+                inputRef={inputRef}
+                active={tab === 'emoji'}
+              />
+            </div>
+            <div
+              id={giphyPanelId}
+              role="tabpanel"
+              className="riffsync-room-chat-media-panel riffsync-room-chat-media-panel--giphy"
+              aria-labelledby={giphyTabId}
+              hidden={tab !== 'giphy'}
+            >
+              <ChatGiphyPickerPanel
+                accessToken={accessToken}
+                onSelect={handleGifSelect}
+                active={tab === 'giphy'}
+              />
+            </div>
           </div>
         </div>
       ) : null}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2029,6 +2029,7 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   max-height: min(70vh, 24rem);
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   border-radius: 8px;
   overflow: hidden;
   background: rgb(12 16 22);
@@ -2068,8 +2069,17 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   color: var(--primary-color);
 }
 
-.riffsync-room-chat-media-panel {
+.riffsync-room-chat-media-body {
+  height: 16.5rem;
   min-height: 0;
+  flex: 0 0 16.5rem;
+  overflow: hidden;
+}
+
+.riffsync-room-chat-media-panel {
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
 }
 
 .riffsync-room-chat-media-panel--emoji {
@@ -2082,7 +2092,6 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   gap: 0.35rem;
   padding: 0.45rem;
   overflow: hidden;
-  flex: 1 1 auto;
 }
 
 .riffsync-room-chat-media-panel[hidden] {


### PR DESCRIPTION
## Summary
- Keeps the compose emoji/GIF picker tab content inside one fixed 16.5rem body.
- Makes GIF search states and result grids scroll within that body instead of resizing the popover.
- Adds regression coverage for the picker body and internal-scroll CSS contract.

Closes #258

## Test plan
- npm test --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web -- ChatComposeMediaPicker.test.tsx ChatGiphyPicker.test.tsx
- npm ci --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web && npm test --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web
- npm run lint --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web
- npm run build --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web