### PR TITLE
[M25] Expose Cast availability in normal room view (#272)

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -58,6 +58,10 @@ vi.mock('../config/publicOrigin', () => ({
   getPublicOrigin: () => 'https://www.test.example',
 }))
 
+vi.mock('../room/cast/useCastAvailability', () => ({
+  useCastAvailability: () => 'checking',
+}))
+
 vi.mock('../session/guestSession', () => ({
   ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
   setGuestDisplayName: (name: string) => name,

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -29,6 +29,7 @@ import { RoomPageSidebar } from '../room/RoomPageSidebar'
 import { RoomRenameModal } from '../room/RoomRenameModal'
 import { RIFFSYNC_SFU_CONFIG_ALERT_ID } from '../room/drawerErrorPresentation'
 import type { RoomSidebarTab } from '../room/roomPageTypes'
+import { useCastAvailability } from '../room/cast/useCastAvailability'
 
 export function RoomPage() {
   const { roomId: roomIdParam } = useParams<{ roomId: string }>()
@@ -226,6 +227,10 @@ export function RoomPage() {
 
   const activeSidebarTab =
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
+  const castAvailability = useCastAvailability(Boolean(room))
+  const onCastToTvClick = useCallback(() => {
+    /* Cast start is implemented in #273. */
+  }, [])
   const viewportWide = useViewportWide()
   const expandedViewActive = expandedView && viewportWide
   const { setExpandedViewActive } = useRoomChrome()
@@ -375,6 +380,8 @@ export function RoomPage() {
     profileAvatarInputRef: profile.profileAvatarInputRef,
     saveProfileDisplayName: profile.saveProfileDisplayName,
     onProfileAvatarSelected: profile.onProfileAvatarSelected,
+    castAvailability,
+    onCastToTvClick,
   }
 
   return (

--- a/apps/web/src/pages/RoomPageCastAvailability.test.tsx
+++ b/apps/web/src/pages/RoomPageCastAvailability.test.tsx
@@ -4,17 +4,18 @@ import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RoomPage } from './RoomPage'
-import { ChatSession } from '../room/sessions/ChatSession'
-import { SfuMediaSession } from '../room/sessions/SfuMediaSession'
-import { TheaterPlayback } from '../room/sessions/TheaterPlayback'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
 import {
-  RETIRED_GUEST_NOT_SHARING_PLACEHOLDER,
-  RETIRED_MESH_HOST_SCREEN_COPY,
-} from './roomPageDrawerStatusTestHelpers'
+  CAST_UNAVAILABLE_MESSAGE,
+  RIFFSYNC_CAST_AVAILABILITY_STATUS_ID,
+} from '../room/cast/castAvailabilityTypes'
+import type { CastAvailabilityState } from '../room/cast/castAvailabilityTypes'
 
 const fetchRoom = vi.fn()
 const fetchRtcIceServers = vi.fn()
+const castAvailabilityState = vi.hoisted(() => ({
+  value: 'checking' as CastAvailabilityState,
+}))
 
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
@@ -52,14 +53,14 @@ vi.mock('../config/publicOrigin', () => ({
   getPublicOrigin: () => 'https://www.test.example',
 }))
 
-vi.mock('../room/cast/useCastAvailability', () => ({
-  useCastAvailability: () => 'checking',
-}))
-
 vi.mock('../session/guestSession', () => ({
   ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
   setGuestDisplayName: (name: string) => name,
   FAN_DISPLAY_NAME_MAX_LEN: 48,
+}))
+
+vi.mock('../room/cast/useCastAvailability', () => ({
+  useCastAvailability: () => castAvailabilityState.value,
 }))
 
 vi.mock('../room/audio/theaterAudioMix', () => ({
@@ -137,15 +138,13 @@ class MockWebSocket {
   }
 }
 
-describe('RoomPage session integration', () => {
+describe('RoomPage Cast availability', () => {
   let container: HTMLDivElement
   let root: Root
-  let chatDisconnectSpy: ReturnType<typeof vi.spyOn>
-  let sfuDisconnectSpy: ReturnType<typeof vi.spyOn>
-  let theaterDisposeSpy: ReturnType<typeof vi.spyOn>
   let webSocketCtor: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    castAvailabilityState.value = 'checking'
     MockWebSocket.instances = []
     webSocketCtor = vi.fn((url: string) => new MockWebSocket(url))
     Object.assign(webSocketCtor, {
@@ -154,10 +153,6 @@ describe('RoomPage session integration', () => {
       CLOSED: MockWebSocket.CLOSED,
     })
     vi.stubGlobal('WebSocket', webSocketCtor)
-
-    chatDisconnectSpy = vi.spyOn(ChatSession.prototype, 'disconnect')
-    sfuDisconnectSpy = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
-    theaterDisposeSpy = vi.spyOn(TheaterPlayback.prototype, 'dispose')
 
     fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
     fetchRoom.mockResolvedValue({
@@ -180,7 +175,7 @@ describe('RoomPage session integration', () => {
 
   afterEach(async () => {
     act(() => root.unmount())
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 50))
     container.remove()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
@@ -200,54 +195,77 @@ describe('RoomPage session integration', () => {
     })
   }
 
-  it('does not import legacy session wiring or SFU modules directly', async () => {
-    const fs = await import('node:fs')
-    const path = await import('node:path')
-    const src = fs.readFileSync(path.join(__dirname, 'RoomPage.tsx'), 'utf8')
-    const forbidden = [
-      'useRoomWebSocket',
-      'useRoomSessionWiring',
-      'startSfuRoomSession',
-      'useChatSession',
-      'useSfuMediaSession',
-      'useTheaterPlayback',
-      'mediasoupSharing',
-      'sfuRelayStatusCopy',
-      'sessions/ChatSession',
-      'sessions/SfuMediaSession',
-      'sessions/TheaterPlayback',
-    ]
-    for (const token of forbidden) {
-      expect(src).not.toContain(token)
-    }
-    expect(src).toContain('useRoomMediaEngine')
+  async function openRoomTab() {
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
+    })
+    const roomTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find(
+      (node) => node.textContent?.trim() === 'Room',
+    )
+    expect(roomTab).not.toBeUndefined()
+    act(() => {
+      ;(roomTab as HTMLButtonElement).click()
+    })
+  }
+
+  it('shows Cast to TV in the normal-view Room tab when sender support is available', async () => {
+    castAvailabilityState.value = 'available'
+    renderRoom()
+    await openRoomTab()
+
+    expect(container.textContent).toContain('Cast to TV')
+    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
   })
 
-  it('constructs session modules on mount and tears them down on unmount', async () => {
+  it('shows local unavailable copy in the Room tab when sender support is absent', async () => {
+    castAvailabilityState.value = 'unavailable'
     renderRoom()
+    await openRoomTab()
 
-    await vi.waitFor(() => {
-      expect(container.querySelector('#riffsync-video-relay-status')).not.toBeNull()
+    const status = container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)
+    expect(status).not.toBeNull()
+    expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('omits Cast availability from expanded view', async () => {
+    castAvailabilityState.value = 'available'
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(min-width: 992px)',
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
     })
 
-    const videoRelayStatus = container.querySelector('#riffsync-video-relay-status')
-    expect(videoRelayStatus).not.toBeNull()
-    expect(videoRelayStatus?.getAttribute('role')).toBe('status')
-    expect(container.textContent).not.toContain(RETIRED_GUEST_NOT_SHARING_PLACEHOLDER)
-    expect(container.querySelector('.riffsync-room-page__guest-video-placeholder')).toBeNull()
-    for (const meshCopy of RETIRED_MESH_HOST_SCREEN_COPY) {
-      expect(container.textContent).not.toContain(meshCopy)
-    }
+    renderRoom()
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__expand-toggle')).not.toBeNull()
+    })
 
-    const chatDisconnectsBeforeUnmount = chatDisconnectSpy.mock.calls.length
-    const sfuDisconnectsBeforeUnmount = sfuDisconnectSpy.mock.calls.length
-    const theaterDisposesBeforeUnmount = theaterDisposeSpy.mock.calls.length
+    act(() => {
+      ;(container.querySelector('.riffsync-room-page__expand-toggle') as HTMLButtonElement).click()
+    })
 
-    act(() => root.unmount())
-    await new Promise((resolve) => setTimeout(resolve, 50))
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-expanded-view="true"]')).not.toBeNull()
+    })
 
-    expect(chatDisconnectSpy.mock.calls.length).toBeGreaterThan(chatDisconnectsBeforeUnmount)
-    expect(sfuDisconnectSpy.mock.calls.length).toBeGreaterThan(sfuDisconnectsBeforeUnmount)
-    expect(theaterDisposeSpy.mock.calls.length).toBeGreaterThan(theaterDisposesBeforeUnmount)
+    expect(container.textContent).not.toContain('Cast to TV')
+    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
+  })
+
+  it('does not surface Cast unavailable copy in chat drawer status', async () => {
+    castAvailabilityState.value = 'unavailable'
+    renderRoom()
+    await openRoomTab()
+
+    expect(container.textContent).toContain(CAST_UNAVAILABLE_MESSAGE)
+    expect(container.textContent?.includes(CAST_UNAVAILABLE_MESSAGE)).toBe(true)
+    const chatDrawerStatus = container.querySelector('#riffsync-chat-drawer-status')
+    expect(chatDrawerStatus?.textContent ?? '').not.toContain(CAST_UNAVAILABLE_MESSAGE)
   })
 })

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -22,6 +22,8 @@ import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
   RIFFSYNC_CHAT_DRAWER_STATUS_ID,
 } from './drawerErrorPresentation'
+import { CastAvailabilityRoomActions } from './cast/CastAvailabilityRoomActions'
+import type { CastAvailabilityState } from './cast/castAvailabilityTypes'
 
 type RoomPageSidebarProps = {
   presentation?: 'sidebar' | 'overlay'
@@ -72,6 +74,8 @@ type RoomPageSidebarProps = {
   profileAvatarInputRef: RefObject<HTMLInputElement | null>
   saveProfileDisplayName: () => void
   onProfileAvatarSelected: (e: ChangeEvent<HTMLInputElement>) => void
+  castAvailability: CastAvailabilityState
+  onCastToTvClick: () => void
 }
 
 export function RoomPageSidebar({
@@ -123,6 +127,8 @@ export function RoomPageSidebar({
   profileAvatarInputRef,
   saveProfileDisplayName,
   onProfileAvatarSelected,
+  castAvailability,
+  onCastToTvClick,
 }: RoomPageSidebarProps) {
   const chatPlane = (
     <section
@@ -363,6 +369,10 @@ export function RoomPageSidebar({
                 Hosting Guide
               </Link>
             ) : null}
+            <CastAvailabilityRoomActions
+              castAvailability={castAvailability}
+              onCastToTvClick={onCastToTvClick}
+            />
             <Link className="gen-button gen-button-wide" to="/">
               Leave Party
             </Link>

--- a/apps/web/src/room/cast/CastAvailabilityRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastAvailabilityRoomActions.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CastAvailabilityRoomActions } from './CastAvailabilityRoomActions'
+import {
+  CAST_UNAVAILABLE_MESSAGE,
+  RIFFSYNC_CAST_AVAILABILITY_STATUS_ID,
+} from './castAvailabilityTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('CastAvailabilityRoomActions', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderActions(castAvailability: 'checking' | 'available' | 'unavailable') {
+    act(() => {
+      root.render(
+        <CastAvailabilityRoomActions castAvailability={castAvailability} onCastToTvClick={vi.fn()} />,
+      )
+    })
+  }
+
+  it('renders nothing while checking', () => {
+    renderActions('checking')
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders Cast to TV when available', () => {
+    renderActions('available')
+    const button = container.querySelector('button')
+    expect(button?.textContent).toBe('Cast to TV')
+    expect(button?.className).toContain('gen-button-wide')
+  })
+
+  it('renders local unavailable status when support is absent', () => {
+    renderActions('unavailable')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)
+    expect(status).not.toBeNull()
+    expect(status?.getAttribute('role')).toBe('status')
+    expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
+    expect(container.querySelector('button')).toBeNull()
+  })
+})

--- a/apps/web/src/room/cast/CastAvailabilityRoomActions.tsx
+++ b/apps/web/src/room/cast/CastAvailabilityRoomActions.tsx
@@ -1,0 +1,36 @@
+import {
+  CAST_UNAVAILABLE_MESSAGE,
+  RIFFSYNC_CAST_AVAILABILITY_STATUS_ID,
+  type CastAvailabilityState,
+} from './castAvailabilityTypes'
+
+type CastAvailabilityRoomActionsProps = {
+  castAvailability: CastAvailabilityState
+  onCastToTvClick: () => void
+}
+
+export function CastAvailabilityRoomActions({
+  castAvailability,
+  onCastToTvClick,
+}: CastAvailabilityRoomActionsProps) {
+  if (castAvailability === 'checking') return null
+
+  if (castAvailability === 'available') {
+    return (
+      <button type="button" className="gen-button gen-button-wide" onClick={onCastToTvClick}>
+        Cast to TV
+      </button>
+    )
+  }
+
+  return (
+    <p
+      id={RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}
+      className="riffsync-room-page__cast-availability-status riffsync-muted"
+      role="status"
+      aria-live="polite"
+    >
+      {CAST_UNAVAILABLE_MESSAGE}
+    </p>
+  )
+}

--- a/apps/web/src/room/cast/castAvailabilityTypes.ts
+++ b/apps/web/src/room/cast/castAvailabilityTypes.ts
@@ -1,0 +1,7 @@
+export type CastAvailabilityState = 'checking' | 'available' | 'unavailable'
+
+export const CAST_UNAVAILABLE_MESSAGE = 'Cast is not available in this browser or device.'
+
+export const RIFFSYNC_CAST_AVAILABILITY_STATUS_ID = 'riffsync-cast-availability-status'
+
+export type CastSenderSupportDetector = () => Promise<boolean>

--- a/apps/web/src/room/cast/castSenderSupportDetector.test.ts
+++ b/apps/web/src/room/cast/castSenderSupportDetector.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { detectCastSenderSupport } from './castSenderSupportDetector'
+
+describe('detectCastSenderSupport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.head.innerHTML = ''
+    delete (window as Window & { __onGCastApiAvailable?: (isAvailable: boolean) => void }).__onGCastApiAvailable
+    delete (window as Window & { chrome?: { cast?: { isAvailable?: boolean } } }).chrome
+  })
+
+  it('returns true when chrome.cast.isAvailable is already true', async () => {
+    ;(window as Window & { chrome?: { cast?: { isAvailable?: boolean } } }).chrome = {
+      cast: { isAvailable: true },
+    }
+
+    await expect(detectCastSenderSupport()).resolves.toBe(true)
+  })
+
+  it('returns false when chrome.cast.isAvailable is already false', async () => {
+    ;(window as Window & { chrome?: { cast?: { isAvailable?: boolean } } }).chrome = {
+      cast: { isAvailable: false },
+    }
+
+    await expect(detectCastSenderSupport()).resolves.toBe(false)
+  })
+
+  it('resolves from __onGCastApiAvailable after loading the Cast framework script', async () => {
+    vi.useFakeTimers()
+
+    const promise = detectCastSenderSupport()
+    await Promise.resolve()
+
+    const script = document.querySelector('script[data-riffsync-cast-framework="true"]')
+    expect(script).not.toBeNull()
+
+    ;(window as Window & { __onGCastApiAvailable?: (isAvailable: boolean) => void }).__onGCastApiAvailable?.(
+      true,
+    )
+
+    await expect(promise).resolves.toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('returns false when the Cast framework script fails to load', async () => {
+    const promise = detectCastSenderSupport()
+    await Promise.resolve()
+
+    const script = document.querySelector('script[data-riffsync-cast-framework="true"]') as HTMLScriptElement
+    script.onerror?.(new Event('error'))
+
+    await expect(promise).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/room/cast/castSenderSupportDetector.ts
+++ b/apps/web/src/room/cast/castSenderSupportDetector.ts
@@ -1,0 +1,68 @@
+import type { CastSenderSupportDetector } from './castAvailabilityTypes'
+
+const CAST_FRAMEWORK_SRC = 'https://www.gstatic.com/cast/sdk/libs/sender/1.0/cast_framework.js'
+const CAST_FRAMEWORK_SCRIPT_SELECTOR = 'script[data-riffsync-cast-framework="true"]'
+const CAST_DETECTION_TIMEOUT_MS = 5000
+
+type CastChromeWindow = Window & {
+  chrome?: {
+    cast?: {
+      isAvailable?: boolean
+    }
+  }
+  __onGCastApiAvailable?: (isAvailable: boolean) => void
+}
+
+function readCastIsAvailable(): boolean | undefined {
+  if (typeof window === 'undefined') return undefined
+  const isAvailable = (window as CastChromeWindow).chrome?.cast?.isAvailable
+  return typeof isAvailable === 'boolean' ? isAvailable : undefined
+}
+
+function waitForCastFrameworkCallback(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const win = window as CastChromeWindow
+    const existing = readCastIsAvailable()
+    if (existing !== undefined) {
+      resolve(existing)
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => resolve(false), CAST_DETECTION_TIMEOUT_MS)
+    const previousCallback = win.__onGCastApiAvailable
+
+    win.__onGCastApiAvailable = (isAvailable) => {
+      window.clearTimeout(timeoutId)
+      if (previousCallback && previousCallback !== win.__onGCastApiAvailable) {
+        previousCallback(isAvailable)
+      }
+      resolve(isAvailable)
+    }
+  })
+}
+
+function ensureCastFrameworkScript(): void {
+  if (typeof document === 'undefined') return
+  if (document.querySelector(CAST_FRAMEWORK_SCRIPT_SELECTOR)) return
+
+  const script = document.createElement('script')
+  script.src = CAST_FRAMEWORK_SRC
+  script.async = true
+  script.dataset.riffsyncCastFramework = 'true'
+  script.onerror = () => {
+    const win = window as CastChromeWindow
+    win.__onGCastApiAvailable?.(false)
+  }
+  document.head.appendChild(script)
+}
+
+/** Post-render Google Cast sender support probe for #272 availability only. */
+export const detectCastSenderSupport: CastSenderSupportDetector = async () => {
+  if (typeof window === 'undefined') return false
+
+  const immediate = readCastIsAvailable()
+  if (immediate !== undefined) return immediate
+
+  ensureCastFrameworkScript()
+  return waitForCastFrameworkCallback()
+}

--- a/apps/web/src/room/cast/useCastAvailability.test.tsx
+++ b/apps/web/src/room/cast/useCastAvailability.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCastAvailability } from './useCastAvailability'
+import type { CastAvailabilityState } from './castAvailabilityTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function Harness({
+  enabled,
+  detect,
+  onState,
+}: {
+  enabled: boolean
+  detect: () => Promise<boolean>
+  onState: (state: CastAvailabilityState) => void
+}) {
+  const state = useCastAvailability(enabled, detect)
+  onState(state)
+  return <span data-testid="state">{state}</span>
+}
+
+describe('useCastAvailability', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('stays checking while disabled', () => {
+    const detect = vi.fn().mockResolvedValue(true)
+    act(() => {
+      root.render(<Harness enabled={false} detect={detect} onState={() => undefined} />)
+    })
+    expect(container.querySelector('[data-testid="state"]')?.textContent).toBe('checking')
+    expect(detect).not.toHaveBeenCalled()
+  })
+
+  it('maps detector success to available', async () => {
+    const detect = vi.fn().mockResolvedValue(true)
+    act(() => {
+      root.render(<Harness enabled={true} detect={detect} onState={() => undefined} />)
+    })
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="state"]')?.textContent).toBe('available')
+    })
+  })
+
+  it('maps detector failure to unavailable', async () => {
+    const detect = vi.fn().mockResolvedValue(false)
+    act(() => {
+      root.render(<Harness enabled={true} detect={detect} onState={() => undefined} />)
+    })
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="state"]')?.textContent).toBe('unavailable')
+    })
+  })
+
+  it('maps detector rejection to unavailable', async () => {
+    const detect = vi.fn().mockRejectedValue(new Error('cast probe failed'))
+    act(() => {
+      root.render(<Harness enabled={true} detect={detect} onState={() => undefined} />)
+    })
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="state"]')?.textContent).toBe('unavailable')
+    })
+  })
+})

