### PR TITLE
docs(ai): riffsync chromecast watch party room contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -6,6 +6,7 @@ Business concepts and rules (language-agnostic). UI maps here via **`docs/archit
 
 - **Episode (catalog row):** a stable **`id`** and **`experimentNumber`**, MST-flavored **`title`/`era`**, YouTube linkage, enrichment from TMDB and optional YouTube thumb URL.
 - **Room:** shared viewing session on **`/room/:id`** with a **mutable current catalog episode** (**`catalogEpisodeId`** / **`videoId`** on the room document — seeded when the **signed-in** host creates the room, then changeable via **in-room picker**); the host (**room admin**) renders **embedded YouTube** for that selection and may **publish** a captured **`MediaStream`** to guests over **WebRTC**; guests consume that stream—**not** parallel iframe timelines kept in sync server-side. The room also carries **host-authoritative layout policy**: **`roomMode`** (**Theater** default | **Video Chat**) and **`avDisabled`** (room-wide participant A/V kill switch), both **durable** on the room document and returned on snapshot/join.
+- **Local Cast session:** optional per-viewer Chromecast viewing state for Cast-capable senders. It is **session-only** client state, entered only from the normal room view, and never persisted on the room document, replayed on join, or fanned out as room state. A local Cast session reuses the expanded-view stage-primary plus chat-overlay composition for the receiver while the sender remains joined as the same participant.
 - **Participant A/V (camera / microphone):** optional **signed-in fan** publish of **`getUserMedia`** streams over the same SFU path as host capture; **default off** until the fan explicitly enables each control. **Anonymous guests** may **subscribe** to participant A/V when **`avDisabled`** is false but **must not publish** participant camera or microphone. Participant A/V is **parallel** to host tab-capture movie broadcast—not a replacement for embed/capture lawful playback.
 - **Participant:** **`sessionId`** + display name (**anonymous**) or **`sub`** (**signed-in optional**) with optional **`avatarUrl`** (public HTTPS, one image per **`sub`**).
 - **Presence (online vs active):** every open room WebSocket connection holds a **RoomPresence** roster row. **Online** means the connection is live on the roster (connected participant). **Active** is a derived engagement signal: the participant had at least one **qualifying control-plane action** within the **active idle window** (**2 minutes**). Qualifying actions (union): **typing start**, **chat send**, **GIF post**, **reaction toggle**, and **qualifying ping** within the window. **Typing start** contributes to **active** (not display-only). Idle viewers who keep heartbeating remain **active** while pings continue inside the window. **`lastActiveAt`** (epoch seconds) is **durable on RoomPresence**, updated on each qualifying route; **`presence_request`** and roster fan-out **rehydrate active** for late joiners and refresh after reconnect. Clients derive **`active`** as **`now - lastActiveAt < 120s`** (or the server precomputes a boolean at broadcast time — tier TW in Phase D).
@@ -71,9 +72,10 @@ Three coexisting modes (see **`integration/authorization.md`**):
 4. **Room mode vs kill switch:** while **`avDisabled`** is true, the room behaves as **Theater-equivalent movie + text chat** (pre-initiative participant A/V behavior); **Video Chat** selection is **unavailable or inert** until A/V is re-enabled. Server enforces kill switch: deny new participant producer grants, tear down active participant producers, broadcast authoritative disabled state.
 5. **Theater layout:** shared **host movie stream** (tab-capture or embed-derived WebRTC) stays **primary** in the stage. A **vertical participant strip** immediately right of the video lists **video-on** participants only. **Microphone-only** participants are **audible** alongside movie audio but **not shown** in the strip. When a participant turns **camera off**, their strip tile **removes immediately** for all remotes; **mic-only** audio continues without a visual tile.
 6. **Video Chat layout:** the movie player region is **replaced** by a **grid of video-on participants** only. **Microphone-only** participants are **audible** but **not shown** in the grid (identity via People tab and chat). Camera-off removes grid tiles promptly; no frozen last-frame tiles. Entering **Video Chat** **fully stops** active host tab-capture (not suspend); returning to **Theater** requires the room admin to start **Share Source Tab** again.
-7. **Reconnect privacy:** after refresh or disconnect, each signed-in fan’s camera and microphone **default off**; the fan must manually re-enable.
-8. **Catalog title:** never replaced by TMDB **`title`** / **`original_title`**.
-9. **Public catalog read** does not require authentication.
+7. **Cast locality:** Chromecast is a viewer-local optional presentation. Cast start, stop, failure, unavailability, or receiver disconnect must not mutate **`roomMode`**, **`avDisabled`**, **`share_state`**, durable room playback fields, SFU permissions, host authority, participant roster authority, or any other participant's room experience.
+8. **Reconnect privacy:** after refresh or disconnect, each signed-in fan’s camera and microphone **default off**; the fan must manually re-enable.
+9. **Catalog title:** never replaced by TMDB **`title`** / **`original_title`**.
+10. **Public catalog read** does not require authentication.
 
 ## Decisions (answered)
 
@@ -218,9 +220,23 @@ Three coexisting modes (see **`integration/authorization.md`**):
 | **Speaking VAD** | Client **`AnalyserNode`**: **`fftSize` 512**, normalized RMS **≥ 0.02** enter, **150ms** attack smoothing, **300ms** hang before clear; no speaking when audio producer **`paused`**. |
 | **Mode transition empty-state** | **Video Chat** zero cameras: **`No cameras on yet. Mic-only participants are still audible.`** **Theater** before capture: host **Share Source Tab** prompt in stage chrome. After **3s** layout timeout: keep sparse copy — **do not** vary **Updating room layout…** by direction. |
 
+## Decisions (answered - Chromecast)
+
+| Question | Decision |
+| --- | --- |
+| Who does Cast affect? | **Only the viewer who starts it.** A room admin cannot Cast for everyone; if the admin starts Cast, it remains local to that admin sender and receiver. |
+| Is Cast a room mode or durable field? | **No.** Cast is session-only client state. It does not write the room document, alter **`roomMode`**, change **`share_state`**, or fan out over room WebSocket. |
+| Where can Cast start? | **Normal room view only** when sender support is available. Expanded view may provide the reusable presentation composition, but it is not a Cast entry point. |
+| What does the sender show while casting? | After confirmed Cast start, the normal stage replaces the regular video surface with **`Now Casting`** and a stop affordance. Chat, presence, sidebar state, and room membership remain intact. |
+| What does stop Cast do? | Stop returns the sender to normal in-page playback and the latest authoritative room snapshot/realtime state without clearing room session or chat state. |
+
 ## Open implementation decisions
 
-_(None for M23 #242 scope.)_
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### chromecast-local-cast-lifecycle
+- Define the local Cast status taxonomy for unavailable, start rejected, receiver disconnected, receiver playback blocked, and stop failed. These remain local playback states, not room-wide realtime drawer failures.
+- Define whether Cast start/stop produce local diagnostics or aggregate telemetry. If added, they must not imply room authority, room activity, or identify receiver devices.
 
 ## Decisions (theater mic mix on host_screen close — #145)
 

--- a/.ai/business_logic/error_state.md
+++ b/.ai/business_logic/error_state.md
@@ -32,6 +32,7 @@ User-visible and system-visible failure modes (catalog + room + embed).
 | **Presence roster stale after reconnect** | Brief **People** tab gap until **`presence_request`** completes; show existing roster or honest loading state — no crash. If roster refresh fails after reconnect, chat drawer shows recoverable status; SFU plane unaffected. |
 | **Video relay plane degraded** | **Separate** status surface (e.g. "Video relay reconnecting"); chat read/send may continue when chat plane is healthy; participant toggles reflect publish/consume errors per taxonomy below. |
 | **Theater playback blocked** | Inline honest copy when **AudioContext** suspend or autoplay blocks movie/mic mix; chat and SFU sessions may still be connected; user action may be required to resume audio (**client-side mix default**). |
+| **Cast unavailable or failed** | Local recoverable Cast status only. Keep normal in-page playback/chat/room participation available; do not leave the room, tear down healthy chat/SFU drawers, stop host share, mutate room state, or imply other participants are affected. |
 
 ## Auth — fan
 
@@ -152,8 +153,15 @@ When **`import.meta.env.DEV`** (or equivalent Vite dev flag), append **` (code: 
 
 ## Open implementation decisions
 
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### existing-room-errors
 - **Empty / transitional UX:** Video Chat zero-camera grid only (**`interface/presentation.md`** — centered sparse copy).
 - **Kill-switch toggle affordance:** visible-disabled with host explanation per **`presentation.md`** (resolved).
+
+### chromecast-local-errors
+- Define stable local Cast error/status codes and copy for unsupported sender, no receiver available, user-canceled start, receiver disconnect, receiver playback blocked, and stop failure.
+- Decide whether Cast failures use a stage-local status line, room action status, or inline alert. The surface must not merge with chat drawer or video-relay drawer health.
 
 ## Primary code pointers (optional)
 

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -49,6 +49,7 @@ MVP slice derived from **`vision.json`** + **`README.md`** — prioritized for s
 | US-P1-03 | fan | federated login (e.g. Facebook) | I can **host** rooms and retain continuity across devices |
 | US-P1-04 | operator | admin catalog + lists | I can curate without editing raw JSON in prod (**depends on US-P1-05**) |
 | US-P1-06 | signed-in fan in room | my **active** badge to persist across brief reconnects when I was recently engaged | late joiners and refresh see accurate engagement state on **People** |
+| US-P1-07 | Cast-capable room viewer | start a viewer-local Cast session from normal room view | I can watch the party on a TV while continuing to chat from my sender device |
 
 ## Out of scope (MVP)
 
@@ -65,6 +66,7 @@ MVP slice derived from **`vision.json`** + **`README.md`** — prioritized for s
 - **Server-side theater audio mixing** (client-side Web Audio mix remains default until follow-on initiative)
 - **Supplementary mic-only stage chrome** (avatar chips, audible-only tile badges) — speaking on **People** rows only for mic-only
 - **Guest join/leave system lines** (signed-in fans only; anonymous guests connect silently)
+- Room-wide Chromecast or host-controlled casting for all participants (Cast is viewer-local only)
 
 ## Decisions (answered — realtime hardening)
 
@@ -92,8 +94,14 @@ MVP slice derived from **`vision.json`** + **`README.md`** — prioritized for s
 
 ## Open implementation decisions
 
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### existing-room-polish
 - **Video Chat empty grid:** copy and layout when **no participant has camera on** (placeholder vs audio-only affordance).
 - **Kill switch control affordance:** participant camera/mic toggles **visible but disabled** with short explanation vs hidden when **`avDisabled`** is true (accessibility vs minimal chrome).
+
+### chromecast-watch-party-room
+- Break the Cast-capable viewer story into issue-sized delivery slices for availability gating, Cast start, sender `Now Casting` state, Stop Cast recovery, and fallback handling.
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -106,6 +106,7 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 | Theater participant audio? | **Client-side mixing** — consumers attach multiple SFU audio consumers (host movie + participant mics); no server-side mixer in MVP. |
 | Video Chat vs host screen? | Clients **stop consuming** host screen producer in **`videoChat`** mode; host **fully stops** tab-capture on enter (resume requires **Share Source Tab** again). |
 | Client vs CDK mesh retirement order? | **#134** removes SPA mesh handlers and modules first; **#135** removes API Gateway **`signaling`** route. After **#134** the SPA ignores inbound **`signaling`** envelopes; orphaned route is harmless until **#135**. |
+| Chromecast room API? | **None.** Viewer-local Cast state does not add HTTP fields, WebSocket routes, `share_state` payload fields, SFU token claims, lobby fields, or room snapshot fields. |
 
 ## Decisions (answered — #101 HTTP room AV)
 

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -55,6 +55,7 @@ Who may do what, and how identity is represented. Aligns with **`docs/architectu
 - **Room-admin authority:** only **`JWT.sub === room.hostSub`** may mutate authoritative playback metadata, **`roomMode`**, **`avDisabled`**, host tab-capture lifecycle, and host-only WebSocket control actions.
 - **Participant publish:** signed-in non-host fans and the host (when using participant toggles) may publish **participant A/V** only; never room-admin playback or layout fields.
 - **AV kill switch (server-enforced):** when **`avDisabled`** is true, deny new participant producer SFU tokens, tear down active participant producers on the SFU, and broadcast authoritative disabled state; room reverts to movie + text chat (no participant A/V publish or consumption).
+- **Viewer-local Cast:** starting, stopping, or failing a Cast session does not grant room-admin authority, does not require host status, and does not change fan/guest chat or SFU permissions. Any connected participant may use local Cast when their browser/device supports it, subject to the same room access they already have.
 - **Moderation:** target **`sessionId`** / **`connectionId`** for anonymous guests; **`sub`** for signed-in hosts (**`docs/architecture.admin.md`**).
 - **Principle:** never require an IdP to **browse catalog**, **join**, **watch**, or **read** room chat; **do** require **fan JWT** to **send** chat (text/emoji/GIF), **react**, **upload avatar**, **publish participant A/V**, or **host**.
 
@@ -70,6 +71,7 @@ Who may do what, and how identity is represented. Aligns with **`docs/architectu
 | Who may publish participant camera/mic? | **Signed-in fans only** (**fanSub** on connection); anonymous guests **subscribe-only** for participant A/V. |
 | AV kill switch enforcement? | **Server-enforced** — deny SFU participant producer tokens, tear down active participant producers, broadcast **`avDisabled`**; not client-cooperative-only. |
 | Host participant A/V while screen sharing? | **Allowed** — host may publish **participant A/V** alongside **host screen** (two video sources on the same SFU router). |
+| Chromecast authority? | **No new authority tier.** Cast is local to the sender/receiver and does not mutate room state or authorize room-wide actions. |
 
 ## SFU join token claims (`SfuJoinClaims`)
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -10,6 +10,15 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 | **Guest viewing** | **WebRTC** **`MediaStream`** from host tab-capture and, when enabled, **participant A/V** over **self-hosted mediasoup SFU** on **`RiffSyncTurn`** — **`POST /v1/webrtc/sfu-token`** + **coturn**. | **SFU mandatory in all environments** (dev, CI, production). **Mesh WebRTC removed.** Multi-producer registry (host screen + N participant cameras/mics). Theater audio mixing is **client-side** (server-side mix **deferred**). Honor browser permission and autoplay policies. |
 | **Thumbnails (optional)** | **`https://img.youtube.com/vi/{id}/{hqdefault|maxresdefault|…}.jpg`** | Reconcile job **`HEAD`** fallback chain; persist resolved URL on catalog row (**`docs/architecture.catalog-images.md`**). No YouTube Data API required for thumbs. |
 
+## Google Cast / Chromecast
+
+| Use | Mechanism | Contract |
+| --- | --- | --- |
+| **Viewer-local Cast** | Browser sender capability detection plus a supported Cast sender/receiver path. Exact SDK calls, receiver application shape, and media/source binding are implementation details. | Optional and availability-gated. Cast entry appears only in normal room view when sender support is present. Cast failure or unavailability leaves normal inline playback/chat/room participation intact. |
+| **Cast presentation** | Reuses the expanded-view composition model: stage-primary/video plus chat overlay, without the sidebar tab strip. | Presentation is local to the sender/receiver pair. It does not create a room-wide Cast mode, change what other participants see, or grant host/admin authority. |
+
+**Boundary:** Cast state is not written to RiffSync HTTP APIs, not sent over the room WebSocket, not represented in **`share_state`**, and not used for SFU token authorization. If a future custom receiver joins RiffSync services directly, that is a new integration/auth review rather than an implied part of this contract.
+
 ## TMDB (The Movie Database)
 
 | Use | Mechanism | Contract |
@@ -82,6 +91,7 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 | Record sessions to S3? | **No** MVP — **no** server-side recording of WebRTC as default product posture; future lawful backends remain pluggable. |
 | Mesh dev fallback? | **No** — SFU + TURN in all environments; mesh removed. |
 | Server-side theater audio mix? | **Deferred** — client-side Web Audio remains default (**`api_contracts.md`**). |
+| Chromecast boundary? | **Viewer-local only.** Optional sender/receiver integration; no room API, WebSocket fan-out, `share_state`, or room-authority change. |
 
 ## Decisions (local disposable profile — #136)
 
@@ -103,6 +113,17 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 | **SFU join JWT** | Harness mints join tokens **in-process** via **`signSfuJoinToken`** (**`infra/cdk/lambda/sfu-join-token-sign.ts`**) using bootstrap **`SFU_JWT_SECRET`** — payload shape matches prod **`SfuJoinClaims`**. |
 | **Fan Cognito JWT** | **Not required** for MVP harness scenarios — room WS stub accepts connections without API Gateway authorizer emulation. |
 | **ICE credentials** | Static-auth coturn credentials from **`infra/local-media/`** fixture config — **no** prod **`GET /v1/webrtc/ice`** call in CI. |
+
+## Open implementation decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### chromecast-provider-boundary
+- Decide the Cast source architecture: rendered RiffSync receiver page, native YouTube Cast path where available, sender media element/stream Cast, tab mirroring guidance, or another supported Cast mechanism.
+- Validate whether guest inbound **`MediaStream`** playback can be cast directly, requires screen/tab mirroring, or needs a receiver that reconnects to RiffSync media services.
+- Determine sender support detection gates before rendering **Cast to TV**, including browser API availability, HTTPS/origin requirements, receiver availability state, and provider failure states.
+- Identify Google Cast receiver registration, application ID, origin allowlist, CSP, iframe, and YouTube policy requirements.
+- If a custom receiver joins room services directly, define receiver identity, room access, and SFU subscribe authorization before implementation.
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/messaging_async.md
+++ b/.ai/integration/messaging_async.md
@@ -19,6 +19,7 @@ Scheduled work, durable events, and side effects that are not synchronous reques
 - **Typing fan-out:** **`typing_start`** broadcasts a room-wide **`typing`** envelope (who is composing); **`typing_stop`** clears that sender's typing flag. Multiple concurrent typers are allowed. Typing state is **not** stored in Dynamo — reconnect clears local typing UI until a new **`typing_start`** arrives.
 - **Join/leave fan-out:** on **RoomPresence** row create/delete for connections with **`fanSub`**, emit ephemeral **`chat_system`** (**`join`** \| **`leave`**) to room members. Guest connections (no **`fanSub`**) produce **no** join/leave line.
 - **Room layout and AV control:** **`roomMode`** and **`avDisabled`** are **durable on the room item** via host **`PATCH`**, then **`room-patch` Lambda** **`PostToConnection`** to all connections in **`roomId`** (#103). **No inbound WebSocket routes** for these fields (contrast **`share_state`**, which is ephemeral fan-out over WS). Late joiners read authoritative values from room snapshot/join; realtime events cover connected clients.
+- **Viewer-local Cast:** Cast start, active, stop, unavailable, and failure state is **not** fan-out traffic. It is not a room WebSocket route, not a **`share_state`** variant, not a durable event, and not replayed to late joiners.
 - **`share_state: stopped` side effects:** ephemeral fan-out only. **Guests detach `host_screen` consumers**; **must not** trigger full SFU session teardown or participant A/V consumer removal. Host unpublishes **`host_screen`** locally. See **`api_contracts.md`** (Realtime hardening).
 - **Chat vs SFU lifecycle decoupling:** room WS reconnect, disconnect, and **`share_state`** handlers **must not** call SFU session **`close()`** without explicit media policy. Chat send failures (**`CHAT_SEND_DROPPED`**) are independent of SFU health when room WS is up. SFU signaling outage **must not** block outbound **`chat`**, **`chat_gif`**, or **`react`** when room WS is **`open`** (**#149**). Each drawer reconnects independently (**`api_contracts.md`**).
 - **AV kill switch side effects:** when **`avDisabled`** becomes true, control plane broadcasts disabled state; SFU integration must **tear down participant producers** (participant class only — not host screen share). Token mint denial prevents re-publish until re-enabled.
@@ -39,6 +40,7 @@ Scheduled work, durable events, and side effects that are not synchronous reques
 | Chat reconnect tears down SFU? | **No** — orthogonal drawer lifecycles; room WS recovery must not close SFU session without media policy. |
 | `share_state: stopped` tears down SFU for guests? | **No** — **`host_screen` consumer detach only**; preserve SFU session and **`participant_av`**. |
 | Chat outbound retry before **`CHAT_SEND_DROPPED`**? | **No retry queue** — first failed send while chat plane unavailable emits **`CHAT_SEND_DROPPED`** (**#140** / **`api_contracts.md`**). |
+| Cast fan-out? | **No.** Cast is local client state and never posted to room members. |
 
 ## Decisions (answered — presence and AV maturity)
 

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -44,6 +44,14 @@ Accessible-by-default contract for presentation and interaction surfaces.
 - Each toggle's error text is referenced by **`aria-describedby`** when publish fails; errors clear when the user successfully enables or dismisses via a successful retry.
 - Stable **`code`** values and copy templates live in **`error_state.md`** (**Participant A/V error taxonomy**).
 
+### Chromecast Cast status
+
+- **Cast to TV** and Stop Cast are semantic controls with visible labels or accessible names.
+- The sender's **`Now Casting`** state is perceivable as text, not color/icon-only, and associated with the Stop Cast control.
+- Cast-active status uses a visible stage-local **`role="status"`** or equivalent polite live region. It must not duplicate chat drawer or video-relay drawer reconnect announcements.
+- Cast failure/unavailable copy is readable by assistive technology at the local Cast surface and must not imply that the room, host share, chat, or other participants failed.
+- The Cast receiver presentation reuses the expanded-view composition model. If chat overlay content is rendered on the receiver, it remains readable presentation only; chat input and authenticated send affordances remain on the sender.
+
 ### Keyboard verification matrix (#106)
 
 | Surface | Requirement |
@@ -66,7 +74,15 @@ Accessible-by-default contract for presentation and interaction surfaces.
 
 ## Open implementation decisions
 
-- **`THEATER_AUDIO_SUSPENDED` a11y:** whether resume uses implicit gesture only or a keyboard-focusable explicit control with accessible name (pairs with **`presentation.md`** theater audio TW item).
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### existing-room-accessibility
+- **`THEATER_AUDIO_SUSPENDED` a11y:** whether resume uses implicit gesture only or a keyboard-focusable explicit control with accessible name (pairs with **`presentation.md`** theater audio item).
+
+### chromecast-accessibility
+- Choose the exact `role="status"` / `aria-live` placement for local Cast starting, active, failed, and stopped states.
+- Define accessible names and descriptions for Cast start/stop controls, including whether the current receiver/device name is exposed or omitted for privacy.
+- Define focus recovery after failed start, successful stop, and receiver disconnect.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -67,6 +67,24 @@ Keyboard, pointer, and permission input contract for room and catalog surfaces.
 - **Not offered < 992px:** toggle absent or **`aria-hidden`** / inert — no expanded keyboard path on narrow viewports in MVP.
 - **Implementation:** the overlay reuses the chat plane without rendering `.riffsync-room-page__tabs`; standard sidebar tabs return immediately after exit.
 
+## Chromecast Cast controls
+
+- **Cast to TV** is keyboard-operable when rendered and appears only in normal room view after sender support is detected.
+- Expanded view must not expose a Cast start control in the tab order. If implementation leaves a Cast affordance mounted for layout reasons, it is inert and unavailable to assistive technology while expanded.
+- During Cast start, focus remains stable unless the implementation moves focus to a visible local status region. Failed start returns focus to the Cast entry or nearby room action surface.
+- After successful Cast start, the sender's stage exposes a keyboard-reachable stop control associated with the **`Now Casting`** state.
+- Stop Cast activation by click, **Enter**, or **Space** returns the sender to normal in-page playback without trapping focus or moving focus into a hidden video surface.
+- Chat compose, jump-to-latest, sidebar tabs, and participant A/V toggles keep their existing keyboard paths while local Cast is active.
+
+## Open implementation decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### chromecast-input-handling
+- Define whether focus moves to Stop Cast after successful start, returns to **Cast to TV** after stop, or remains on the activating control until the user moves it.
+- Define keyboard and pointer behavior for the expanded-view toggle while local Cast is active.
+- Define touch target placement and hit area for Cast start/stop on narrow normal-view layouts if Cast is supported there.
+
 ## Primary code pointers (optional)
 
 - **`apps/web/src/pages/RoomPage.tsx`** — thin shell; AV toggles and host bar extend existing chat-column and stage handlers.

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -112,6 +112,17 @@ When the host starts screen-share and guests receive authoritative **`share_stat
 
 Implementation note: the expanded toggle is client-local React state in `RoomPage.tsx`; no room snapshot patch or WebSocket fan-out is sent when a viewer enters or exits expanded view.
 
+### Chromecast Cast flow (local UI)
+
+1. **Availability gate:** In normal room view, a Cast-capable sender may see **Cast to TV** after local sender support is detected. Unsupported or unavailable Cast never blocks the normal stage, chat, expanded view, or room controls.
+2. **Expanded-view exclusion:** Expanded view does not expose Cast entry. A viewer starts Cast from normal room view; the implementation may reuse expanded-view composition internally without toggling the sender into expanded view.
+3. **Start Cast:** Activating **Cast to TV** begins a local Cast start attempt. The sender keeps the normal room session joined and chat usable during the attempt.
+4. **Successful start:** Only after Cast start is confirmed, the sender's normal stage replaces the regular video surface with **`Now Casting`** plus a stop affordance. Other participants receive no room event and see no change.
+5. **Receiver presentation:** The TV presentation follows the expanded-view composition model: stage primary/video plus chat overlay, no sidebar tab strip.
+6. **Chat while casting:** Chat send/read/reaction/GIF behavior follows the same signed-in and anonymous rules as normal room view; Cast state must not block chat when the chat plane is healthy.
+7. **Stop Cast:** Stop, receiver disconnect, or equivalent ended-session signal returns the sender to normal in-page playback. Room session, chat state, selected sidebar tab, and latest authoritative room state remain intact.
+8. **Failure / unavailable:** Start rejection, platform policy block, receiver loss before active Cast, or unsupported sender state returns to normal in-page playback with local recoverable status only. Do not leave the room, reset chat, or tear down healthy SFU/video relay state.
+
 ### Presence, typing, and People badges
 
 1. **Roster on join:** Client sends **`presence_request`** after room WebSocket connect; server returns **`presence`** roster (with **`lastActiveAt`** / **`active`**) and requester-only **`chat_history`** (capped durable messages — **excludes** ephemeral join/leave system lines).
@@ -199,7 +210,13 @@ Mesh-only strings (**`negotiating_ice`**, **`recovering_ice`**, **`Establishing 
 
 ## Open implementation decisions
 
-_(None for M23 #242 scope.)_
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### chromecast-interaction-flow
+- Specify Cast start transition ordering: detect support, set local starting state, attempt Cast, and swap to **`Now Casting`** only after confirmed success.
+- Specify failed start behavior: reset to idle or failed, keep normal playback visible, keep chat draft/session state intact, and expose a retryable local error.
+- Specify Stop Cast behavior for sender stop, receiver disconnect, SDK-ended events, room leave, route change, and reload.
+- Define behavior when a user attempts to enter expanded view while local Cast is active.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -214,9 +214,23 @@ When **iOS Safari** (iPad and iPhone) opens the **software keyboard** on **`/roo
 | **Host control bar** | **Remains below the stage** in expanded and standard layouts (host-only). |
 | **State** | **Session-only** client state — **no** `localStorage` persistence; full reload returns to **standard** layout. |
 | **Drawers** | Chat and video-relay drawer status rules **unchanged** — chat banner lives inside the overlay; video-relay status stays on the stage playback surface. |
-| **Chromecast (future)** | Implement expanded layout as a **reusable shell** (stage-primary + chat overlay) suitable as a future Cast receiver target. **No** Cast SDK or receiver work in #259. |
+| **Chromecast composition** | The expanded layout's **stage-primary + chat overlay** shell is the presentation model for optional viewer-local Cast. Cast work reuses this model without making expanded view itself the Cast entry point. |
 
 Implementation: `RoomPage.tsx` owns session-only expanded state, `RoomPageSidebar.tsx` renders the shared chat plane as either sidebar or overlay, and `StageParticipantLayout.tsx` renders Theater cameras in a bottom horizontal row (standard and expanded desktop layouts).
+
+### Chromecast Cast view (viewer-local)
+
+Optional Chromecast support is a local room presentation layer for Cast-capable senders. It is **not** a room mode, not host-authoritative, and not visible to other participants unless they independently Cast from their own device.
+
+| Concern | Contract |
+| --- | --- |
+| **Availability** | Show **Cast to TV** only in **normal room view** when sender support is detected. Cast entry is hidden or inert in expanded view. Missing support must not block normal playback, chat, expanded view, host controls, or room participation. |
+| **Start point** | Cast starts from the standard stage/sidebar room layout only. The sender does not need to enter expanded view before starting Cast. |
+| **Receiver presentation** | Reuse the expanded-view composition model: stage primary/video plus bottom-right chat overlay. The Cast presentation does **not** include the sidebar tab strip; **People**, **Room**, and **Profile** remain sender-side room surfaces. |
+| **Sender active state** | After confirmed Cast start, the sender's normal stage replaces the regular video/playback surface with **`Now Casting`** and a stop affordance. The regular in-page video surface does not remain visible while local Cast is active. |
+| **Chat while casting** | Sender chat remains interactive under existing rules: signed-in fans may send text, GIFs, and reactions when chat is healthy; anonymous guests may read and retain the sign-in gate for send. |
+| **Stop Cast** | Stop returns the sender to normal in-page playback without clearing chat scrollback, compose state, selected sidebar tab, presence, room membership, or authoritative room snapshot state. |
+| **Failure / unavailable** | Cast unavailable, blocked, rejected, or failed start surfaces honest local status and leaves normal in-page playback/chat intact. It never implies the room failed or that other participants changed state. |
 
 ## Accessibility & motion (baseline)
 
@@ -277,8 +291,18 @@ Implementation: `RoomPage.tsx` owns session-only expanded state, `RoomPageSideba
 
 ## Open implementation decisions
 
-- **Theater audio resume control:** persistent **Enable party audio** chrome when **`THEATER_AUDIO_SUSPENDED`** — deferred; #140 uses implicit gesture resume per **`execution_model.md`**.
-- **Telemetry / UX story event names** for layout transition timeout — deferred; per-drawer reconnect and tile lifecycle client log **`event`** names are normative in **`operations/observability.md`** Decisions (#157); not #150.
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### existing-room-polish
+- **Theater audio resume control:** persistent **Enable party audio** chrome when **`THEATER_AUDIO_SUSPENDED`** — deferred; current room runtime uses implicit gesture resume per **`execution_model.md`**.
+- **Telemetry / UX story event names** for layout transition timeout — deferred; per-drawer reconnect and tile lifecycle client log **`event`** names are normative in **`operations/observability.md`** Decisions.
+
+### chromecast-presentation
+- Decide the exact normal-view placement for **Cast to TV** within existing room chrome.
+- Decide whether unavailable Cast is hidden only, disabled with explanatory text, or shown after a failed support check.
+- Define the Cast-active stage details: visible heading/copy beyond **`Now Casting`**, stop action priority, and coexistence with existing video-relay status.
+- Define whether Cast-active mode hides the expanded-view toggle or leaves it inert with explanation while the normal stage is replaced by **`Now Casting`**.
+- Define exact Cast recovery/status copy beyond the settled labels **Cast to TV**, **`Now Casting`**, and stop wording.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -36,6 +36,19 @@ Extract three runtime modules with **explicit lifecycle APIs** and **no cross-dr
 | **`SfuMediaSession`** | Direct **SFU signaling WebSocket** per tab (**one session per tab**): ICE/TURN attach, **mandatory per-`producerClass` send transport isolation** (**`host_screen`** and **`participant_av`** each own a send transport within the same signaling socket), mediasoup produce/consume, per-kind unpublish (**#143** / **#144**), **`newProducer`** / **`producerClosed`** dispatch to subscribers. **No** session-level **`close()`** for class-scoped failures — partial unpublish and transport recovery only. | Close room WebSocket or block chat send on SFU failure. |
 | **`TheaterPlayback`** | YouTube iframe lifecycle, **client-side Web Audio** mix graph (host movie audio + **`participant_av`** audio consumers at equal gain **1.0**), **`AudioContext`** suspend/resume policy. | Own SFU signaling socket; must subscribe to **`SfuMediaSession`** for consumer attach/detach. |
 
+### Local Cast controller
+
+Chromecast runtime state belongs to the room shell as a **client-local controller**, not to **`ChatSession`**, **`SfuMediaSession`**, or **`TheaterPlayback`**. It may coordinate with presentation and media/source helpers, but it must not become a drawer in **`RoomRealtimeSdk.getDiagnostics()`** unless a later contract explicitly adds a Cast diagnostics surface.
+
+| Concern | Contract |
+| --- | --- |
+| **State scope** | Per browser tab, session-only; no room document persistence, `localStorage`, room WebSocket fan-out, or SFU token claim. |
+| **Entry gate** | Start only from normal room view after sender support is detected. Expanded view is not a valid start point. |
+| **Start transition** | Keep the normal in-page video visible until Cast start succeeds. Swap the sender stage to **`Now Casting`** only after confirmed success. |
+| **Active state** | While active, the sender remains joined to the room and chat stays controlled by **`ChatSession`**. Cast active state must not close healthy chat or SFU sessions. |
+| **Stop / failure** | Stop, unavailable, rejected start, receiver disconnect, route leave, or reload converges on local cleanup and returns to normal in-page playback without clearing room session or chat state. |
+| **Authority** | Cast state never changes **`roomMode`**, **`avDisabled`**, **`share_state`**, host screen publishing, participant A/V publish eligibility, or other participants' presentation. |
+
 ### Application SDK surface (narrow public API)
 
 Room code outside these modules calls only:
@@ -137,6 +150,7 @@ Each module implements the four drawer lifecycle states. Internal enums may diff
 | SFU signaling **`close`** alone | Room WS **`disconnect()`**, chat log clear |
 | **`share_state: stopped`** | Full SFU session close; participant AV producer teardown |
 | Chat send failure | SFU reconnect or unpublish |
+| Cast failure / stop | ChatSession teardown, SfuMediaSession teardown, host **`share_state`** mutation, room leave, or participant A/V policy change |
 
 ### Decouple destructive hooks (room WebSocket → media)
 
@@ -393,7 +407,17 @@ M18 hardening enforces the #140 transition tables in live React wiring. Normativ
 
 ## Open implementation decisions
 
-- **Harness extension (M24)** — **`realtime-conformance`** steps for typing routes, **`lastActiveAt`** / **active** fan-out after **`presence_request`**, and drawer-isolation matrix extensions documented in **`.ai/operations/observability.md`** (**#243**).
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### existing-realtime-harness
+- **Harness extension** — **`realtime-conformance`** steps for typing routes, **`lastActiveAt`** / **active** fan-out after **`presence_request`**, and drawer-isolation matrix extensions documented in **`.ai/operations/observability.md`**.
+
+### chromecast-runtime-controller
+- Define the Cast controller home and public shape, likely a room-shell hook or module owned near `RoomPage` rather than existing realtime session modules.
+- Choose local lifecycle states exposed to UI and diagnostics, such as unavailable, idle, starting, casting, stopping, failed, and receiver disconnected.
+- Decide source binding for the expanded-view-like Cast presentation: hidden/offscreen reusable shell, receiver reconstruction, media element/stream Cast, or provider-native path.
+- Decide playback element behavior while casting: mounted but hidden, detached, or replaced by Cast placeholder without violating **`TheaterPlayback`** cleanup rules.
+- Decide Cast-specific test hooks or diagnostics without overloading `getDiagnostics().drawers.*` unless a later contract adds a Cast drawer.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/lifecycle_shutdown.md
+++ b/.ai/runtime/lifecycle_shutdown.md
@@ -12,6 +12,8 @@ Realtime modules (**`ChatSession`**, **`SfuMediaSession`**, **`TheaterPlayback`*
 | **`share_state: stopped`** (guest) | **unchanged** | **Partial:** detach **`host_screen`** consumers only; **keep** session + **`participant_av`** | Remove host-screen audio node from mix; **keep** participant mic nodes |
 | **`avDisabled`** | **unchanged** (chat may continue) | Stop participant AV per kill-switch | Remove participant audio from mix |
 
+Local Cast state follows the same independence rule: Cast stop, failure, or receiver disconnect clears local Cast resources and sender **`Now Casting`** UI only. It must not tear down **`ChatSession`**, **`SfuMediaSession`**, or **`TheaterPlayback`** unless the user also leaves the room or another explicit media policy applies.
+
 ## Typing and active teardown (`ChatSession`)
 
 | Trigger | Contract |
@@ -52,6 +54,13 @@ Realtime modules (**`ChatSession`**, **`SfuMediaSession`**, **`TheaterPlayback`*
 - **Theater audio:** Multiple SFU audio consumers (host movie + participant mics) mixed **client-side** via **Web Audio API** at **equal gain (1.0)** — no automatic ducking in MVP. Kill switch on stops subscribing to participant audio and tears down participant consumers.
 - **Kill switch mid-publish:** On authoritative **`avDisabled`** room WebSocket event, immediately **`track.stop()`** on local **`getUserMedia`**, close participant producers, and tear down participant AV consumers locally — do **not** wait for SFU token expiry.
 
+## SPA local Cast
+
+- **Stop Cast:** user stop, receiver disconnect, sender SDK-ended event, or stop failure all converge on one best-effort cleanup path that clears local Cast-active UI and returns to normal in-page playback.
+- **Room leave / navigate / reload:** clear local Cast state and release Cast/source resources best-effort before or alongside global room teardown. Failure to stop an already-ended receiver session must not block room leave.
+- **Cast start failure:** restore or keep normal in-page playback visible, keep chat draft/session state intact, and avoid closing healthy chat or SFU drawers.
+- **Expanded view state:** Cast starts only from normal view. If stale expanded-view local state exists internally, cleanup must not re-enter expanded view after Cast stop unless a later interface contract permits it.
+
 ## Participant A/V errors (client)
 
 | Condition | UX |
@@ -82,6 +91,15 @@ Realtime modules (**`ChatSession`**, **`SfuMediaSession`**, **`TheaterPlayback`*
 | Topic | Decision |
 | --- | --- |
 | **`typing_stop` on tab close** | Browser **`beforeunload`** may emit **`typing_stop`** best-effort only; authoritative clear is server **`$disconnect`** (removes typing fan-out state) plus client teardown. |
+
+## Open implementation decisions
+
+Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### chromecast-lifecycle-shutdown
+- Specify cleanup ordering for user stop, receiver disconnect, sender SDK-ended event, route change, reload, and room teardown.
+- Decide whether stop failure keeps **`Now Casting`** visible with retry, returns to normal playback with warning, or attempts a second best-effort cleanup.
+- Define how Cast cleanup coordinates with hidden or detached playback/source elements without leaking media handles.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/startup_bootstrap.md
+++ b/.ai/runtime/startup_bootstrap.md
@@ -16,6 +16,7 @@
 - **Media API separation:** Host lawful movie path uses **`getDisplayMedia`** (tab capture). Participant AV uses **`getUserMedia`**. Never substitute one for the other.
 - **Reconnect:** After refresh or disconnect, participant camera and microphone default **off**; fan must re-enable manually (privacy-first). **Drawer-independent:** room WS reconnect does not reset SFU session (and vice versa) unless that drawer failed — healthy module stays **`connected`**.
 - **Anonymous guests:** Subscribe-only for participant AV; no **`getUserMedia`** publish bootstrap. Attach participant AV SFU consumers **eagerly** after room snapshot + WebSocket open when **`avDisabled === false`**.
+- **Local Cast detection:** Chromecast sender support detection is optional and runs after the normal room shell can render. Missing Cast support or Cast SDK load failure must not block room snapshot, chat join, SFU bootstrap, normal playback, expanded view, or host controls.
 - **General:** read **`sessionId`** / display name from **localStorage**; configure API Gateway **WebSocket URL** + HTTP **API base URL** from build-time env (**`architecture.frontend.md`**). **Production** SPA canonical page origin is **`https://riffsync.tv`** (**`.ai/runtime/configuration.md`**, **`.ai/project.json`** **`public_domain`**).
 - **Fan auth:** Hosted UI + PKCE on **`/auth/callback`**; fan tokens in the fan **localStorage** namespace; fan refresh and API attachment independent of staff.
 
@@ -55,6 +56,7 @@ Developers **cannot** exercise watch-party media without a running SFU (+ TURN w
 | Roster GSI race on participant token? | Reuse **`SfuMediaSession`** backoff — suppress user-visible token error for roster **403** on attempts **1–3** (same as host/guest race handling). |
 | Mesh vs SFU local? | **SFU only.** Mesh removed. Local + CI use disposable SFU + TURN profile (above). |
 | Drawer reconnect? | **Independent** — bootstrap/reconnect loops are per module; see **`execution_model.md`**. |
+| Cast bootstrap? | **Post-render optional detection.** Cast availability gates only the local **Cast to TV** affordance; it is not part of the required room bootstrap chain. |
 
 ## Decisions (local media bootstrap — #136)
 


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** riffsync-chromecast-watch-party-room
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and cross-repo coherence before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.