### PR TITLE
Camera positioning in new room modes

### DIFF
--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -60,7 +60,7 @@ Keyboard, pointer, and permission input contract for room and catalog surfaces.
 
 - **Expand / exit** control is a native **`<button>`** on the stage region — keyboard activatable (**Enter** / **Space**); not pointer-only.
 - Control is **revealed on stage hover** for pointer users; **:focus-visible** keeps it visible for keyboard users.
-- **Theater camera row:** participant tiles are informational video surfaces and must not add unexpected tab stops or steal focus when the row appears, scrolls, or wraps. Tile labels and speaking affordances remain available through visible text and accessible names.
+- **Theater camera row (standard and expanded):** participant tiles are informational video surfaces and must not add unexpected tab stops or steal focus when the row appears, scrolls, or wraps. Tile labels and speaking affordances remain available through visible text and accessible names.
 - **Tab order in expanded view:** expand/exit toggle → chat overlay (drawer status if present → message log scroll region → jump-to-latest when visible → AV toggles when rendered → compose) → host control bar (host only). **No** sidebar tab strip in tab order while expanded.
 - **People / Room / Profile:** reachable only after **exit expanded view** (or via site chrome navigation).
 - **Touch targets:** expand/exit control minimum **44×44** CSS px.

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -216,7 +216,7 @@ When **iOS Safari** (iPad and iPhone) opens the **software keyboard** on **`/roo
 | **Drawers** | Chat and video-relay drawer status rules **unchanged** — chat banner lives inside the overlay; video-relay status stays on the stage playback surface. |
 | **Chromecast (future)** | Implement expanded layout as a **reusable shell** (stage-primary + chat overlay) suitable as a future Cast receiver target. **No** Cast SDK or receiver work in #259. |
 
-Implementation: `RoomPage.tsx` owns session-only expanded state, `RoomPageSidebar.tsx` renders the shared chat plane as either sidebar or overlay, and `StageParticipantLayout.tsx` switches Theater cameras from the desktop side strip to the expanded bottom row.
+Implementation: `RoomPage.tsx` owns session-only expanded state, `RoomPageSidebar.tsx` renders the shared chat plane as either sidebar or overlay, and `StageParticipantLayout.tsx` renders Theater cameras in a bottom horizontal row (standard and expanded desktop layouts).
 
 ## Accessibility & motion (baseline)
 

--- a/apps/web/src/room/stage/StageParticipantLayout.test.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.test.tsx
@@ -55,7 +55,7 @@ describe('StageParticipantLayout', () => {
     expect(container.textContent).toContain('Updating room layout')
   })
 
-  it('renders self tile in desktop theater strip', () => {
+  it('renders self tile in desktop theater bottom row', () => {
     const stream = new MediaStream()
     renderLayout({
       roomMode: 'theater',
@@ -71,7 +71,8 @@ describe('StageParticipantLayout', () => {
         },
       ],
     })
-    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-row--desktop')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
     expect(container.textContent).toContain('You')
   })
 
@@ -93,6 +94,7 @@ describe('StageParticipantLayout', () => {
       ],
     })
     expect(container.querySelector('.riffsync-room-page__participant-row--expanded')).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-row--desktop')).toBeNull()
     expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
     expect(container.textContent).toContain('You')
   })
@@ -135,7 +137,7 @@ describe('StageParticipantLayout', () => {
       expect(container.textContent).toContain(VIDEO_CHAT_EMPTY_COPY)
     })
 
-    it('removes remote tile from Theater desktop strip when consumer detaches', () => {
+    it('removes remote tile from Theater desktop bottom row when consumer detaches', () => {
       renderLayout({
         roomMode: 'theater',
         viewportWide: true,
@@ -144,7 +146,7 @@ describe('StageParticipantLayout', () => {
       const video = container.querySelector(
         'video.riffsync-room-page__participant-tile-video',
       ) as HTMLVideoElement | null
-      expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).not.toBeNull()
+      expect(container.querySelector('.riffsync-room-page__participant-row--desktop')).not.toBeNull()
 
       renderLayout({
         roomMode: 'theater',
@@ -152,7 +154,7 @@ describe('StageParticipantLayout', () => {
         tiles: [],
       })
       assertTileRemoved(video)
-      expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
+      expect(container.querySelector('.riffsync-room-page__participant-row--desktop')).toBeNull()
     })
 
     it('removes remote tile from narrow horizontal row when consumer detaches', () => {
@@ -193,6 +195,6 @@ describe('StageParticipantLayout', () => {
       ],
     })
     expect(container.querySelector('.riffsync-room-page__participant-row--narrow')).not.toBeNull()
-    expect(container.querySelector('.riffsync-room-page__participant-strip--desktop')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__participant-row--desktop')).toBeNull()
   })
 })

--- a/apps/web/src/room/stage/StageParticipantLayout.tsx
+++ b/apps/web/src/room/stage/StageParticipantLayout.tsx
@@ -27,7 +27,7 @@ export function StageParticipantLayout({
   playback,
   expandedView = false,
 }: StageParticipantLayoutProps) {
-  const showDesktopStrip =
+  const showDesktopTheaterRow =
     avSurfacesEnabled && viewportWide && !expandedView && roomMode === 'theater' && tiles.length > 0
   const showExpandedTheaterRow =
     avSurfacesEnabled && viewportWide && expandedView && roomMode === 'theater' && tiles.length > 0
@@ -58,14 +58,6 @@ export function StageParticipantLayout({
         {roomMode === 'theater' ? (
           <div className="riffsync-room-page__theater-row">
             <div className="riffsync-room-page__theater-playback">{playback}</div>
-            {showDesktopStrip ? (
-              <div
-                className="riffsync-room-page__participant-strip riffsync-room-page__participant-strip--desktop"
-                aria-label="Participant cameras"
-              >
-                {tileList}
-              </div>
-            ) : null}
           </div>
         ) : (
           <div
@@ -82,12 +74,14 @@ export function StageParticipantLayout({
           </div>
         )}
       </div>
-      {showNarrowRow || showExpandedTheaterRow ? (
+      {showNarrowRow || showExpandedTheaterRow || showDesktopTheaterRow ? (
         <div
           className={`riffsync-room-page__participant-row ${
             showExpandedTheaterRow
               ? 'riffsync-room-page__participant-row--expanded'
-              : 'riffsync-room-page__participant-row--narrow'
+              : showDesktopTheaterRow
+                ? 'riffsync-room-page__participant-row--desktop'
+                : 'riffsync-room-page__participant-row--narrow'
           }`}
           aria-label="Participant cameras"
         >

--- a/apps/web/src/room/stage/stageParticipantTiles.test.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.test.ts
@@ -7,7 +7,7 @@ import {
   buildStageParticipantTiles,
   sortRosterForStage,
   stageLayoutSurfaceClass,
-  stageLayoutUsesDesktopStrip,
+  stageLayoutUsesDesktopTheaterRow,
   stageLayoutUsesNarrowRow,
 } from './stageParticipantTiles'
 
@@ -196,10 +196,10 @@ describe('stageParticipantTiles', () => {
     expect(stageLayoutUsesNarrowRow(true)).toBe(false)
   })
 
-  it('uses desktop strip only in theater with tiles on wide viewport', () => {
-    expect(stageLayoutUsesDesktopStrip(true, 'theater', 2)).toBe(true)
-    expect(stageLayoutUsesDesktopStrip(true, 'videoChat', 2)).toBe(false)
-    expect(stageLayoutUsesDesktopStrip(true, 'theater', 0)).toBe(false)
-    expect(stageLayoutUsesDesktopStrip(false, 'theater', 2)).toBe(false)
+  it('uses desktop theater row only in theater with tiles on wide viewport', () => {
+    expect(stageLayoutUsesDesktopTheaterRow(true, 'theater', 2)).toBe(true)
+    expect(stageLayoutUsesDesktopTheaterRow(true, 'videoChat', 2)).toBe(false)
+    expect(stageLayoutUsesDesktopTheaterRow(true, 'theater', 0)).toBe(false)
+    expect(stageLayoutUsesDesktopTheaterRow(false, 'theater', 2)).toBe(false)
   })
 })

--- a/apps/web/src/room/stage/stageParticipantTiles.ts
+++ b/apps/web/src/room/stage/stageParticipantTiles.ts
@@ -144,7 +144,7 @@ export function stageLayoutUsesNarrowRow(viewportWide: boolean): boolean {
   return !viewportWide
 }
 
-export function stageLayoutUsesDesktopStrip(
+export function stageLayoutUsesDesktopTheaterRow(
   viewportWide: boolean,
   roomMode: 'theater' | 'videoChat',
   tileCount: number,

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -981,35 +981,12 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   gap: 0.5rem;
 }
 
-@media (min-width: 992px) {
-  .riffsync-room-page__theater-row {
-    flex-direction: row;
-    align-items: stretch;
-  }
-}
-
 .riffsync-room-page__theater-playback {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
   display: flex;
   flex-direction: column;
-}
-
-.riffsync-room-page__participant-strip--desktop {
-  display: none;
-}
-
-@media (min-width: 992px) {
-  .riffsync-room-page__participant-strip--desktop {
-    display: flex;
-    flex-direction: column;
-    flex: 0 0 148px;
-    gap: 0.45rem;
-    max-height: 100%;
-    overflow-y: auto;
-    padding-inline: 0.1rem;
-  }
 }
 
 .riffsync-room-page__participant-grid {
@@ -1040,6 +1017,10 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   padding-bottom: 0.15rem;
 }
 
+.riffsync-room-page__participant-row--desktop {
+  display: none;
+}
+
 .riffsync-room-page__participant-row--expanded {
   display: flex;
   flex-direction: row;
@@ -1056,6 +1037,20 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 @media (min-width: 992px) {
   .riffsync-room-page__participant-row--narrow {
     display: none;
+  }
+
+  .riffsync-room-page__participant-row--desktop {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    overflow-x: auto;
+    padding: 0.15rem 0.2rem 0;
+    flex-shrink: 0;
+  }
+
+  .riffsync-room-page__participant-row--desktop .riffsync-room-page__participant-tile {
+    width: min(14vw, 168px);
   }
 }
 
@@ -1093,10 +1088,6 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 }
 
 @media (min-width: 992px) {
-  .riffsync-room-page__participant-strip--desktop .riffsync-room-page__participant-tile {
-    width: 100%;
-  }
-
   .riffsync-room-page__participant-grid .riffsync-room-page__participant-tile {
     width: auto;
   }


### PR DESCRIPTION
## Summary

- Moves standard desktop Theater participant cameras from a right-side vertical strip to a horizontal row directly beneath the movie/stage primary.
- Keeps expanded Theater camera row beneath the movie and preserves the #259 bottom-right chat overlay placement.
- Updates layout CSS, unit tests, and `.ai/interface` contracts to match shipped behavior.

Closes #261

## Test plan

- [x] `npm test --prefix apps/web` (all unit tests pass)
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual: Theater mode at desktop width with cameras on shows horizontal row below movie, not in chat column
- [ ] Manual: Expanded Theater shows bottom camera row without displacing chat overlay
- [ ] Manual: Video Chat grid remains primary; mic-only participants stay off-stage
- [ ] Manual: Camera-off removes tiles promptly; expand/exit control hover and keyboard focus behavior