### PR TITLE
Lobby host display and reliable host tracking (#257)

### DIFF
--- a/apps/web/src/api/roomsApi.ts
+++ b/apps/web/src/api/roomsApi.ts
@@ -20,6 +20,8 @@ export interface LobbyRoomRow {
   lastActivityAt?: number
   /** Host-editable headline for the lobby row. */
   displayTitle?: string
+  /** FanProfiles display name for the room host (never hostSub). */
+  hostDisplayName: string
   /** WebSocket connections for this room (tabs / live sockets; not unique people). */
   liveConnectionCount?: number
 }

--- a/apps/web/src/pages/LobbyPage.test.tsx
+++ b/apps/web/src/pages/LobbyPage.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LobbyResponse } from '../api/roomsApi'
+import { LobbyPage } from './LobbyPage'
+
+const fetchLobby = vi.fn<(sessionId: string) => Promise<LobbyResponse>>()
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    fetchLobby: (sessionId: string) => fetchLobby(sessionId),
+  }
+})
+
+vi.mock('../session/guestSession', () => ({
+  ensureGuestSession: () => ({ sessionId: 'guest-session-1' }),
+}))
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.test',
+}))
+
+describe('LobbyPage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    fetchLobby.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderPage() {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <LobbyPage />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('renders Hosted by line below each lobby row title', async () => {
+    fetchLobby.mockResolvedValue({
+      rooms: [
+        {
+          roomId: 'room-1',
+          catalogEpisodeId: 'ep-1',
+          displayTitle: 'Night of the Living Bread',
+          hostDisplayName: 'CosmicCrow123',
+          liveConnectionCount: 2,
+          lastActivityAt: Date.now() - 60_000,
+        },
+      ],
+    })
+
+    renderPage()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('Hosted by CosmicCrow123')
+    expect(container.textContent).toContain('Night of the Living Bread')
+  })
+})

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -81,6 +81,9 @@ export function LobbyPage() {
                   <h2 className="riffsync-lobby-list__title">
                     <Link to={`/room/${encodeURIComponent(row.roomId)}`}>{headline}</Link>
                   </h2>
+                  <p className="riffsync-lobby-list__host riffsync-muted">
+                    Hosted by {row.hostDisplayName}
+                  </p>
                   <div className="riffsync-lobby-list__stats">
                     {activity ? (
                       <span className="riffsync-lobby-list__activity riffsync-muted">{activity}</span>

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -511,6 +511,13 @@ export class ChatSession {
     }
   }
 
+  /** Persist refreshed fan JWT so automatic reconnects keep publisher/host presence. */
+  updateAccessToken(accessToken: string | null): void {
+    if (this.connectOptions) {
+      this.connectOptions = { ...this.connectOptions, accessToken }
+    }
+  }
+
   disconnect(): void {
     this.cancelled = true
     this.enabled = false

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -440,6 +440,7 @@ export class RoomRealtimeSdk {
       this.joinOptions.accessToken = accessToken
     }
     this.sfu?.updatePublishGate({ fanToken: accessToken })
+    this.chat?.updateAccessToken(accessToken)
   }
 
   /**

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2605,6 +2605,12 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   text-decoration: underline;
 }
 
+.riffsync-lobby-list__host {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
 .riffsync-lobby-list__stats {
   display: flex;
   flex-wrap: wrap;

--- a/infra/cdk/lambda/fan-profile-shared.test.ts
+++ b/infra/cdk/lambda/fan-profile-shared.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 
-import { avatarUrlFromStoredProfile, batchAvatarUrlsByFanSub } from './fan-profile-shared';
+import { avatarUrlFromStoredProfile, batchAvatarUrlsByFanSub, batchDisplayNamesByFanSub, displayNameFromStoredProfile } from './fan-profile-shared';
 
 describe('avatarUrlFromStoredProfile', () => {
   it('returns trimmed https URL when set', () => {
@@ -13,6 +13,17 @@ describe('avatarUrlFromStoredProfile', () => {
   it('returns undefined for blank or missing avatarUrl', () => {
     expect(avatarUrlFromStoredProfile({ avatarUrl: '   ' })).toBeUndefined();
     expect(avatarUrlFromStoredProfile(undefined)).toBeUndefined();
+  });
+});
+
+describe('displayNameFromStoredProfile', () => {
+  it('returns trimmed display name when set', () => {
+    expect(displayNameFromStoredProfile({ displayName: '  Cosmic Crow  ' })).toBe('Cosmic Crow');
+  });
+
+  it('returns undefined for blank or missing displayName', () => {
+    expect(displayNameFromStoredProfile({ displayName: '   ' })).toBeUndefined();
+    expect(displayNameFromStoredProfile(undefined)).toBeUndefined();
   });
 });
 
@@ -38,6 +49,32 @@ describe('batchAvatarUrlsByFanSub', () => {
 
     expect(map.size).toBe(1);
     expect(map.get('fan-a')).toBe('https://cdn.example/a.png');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('batchDisplayNamesByFanSub', () => {
+  const send = vi.fn();
+
+  beforeEach(() => {
+    send.mockReset();
+  });
+
+  it('batch-reads display names keyed by fan sub', async () => {
+    send.mockResolvedValue({
+      Responses: {
+        FanProfiles: [
+          { sub: 'fan-a', displayName: 'Alpha Fan' },
+          { sub: 'fan-b', displayName: '' },
+        ],
+      },
+    });
+
+    const doc = { send } as unknown as DynamoDBDocumentClient;
+    const map = await batchDisplayNamesByFanSub(doc, 'FanProfiles', ['fan-a', 'fan-b', 'fan-a']);
+
+    expect(map.size).toBe(1);
+    expect(map.get('fan-a')).toBe('Alpha Fan');
     expect(send).toHaveBeenCalledTimes(1);
   });
 });

--- a/infra/cdk/lambda/fan-profile-shared.ts
+++ b/infra/cdk/lambda/fan-profile-shared.ts
@@ -55,6 +55,15 @@ export function avatarUrlFromStoredProfile(item: Record<string, unknown> | undef
   return typeof au === 'string' && au.trim() !== '' ? au.trim() : undefined;
 }
 
+/** Non-empty display name from a FanProfiles row (omitted when unset). */
+export function displayNameFromStoredProfile(item: Record<string, unknown> | undefined): string | undefined {
+  const dn = item?.displayName;
+  if (typeof dn !== 'string' || dn.trim() === '') {
+    return undefined;
+  }
+  return dn.trim().slice(0, FAN_DISPLAY_NAME_MAX_LEN);
+}
+
 /** Batch-read `avatarUrl` for fan Cognito subs (DynamoDB keys: `{ sub }`). */
 export async function batchAvatarUrlsByFanSub(
   doc: DynamoDBDocumentClient,
@@ -86,6 +95,44 @@ export async function batchAvatarUrlsByFanSub(
       const url = avatarUrlFromStoredProfile(item);
       if (sub && url) {
         result.set(sub, url);
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Batch-read `displayName` for fan Cognito subs (DynamoDB keys: `{ sub }`). */
+export async function batchDisplayNamesByFanSub(
+  doc: DynamoDBDocumentClient,
+  table: string,
+  fanSubs: readonly string[],
+): Promise<Map<string, string>> {
+  const unique = [...new Set(fanSubs.filter((s) => s.length > 0))];
+  const result = new Map<string, string>();
+  if (unique.length === 0) {
+    return result;
+  }
+
+  for (let i = 0; i < unique.length; i += 100) {
+    const chunk = unique.slice(i, i + 100);
+    const out = await doc.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [table]: {
+            Keys: chunk.map((sub) => ({ sub })),
+            ProjectionExpression: '#sub, displayName',
+            ExpressionAttributeNames: { '#sub': 'sub' },
+          },
+        },
+      }),
+    );
+    const items = (out.Responses?.[table] ?? []) as Record<string, unknown>[];
+    for (const item of items) {
+      const sub = typeof item.sub === 'string' ? item.sub : '';
+      const name = displayNameFromStoredProfile(item);
+      if (sub && name) {
+        result.set(sub, name);
       }
     }
   }

--- a/infra/cdk/lambda/lobby-get.test.ts
+++ b/infra/cdk/lambda/lobby-get.test.ts
@@ -13,6 +13,7 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
     from: vi.fn(() => ({ send: mocks.docSend })),
   },
   QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  BatchGetCommand: vi.fn((input: unknown) => ({ input, kind: 'BatchGet' })),
 }));
 
 import { handler } from './lobby-get';
