### PR TITLE
Expanded view: full-stage video with chat overlay

### DIFF
--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -65,6 +65,7 @@ Keyboard, pointer, and permission input contract for room and catalog surfaces.
 - **People / Room / Profile:** reachable only after **exit expanded view** (or via site chrome navigation).
 - **Touch targets:** expand/exit control minimum **44×44** CSS px.
 - **Not offered < 992px:** toggle absent or **`aria-hidden`** / inert — no expanded keyboard path on narrow viewports in MVP.
+- **Implementation:** the overlay reuses the chat plane without rendering `.riffsync-room-page__tabs`; standard sidebar tabs return immediately after exit.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -110,6 +110,8 @@ When the host starts screen-share and guests receive authoritative **`share_stat
 6. **Room mode change while expanded:** Apply new mode to stage primary **without** forcing exit — overlay chat rules stay the same.
 7. **Reload / navigate away:** Expanded state **clears** — standard layout on return.
 
+Implementation note: the expanded toggle is client-local React state in `RoomPage.tsx`; no room snapshot patch or WebSocket fan-out is sent when a viewer enters or exits expanded view.
+
 ### Presence, typing, and People badges
 
 1. **Roster on join:** Client sends **`presence_request`** after room WebSocket connect; server returns **`presence`** roster (with **`lastActiveAt`** / **`active`**) and requester-only **`chat_history`** (capped durable messages — **excludes** ephemeral join/leave system lines).

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -216,6 +216,8 @@ When **iOS Safari** (iPad and iPhone) opens the **software keyboard** on **`/roo
 | **Drawers** | Chat and video-relay drawer status rules **unchanged** — chat banner lives inside the overlay; video-relay status stays on the stage playback surface. |
 | **Chromecast (future)** | Implement expanded layout as a **reusable shell** (stage-primary + chat overlay) suitable as a future Cast receiver target. **No** Cast SDK or receiver work in #259. |
 
+Implementation: `RoomPage.tsx` owns session-only expanded state, `RoomPageSidebar.tsx` renders the shared chat plane as either sidebar or overlay, and `StageParticipantLayout.tsx` switches Theater cameras from the desktop side strip to the expanded bottom row.
+
 ## Accessibility & motion (baseline)
 
 - Prefer **semantic headings** and **focus order** that match visual flow; **keyboard** paths for **Play**, **share**, **lobby join** before shipping broadly.

--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -265,6 +265,12 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     expect(container.textContent).not.toContain(RETIRED_COMBINED_STATUS_COPY)
   }
 
