### PR TITLE
feat(room): start Cast with custom receiver presentation (#273)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -43,3 +43,6 @@
 # SFU_JWT_SECRET so POST /v1/webrtc/sfu-token JWTs verify against the disposable SFU.
 
 # Local development: without `VITE_PUBLIC_API_BASE_URL`, `vite dev` loads `data/catalog/episodes.json` as fallback.
+
+# Google Cast custom receiver application id (Cast Console registration for `/cast/receiver`).
+# VITE_CAST_RECEIVER_APP_ID=

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -5,6 +5,7 @@ import { CatalogPage } from './pages/CatalogPage'
 import { LobbyPage } from './pages/LobbyPage'
 import { AccountPage } from './pages/AccountPage'
 import { RoomPage } from './pages/RoomPage'
+import { CastReceiverPage } from './pages/cast/CastReceiverPage'
 import { SoloWatchPage } from './pages/SoloWatchPage'
 import { AuthCallbackPage } from './pages/AuthCallbackPage'
 import { PrivacyPolicyPage } from './pages/PrivacyPolicyPage'
@@ -26,6 +27,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
       <Route path="/admin/auth/callback" element={<StaffAuthCallbackPage />} />
+      <Route path="/cast/receiver" element={<CastReceiverPage />} />
       <Route path="/admin/login" element={<AdminLoginPage />} />
       <Route path="/admin" element={<StaffAdminGate />}>
         <Route element={<AdminLayout />}>

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -30,6 +30,7 @@ import { RoomRenameModal } from '../room/RoomRenameModal'
 import { RIFFSYNC_SFU_CONFIG_ALERT_ID } from '../room/drawerErrorPresentation'
 import type { RoomSidebarTab } from '../room/roomPageTypes'
 import { useCastAvailability } from '../room/cast/useCastAvailability'
+import { useCastStartSession } from '../room/cast/useCastStartSession'
 
 export function RoomPage() {
   const { roomId: roomIdParam } = useParams<{ roomId: string }>()
@@ -227,12 +228,23 @@ export function RoomPage() {
 
   const activeSidebarTab =
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
-  const castAvailability = useCastAvailability(Boolean(room))
-  const onCastToTvClick = useCallback(() => {
-    /* Cast start is implemented in #273. */
-  }, [])
   const viewportWide = useViewportWide()
   const expandedViewActive = expandedView && viewportWide
+  const castAvailability = useCastAvailability(Boolean(room))
+  const { castStartLifecycle, startCast, castToTvButtonRef } = useCastStartSession({
+    enabled: Boolean(room) && castAvailability === 'available',
+    expandedViewActive,
+    roomMode,
+    youtubeVideoId,
+    isPublisher,
+    hasHostCaptureStream: Boolean(captureStream),
+    hasGuestRelayStream: Boolean(guestRemote),
+    chat,
+    chatMemberLabels,
+  })
+  const onCastToTvClick = useCallback(() => {
+    void startCast()
+  }, [startCast])
   const { setExpandedViewActive } = useRoomChrome()
 
   useEffect(() => {
@@ -381,7 +393,9 @@ export function RoomPage() {
     saveProfileDisplayName: profile.saveProfileDisplayName,
     onProfileAvatarSelected: profile.onProfileAvatarSelected,
     castAvailability,
+    castStartLifecycle,
     onCastToTvClick,
+    castToTvButtonRef,
   }
 
   return (

--- a/apps/web/src/pages/RoomPageCastStart.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStart.test.tsx
@@ -6,16 +6,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RoomPage } from './RoomPage'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
 import {
-  CAST_UNAVAILABLE_MESSAGE,
-  RIFFSYNC_CAST_AVAILABILITY_STATUS_ID,
-} from '../room/cast/castAvailabilityTypes'
-import type { CastAvailabilityState } from '../room/cast/castAvailabilityTypes'
+  CAST_STARTING_MESSAGE,
+  CAST_START_REJECTED_MESSAGE,
+  RIFFSYNC_CAST_START_STATUS_ID,
+} from '../room/cast/castStartStatusCopy'
+import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
 
 const fetchRoom = vi.fn()
 const fetchRtcIceServers = vi.fn()
-const castAvailabilityState = vi.hoisted(() => ({
-  value: 'checking' as CastAvailabilityState,
-}))
+const castStartLifecycle = vi.hoisted(() => ({ value: 'idle' as CastStartLifecycle }))
+const startCast = vi.hoisted(() => vi.fn())
 
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
@@ -60,13 +60,13 @@ vi.mock('../session/guestSession', () => ({
 }))
 
 vi.mock('../room/cast/useCastAvailability', () => ({
-  useCastAvailability: () => castAvailabilityState.value,
+  useCastAvailability: () => 'available',
 }))
 
 vi.mock('../room/cast/useCastStartSession', () => ({
   useCastStartSession: () => ({
-    castStartLifecycle: 'idle',
-    startCast: vi.fn(),
+    castStartLifecycle: castStartLifecycle.value,
+    startCast,
     castToTvButtonRef: { current: null },
   }),
 }))
@@ -109,8 +109,6 @@ vi.mock('../api/webrtcSfuApi', () => ({
   }),
 }))
 
-type WsListener = (ev?: { data?: string; code?: number; reason?: string }) => void
-
 class MockWebSocket {
   static instances: MockWebSocket[] = []
   static CONNECTING = 0
@@ -118,49 +116,32 @@ class MockWebSocket {
   static CLOSED = 3
 
   readyState = MockWebSocket.CONNECTING
-  private listeners = new Map<string, Set<WsListener>>()
 
   constructor(url: string) {
     void url
     MockWebSocket.instances.push(this)
     queueMicrotask(() => {
       this.readyState = MockWebSocket.OPEN
-      for (const fn of this.listeners.get('open') ?? []) fn()
     })
   }
 
-  addEventListener(type: string, fn: WsListener) {
-    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
-    this.listeners.get(type)!.add(fn)
-  }
-
-  removeEventListener(type: string, fn: WsListener) {
-    this.listeners.get(type)?.delete(fn)
-  }
-
+  addEventListener() {}
+  removeEventListener() {}
   send() {}
-
   close() {
     this.readyState = MockWebSocket.CLOSED
-    for (const fn of this.listeners.get('close') ?? []) fn({ code: 1000, reason: '' })
   }
 }
 
-describe('RoomPage Cast availability', () => {
+describe('RoomPage Cast start', () => {
   let container: HTMLDivElement
   let root: Root
-  let webSocketCtor: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    castAvailabilityState.value = 'checking'
+    castStartLifecycle.value = 'idle'
+    startCast.mockReset()
     MockWebSocket.instances = []
-    webSocketCtor = vi.fn((url: string) => new MockWebSocket(url))
-    Object.assign(webSocketCtor, {
-      CONNECTING: MockWebSocket.CONNECTING,
-      OPEN: MockWebSocket.OPEN,
-      CLOSED: MockWebSocket.CLOSED,
-    })
-    vi.stubGlobal('WebSocket', webSocketCtor)
+    vi.stubGlobal('WebSocket', MockWebSocket)
 
     fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
     fetchRoom.mockResolvedValue({
@@ -189,7 +170,7 @@ describe('RoomPage Cast availability', () => {
     vi.clearAllMocks()
   })
 
-  function renderRoom() {
+  async function openRoomTab() {
     act(() => {
       root.render(
         <MemoryRouter initialEntries={['/room/room-test-1']}>
@@ -201,79 +182,33 @@ describe('RoomPage Cast availability', () => {
         </MemoryRouter>,
       )
     })
-  }
 
-  async function openRoomTab() {
     await vi.waitFor(() => {
       expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
     })
+
     const roomTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find(
       (node) => node.textContent?.trim() === 'Room',
     )
-    expect(roomTab).not.toBeUndefined()
     act(() => {
       ;(roomTab as HTMLButtonElement).click()
     })
   }
 
-  it('shows Cast to TV in the normal-view Room tab when sender support is available', async () => {
-    castAvailabilityState.value = 'available'
-    renderRoom()
+  it('shows local starting status when Cast start is in progress', async () => {
+    castStartLifecycle.value = 'starting'
     await openRoomTab()
 
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_STARTING_MESSAGE)
+  })
+
+  it('shows rejected status after failed Cast start', async () => {
+    castStartLifecycle.value = 'start_failed'
+    await openRoomTab()
+
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_START_REJECTED_MESSAGE)
     expect(container.textContent).toContain('Cast to TV')
-    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
-  })
-
-  it('shows local unavailable copy in the Room tab when sender support is absent', async () => {
-    castAvailabilityState.value = 'unavailable'
-    renderRoom()
-    await openRoomTab()
-
-    const status = container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)
-    expect(status).not.toBeNull()
-    expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
-    expect(container.textContent).not.toContain('Cast to TV')
-  })
-
-  it('omits Cast availability from expanded view', async () => {
-    castAvailabilityState.value = 'available'
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      configurable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === '(min-width: 992px)',
-        media: query,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      })),
-    })
-
-    renderRoom()
-    await vi.waitFor(() => {
-      expect(container.querySelector('.riffsync-room-page__expand-toggle')).not.toBeNull()
-    })
-
-    act(() => {
-      ;(container.querySelector('.riffsync-room-page__expand-toggle') as HTMLButtonElement).click()
-    })
-
-    await vi.waitFor(() => {
-      expect(container.querySelector('[data-expanded-view="true"]')).not.toBeNull()
-    })
-
-    expect(container.textContent).not.toContain('Cast to TV')
-    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
-  })
-
-  it('does not surface Cast unavailable copy in chat drawer status', async () => {
-    castAvailabilityState.value = 'unavailable'
-    renderRoom()
-    await openRoomTab()
-
-    expect(container.textContent).toContain(CAST_UNAVAILABLE_MESSAGE)
-    expect(container.textContent?.includes(CAST_UNAVAILABLE_MESSAGE)).toBe(true)
-    const chatDrawerStatus = container.querySelector('#riffsync-chat-drawer-status')
-    expect(chatDrawerStatus?.textContent ?? '').not.toContain(CAST_UNAVAILABLE_MESSAGE)
   })
 })

--- a/apps/web/src/pages/cast/CastReceiverPage.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPage.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react'
+import type { CastChatOverlayLine, CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+import {
+  CastReceiverPresentation,
+} from './CastReceiverPresentation'
+import { canConfirmCastReceiverRender } from './castReceiverRenderConfirmation'
+import {
+  getCastReceiverContextForTests,
+  sendCastReceiverRenderConfirmed,
+  sendCastReceiverRenderFailed,
+  startCastReceiverSession,
+} from './castReceiverSession'
+
+export function CastReceiverPage() {
+  const [snapshot, setSnapshot] = useState<CastPresentationSnapshot | null>(null)
+  const [chatMessages, setChatMessages] = useState<CastChatOverlayLine[]>([])
+  const renderConfirmedRef = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void startCastReceiverSession({
+      onPresentationSnapshot: (nextSnapshot) => {
+        if (cancelled) return
+        setSnapshot(nextSnapshot)
+        setChatMessages(nextSnapshot.chatOverlay.messages)
+      },
+      onChatOverlayUpdate: (messages) => {
+        if (cancelled) return
+        setChatMessages(messages)
+      },
+    }).catch(() => {
+      const context = getCastReceiverContextForTests()
+      if (context) sendCastReceiverRenderFailed(context, 'receiver_bootstrap_failed')
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (renderConfirmedRef.current) return
+    if (!canConfirmCastReceiverRender(snapshot)) return
+
+    const context = getCastReceiverContextForTests()
+    if (!context) return
+
+    renderConfirmedRef.current = true
+    sendCastReceiverRenderConfirmed(context)
+  }, [snapshot, chatMessages])
+
+  return <CastReceiverPresentation snapshot={snapshot} chatMessages={chatMessages} />
+}

--- a/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { CastReceiverPresentation } from './CastReceiverPresentation'
+import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('CastReceiverPresentation', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderPresentation(snapshot: CastPresentationSnapshot | null, chatMessages = snapshot?.chatOverlay.messages ?? []) {
+    act(() => {
+      root.render(<CastReceiverPresentation snapshot={snapshot} chatMessages={chatMessages} />)
+    })
+  }
+
+  it('renders stage-primary video and chat overlay from sender snapshot', () => {
+    const snapshot: CastPresentationSnapshot = {
+      roomMode: 'theater',
+      stagePrimary: {
+        kind: 'youtube_embed',
+        youtubeVideoId: 'abc123',
+        label: 'Party video',
+      },
+      chatOverlay: {
+        messages: [{ id: 'm1', kind: 'text', text: 'Fan: hello', senderLabel: 'Fan' }],
+      },
+    }
+
+    renderPresentation(snapshot)
+    expect(container.querySelector('[data-testid="cast-receiver-stage-primary"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="cast-receiver-chat-overlay"]')).not.toBeNull()
+    expect(container.textContent).toContain('Fan: hello')
+    expect(container.querySelector('iframe')?.getAttribute('src')).toContain('abc123')
+  })
+
+  it('does not render sidebar tabs or compose controls', () => {
+    const snapshot: CastPresentationSnapshot = {
+      roomMode: 'theater',
+      stagePrimary: { kind: 'live_video_placeholder', label: 'Party video' },
+      chatOverlay: { messages: [] },
+    }
+
+    renderPresentation(snapshot)
+    expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
+    expect(container.querySelector('input[type="text"]')).toBeNull()
+    expect(container.querySelector('button')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/cast/CastReceiverPresentation.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.tsx
@@ -1,0 +1,99 @@
+import type { CastChatOverlayLine, CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+
+type CastReceiverChatOverlayProps = {
+  messages: CastChatOverlayLine[]
+}
+
+export function CastReceiverChatOverlay({ messages }: CastReceiverChatOverlayProps) {
+  return (
+    <section
+      className="riffsync-cast-receiver__chat-overlay"
+      aria-label="Chat overlay"
+      data-testid="cast-receiver-chat-overlay"
+    >
+      <ul className="riffsync-cast-receiver__chat-log">
+        {messages.map((line) => (
+          <li
+            key={line.id}
+            className={`riffsync-cast-receiver__chat-line riffsync-cast-receiver__chat-line--${line.kind}`}
+          >
+            {line.text}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+type CastReceiverStagePrimaryProps = {
+  snapshot: CastPresentationSnapshot
+}
+
+export function CastReceiverStagePrimary({ snapshot }: CastReceiverStagePrimaryProps) {
+  const { stagePrimary } = snapshot
+
+  if (stagePrimary.kind === 'youtube_embed' && stagePrimary.youtubeVideoId) {
+    const src = `https://www.youtube.com/embed/${encodeURIComponent(stagePrimary.youtubeVideoId)}?playsinline=1`
+    return (
+      <div className="riffsync-cast-receiver__stage-primary" data-testid="cast-receiver-stage-primary">
+        <iframe
+          className="riffsync-cast-receiver__youtube"
+          title="Party video"
+          src={src}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    )
+  }
+
+  if (stagePrimary.kind === 'video_chat_grid') {
+    return (
+      <div
+        className="riffsync-cast-receiver__stage-primary riffsync-cast-receiver__stage-primary--grid"
+        data-testid="cast-receiver-stage-primary"
+        role="img"
+        aria-label={stagePrimary.label ?? 'Participant cameras'}
+      >
+        <p className="riffsync-cast-receiver__stage-placeholder">{stagePrimary.label ?? 'Participant cameras'}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="riffsync-cast-receiver__stage-primary riffsync-cast-receiver__stage-primary--live"
+      data-testid="cast-receiver-stage-primary"
+      role="img"
+      aria-label={stagePrimary.label ?? 'Party video'}
+    >
+      <p className="riffsync-cast-receiver__stage-placeholder">{stagePrimary.label ?? 'Party video'}</p>
+    </div>
+  )
+}
+
+type CastReceiverPresentationProps = {
+  snapshot: CastPresentationSnapshot | null
+  chatMessages: CastChatOverlayLine[]
+}
+
+export function CastReceiverPresentation({ snapshot, chatMessages }: CastReceiverPresentationProps) {
+  if (!snapshot) {
+    return (
+      <div className="riffsync-cast-receiver" aria-busy="true">
+        <p className="riffsync-cast-receiver__waiting" role="status">
+          Waiting for party presentation…
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="riffsync-cast-receiver" data-testid="cast-receiver-presentation">
+      <div className="riffsync-cast-receiver__stage">
+        <CastReceiverStagePrimary snapshot={snapshot} />
+        <CastReceiverChatOverlay messages={chatMessages} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/cast/castReceiverRenderConfirmation.ts
+++ b/apps/web/src/pages/cast/castReceiverRenderConfirmation.ts
@@ -1,0 +1,5 @@
+import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+
+export function canConfirmCastReceiverRender(snapshot: CastPresentationSnapshot | null): boolean {
+  return Boolean(snapshot?.stagePrimary)
+}

--- a/apps/web/src/pages/cast/castReceiverSession.ts
+++ b/apps/web/src/pages/cast/castReceiverSession.ts
@@ -1,0 +1,135 @@
+import type {
+  CastChatOverlayLine,
+  CastPresentationSnapshot,
+  CastSenderOutboundMessage,
+} from '../../room/cast/castChannelProtocol'
+import { RIFFSYNC_CAST_NAMESPACE } from '../../room/cast/castChannelProtocol'
+
+const CAST_RECEIVER_FRAMEWORK_SRC =
+  'https://www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js'
+
+type CastReceiverFrameworkWindow = Window & {
+  cast?: {
+    framework?: {
+      CastReceiverContext: {
+        getInstance: () => CastReceiverContextInstance
+      }
+      CastReceiverOptions: new () => Record<string, never>
+    }
+  }
+}
+
+type CastReceiverContextInstance = {
+  start: (options?: Record<string, never>) => void
+  addCustomMessageListener: (
+    namespace: string,
+    handler: (event: { data?: string }) => void,
+  ) => void
+  sendCustomMessage: (namespace: string, message: unknown) => void
+}
+
+function parseSenderMessage(raw: unknown): CastSenderOutboundMessage | null {
+  if (!raw || typeof raw !== 'object') return null
+  const type = (raw as { type?: unknown }).type
+  if (type === 'presentation_snapshot') {
+    const snapshot = (raw as { snapshot?: unknown }).snapshot
+    if (!snapshot || typeof snapshot !== 'object') return null
+    return { type: 'presentation_snapshot', snapshot: snapshot as CastPresentationSnapshot }
+  }
+  if (type === 'chat_overlay_update') {
+    const messages = (raw as { messages?: unknown }).messages
+    if (!Array.isArray(messages)) return null
+    return { type: 'chat_overlay_update', messages: messages as CastChatOverlayLine[] }
+  }
+  return null
+}
+
+function ensureReceiverFrameworkScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof document === 'undefined') {
+      reject(new Error('Receiver requires a browser document'))
+      return
+    }
+
+    const existing = document.querySelector('script[data-riffsync-cast-receiver-framework="true"]')
+    if (existing) {
+      resolve()
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = CAST_RECEIVER_FRAMEWORK_SRC
+    script.async = true
+    script.dataset.riffsyncCastReceiverFramework = 'true'
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Cast receiver framework failed to load'))
+    document.head.appendChild(script)
+  })
+}
+
+export type CastReceiverPresentationHandlers = {
+  onPresentationSnapshot: (snapshot: CastPresentationSnapshot) => void
+  onChatOverlayUpdate: (messages: CastChatOverlayLine[]) => void
+}
+
+export type CastReceiverSession = {
+  stop: () => void
+}
+
+export async function startCastReceiverSession(
+  handlers: CastReceiverPresentationHandlers,
+): Promise<CastReceiverSession> {
+  await ensureReceiverFrameworkScript()
+
+  const framework = (window as CastReceiverFrameworkWindow).cast?.framework
+  if (!framework) {
+    throw new Error('Cast receiver framework unavailable')
+  }
+
+  const context = framework.CastReceiverContext.getInstance()
+
+  context.addCustomMessageListener(RIFFSYNC_CAST_NAMESPACE, (event) => {
+    if (!event.data) return
+    try {
+      const parsed = JSON.parse(event.data) as unknown
+      const message = parseSenderMessage(parsed)
+      if (!message) return
+      if (message.type === 'presentation_snapshot') {
+        handlers.onPresentationSnapshot(message.snapshot)
+        return
+      }
+      if (message.type === 'chat_overlay_update') {
+        handlers.onChatOverlayUpdate(message.messages)
+      }
+    } catch {
+      /* Ignore malformed sender messages. */
+    }
+  })
+
+  context.start(new framework.CastReceiverOptions())
+
+  return {
+    stop: () => {
+      /* Receiver lifecycle teardown is owned by the Cast runtime. */
+    },
+  }
+}
+
+export function sendCastReceiverRenderConfirmed(context: CastReceiverContextInstance): void {
+  context.sendCustomMessage(RIFFSYNC_CAST_NAMESPACE, JSON.stringify({ type: 'render_confirmed' }))
+}
+
+export function sendCastReceiverRenderFailed(
+  context: CastReceiverContextInstance,
+  reason?: string,
+): void {
+  context.sendCustomMessage(
+    RIFFSYNC_CAST_NAMESPACE,
+    JSON.stringify({ type: 'render_failed', reason }),
+  )
+}
+
+export function getCastReceiverContextForTests(): CastReceiverContextInstance | null {
+  const framework = (window as CastReceiverFrameworkWindow).cast?.framework
+  return framework?.CastReceiverContext.getInstance() ?? null
+}

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -22,8 +22,9 @@ import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
   RIFFSYNC_CHAT_DRAWER_STATUS_ID,
 } from './drawerErrorPresentation'
-import { CastAvailabilityRoomActions } from './cast/CastAvailabilityRoomActions'
+import { CastStartRoomActions } from './cast/CastStartRoomActions'
 import type { CastAvailabilityState } from './cast/castAvailabilityTypes'
+import type { CastStartLifecycle } from './cast/castChannelProtocol'
 
 type RoomPageSidebarProps = {
   presentation?: 'sidebar' | 'overlay'
@@ -75,7 +76,9 @@ type RoomPageSidebarProps = {
   saveProfileDisplayName: () => void
   onProfileAvatarSelected: (e: ChangeEvent<HTMLInputElement>) => void
   castAvailability: CastAvailabilityState
+  castStartLifecycle: CastStartLifecycle
   onCastToTvClick: () => void
+  castToTvButtonRef: RefObject<HTMLButtonElement | null>
 }
 
 export function RoomPageSidebar({
@@ -128,7 +131,9 @@ export function RoomPageSidebar({
   saveProfileDisplayName,
   onProfileAvatarSelected,
   castAvailability,
+  castStartLifecycle,
   onCastToTvClick,
+  castToTvButtonRef,
 }: RoomPageSidebarProps) {
   const chatPlane = (
     <section
@@ -369,9 +374,11 @@ export function RoomPageSidebar({
                 Hosting Guide
               </Link>
             ) : null}
-            <CastAvailabilityRoomActions
+            <CastStartRoomActions
               castAvailability={castAvailability}
+              castStartLifecycle={castStartLifecycle}
               onCastToTvClick={onCastToTvClick}
+              castToTvButtonRef={castToTvButtonRef}
             />
             <Link className="gen-button gen-button-wide" to="/">
               Leave Party

--- a/apps/web/src/room/cast/CastStartRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CastStartRoomActions } from './CastStartRoomActions'
+import {
+  CAST_STARTING_MESSAGE,
+  CAST_START_REJECTED_MESSAGE,
+  RIFFSYNC_CAST_START_STATUS_ID,
+} from './castStartStatusCopy'
+import { CAST_UNAVAILABLE_MESSAGE, RIFFSYNC_CAST_AVAILABILITY_STATUS_ID } from './castAvailabilityTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('CastStartRoomActions', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderActions(
+    castAvailability: 'checking' | 'available' | 'unavailable',
+    castStartLifecycle: 'idle' | 'starting' | 'casting' | 'start_failed' = 'idle',
+  ) {
+    act(() => {
+      root.render(
+        <CastStartRoomActions
+          castAvailability={castAvailability}
+          castStartLifecycle={castStartLifecycle}
+          onCastToTvClick={vi.fn()}
+        />,
+      )
+    })
+  }
+
+  it('renders Cast to TV when available and idle', () => {
+    renderActions('available', 'idle')
+    expect(container.textContent).toContain('Cast to TV')
+  })
+
+  it('shows starting status without replacing playback surfaces', () => {
+    renderActions('available', 'starting')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_STARTING_MESSAGE)
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('shows rejected status and retry button', () => {
+    renderActions('available', 'start_failed')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_START_REJECTED_MESSAGE)
+    expect(container.textContent).toContain('Cast to TV')
+  })
+
+  it('shows unavailable copy when sender support is missing', () => {
+    renderActions('unavailable')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
+  })
+})

--- a/apps/web/src/room/cast/CastStartRoomActions.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.tsx
@@ -1,0 +1,92 @@
+import type { RefObject } from 'react'
+import {
+  CAST_STARTING_MESSAGE,
+  CAST_START_REJECTED_MESSAGE,
+  RIFFSYNC_CAST_START_STATUS_ID,
+} from './castStartStatusCopy'
+import type { CastStartLifecycle } from './castChannelProtocol'
+import {
+  CAST_UNAVAILABLE_MESSAGE,
+  RIFFSYNC_CAST_AVAILABILITY_STATUS_ID,
+  type CastAvailabilityState,
+} from './castAvailabilityTypes'
+
+type CastStartRoomActionsProps = {
+  castAvailability: CastAvailabilityState
+  castStartLifecycle: CastStartLifecycle
+  onCastToTvClick: () => void
+  castToTvButtonRef?: RefObject<HTMLButtonElement | null>
+}
+
+export function CastStartRoomActions({
+  castAvailability,
+  castStartLifecycle,
+  onCastToTvClick,
+  castToTvButtonRef,
+}: CastStartRoomActionsProps) {
+  if (castAvailability === 'checking') return null
+
+  if (castAvailability === 'unavailable') {
+    return (
+      <p
+        id={RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}
+        className="riffsync-room-page__cast-availability-status riffsync-muted"
+        role="status"
+        aria-live="polite"
+      >
+        {CAST_UNAVAILABLE_MESSAGE}
+      </p>
+    )
+  }
+
+  if (castStartLifecycle === 'starting') {
+    return (
+      <p
+        id={RIFFSYNC_CAST_START_STATUS_ID}
+        className="riffsync-room-page__cast-start-status riffsync-muted"
+        role="status"
+        aria-live="polite"
+      >
+        {CAST_STARTING_MESSAGE}
+      </p>
+    )
+  }
+
+  if (castStartLifecycle === 'start_failed') {
+    return (
+      <>
+        <p
+          id={RIFFSYNC_CAST_START_STATUS_ID}
+          className="riffsync-room-page__cast-start-status riffsync-muted"
+          role="status"
+          aria-live="polite"
+        >
+          {CAST_START_REJECTED_MESSAGE}
+        </p>
+        <button
+          ref={castToTvButtonRef}
+          type="button"
+          className="gen-button gen-button-wide"
+          onClick={onCastToTvClick}
+        >
+          Cast to TV
+        </button>
+      </>
+    )
+  }
+
+  if (castStartLifecycle === 'casting') {
+    return null
+  }
+
+  return (
+    <button
+      ref={castToTvButtonRef}
+      type="button"
+      className="gen-button gen-button-wide"
+      onClick={onCastToTvClick}
+    >
+      Cast to TV
+    </button>
+  )
+}

--- a/apps/web/src/room/cast/buildCastPresentationSnapshot.test.ts
+++ b/apps/web/src/room/cast/buildCastPresentationSnapshot.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildCastPresentationSnapshot } from './buildCastPresentationSnapshot'
+
+describe('buildCastPresentationSnapshot', () => {
+  it('uses youtube embed metadata for theater guests without relay video', () => {
+    const snapshot = buildCastPresentationSnapshot({
+      roomMode: 'theater',
+      youtubeVideoId: 'abc123',
+      isPublisher: false,
+      hasHostCaptureStream: false,
+      hasGuestRelayStream: false,
+      chat: [{ kind: 'text', messageId: 'm1', sessionId: 's1', displayName: 'Fan', text: 'hello', ts: 1 }],
+      chatMemberLabels: new Map([['s1', 'Fan']]),
+    })
+
+    expect(snapshot.stagePrimary).toEqual({
+      kind: 'youtube_embed',
+      youtubeVideoId: 'abc123',
+      label: 'Party video',
+    })
+    expect(snapshot.chatOverlay.messages[0]?.text).toBe('Fan: hello')
+  })
+
+  it('uses live video placeholder when host capture is active', () => {
+    const snapshot = buildCastPresentationSnapshot({
+      roomMode: 'theater',
+      youtubeVideoId: 'abc123',
+      isPublisher: true,
+      hasHostCaptureStream: true,
+      hasGuestRelayStream: false,
+      chat: [],
+      chatMemberLabels: new Map(),
+    })
+
+    expect(snapshot.stagePrimary.kind).toBe('live_video_placeholder')
+  })
+})

--- a/apps/web/src/room/cast/buildCastPresentationSnapshot.ts
+++ b/apps/web/src/room/cast/buildCastPresentationSnapshot.ts
@@ -1,0 +1,96 @@
+import type { RoomMode } from '../../api/roomsApi'
+import type { ChatLine } from '../roomPageTypes'
+import { formatChatSystemText } from '../chatSystemLine'
+import { isEmojiOnlyChatMessage } from '../chatEmojiDisplay'
+import type { CastChatOverlayLine, CastPresentationSnapshot } from './castChannelProtocol'
+
+export type BuildCastPresentationSnapshotInput = {
+  roomMode: RoomMode
+  youtubeVideoId: string | null | undefined
+  isPublisher: boolean
+  hasHostCaptureStream: boolean
+  hasGuestRelayStream: boolean
+  chat: ChatLine[]
+  chatMemberLabels: Map<string, string>
+}
+
+function resolveStagePrimary(input: BuildCastPresentationSnapshotInput): CastPresentationSnapshot['stagePrimary'] {
+  if (input.roomMode === 'videoChat') {
+    return {
+      kind: 'video_chat_grid',
+      label: 'Participant cameras',
+    }
+  }
+
+  if (input.isPublisher && input.hasHostCaptureStream) {
+    return {
+      kind: 'live_video_placeholder',
+      label: 'Host shared stream',
+    }
+  }
+
+  if (!input.isPublisher && input.hasGuestRelayStream) {
+    return {
+      kind: 'live_video_placeholder',
+      label: 'Party video',
+    }
+  }
+
+  const youtubeVideoId = input.youtubeVideoId?.trim()
+  if (youtubeVideoId) {
+    return {
+      kind: 'youtube_embed',
+      youtubeVideoId,
+      label: 'Party video',
+    }
+  }
+
+  return {
+    kind: 'live_video_placeholder',
+    label: 'Waiting for party video',
+  }
+}
+
+function toOverlayLine(line: ChatLine, chatMemberLabels: Map<string, string>): CastChatOverlayLine | null {
+  if (line.kind === 'system') {
+    return {
+      id: line.messageId,
+      kind: 'system',
+      text: formatChatSystemText(line.displayName, line.systemEvent),
+    }
+  }
+
+  if (line.kind === 'gif') {
+    const senderLabel = chatMemberLabels.get(line.sessionId) ?? line.displayName ?? 'Guest'
+    return {
+      id: line.messageId,
+      kind: 'gif',
+      text: `${senderLabel}: GIF`,
+      senderLabel,
+    }
+  }
+
+  const senderLabel = chatMemberLabels.get(line.sessionId) ?? line.displayName ?? 'Guest'
+  const text = line.text.trim()
+  if (!text) return null
+  return {
+    id: line.messageId,
+    kind: 'text',
+    text: isEmojiOnlyChatMessage(text) ? text : `${senderLabel}: ${text}`,
+    senderLabel,
+  }
+}
+
+export function buildCastPresentationSnapshot(
+  input: BuildCastPresentationSnapshotInput,
+): CastPresentationSnapshot {
+  const messages = input.chat
+    .map((line) => toOverlayLine(line, input.chatMemberLabels))
+    .filter((line): line is CastChatOverlayLine => line !== null)
+
+  return {
+    roomMode: input.roomMode,
+    stagePrimary: resolveStagePrimary(input),
+    chatOverlay: { messages },
+  }
+}

--- a/apps/web/src/room/cast/castChannelProtocol.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.ts
@@ -1,0 +1,45 @@
+import type { RoomMode } from '../../api/roomsApi'
+
+export const RIFFSYNC_CAST_NAMESPACE = 'urn:x-cast:com.riffsync.presentation'
+
+export type CastStartLifecycle = 'idle' | 'starting' | 'casting' | 'start_failed'
+
+export type CastStagePrimaryKind = 'youtube_embed' | 'live_video_placeholder' | 'video_chat_grid'
+
+export type CastChatOverlayLine = {
+  id: string
+  kind: 'text' | 'gif' | 'system'
+  text: string
+  senderLabel?: string
+}
+
+export type CastPresentationSnapshot = {
+  roomMode: RoomMode
+  stagePrimary: {
+    kind: CastStagePrimaryKind
+    youtubeVideoId?: string
+    label?: string
+  }
+  chatOverlay: {
+    messages: CastChatOverlayLine[]
+  }
+}
+
+export type CastSenderOutboundMessage =
+  | { type: 'presentation_snapshot'; snapshot: CastPresentationSnapshot }
+  | { type: 'chat_overlay_update'; messages: CastChatOverlayLine[] }
+
+export type CastReceiverOutboundMessage =
+  | { type: 'render_confirmed' }
+  | { type: 'render_failed'; reason?: string }
+
+export function parseCastReceiverOutboundMessage(raw: unknown): CastReceiverOutboundMessage | null {
+  if (!raw || typeof raw !== 'object') return null
+  const type = (raw as { type?: unknown }).type
+  if (type === 'render_confirmed') return { type: 'render_confirmed' }
+  if (type === 'render_failed') {
+    const reason = (raw as { reason?: unknown }).reason
+    return { type: 'render_failed', reason: typeof reason === 'string' ? reason : undefined }
+  }
+  return null
+}

--- a/apps/web/src/room/cast/castSenderClient.ts
+++ b/apps/web/src/room/cast/castSenderClient.ts
@@ -1,0 +1,183 @@
+import { RIFFSYNC_CAST_NAMESPACE } from './castChannelProtocol'
+
+export type CastSenderSessionHandle = {
+  sendMessage: (message: unknown) => Promise<void>
+  addMessageListener: (handler: (message: unknown) => void) => () => void
+  end: () => Promise<void>
+}
+
+export type CastSenderClient = {
+  requestSession: () => Promise<CastSenderSessionHandle>
+}
+
+export type CastSenderClientFactory = () => CastSenderClient
+
+const CAST_FRAMEWORK_SRC = 'https://www.gstatic.com/cast/sdk/libs/sender/1.0/cast_framework.js'
+const CAST_FRAMEWORK_SCRIPT_SELECTOR = 'script[data-riffsync-cast-framework="true"]'
+const CAST_FRAMEWORK_READY_TIMEOUT_MS = 5000
+
+type CastFrameworkWindow = Window & {
+  cast?: {
+    framework?: {
+      CastContext: {
+        getInstance: () => CastContextInstance
+      }
+      CastContextEventType: {
+        CAST_STATE_CHANGED: string
+        SESSION_STATE_CHANGED: string
+      }
+      AutoJoinPolicy: {
+        ORIGIN_SCOPED: string
+      }
+      SessionState: {
+        SESSION_STARTED: string
+        SESSION_ENDED: string
+      }
+      CastState: {
+        NO_DEVICES_AVAILABLE: string
+      }
+    }
+  }
+  __onGCastApiAvailable?: (isAvailable: boolean) => void
+}
+
+type CastContextInstance = {
+  setOptions: (options: { receiverApplicationId: string; autoJoinPolicy: string }) => void
+  requestSession: () => Promise<CastSessionInstance>
+  addEventListener: (type: string, handler: (event: { sessionState?: string; castState?: string }) => void) => void
+  removeEventListener: (type: string, handler: (event: { sessionState?: string; castState?: string }) => void) => void
+}
+
+type CastSessionInstance = {
+  sendMessage: (namespace: string, message: unknown) => Promise<void>
+  addMessageListener: (namespace: string, handler: (namespace: string, message: string) => void) => void
+  removeMessageListener: (namespace: string, handler: (namespace: string, message: string) => void) => void
+  endSession: (stopCasting?: boolean) => void
+}
+
+function readCastFramework(): CastFrameworkWindow['cast'] | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as CastFrameworkWindow).cast
+}
+
+function ensureCastFrameworkScript(): void {
+  if (typeof document === 'undefined') return
+  if (document.querySelector(CAST_FRAMEWORK_SCRIPT_SELECTOR)) return
+
+  const script = document.createElement('script')
+  script.src = CAST_FRAMEWORK_SRC
+  script.async = true
+  script.dataset.riffsyncCastFramework = 'true'
+  script.onerror = () => {
+    const win = window as CastFrameworkWindow
+    win.__onGCastApiAvailable?.(false)
+  }
+  document.head.appendChild(script)
+}
+
+async function waitForCastFramework(): Promise<NonNullable<CastFrameworkWindow['cast']>> {
+  const immediate = readCastFramework()?.framework
+  if (immediate) return readCastFramework()!
+
+  ensureCastFrameworkScript()
+
+  return await new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => reject(new Error('Cast framework load timed out')), CAST_FRAMEWORK_READY_TIMEOUT_MS)
+    const win = window as CastFrameworkWindow
+    const previousCallback = win.__onGCastApiAvailable
+
+    win.__onGCastApiAvailable = (isAvailable) => {
+      window.clearTimeout(timeoutId)
+      if (previousCallback && previousCallback !== win.__onGCastApiAvailable) {
+        previousCallback(isAvailable)
+      }
+      if (!isAvailable || !readCastFramework()?.framework) {
+        reject(new Error('Cast framework unavailable'))
+        return
+      }
+      resolve(readCastFramework()!)
+    }
+  })
+}
+
+function wrapCastSession(session: CastSessionInstance): CastSenderSessionHandle {
+  const listeners = new Set<(message: unknown) => void>()
+
+  const frameworkListener = (_namespace: string, message: string) => {
+    try {
+      const parsed = JSON.parse(message) as unknown
+      for (const listener of listeners) listener(parsed)
+    } catch {
+      /* Ignore malformed receiver messages. */
+    }
+  }
+
+  session.addMessageListener(RIFFSYNC_CAST_NAMESPACE, frameworkListener)
+
+  return {
+    sendMessage: async (message) => {
+      await session.sendMessage(RIFFSYNC_CAST_NAMESPACE, message)
+    },
+    addMessageListener: (handler) => {
+      listeners.add(handler)
+      return () => listeners.delete(handler)
+    },
+    end: async () => {
+      session.removeMessageListener(RIFFSYNC_CAST_NAMESPACE, frameworkListener)
+      session.endSession(true)
+    },
+  }
+}
+
+export function getCastReceiverApplicationId(): string | null {
+  const configured = import.meta.env.VITE_CAST_RECEIVER_APP_ID?.trim()
+  return configured || null
+}
+
+export function createDefaultCastSenderClient(): CastSenderClient {
+  return {
+    requestSession: async () => {
+      const receiverApplicationId = getCastReceiverApplicationId()
+      if (!receiverApplicationId) {
+        throw new Error('Cast receiver application id is not configured')
+      }
+
+      const cast = await waitForCastFramework()
+      const framework = cast.framework!
+      const context = framework.CastContext.getInstance()
+      context.setOptions({
+        receiverApplicationId,
+        autoJoinPolicy: framework.AutoJoinPolicy.ORIGIN_SCOPED,
+      })
+
+      return await new Promise<CastSenderSessionHandle>((resolve, reject) => {
+        let settled = false
+
+        const onSessionStateChanged = (event: { sessionState?: string }) => {
+          if (event.sessionState === framework.SessionState.SESSION_ENDED && !settled) {
+            settled = true
+            context.removeEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, onSessionStateChanged)
+            reject(new Error('Cast session ended before start completed'))
+          }
+        }
+
+        context.addEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, onSessionStateChanged)
+
+        void context
+          .requestSession()
+          .then((session) => {
+            if (settled) return
+            settled = true
+            context.removeEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, onSessionStateChanged)
+            resolve(wrapCastSession(session))
+          })
+          .catch((error: unknown) => {
+            if (settled) return
+            settled = true
+            context.removeEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, onSessionStateChanged)
+            reject(error instanceof Error ? error : new Error('Cast session request failed'))
+          })
+      })
+    },
+  }
+}

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createCastStartController } from './castStartController'
+import type { CastPresentationSnapshot } from './castChannelProtocol'
+import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
+
+const snapshot: CastPresentationSnapshot = {
+  roomMode: 'theater',
+  stagePrimary: {
+    kind: 'youtube_embed',
+    youtubeVideoId: 'abc123',
+    label: 'Party video',
+  },
+  chatOverlay: {
+    messages: [{ id: 'm1', kind: 'text', text: 'Host: hello', senderLabel: 'Host' }],
+  },
+}
+
+function createMockSession(handlers: {
+  onSend?: (message: unknown) => void
+  confirmAfterSend?: boolean
+}): CastSenderSessionHandle {
+  const listeners = new Set<(message: unknown) => void>()
+  return {
+    sendMessage: async (message) => {
+      handlers.onSend?.(message)
+      if (handlers.confirmAfterSend) {
+        for (const listener of listeners) listener({ type: 'render_confirmed' })
+      }
+    },
+    addMessageListener: (handler) => {
+      listeners.add(handler)
+      return () => listeners.delete(handler)
+    },
+    end: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createMockClient(session: CastSenderSessionHandle): CastSenderClient {
+  return {
+    requestSession: vi.fn().mockResolvedValue(session),
+  }
+}
+
+describe('createCastStartController', () => {
+  it('transitions to casting after receiver render confirmation', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    const states: string[] = []
+    controller.subscribe((state) => states.push(state.lifecycle))
+
+    await controller.startCast(snapshot)
+
+    expect(states).toEqual(['starting', 'casting'])
+    expect(session.end).not.toHaveBeenCalled()
+  })
+
+  it('maps launch failure to start_failed and ends the session', async () => {
+    const session = createMockSession({})
+    const client: CastSenderClient = {
+      requestSession: vi.fn().mockRejectedValue(new Error('user cancelled')),
+    }
+    const controller = createCastStartController({ client, confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).not.toHaveBeenCalled()
+  })
+
+  it('maps render confirmation timeout to start_failed', async () => {
+    vi.useFakeTimers()
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 50 })
+
+    const promise = controller.startCast(snapshot)
+    await vi.advanceTimersByTimeAsync(60)
+    await promise
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('proxies chat overlay updates while casting', async () => {
+    const sent: unknown[] = []
+    const session = createMockSession({
+      confirmAfterSend: true,
+      onSend: (message) => sent.push(message),
+    })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    await controller.sendChatOverlayUpdate({
+      ...snapshot,
+      chatOverlay: {
+        messages: [{ id: 'm2', kind: 'text', text: 'Host: updated', senderLabel: 'Host' }],
+      },
+    })
+
+    expect(sent[1]).toEqual({
+      type: 'chat_overlay_update',
+      messages: [{ id: 'm2', kind: 'text', text: 'Host: updated', senderLabel: 'Host' }],
+    })
+  })
+})

--- a/apps/web/src/room/cast/castStartController.ts
+++ b/apps/web/src/room/cast/castStartController.ts
@@ -1,0 +1,136 @@
+import type { CastPresentationSnapshot, CastStartLifecycle } from './castChannelProtocol'
+import { parseCastReceiverOutboundMessage } from './castChannelProtocol'
+import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
+
+export const CAST_RENDER_CONFIRMATION_TIMEOUT_MS = 15000
+
+export type CastStartControllerState = {
+  lifecycle: CastStartLifecycle
+}
+
+export type CastStartController = {
+  getState: () => CastStartControllerState
+  subscribe: (listener: (state: CastStartControllerState) => void) => () => void
+  startCast: (snapshot: CastPresentationSnapshot) => Promise<void>
+  sendChatOverlayUpdate: (snapshot: CastPresentationSnapshot) => Promise<void>
+  resetStartFailure: () => void
+  stopCast: () => Promise<void>
+}
+
+type CreateCastStartControllerOptions = {
+  client: CastSenderClient
+  confirmationTimeoutMs?: number
+}
+
+export function createCastStartController({
+  client,
+  confirmationTimeoutMs = CAST_RENDER_CONFIRMATION_TIMEOUT_MS,
+}: CreateCastStartControllerOptions): CastStartController {
+  let lifecycle: CastStartLifecycle = 'idle'
+  let session: CastSenderSessionHandle | null = null
+  let removeMessageListener: (() => void) | null = null
+  let confirmationTimer: ReturnType<typeof setTimeout> | null = null
+  const listeners = new Set<(state: CastStartControllerState) => void>()
+
+  const emit = () => {
+    const state = { lifecycle }
+    for (const listener of listeners) listener(state)
+  }
+
+  const clearConfirmationTimer = () => {
+    if (confirmationTimer !== null) {
+      clearTimeout(confirmationTimer)
+      confirmationTimer = null
+    }
+  }
+
+  const cleanupSession = async () => {
+    clearConfirmationTimer()
+    removeMessageListener?.()
+    removeMessageListener = null
+    const activeSession = session
+    session = null
+    if (activeSession) {
+      try {
+        await activeSession.end()
+      } catch {
+        /* Best-effort Cast cleanup. */
+      }
+    }
+  }
+
+  const failStart = async () => {
+    await cleanupSession()
+    lifecycle = 'start_failed'
+    emit()
+  }
+
+  const confirmStart = () => {
+    clearConfirmationTimer()
+    lifecycle = 'casting'
+    emit()
+  }
+
+  return {
+    getState: () => ({ lifecycle }),
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    startCast: async (snapshot) => {
+      if (lifecycle === 'starting' || lifecycle === 'casting') return
+
+      lifecycle = 'starting'
+      emit()
+
+      try {
+        const nextSession = await client.requestSession()
+        session = nextSession
+
+        removeMessageListener = nextSession.addMessageListener((raw) => {
+          const message = parseCastReceiverOutboundMessage(raw)
+          if (!message) return
+          if (message.type === 'render_confirmed') {
+            confirmStart()
+            return
+          }
+          if (message.type === 'render_failed') {
+            void failStart()
+          }
+        })
+
+        confirmationTimer = setTimeout(() => {
+          void failStart()
+        }, confirmationTimeoutMs)
+
+        await nextSession.sendMessage({
+          type: 'presentation_snapshot',
+          snapshot,
+        })
+      } catch {
+        await failStart()
+      }
+    },
+    sendChatOverlayUpdate: async (snapshot) => {
+      if (lifecycle !== 'casting' || !session) return
+      try {
+        await session.sendMessage({
+          type: 'chat_overlay_update',
+          messages: snapshot.chatOverlay.messages,
+        })
+      } catch {
+        /* Receiver disconnect handling belongs to later slices. */
+      }
+    },
+    resetStartFailure: () => {
+      if (lifecycle !== 'start_failed') return
+      lifecycle = 'idle'
+      emit()
+    },
+    stopCast: async () => {
+      await cleanupSession()
+      lifecycle = 'idle'
+      emit()
+    },
+  }
+}

--- a/apps/web/src/room/cast/castStartStatusCopy.ts
+++ b/apps/web/src/room/cast/castStartStatusCopy.ts
@@ -1,0 +1,6 @@
+export const CAST_STARTING_MESSAGE = 'Starting Cast…'
+
+export const CAST_START_REJECTED_MESSAGE =
+  'Cast could not start. Try again from this browser or device.'
+
+export const RIFFSYNC_CAST_START_STATUS_ID = 'riffsync-cast-start-status'

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import type { RoomMode } from '../../api/roomsApi'
+import type { ChatLine } from '../roomPageTypes'
+import {
+  buildCastPresentationSnapshot,
+  type BuildCastPresentationSnapshotInput,
+} from './buildCastPresentationSnapshot'
+import type { CastStartLifecycle } from './castChannelProtocol'
+import { createCastStartController, type CastStartController } from './castStartController'
+import { createDefaultCastSenderClient, type CastSenderClientFactory } from './castSenderClient'
+
+export type UseCastStartSessionInput = {
+  enabled: boolean
+  expandedViewActive: boolean
+  roomMode: RoomMode
+  youtubeVideoId: string | null | undefined
+  isPublisher: boolean
+  hasHostCaptureStream: boolean
+  hasGuestRelayStream: boolean
+  chat: ChatLine[]
+  chatMemberLabels: Map<string, string>
+  createSenderClient?: CastSenderClientFactory
+}
+
+export type UseCastStartSessionResult = {
+  castStartLifecycle: CastStartLifecycle
+  startCast: () => Promise<void>
+  castToTvButtonRef: RefObject<HTMLButtonElement | null>
+}
+
+export function useCastStartSession({
+  enabled,
+  expandedViewActive,
+  roomMode,
+  youtubeVideoId,
+  isPublisher,
+  hasHostCaptureStream,
+  hasGuestRelayStream,
+  chat,
+  chatMemberLabels,
+  createSenderClient = createDefaultCastSenderClient,
+}: UseCastStartSessionInput): UseCastStartSessionResult {
+  const castToTvButtonRef = useRef<HTMLButtonElement | null>(null)
+  const [controller] = useState<CastStartController>(() =>
+    createCastStartController({ client: createSenderClient() }),
+  )
+  const [castStartLifecycle, setCastStartLifecycle] = useState<CastStartLifecycle>('idle')
+
+  const snapshotInput = useMemo<BuildCastPresentationSnapshotInput>(
+    () => ({
+      roomMode,
+      youtubeVideoId,
+      isPublisher,
+      hasHostCaptureStream,
+      hasGuestRelayStream,
+      chat,
+      chatMemberLabels,
+    }),
+    [
+      roomMode,
+      youtubeVideoId,
+      isPublisher,
+      hasHostCaptureStream,
+      hasGuestRelayStream,
+      chat,
+      chatMemberLabels,
+    ],
+  )
+
+  const buildSnapshot = useCallback(
+    () => buildCastPresentationSnapshot(snapshotInput),
+    [snapshotInput],
+  )
+
+  useEffect(() => controller.subscribe((state) => setCastStartLifecycle(state.lifecycle)), [controller])
+
+  useEffect(() => {
+    if (!enabled) return
+    return () => {
+      void controller.stopCast()
+    }
+  }, [controller, enabled])
+
+  useEffect(() => {
+    if (castStartLifecycle !== 'casting') return
+    void controller.sendChatOverlayUpdate(buildSnapshot())
+  }, [buildSnapshot, castStartLifecycle, chat, controller])
+
+  const startCast = useCallback(async () => {
+    if (!enabled || expandedViewActive) return
+
+    if (controller.getState().lifecycle === 'start_failed') {
+      controller.resetStartFailure()
+    }
+
+    await controller.startCast(buildSnapshot())
+  }, [buildSnapshot, controller, enabled, expandedViewActive])
+
+  useEffect(() => {
+    if (castStartLifecycle !== 'start_failed') return
+    castToTvButtonRef.current?.focus()
+  }, [castStartLifecycle])
+
+  return {
+    castStartLifecycle,
+    startCast,
+    castToTvButtonRef,
+  }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2032,6 +2032,86 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   line-height: 1.35;
 }
 
+.riffsync-room-page__cast-start-status {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.riffsync-cast-receiver {
+  min-height: 100dvh;
+  background: #0d1117;
+  color: #e6edf3;
+}
+
+.riffsync-cast-receiver__waiting {
+  margin: 0;
+  padding: 2rem;
+}
+
+.riffsync-cast-receiver__stage {
+  position: relative;
+  min-height: 100dvh;
+  background: #000;
+}
+
+.riffsync-cast-receiver__stage-primary {
+  position: absolute;
+  inset: 0;
+}
+
+.riffsync-cast-receiver__youtube {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.riffsync-cast-receiver__stage-placeholder {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+}
+
+.riffsync-cast-receiver__chat-overlay {
+  position: absolute;
+  right: clamp(0.75rem, 1.4vw, 1.1rem);
+  bottom: clamp(0.75rem, 1.4vw, 1.1rem);
+  z-index: 2;
+  width: clamp(16rem, 30%, 24rem);
+  max-height: 40%;
+  min-height: 8rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: rgb(7 10 14 / 0.42);
+  border: 1px solid rgb(255 255 255 / 0.16);
+  border-radius: 8px;
+  box-shadow: 0 14px 40px rgb(0 0 0 / 0.38);
+  backdrop-filter: blur(6px);
+}
+
+.riffsync-cast-receiver__chat-log {
+  list-style: none;
+  margin: 0;
+  padding: 0.75rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.riffsync-cast-receiver__chat-line {
+  margin: 0 0 0.45rem;
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.riffsync-cast-receiver__chat-line--system {
+  color: rgb(255 255 255 / 0.62);
+  font-style: italic;
+}
+
 .riffsync-room-page__chat-heading {
   margin: 0;
   font-family: var(--title-fonts);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -20,6 +20,8 @@ interface ImportMetaEnv {
    * When set, takes precedence over token-embedded **`wsUrl`** from **`POST /v1/webrtc/sfu-token`** (local disposable SFU).
    */
   readonly VITE_PUBLIC_SFU_WS_URL?: string
+  /** Google Cast custom receiver application id for sender launch (#273). */
+  readonly VITE_CAST_RECEIVER_APP_ID?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Add a viewer-local Cast start controller that launches the custom RiffSync receiver page from normal room view and waits for receiver render confirmation before entering the local `casting` lifecycle state.
- Proxy presentation snapshots and chat overlay updates over the Cast sender/receiver channel; the receiver renders stage-primary video plus a bottom-right chat overlay without joining room services.
- Surface local `CAST_STARTING` and `CAST_START_REJECTED` status in the Room sidebar without touching chat drawer, video-relay, or host feedback surfaces.

## Test plan

- [x] `cd apps/web && npm ci && npm run build && npm test && npm run lint`
- [ ] Manual: open a room with Cast sender support, start Cast from the Room tab, confirm receiver shows stage video + chat overlay and sender keeps normal playback while starting
- [ ] Manual: cancel launch / simulate failure and confirm `CAST_START_REJECTED` copy with focus returned to Cast to TV
- [ ] Manual: confirm Cast start is absent in expanded view

Closes #273