@@ -22,6 +23,7 @@ describe('lobby-get handler', () => {
     vi.clearAllMocks();
     process.env.ROOMS_TABLE_NAME = 'rooms';
     process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
     process.env.STALE_ROOM_MS = String(45 * 60 * 1000);
   });
 
@@ -34,25 +36,72 @@ describe('lobby-get handler', () => {
         Items: [
           {
             roomId: 'room-active',
+            hostSub: 'host-active',
             catalogEpisodeId: 'ep-1',
             lastActivityAt: nowMs - 1_000,
             lobbyCleanupAfter: nowMs + 60_000,
           },
           {
             roomId: 'room-expired',
+            hostSub: 'host-expired',
             catalogEpisodeId: 'ep-2',
             lastActivityAt: nowMs - 1_000,
             lobbyCleanupAfter: nowMs - 1,
           },
         ],
       })
-      .mockResolvedValueOnce({ Count: 0 })
+      .mockResolvedValueOnce({
+        Responses: {
+          FanProfiles: [{ sub: 'host-active', displayName: 'Active Host' }],
+        },
+      })
       .mockResolvedValueOnce({ Count: 2 });
 
     const res = await handler({} as Parameters<typeof handler>[0], {} as Parameters<typeof handler>[1], () => undefined);
     expect(res.statusCode).toBe(200);
 