+  function expandViewButton() {
+    return Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Expand view' || button.textContent === 'Exit expanded view',
+    ) as HTMLButtonElement | undefined
+  }
+
   it('chat-only reconnecting: chat banner uses drawerErrorPresentation copy; video-relay omits chat copy', async () => {
     drawerStatusMockConfig.set({
       diagnostics: drawerDiagnostics({
@@ -454,5 +460,44 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     expect(
       chatBanner()!.compareDocumentPosition(tabs!) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
+  })
+
+  it('switches desktop expanded view to a chat-only overlay without sidebar tabs (#259)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'reconnecting' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoom()
+
+    await vi.waitFor(() => {
+      expect(expandViewButton()?.textContent).toBe('Expand view')
+    })
+
+    act(() => {
+      expandViewButton()?.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__stage--expanded')).not.toBeNull()
+    })
+
+    expect(expandViewButton()?.textContent).toBe('Exit expanded view')
+    expect(container.querySelector('.riffsync-room-page__chat--overlay')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__chat-column')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
+    expect(chatBanner()?.closest('.riffsync-room-page__chat--overlay')).not.toBeNull()
+
+    act(() => {
+      expandViewButton()?.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__stage--expanded')).toBeNull()
+    })
+    expect(container.querySelector('.riffsync-room-page__chat-column')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__tabs')).not.toBeNull()
   })
 })

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -44,6 +44,7 @@ export function RoomPage() {
   const [hostBarErr, setHostBarErr] = useState<string | null>(null)
   const [shareHint, setShareHint] = useState<string | null>(null)
   const [roomSidebarTab, setRoomSidebarTab] = useState<RoomSidebarTab>('chat')
+  const [expandedView, setExpandedView] = useState(false)
   const [renameModalOpen, setRenameModalOpen] = useState(false)
   const [renameModalDraft, setRenameModalDraft] = useState('')
   const [myAvatarUrl, setMyAvatarUrl] = useState<string | null>(null)
@@ -222,8 +223,11 @@ export function RoomPage() {
     }
   }, [isPublisher, roomMode, setRoom, stopCapture])
 
-  const roomChatTabActive =
-    (!fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab) === 'chat'
+  const activeSidebarTab =
+    !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
+  const viewportWide = useViewportWide()
+  const expandedViewActive = expandedView && viewportWide
+  const roomChatTabActive = expandedViewActive || activeSidebarTab === 'chat'
   const {
     logRef: chatLogRef,
     showJumpToLatest,
@@ -231,7 +235,6 @@ export function RoomPage() {
     jumpToLatest,
   } = useChatLogStickToBottom(chat.length, roomChatTabActive)
 
-  const viewportWide = useViewportWide()
   const avSurfacesEnabled = !avDisabled
 
   const saveRenameFromModal = async (): Promise<boolean> => {
@@ -315,8 +318,55 @@ export function RoomPage() {
 
   const backdropImageUrl = catalogEp?.backdropImageUrl?.trim()
   const viewerCount = peopleShown.length
-  const activeSidebarTab =
-    !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
+  const roomSidebarProps = {
+    wsBase,
+    fanToken,
+    roomId,
+    sessionId,
+    myAvatarUrl,
+    activeSidebarTab,
+    setRoomSidebarTab,
+    viewerCount,
+    chat,
+    chatReactions,
+    remoteTyping,
+    chatMemberLabels,
+    chatDraft,
+    setChatDraft,
+    notifyComposeBlur,
+    chatLogRef,
+    chatInputRef,
+    showJumpToLatest,
+    jumpToLatestLabel,
+    jumpToLatest,
+    chatDrawerBanner,
+    chatComposeStatus,
+    sendChat,
+    sendChatGif,
+    toggleChatReaction,
+    peopleShown,
+    participantProducerBySessionId,
+    speakingBySessionId,
+    isPublisher,
+    experimentalFeatures,
+    shareHint,
+    onCopyShare: () => void copyShare(),
+    onOpenRenameModal: openRenameModal,
+    avDisabled,
+    participantAvController,
+    announceRoomA11y,
+    profileDraft: profile.profileDraft,
+    setProfileDraft: profile.setProfileDraft,
+    profileSaveErr: profile.profileSaveErr,
+    profileSaving: profile.profileSaving,
+    profileAvatarUrl: profile.profileAvatarUrl,
+    profileAvatarLoading: profile.profileAvatarLoading,
+    profileAvatarUploading: profile.profileAvatarUploading,
+    profileAvatarErr: profile.profileAvatarErr,
+    profileAvatarInputRef: profile.profileAvatarInputRef,
+    saveProfileDisplayName: profile.saveProfileDisplayName,
+    onProfileAvatarSelected: profile.onProfileAvatarSelected,
+  }
 
   return (
     <div
@@ -351,14 +401,29 @@ export function RoomPage() {
             {sfuConfigAlert}
           </p>
         ) : null}
-        <div className="riffsync-room-page__stage">
-          <div className="riffsync-room-page__theater">
+        <div
+          className={`riffsync-room-page__stage${expandedViewActive ? ' riffsync-room-page__stage--expanded' : ''}`}
+          data-expanded-view={expandedViewActive ? 'true' : 'false'}
+        >
+          <div className={`riffsync-room-page__theater${expandedViewActive ? ' riffsync-room-page__theater--expanded' : ''}`}>
+            {viewportWide ? (
+              <button
+                type="button"
+                className="riffsync-room-page__expand-toggle"
+                aria-pressed={expandedViewActive}
+                onClick={() => setExpandedView((value) => !value)}
+              >
+                {expandedViewActive ? 'Exit expanded view' : 'Expand view'}
+              </button>
+            ) : null}
+            {expandedViewActive ? <RoomPageSidebar presentation="overlay" {...roomSidebarProps} activeSidebarTab="chat" /> : null}
             <StageParticipantLayout
               roomMode={roomMode}
               tiles={stageParticipantTiles}
               layoutUpdating={stageLayoutUpdating}
               viewportWide={viewportWide}
               avSurfacesEnabled={avSurfacesEnabled}
+              expandedView={expandedViewActive}
               playback={
                 <RoomPlaybackPanel
                   isPublisher={isPublisher}
@@ -382,55 +447,7 @@ export function RoomPage() {
             />
           </div>
 
-          <RoomPageSidebar
-            wsBase={wsBase}
-            fanToken={fanToken}
-            roomId={roomId}
-            sessionId={sessionId}
-            myAvatarUrl={myAvatarUrl}
-            activeSidebarTab={activeSidebarTab}
-            setRoomSidebarTab={setRoomSidebarTab}
-            viewerCount={viewerCount}
-            chat={chat}
-            chatReactions={chatReactions}
-            remoteTyping={remoteTyping}
-            chatMemberLabels={chatMemberLabels}
-            chatDraft={chatDraft}
-            setChatDraft={setChatDraft}
-            notifyComposeBlur={notifyComposeBlur}
-            chatLogRef={chatLogRef}
-            chatInputRef={chatInputRef}
-            showJumpToLatest={showJumpToLatest}
-            jumpToLatestLabel={jumpToLatestLabel}
-            jumpToLatest={jumpToLatest}
-            chatDrawerBanner={chatDrawerBanner}
-            chatComposeStatus={chatComposeStatus}
-            sendChat={sendChat}
-            sendChatGif={sendChatGif}
-            toggleChatReaction={toggleChatReaction}
-            peopleShown={peopleShown}
-            participantProducerBySessionId={participantProducerBySessionId}
-            speakingBySessionId={speakingBySessionId}
-            isPublisher={isPublisher}
-            experimentalFeatures={experimentalFeatures}
-            shareHint={shareHint}
-            onCopyShare={() => void copyShare()}
-            onOpenRenameModal={openRenameModal}
-            avDisabled={avDisabled}
-            participantAvController={participantAvController}
-            announceRoomA11y={announceRoomA11y}
-            profileDraft={profile.profileDraft}
-            setProfileDraft={profile.setProfileDraft}
-            profileSaveErr={profile.profileSaveErr}
-            profileSaving={profile.profileSaving}
-            profileAvatarUrl={profile.profileAvatarUrl}
-            profileAvatarLoading={profile.profileAvatarLoading}
-            profileAvatarUploading={profile.profileAvatarUploading}
-            profileAvatarErr={profile.profileAvatarErr}
-            profileAvatarInputRef={profile.profileAvatarInputRef}
-            saveProfileDisplayName={profile.saveProfileDisplayName}
-            onProfileAvatarSelected={profile.onProfileAvatarSelected}
-          />
+          {!expandedViewActive ? <RoomPageSidebar {...roomSidebarProps} /> : null}
         </div>
         {isPublisher && experimentalFeatures ? (
           <HostControlBar

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from './drawerErrorPresentation'
 
 type RoomPageSidebarProps = {
+  presentation?: 'sidebar' | 'overlay'
   wsBase: string | undefined
   fanToken: string | null
   roomId: string
@@ -74,6 +75,7 @@ type RoomPageSidebarProps = {
 }
 
 export function RoomPageSidebar({
+  presentation = 'sidebar',
   wsBase,
   fanToken,
   roomId,
@@ -122,9 +124,11 @@ export function RoomPageSidebar({
   saveProfileDisplayName,
   onProfileAvatarSelected,
 }: RoomPageSidebarProps) {
-  return (
-    <aside className="riffsync-room-page__chat-column" aria-label="Room sidebar">
-      <section className="riffsync-room-page__chat" aria-label="Chat and viewers">
+  const chatPlane = (
+    <section
+      className={`riffsync-room-page__chat${presentation === 'overlay' ? ' riffsync-room-page__chat--overlay' : ''}`}
+      aria-label={presentation === 'overlay' ? 'Chat overlay' : 'Chat and viewers'}
+    >
         {!wsBase ? (
           <p className="riffsync-room-page__ws-banner riffsync-muted" role="status">
             Chat and viewer list require <code>VITE_PUBLIC_WS_URL</code> on this deployment.
@@ -142,6 +146,7 @@ export function RoomPageSidebar({
           </p>
         ) : null}
 
+        {presentation === 'sidebar' ? (
         <div className="riffsync-room-page__chat-toolbar">
           <div className="riffsync-room-page__tabs">
             <button
@@ -180,6 +185,7 @@ export function RoomPageSidebar({
             ) : null}
           </div>
         </div>
+        ) : null}
 
         {activeSidebarTab === 'chat' ? (
           <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--chat">
@@ -276,7 +282,7 @@ export function RoomPageSidebar({
           </div>
         ) : null}
 
-        {activeSidebarTab === 'people' ? (
+        {presentation === 'sidebar' && activeSidebarTab === 'people' ? (
           <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--people">
             <ul className="riffsync-room-page__people-list" aria-label="People currently connected">
               {peopleShown.map((p) => {
@@ -337,7 +343,7 @@ export function RoomPageSidebar({
           </div>
         ) : null}
 
-        {activeSidebarTab === 'room' ? (
+        {presentation === 'sidebar' && activeSidebarTab === 'room' ? (
           <div className="riffsync-room-page__tab-panel riffsync-room-page__room-panel">
             <button type="button" className="gen-button gen-button-wide" onClick={onCopyShare}>
               Copy Party Link
@@ -364,7 +370,7 @@ export function RoomPageSidebar({
           </div>
         ) : null}
 
-        {activeSidebarTab === 'profile' ? (
+        {presentation === 'sidebar' && activeSidebarTab === 'profile' ? (
           <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--profile">
             <p className="riffsync-muted riffsync-room-page__profile-lede">
               This name appears in chat, the viewer list, and across devices when you&apos;re signed in.
@@ -519,6 +525,13 @@ export function RoomPageSidebar({
           ) : null}
         </div>
       </section>
+  )
+
+  if (presentation === 'overlay') return chatPlane
+
+  return (
+    <aside className="riffsync-room-page__chat-column" aria-label="Room sidebar">
+      {chatPlane}
     </aside>
   )
 }

--- a/apps/web/src/room/chatDrawerUxWiring.test.ts
+++ b/apps/web/src/room/chatDrawerUxWiring.test.ts
@@ -21,8 +21,9 @@ describe('chat drawer UX wiring (#207)', () => {
 
   it('RoomPage passes chat drawer props into RoomPageSidebar', () => {
     const src = readSrc('../pages/RoomPage.tsx')
-    expect(src).toMatch(/chatDrawerBanner=\{chatDrawerBanner\}/)
-    expect(src).toMatch(/chatComposeStatus=\{chatComposeStatus\}/)
+    expect(src).toMatch(/const roomSidebarProps = \{[\s\S]*chatDrawerBanner,[\s\S]*chatComposeStatus,/)
+    expect(src).toMatch(/<RoomPageSidebar presentation="overlay" \{\.\.\.roomSidebarProps\}/)
+    expect(src).toMatch(/<RoomPageSidebar \{\.\.\.roomSidebarProps\}/)
     expect(src).toContain('useRoomMediaEngine')
   })
 

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -75,6 +75,28 @@ describe('StageParticipantLayout', () => {
     expect(container.textContent).toContain('You')
   })
 
+  it('moves theater participant cameras to a bottom row in expanded view', () => {
+    const stream = new MediaStream()
+    renderLayout({
+      roomMode: 'theater',
+      viewportWide: true,
+      expandedView: true,
+      tiles: [
+        {
+          key: 'self',
+          sessionId: 'me',
+          label: 'You',
+          isSelf: true,
+          stream,
+          speaking: false,
+        },
+      ],
+    })
+    expect(container.querySelector('.riffsync-room-page__participant-row--expanded')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
+    expect(container.textContent).toContain('You')
+  })
+
   describe('producerClosed regression (tile detach across stage surfaces)', () => {
     const remoteTile = {
       key: 'remote-1',

--- a/apps/web/src/room/stage/StageParticipantLayout.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.tsx
@@ -15,6 +15,7 @@ type StageParticipantLayoutProps = {
   viewportWide: boolean
   avSurfacesEnabled: boolean
   playback: ReactNode
+  expandedView?: boolean
 }
 
 export function StageParticipantLayout({
@@ -24,8 +25,12 @@ export function StageParticipantLayout({
   viewportWide,
   avSurfacesEnabled,
   playback,
+  expandedView = false,
 }: StageParticipantLayoutProps) {
-  const showDesktopStrip = avSurfacesEnabled && viewportWide && roomMode === 'theater' && tiles.length > 0
+  const showDesktopStrip =
+    avSurfacesEnabled && viewportWide && !expandedView && roomMode === 'theater' && tiles.length > 0
+  const showExpandedTheaterRow =
+    avSurfacesEnabled && viewportWide && expandedView && roomMode === 'theater' && tiles.length > 0
   const showNarrowRow =
     avSurfacesEnabled && !viewportWide && roomMode === 'theater' && tiles.length > 0
   const showVideoChatEmpty =
@@ -77,9 +82,13 @@ export function StageParticipantLayout({
           </div>
         )}
       </div>
-      {showNarrowRow ? (
+      {showNarrowRow || showExpandedTheaterRow ? (
         <div
-          className="riffsync-room-page__participant-row riffsync-room-page__participant-row--narrow"
+          className={`riffsync-room-page__participant-row ${
+            showExpandedTheaterRow
+              ? 'riffsync-room-page__participant-row--expanded'
+              : 'riffsync-room-page__participant-row--narrow'
+          }`}
           aria-label="Participant cameras"
         >
           {tileList}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -785,6 +785,10 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
     max-height: 100%;
     overflow: hidden;
   }
+
+  .riffsync-room-page__stage--expanded {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .riffsync-room-page__host-bar {
@@ -872,11 +876,61 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 }
 
 .riffsync-room-page__theater {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+}
+
+.riffsync-room-page__expand-toggle {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  z-index: 8;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / 0.24);
+  background: rgb(5 8 12 / 0.68);
+  color: var(--white-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.1;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.42);
+}
+
+.riffsync-room-page__expand-toggle:hover,
+.riffsync-room-page__expand-toggle:focus-visible,
+.riffsync-room-page__expand-toggle[aria-pressed='true'] {
+  border-color: rgb(255 255 255 / 0.42);
+  background: rgb(18 23 31 / 0.86);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .riffsync-room-page__expand-toggle {
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      opacity 140ms ease,
+      visibility 140ms ease;
+  }
+
+  .riffsync-room-page__theater:hover .riffsync-room-page__expand-toggle,
+  .riffsync-room-page__theater:focus-within .riffsync-room-page__expand-toggle {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .riffsync-room-page__expand-toggle {
+    transition: none;
+  }
 }
 
 .riffsync-room-page__stage-media {
@@ -984,6 +1038,19 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   gap: 0.45rem;
   overflow-x: auto;
   padding-bottom: 0.15rem;
+}
+
+.riffsync-room-page__participant-row--expanded {
+  display: flex;
+  flex-direction: row;
+  gap: 0.45rem;
+  overflow-x: auto;
+  padding: 0.15rem 0.2rem 0;
+  flex-shrink: 0;
+}
+
+.riffsync-room-page__participant-row--expanded .riffsync-room-page__participant-tile {
+  width: min(16vw, 180px);
 }
 
 @media (min-width: 992px) {
@@ -1419,6 +1486,35 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   backdrop-filter: blur(8px);
   /* Popovers above compose open upward; overflow:hidden on this box clipped them. */
   overflow: visible;
+}
+
+.riffsync-room-page__chat--overlay {
+  position: absolute;
+  right: clamp(0.75rem, 1.4vw, 1.1rem);
+  bottom: clamp(0.75rem, 1.4vw, 1.1rem);
+  z-index: 7;
+  width: clamp(20rem, 40%, 32rem);
+  height: min(50%, 30rem);
+  min-height: min(16rem, 50%);
+  max-height: 50%;
+  background: rgb(7 10 14 / 0.42);
+  border-color: rgb(255 255 255 / 0.16);
+  box-shadow: 0 14px 40px rgb(0 0 0 / 0.38);
+  backdrop-filter: blur(6px);
+}
+
+.riffsync-room-page__chat--overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2.75rem;
+  pointer-events: none;
+  border-radius: 8px 8px 0 0;
+  background: linear-gradient(rgb(0 0 0 / 0.32), rgb(0 0 0 / 0));
+}
+
+.riffsync-room-page__chat--overlay .riffsync-room-page__sidebar-footer {
+  background: rgb(5 8 11 / 0.32);
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
## Summary
- Adds a desktop-only in-page expanded room view with an accessible stage toggle and transparent bottom-right chat overlay.
- Reuses the room chat plane for the overlay while omitting People / Room / Profile tabs until the viewer exits expanded view.
- Moves Theater participant cameras to a bottom row in expanded view and syncs the `.ai/interface` contracts for #259.

## Test plan
- `npm --prefix apps/web test`
- `npm --prefix apps/web run lint` (passes with an existing `CatalogPage.tsx` warning)
- `npm --prefix apps/web run build`

Closes #259