### PR TITLE
fix(room): polish expanded view chrome, chat overlay, and toggle

### DIFF
--- a/apps/web/src/layouts/SiteLayout.tsx
+++ b/apps/web/src/layouts/SiteLayout.tsx
@@ -2,16 +2,37 @@ import { Outlet, useMatch, useSearchParams } from 'react-router-dom'
 import { SiteHeader } from '../components/site/SiteHeader'
 import { SiteFooter } from '../components/site/SiteFooter'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import { useRoomChromeOptional } from '../room/useRoomChrome'
 import { useVisualViewportRoomShell } from '../room/useVisualViewportRoomShell'
 
-export function SiteLayout() {
+function SiteLayoutShell() {
   const roomMatch = useMatch({ path: '/room/:roomId', end: true })
+  const compactChrome = Boolean(roomMatch)
+  const viewportShell = useVisualViewportRoomShell(compactChrome)
+  const roomChrome = useRoomChromeOptional()
+  const expandedViewActive = Boolean(roomChrome?.expandedViewActive)
+
+  return (
+    <div
+      className={`riffsync-site${compactChrome ? ` riffsync-site--room${viewportShell.className}` : ''}${expandedViewActive ? ' riffsync-site--room-expanded' : ''}`}
+      style={compactChrome ? viewportShell.style : undefined}
+    >
+      {expandedViewActive ? null : <SiteHeader compact={compactChrome} />}
+      <main
+        id="riffsync-main"
+        className={`riffsync-main${compactChrome ? ' riffsync-main--room' : ''}${expandedViewActive ? ' riffsync-main--room-expanded' : ''}`}
+      >
+        <Outlet />
+      </main>
+      {!roomMatch ? <SiteFooter compact={false} /> : null}
+    </div>
+  )
+}
+
+export function SiteLayout() {
   const watchMatch = useMatch({ path: '/watch/:catalogEpisodeId', end: true })
   const [searchParams] = useSearchParams()
   const partyCaptureBare = Boolean(watchMatch && searchParams.get('partyCapture') === '1')
-
-  const compactChrome = Boolean(roomMatch)
-  const viewportShell = useVisualViewportRoomShell(compactChrome)
 
   if (partyCaptureBare) {
     return (
@@ -25,16 +46,7 @@ export function SiteLayout() {
 
   return (
     <RoomChromeProvider>
-      <div
-        className={`riffsync-site${compactChrome ? ` riffsync-site--room${viewportShell.className}` : ''}`}
-        style={compactChrome ? viewportShell.style : undefined}
-      >
-        <SiteHeader compact={compactChrome} />
-        <main id="riffsync-main" className={`riffsync-main${compactChrome ? ' riffsync-main--room' : ''}`}>
-          <Outlet />
-        </main>
-        {!roomMatch ? <SiteFooter compact={false} /> : null}
-      </div>
+      <SiteLayoutShell />
     </RoomChromeProvider>
   )
 }

--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -4,7 +4,9 @@ import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RoomPage } from './RoomPage'
+import { SiteLayout } from '../layouts/SiteLayout'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import { useRoomChrome } from '../room/useRoomChrome'
 import {
   CHAT_RECONNECTING_COPY,
   drawerDiagnostics,
@@ -244,6 +246,7 @@ describe('RoomPage drawer status banner integration (#209)', () => {
       root.render(
         <MemoryRouter initialEntries={['/room/room-test-1']}>
           <RoomChromeProvider>
+            <RoomChromeExpandedProbe />
             <Routes>
               <Route path="/room/:roomId" element={<RoomPage />} />
             </Routes>
@@ -251,6 +254,24 @@ describe('RoomPage drawer status banner integration (#209)', () => {
         </MemoryRouter>,
       )
     })
+  }
+
+  function renderRoomWithSiteLayout() {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/room/room-test-1']}>
+          <Routes>
+            <Route element={<SiteLayout />}>
+              <Route path="/room/:roomId" element={<RoomPage />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  function roomChromeExpandedProbe() {
+    return container.querySelector('[data-testid="room-chrome-expanded"]')
   }
 
   function chatBanner() {
@@ -484,6 +505,7 @@ describe('RoomPage drawer status banner integration (#209)', () => {
       expect(container.querySelector('.riffsync-room-page__stage--expanded')).not.toBeNull()
     })
 
+    expect(roomChromeExpandedProbe()?.getAttribute('data-expanded')).toBe('true')
     expect(expandViewButton()?.textContent).toBe('Exit expanded view')
     expect(container.querySelector('.riffsync-room-page__chat--overlay')).not.toBeNull()
     expect(container.querySelector('.riffsync-room-page__chat-column')).toBeNull()
@@ -497,7 +519,50 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     await vi.waitFor(() => {
       expect(container.querySelector('.riffsync-room-page__stage--expanded')).toBeNull()
     })
+    expect(roomChromeExpandedProbe()?.getAttribute('data-expanded')).toBe('false')
     expect(container.querySelector('.riffsync-room-page__chat-column')).not.toBeNull()
     expect(container.querySelector('.riffsync-room-page__tabs')).not.toBeNull()
   })
+
+  it('hides compact header and applies expanded site chrome class (#259)', async () => {
+    drawerStatusMockConfig.set({
+      diagnostics: drawerDiagnostics({
+        chat: { state: 'connected' },
+        sfuSignaling: { state: 'connected' },
+      }),
+      guestShareFsm: 'running',
+    })
+    renderRoomWithSiteLayout()
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-header--compact')).not.toBeNull()
+      expect(expandViewButton()?.textContent).toBe('Expand view')
+    })
+
+    act(() => {
+      expandViewButton()?.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-site--room-expanded')).not.toBeNull()
+      expect(container.querySelector('.riffsync-main--room-expanded')).not.toBeNull()
+      expect(container.querySelector('.riffsync-header--compact')).toBeNull()
+    })
+
+    act(() => {
+      expandViewButton()?.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-site--room-expanded')).toBeNull()
+      expect(container.querySelector('.riffsync-header--compact')).not.toBeNull()
+    })
+  })
 })
+
+function RoomChromeExpandedProbe() {
+  const { expandedViewActive } = useRoomChrome()
+  return (
+    <div data-testid="room-chrome-expanded" data-expanded={expandedViewActive ? 'true' : 'false'} />
+  )
+}

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../room/hostRoomControls'
 import { StageParticipantLayout } from '../room/stage/StageParticipantLayout'
 import { enteredVideoChatMode } from '../room/roomMediaLifecycle'
+import { useRoomChrome } from '../room/useRoomChrome'
 import { useRoomSnapshot } from '../room/useRoomSnapshot'
 import { detectExperimentalRoomFeatures } from '../room/experimentalRoomFeatures'
 import { useRoomMediaEngine } from '../room/useRoomMediaEngine'
@@ -227,6 +228,13 @@ export function RoomPage() {
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
   const viewportWide = useViewportWide()
   const expandedViewActive = expandedView && viewportWide
+  const { setExpandedViewActive } = useRoomChrome()
+
+  useEffect(() => {
+    setExpandedViewActive(expandedViewActive)
+    return () => setExpandedViewActive(false)
+  }, [expandedViewActive, setExpandedViewActive])
+
   const roomChatTabActive = expandedViewActive || activeSidebarTab === 'chat'
   const {
     logRef: chatLogRef,

--- a/apps/web/src/room/RoomChromeProvider.tsx
+++ b/apps/web/src/room/RoomChromeProvider.tsx
@@ -3,13 +3,17 @@ import { RoomChromeContext } from './roomChromeContext'
 
 export function RoomChromeProvider({ children }: { children: ReactNode }) {
   const [nowPlayingLabel, setNowPlayingLabelState] = useState<string | null>(null)
+  const [expandedViewActive, setExpandedViewActiveState] = useState(false)
   const setNowPlayingLabel = useCallback((label: string | null) => {
     setNowPlayingLabelState(label)
   }, [])
+  const setExpandedViewActive = useCallback((active: boolean) => {
+    setExpandedViewActiveState(active)
+  }, [])
 
   const value = useMemo(
-    () => ({ nowPlayingLabel, setNowPlayingLabel }),
-    [nowPlayingLabel, setNowPlayingLabel],
+    () => ({ nowPlayingLabel, setNowPlayingLabel, expandedViewActive, setExpandedViewActive }),
+    [nowPlayingLabel, setNowPlayingLabel, expandedViewActive, setExpandedViewActive],
   )
 
   return <RoomChromeContext.Provider value={value}>{children}</RoomChromeContext.Provider>

--- a/apps/web/src/room/roomChromeContext.ts
+++ b/apps/web/src/room/roomChromeContext.ts
@@ -3,6 +3,8 @@ import { createContext } from 'react'
 export type RoomChromeContextValue = {
   nowPlayingLabel: string | null
   setNowPlayingLabel: (label: string | null) => void
+  expandedViewActive: boolean
+  setExpandedViewActive: (active: boolean) => void
 }
 
 export const RoomChromeContext = createContext<RoomChromeContextValue | null>(null)

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -558,6 +558,26 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   --riffsync-room-stage-max-height: calc(100dvh - var(--riffsync-room-chrome-height));
 }
 
+.riffsync-site--room.riffsync-site--room-expanded {
+  --riffsync-room-chrome-height: 0px;
+  --riffsync-room-stage-max-height: 100dvh;
+}
+
+@media (min-width: 992px) {
+  .riffsync-main--room-expanded {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .riffsync-main--room-expanded .container.riffsync-room-page {
+    padding-inline: 0;
+  }
+
+  .riffsync-room-page__stage--expanded {
+    gap: 0;
+  }
+}
+
 @media (max-width: 991px) {
   .riffsync-site--room.riffsync-site--room-vv-keyboard {
     position: fixed;
@@ -905,8 +925,7 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 }
 
 .riffsync-room-page__expand-toggle:hover,
-.riffsync-room-page__expand-toggle:focus-visible,
-.riffsync-room-page__expand-toggle[aria-pressed='true'] {
+.riffsync-room-page__expand-toggle:focus-visible {
   border-color: rgb(255 255 255 / 0.42);
   background: rgb(18 23 31 / 0.86);
 }
@@ -921,7 +940,7 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   }
 
   .riffsync-room-page__theater:hover .riffsync-room-page__expand-toggle,
-  .riffsync-room-page__theater:focus-within .riffsync-room-page__expand-toggle {
+  .riffsync-room-page__expand-toggle:focus-visible {
     opacity: 1;
     visibility: visible;
   }
@@ -1484,10 +1503,11 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   right: clamp(0.75rem, 1.4vw, 1.1rem);
   bottom: clamp(0.75rem, 1.4vw, 1.1rem);
   z-index: 7;
-  width: clamp(20rem, 40%, 32rem);
-  height: min(50%, 30rem);
-  min-height: min(16rem, 50%);
-  max-height: 50%;
+  flex: none;
+  width: clamp(16rem, 30%, 24rem);
+  height: min(40%, 24rem);
+  min-height: 0;
+  max-height: 40%;
   background: rgb(7 10 14 / 0.42);
   border-color: rgb(255 255 255 / 0.16);
   box-shadow: 0 14px 40px rgb(0 0 0 / 0.38);
@@ -1497,11 +1517,19 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 .riffsync-room-page__chat--overlay::before {
   content: '';
   position: absolute;
-  inset: 0 0 auto;
-  height: 2.75rem;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3.5rem;
   pointer-events: none;
+  z-index: 2;
   border-radius: 8px 8px 0 0;
-  background: linear-gradient(rgb(0 0 0 / 0.32), rgb(0 0 0 / 0));
+  background: linear-gradient(rgb(7 10 14 / 0.72), rgb(7 10 14 / 0));
+}
+
+.riffsync-room-page__chat--overlay .riffsync-room-page__tab-panel--chat {
+  position: relative;
+  z-index: 1;
 }
 
 .riffsync-room-page__chat--overlay .riffsync-room-page__sidebar-footer {
@@ -1532,6 +1560,13 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
     height: 100%;
     max-height: 100%;
     min-height: 0;
+  }
+
+  .riffsync-room-page__chat--overlay {
+    height: min(40dvh, 24rem);
+    max-height: 40%;
+    width: clamp(16rem, 28%, 24rem);
+    flex: none;
   }
 }
 


### PR DESCRIPTION
Hide the compact header in expanded view so video uses the full viewport, constrain the chat overlay to the lower portion of the screen, and reveal the expand/exit control only on theater hover or keyboard focus.