-    const body = JSON.parse(String(res.body)) as { rooms: Array<{ roomId: string }> };
+    const body = JSON.parse(String(res.body)) as {
+      rooms: Array<{ roomId: string; hostDisplayName?: string; hostSub?: string }>;
+    };
     expect(body.rooms.map((r) => r.roomId)).toEqual(['room-active']);
+    expect(body.rooms[0]?.hostDisplayName).toBe('Active Host');
+    expect(body.rooms[0]).not.toHaveProperty('hostSub');
+  });
+
+  it('omits rooms whose host lacks a FanProfiles displayName', async () => {
+    const nowMs = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(nowMs);
+
+    mocks.docSend
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            roomId: 'room-named',
+            hostSub: 'host-named',
+            catalogEpisodeId: 'ep-1',
+            lastActivityAt: nowMs - 1_000,
+          },
+          {
+            roomId: 'room-anonymous',
+            hostSub: 'host-anonymous',
+            catalogEpisodeId: 'ep-2',
+            lastActivityAt: nowMs - 1_000,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Responses: {
+          FanProfiles: [{ sub: 'host-named', displayName: 'Named Host' }],
+        },
+      })
+      .mockResolvedValueOnce({ Count: 1 });
+
+    const res = await handler({} as Parameters<typeof handler>[0], {} as Parameters<typeof handler>[1], () => undefined);
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(String(res.body)) as { rooms: Array<{ roomId: string; hostDisplayName: string }> };
+    expect(body.rooms).toEqual([
+      expect.objectContaining({ roomId: 'room-named', hostDisplayName: 'Named Host' }),
+    ]);
   });
 });

--- a/infra/cdk/lambda/lobby-get.ts
+++ b/infra/cdk/lambda/lobby-get.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { batchDisplayNamesByFanSub } from './fan-profile-shared';
 import { shouldExcludeFromLobby } from './room-lobby-cleanup';
 import { defaultStaleRoomMs, LOBBY_PARTITION } from './room-shared';
 