--- a/apps/web/src/room/cast/useCastAvailability.ts
+++ b/apps/web/src/room/cast/useCastAvailability.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import type { CastAvailabilityState, CastSenderSupportDetector } from './castAvailabilityTypes'
+import { detectCastSenderSupport } from './castSenderSupportDetector'
+
+export function useCastAvailability(
+  enabled: boolean,
+  detect: CastSenderSupportDetector = detectCastSenderSupport,
+): CastAvailabilityState {
+  const [probeResult, setProbeResult] = useState<'available' | 'unavailable' | null>(null)
+  const [probeEnabled, setProbeEnabled] = useState(enabled)
+
+  if (probeEnabled !== enabled) {
+    setProbeEnabled(enabled)
+    setProbeResult(null)
+  }
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    void detect()
+      .then((available) => {
+        if (!cancelled) setProbeResult(available ? 'available' : 'unavailable')
+      })
+      .catch(() => {
+        if (!cancelled) setProbeResult('unavailable')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [detect, enabled])
+
+  if (!enabled || probeResult === null) return 'checking'
+  return probeResult
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2026,6 +2026,12 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   box-sizing: border-box;
 }
 
+.riffsync-room-page__cast-availability-status {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
 .riffsync-room-page__chat-heading {
   margin: 0;
   font-family: var(--title-fonts);


### PR DESCRIPTION
## Summary

- Add viewer-local Cast sender support detection that runs after the room shell renders, without blocking chat, SFU, or playback bootstrap.
- Show **Cast to TV** in the normal-view **Room** sidebar when sender support is available; show local unavailable copy at the Cast surface when detection completes without support.
- Keep Cast UI out of expanded view and away from drawer status surfaces, host controls, and stage playback.

Closes #272

## Test plan

- [x] `cd apps/web && npm ci && npm run build && npm test && npm run lint`
- [ ] Open a room in normal view on a Cast-capable browser and confirm **Cast to TV** appears under the **Room** tab
- [ ] Enter expanded view and confirm Cast affordances are not visible or focusable
- [ ] On an unsupported browser, confirm room playback/chat remain unchanged and unavailable copy appears only in the Room tab Cast surface