@@ -24,7 +25,8 @@ async function countConnectionsForRoom(connectionsTable: string, roomId: string)
 export const handler: APIGatewayProxyHandlerV2 = async (_event) => {
   const roomsTable = process.env.ROOMS_TABLE_NAME;
   const presenceTable = process.env.ROOM_PRESENCE_TABLE_NAME;
-  if (!roomsTable || !presenceTable) {
+  const fanProfilesTable = process.env.FAN_PROFILES_TABLE_NAME;
+  if (!roomsTable || !presenceTable || !fanProfilesTable) {
     return { statusCode: 500, body: JSON.stringify({ error: 'Missing table env' }) };
   }
 
@@ -51,11 +53,23 @@ export const handler: APIGatewayProxyHandlerV2 = async (_event) => {
     (row) => !shouldExcludeFromLobby(row, nowMs),
   );
 
+  const hostSubs = rows
+    .map((r) => (typeof r.hostSub === 'string' ? r.hostSub : ''))
+    .filter((s) => s.length > 0);
+  const displayNamesByHostSub = await batchDisplayNamesByFanSub(client, fanProfilesTable, hostSubs);
+
+  const listedRows = rows.filter((r) => {
+    const hostSub = typeof r.hostSub === 'string' ? r.hostSub : '';
+    return hostSub.length > 0 && displayNamesByHostSub.has(hostSub);
+  });
+
   const counts = await Promise.all(
-    rows.map((r) => countConnectionsForRoom(presenceTable, String(r.roomId ?? ''))),
+    listedRows.map((r) => countConnectionsForRoom(presenceTable, String(r.roomId ?? ''))),
   );
 
-  const roomsOut = rows.map((r, i) => {
+  const roomsOut = listedRows.map((r, i) => {
+    const hostSub = String(r.hostSub ?? '');
+    const hostDisplayName = displayNamesByHostSub.get(hostSub) ?? '';
     const catalogEpisodeId = String(r.catalogEpisodeId ?? '');
     const trimmedDisplay =
       typeof r.displayTitle === 'string' && r.displayTitle.trim() !== ''
@@ -68,6 +82,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (_event) => {
       lastActivityAt: r.lastActivityAt,
       catalogEpisodeId,
       youtubeVideoId: r.youtubeVideoId,
+      hostDisplayName,
       ...(trimmedDisplay !== undefined ? { displayTitle: trimmedDisplay } : {}),
       liveConnectionCount: counts[i] ?? 0,
     };

--- a/infra/cdk/lambda/room-lobby-cleanup.test.ts
+++ b/infra/cdk/lambda/room-lobby-cleanup.test.ts
@@ -26,6 +26,7 @@ import {
   clearLobbyCleanupPending,
   defaultHostDisconnectGraceMs,
   hasHostPresence,
+  maintainPublicLobbyOnHostConnect,
   markLobbyCleanupPendingIfLastHostGone,
   removeRoomFromPublicLobby,
   shouldExcludeFromLobby,
@@ -189,6 +190,55 @@ describe('room-lobby-cleanup async helpers', () => {
         kind: 'Update',
         input: expect.objectContaining({
           UpdateExpression: 'REMOVE #lpk, #lsk, #lca, #hld',
+        }),
+      }),
+    );
+  });
+
+  it('maintainPublicLobbyOnHostConnect re-indexes public rooms and clears grace fields', async () => {
+    mocks.docSend.mockResolvedValue({});
+    const nowMs = 1_700_000_000_000;
+
+    await maintainPublicLobbyOnHostConnect({
+      doc,
+      roomsTable: 'rooms',
+      roomId: 'room-1',
+      room: { visibility: 'public' },
+      nowMs,
+    });
+
+    expect(mocks.docSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'Update',
+        input: expect.objectContaining({
+          TableName: 'rooms',
+          Key: { roomId: 'room-1' },
+          UpdateExpression: 'SET #lpk = :lpk, #lsk = :lsk, #vat = :vat REMOVE #lca, #hld',
+          ExpressionAttributeValues: expect.objectContaining({
+            ':lpk': 'PUBLIC',
+            ':lsk': expect.stringContaining('room-1'),
+            ':vat': nowMs,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('maintainPublicLobbyOnHostConnect only clears grace fields for private rooms', async () => {
+    mocks.docSend.mockResolvedValue({});
+
+    await maintainPublicLobbyOnHostConnect({
+      doc,
+      roomsTable: 'rooms',
+      roomId: 'room-private',
+      room: { visibility: 'private' },
+    });
+
+    expect(mocks.docSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'Update',
+        input: expect.objectContaining({
+          UpdateExpression: 'REMOVE #lca, #hld',
         }),
       }),
     );

--- a/infra/cdk/lambda/room-lobby-cleanup.ts
+++ b/infra/cdk/lambda/room-lobby-cleanup.ts
@@ -1,5 +1,5 @@
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
-import { defaultStaleRoomMs } from './room-shared';
+import { defaultStaleRoomMs, lobbySortKey, LOBBY_PARTITION } from './room-shared';
 import { queryRoomPresenceItems } from './ws-shared';
 
 /** Grace period before a hostless public room is hidden from the lobby (default 90s). */
@@ -88,6 +88,47 @@ export async function clearLobbyCleanupPending(params: {
         ExpressionAttributeNames: {
           '#lca': 'lobbyCleanupAfter',
           '#hld': 'hostLastDisconnectedAt',
+        },
+      }),
+    )
+    .catch(() => undefined);
+}
+
+/**
+ * When the host reconnects over WebSocket: clear lobby grace fields and re-index public rooms
+ * whose `lobbyPk`/`lobbySk` were removed by the sweeper after a host disconnect.
+ */
+export async function maintainPublicLobbyOnHostConnect(params: {
+  doc: DynamoDBDocumentClient;
+  roomsTable: string;
+  roomId: string;
+  room: Record<string, unknown>;
+  nowMs?: number;
+}): Promise<void> {
+  const { doc, roomsTable, roomId, room } = params;
+  if (room.visibility !== 'public') {
+    await clearLobbyCleanupPending({ doc, roomsTable, roomId });
+    return;
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  await doc
+    .send(
+      new UpdateCommand({
+        TableName: roomsTable,
+        Key: { roomId },
+        UpdateExpression: 'SET #lpk = :lpk, #lsk = :lsk, #vat = :vat REMOVE #lca, #hld',
+        ExpressionAttributeNames: {
+          '#lpk': 'lobbyPk',
+          '#lsk': 'lobbySk',
+          '#vat': 'lastActivityAt',
+          '#lca': 'lobbyCleanupAfter',
+          '#hld': 'hostLastDisconnectedAt',
+        },
+        ExpressionAttributeValues: {
+          ':lpk': LOBBY_PARTITION,
+          ':lsk': lobbySortKey(nowMs, roomId),
+          ':vat': nowMs,
         },
       }),
     )

--- a/infra/cdk/lambda/webrtc-sfu-token.test.ts
+++ b/infra/cdk/lambda/webrtc-sfu-token.test.ts
@@ -333,6 +333,24 @@ describe('webrtc-sfu-token handler', () => {
     expect(body.code).toBe('unknown_session');
   });
 
+  it('grants host_screen when the host JWT is valid but the presence row lacks hostSub', async () => {
+    stubRoomAndPresence({
+      myConn: { fanSub: hostSub },
+    });
+    mocks.verifyAccessToken.mockResolvedValue({ sub: hostSub });
+
+    const res = await handler(
+      tokenEvent({
+        authorization: 'Bearer host-jwt',
+        body: { producerClass: 'host_screen' },
+      }),
+    );
+    expect(res.statusCode).toBe(200);
+    const body = parseBody(res);
+    expect(body.role).toBe('producer');
+    expect(body.producerClass).toBe('host_screen');
+  });
+
   it('returns not_host when a non-host requests host_screen', async () => {
     stubRoomAndPresence({ myConn: { fanSub } });
     mocks.verifyAccessToken.mockResolvedValue({ sub: fanSub });

--- a/infra/cdk/lambda/webrtc-sfu-token.ts
+++ b/infra/cdk/lambda/webrtc-sfu-token.ts
@@ -138,10 +138,6 @@ function fanSubFromConn(conn: JsonRecord): string {
   return typeof conn.fanSub === 'string' ? conn.fanSub.trim() : '';
 }
 
-function isHostConnection(conn: JsonRecord, roomHostSub: string): boolean {
-  return typeof conn.hostSub === 'string' && conn.hostSub === roomHostSub;
-}
-
 function checkParticipantMintRateLimit(fanSub: string): boolean {
   const now = Date.now();
   const windowMs = 60_000;
@@ -289,7 +285,8 @@ async function resolveGrant(
   const wantsParticipantAv = requested.includes('participant_av');
 
   if (wantsHostScreen) {
-    if (!isHostJwt || !isHostConnection(myConn, roomHostSub)) {
+    /** HTTP Authorization is authoritative; WS `$connect` may omit `hostSub` when the query JWT fails. */
+    if (!isHostJwt) {
       return {
         status: 403,
         code: 'not_host',
@@ -319,7 +316,7 @@ async function resolveGrant(
   }
 
   if (wantsParticipantAv) {
-    if (isHostJwt && isHostConnection(myConn, roomHostSub)) {
+    if (isHostJwt) {
       const avGrant = await resolveParticipantAvGrant(
         room,
         presenceTable,

--- a/infra/cdk/lambda/ws-connect-chat-system.test.ts
+++ b/infra/cdk/lambda/ws-connect-chat-system.test.ts
@@ -23,7 +23,7 @@ vi.mock('./cognito-jwt', () => ({
 }));
 
 vi.mock('./room-lobby-cleanup', () => ({
-  clearLobbyCleanupPending: vi.fn(async () => undefined),
+  maintainPublicLobbyOnHostConnect: vi.fn(async () => undefined),
 }));
 
 vi.mock('./ws-chat-system-shared', () => ({

--- a/infra/cdk/lambda/ws-connect.test.ts
+++ b/infra/cdk/lambda/ws-connect.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   docSend: vi.fn(),
-  clearLobbyCleanupPending: vi.fn(),
+  maintainPublicLobbyOnHostConnect: vi.fn(),
   broadcastRoomPresenceNow: vi.fn(),
   verifyAccessToken: vi.fn(),
 }));
@@ -24,7 +24,7 @@ vi.mock('./cognito-jwt', () => ({
 }));
 
 vi.mock('./room-lobby-cleanup', () => ({
-  clearLobbyCleanupPending: mocks.clearLobbyCleanupPending,
+  maintainPublicLobbyOnHostConnect: mocks.maintainPublicLobbyOnHostConnect,
 }));
 
 vi.mock('./ws-shared', () => ({
@@ -50,13 +50,13 @@ describe('ws-connect handler', () => {
     process.env.ROOM_PRESENCE_TABLE_NAME = 'presence';
     mocks.docSend.mockResolvedValue({});
     mocks.verifyAccessToken.mockResolvedValue({ sub: 'host-sub-1' });
-    mocks.clearLobbyCleanupPending.mockResolvedValue(undefined);
+    mocks.maintainPublicLobbyOnHostConnect.mockResolvedValue(undefined);
     mocks.broadcastRoomPresenceNow.mockResolvedValue(undefined);
   });
 
-  it('clears pending lobby cleanup when the host reconnects', async () => {
+  it('maintains public lobby index when the host reconnects', async () => {
     mocks.docSend.mockResolvedValueOnce({
-      Item: { hostSub: 'host-sub-1' },
+      Item: { hostSub: 'host-sub-1', visibility: 'public' },
     });
 
     await handler(
@@ -72,8 +72,12 @@ describe('ws-connect handler', () => {
       () => undefined,
     );
 
-    expect(mocks.clearLobbyCleanupPending).toHaveBeenCalledWith(
-      expect.objectContaining({ roomsTable: 'rooms', roomId: 'room-1' }),
+    expect(mocks.maintainPublicLobbyOnHostConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomsTable: 'rooms',
+        roomId: 'room-1',
+        room: expect.objectContaining({ hostSub: 'host-sub-1', visibility: 'public' }),
+      }),
     );
     expect(mocks.broadcastRoomPresenceNow).toHaveBeenCalledWith(
       expect.objectContaining({ roomId: 'room-1', except: 'conn-1' }),
@@ -82,12 +86,15 @@ describe('ws-connect handler', () => {
     const transact = mocks.docSend.mock.calls.find(
       (call) => (call[0] as { kind?: string }).kind === 'TransactWrite',
     )?.[0] as { input?: { TransactItems?: Array<{ Put?: { Item?: Record<string, unknown> } }> } };
+    const connPut = transact?.input?.TransactItems?.[0]?.Put?.Item;
     const presencePut = transact?.input?.TransactItems?.[1]?.Put?.Item;
+    expect(connPut?.hostSub).toBe('host-sub-1');
+    expect(presencePut?.hostSub).toBe('host-sub-1');
     expect(presencePut?.lastActiveAt).toEqual(expect.any(Number));
     expect(presencePut?.fanSub).toBe('host-sub-1');
   });
 
-  it('does not clear pending cleanup for guest connections', async () => {
+  it('does not maintain lobby cleanup for guest connections', async () => {
     mocks.verifyAccessToken.mockResolvedValue(null);
     mocks.docSend.mockResolvedValueOnce({
       Item: { hostSub: 'host-sub-1' },
@@ -105,7 +112,7 @@ describe('ws-connect handler', () => {
       () => undefined,
     );
 
-    expect(mocks.clearLobbyCleanupPending).not.toHaveBeenCalled();
+    expect(mocks.maintainPublicLobbyOnHostConnect).not.toHaveBeenCalled();
 
     const transact = mocks.docSend.mock.calls.find(
       (call) => (call[0] as { kind?: string }).kind === 'TransactWrite',

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
 import { verifyAccessToken } from './cognito-jwt';
-import { clearLobbyCleanupPending } from './room-lobby-cleanup';
+import { maintainPublicLobbyOnHostConnect } from './room-lobby-cleanup';
 import { fanOutChatSystem, isWithinJoinReconnectCooldown } from './ws-chat-system-shared';
 import { broadcastRoomPresenceNow, presenceDisplayNameForSession } from './ws-shared';
 
@@ -128,7 +128,9 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
   );
 
   if (hostSub) {
-    await clearLobbyCleanupPending({ doc: client, roomsTable, roomId }).catch(() => undefined);
+    await maintainPublicLobbyOnHostConnect({ doc: client, roomsTable, roomId, room }).catch(
+      () => undefined,
+    );
   }
 
   await broadcastRoomPresenceNow({

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -486,6 +486,7 @@ export class ApiCatalogStack extends cdk.Stack {
         ROOMS_TABLE_NAME: this.roomsTable.tableName,
         CONNECTIONS_TABLE_NAME: this.connectionsTable.tableName,
         ROOM_PRESENCE_TABLE_NAME: this.roomPresenceTable.tableName,
+        FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
         STALE_ROOM_MS: String(staleRoomMs),
         NODE_OPTIONS: '--enable-source-maps',
       },
@@ -499,6 +500,7 @@ export class ApiCatalogStack extends cdk.Stack {
     this.roomsTable.grantReadData(lobbyGetFn);
     this.connectionsTable.grantReadData(lobbyGetFn);
     this.roomPresenceTable.grantReadData(lobbyGetFn);
+    this.fanProfilesTable.grantReadData(lobbyGetFn);
 
     const lobbySweeperFn = new lambdaNodejs.NodejsFunction(this, 'LobbySweeperFn', {
       runtime: lambda.Runtime.NODEJS_24_X,


### PR DESCRIPTION
## Summary

Epic #257 on shared branch `feature/issue-257`:

### #260 (merged in prior commit)
- **`GET /v1/lobby`** batch-reads **FanProfiles** for each room's `hostSub`, returns **`hostDisplayName`**, omits rooms without a profile display name.
- **`/lobby`** renders **Hosted by {hostDisplayName}** below each row title.

### #239 (this commit)
- **`ws-connect`**: host `$connect` on public rooms calls **`maintainPublicLobbyOnHostConnect`** to restore **`lobbyPk`/`lobbySk`**, bump **`lastActivityAt`**, and clear grace fields after sweeper removal.
- **`webrtc-sfu-token`**: host **`host_screen`** grants trust HTTP JWT when presence rows lack **`hostSub`** (WS query JWT miss on reconnect).
- **Client**: **`ChatSession.updateAccessToken`** keeps refreshed fan JWT on automatic WS reconnect options.

## Test plan

- [x] `npm run test --prefix infra/cdk` (room-lobby-cleanup, ws-connect, webrtc-sfu-token)
- [x] `npm test --prefix apps/web`

Closes #239
Closes #260