### PR TITLE
[M25] Replace sender stage with Now Casting and Stop Cast (#274)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -31,6 +31,7 @@ import { RIFFSYNC_SFU_CONFIG_ALERT_ID } from '../room/drawerErrorPresentation'
 import type { RoomSidebarTab } from '../room/roomPageTypes'
 import { useCastAvailability } from '../room/cast/useCastAvailability'
 import { useCastStartSession } from '../room/cast/useCastStartSession'
+import { CastActiveStagePanel } from '../room/cast/CastActiveStagePanel'
 
 export function RoomPage() {
   const { roomId: roomIdParam } = useParams<{ roomId: string }>()
@@ -229,22 +230,27 @@ export function RoomPage() {
   const activeSidebarTab =
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
   const viewportWide = useViewportWide()
-  const expandedViewActive = expandedView && viewportWide
   const castAvailability = useCastAvailability(Boolean(room))
-  const { castStartLifecycle, startCast, castToTvButtonRef } = useCastStartSession({
-    enabled: Boolean(room) && castAvailability === 'available',
-    expandedViewActive,
-    roomMode,
-    youtubeVideoId,
-    isPublisher,
-    hasHostCaptureStream: Boolean(captureStream),
-    hasGuestRelayStream: Boolean(guestRemote),
-    chat,
-    chatMemberLabels,
-  })
+  const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
+    useCastStartSession({
+      enabled: Boolean(room) && castAvailability === 'available',
+      expandedViewActive: expandedView && viewportWide,
+      roomMode,
+      youtubeVideoId,
+      isPublisher,
+      hasHostCaptureStream: Boolean(captureStream),
+      hasGuestRelayStream: Boolean(guestRemote),
+      chat,
+      chatMemberLabels,
+    })
+  const castActive = castStartLifecycle === 'casting'
+  const expandedViewActive = expandedView && viewportWide && !castActive
   const onCastToTvClick = useCallback(() => {
     void startCast()
   }, [startCast])
+  const onStopCastClick = useCallback(() => {
+    stopCast()
+  }, [stopCast])
   const { setExpandedViewActive } = useRoomChrome()
 
   useEffect(() => {
@@ -436,7 +442,7 @@ export function RoomPage() {
           data-expanded-view={expandedViewActive ? 'true' : 'false'}
         >
           <div className={`riffsync-room-page__theater${expandedViewActive ? ' riffsync-room-page__theater--expanded' : ''}`}>
-            {viewportWide ? (
+            {viewportWide && !castActive ? (
               <button
                 type="button"
                 className="riffsync-room-page__expand-toggle"
@@ -455,24 +461,31 @@ export function RoomPage() {
               avSurfacesEnabled={avSurfacesEnabled}
               expandedView={expandedViewActive}
               playback={
-                <RoomPlaybackPanel
-                  isPublisher={isPublisher}
-                  captureStream={captureStream}
-                  captureErr={captureErr}
-                  patchErr={patchErr}
-                  renameModalOpen={renameModalOpen}
-                  guestRemote={guestRemote}
-                  fanToken={fanToken}
-                  theaterPlaybackSnapshot={theaterPlaybackSnapshot}
-                  videoRelayStatus={videoRelayStatus}
-                  theaterAudioStatus={theaterAudioStatus}
-                  bindHostCaptureVideo={bindHostCaptureVideo}
-                  bindGuestVideo={bindGuestVideo}
-                  playHostCapturePreview={playHostCapturePreview}
-                  playGuestVideo={playGuestVideo}
-                  startCapture={startCapture}
-                  openCapturePlayerTab={openCapturePlayerTab}
-                />
+                castActive ? (
+                  <CastActiveStagePanel
+                    onStopCast={onStopCastClick}
+                    stopCastButtonRef={stopCastButtonRef}
+                  />
+                ) : (
+                  <RoomPlaybackPanel
+                    isPublisher={isPublisher}
+                    captureStream={captureStream}
+                    captureErr={captureErr}
+                    patchErr={patchErr}
+                    renameModalOpen={renameModalOpen}
+                    guestRemote={guestRemote}
+                    fanToken={fanToken}
+                    theaterPlaybackSnapshot={theaterPlaybackSnapshot}
+                    videoRelayStatus={videoRelayStatus}
+                    theaterAudioStatus={theaterAudioStatus}
+                    bindHostCaptureVideo={bindHostCaptureVideo}
+                    bindGuestVideo={bindGuestVideo}
+                    playHostCapturePreview={playHostCapturePreview}
+                    playGuestVideo={playGuestVideo}
+                    startCapture={startCapture}
+                    openCapturePlayerTab={openCapturePlayerTab}
+                  />
+                )
               }
             />
           </div>

--- a/apps/web/src/pages/RoomPageCastActive.test.tsx
+++ b/apps/web/src/pages/RoomPageCastActive.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomPage } from './RoomPage'
+import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import {
+  CAST_ACTIVE_HEADING,
+  CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_BUTTON_LABEL,
+} from '../room/cast/castActiveStatusCopy'
+import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
+
+const fetchRoom = vi.fn()
+const fetchRtcIceServers = vi.fn()
+const castStartLifecycle = vi.hoisted(() => ({ value: 'idle' as CastStartLifecycle }))
+const startCast = vi.hoisted(() => vi.fn())
+const stopCast = vi.hoisted(() => vi.fn())
+const castToTvButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
+const stopCastButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    fetchRoom: (...args: unknown[]) => fetchRoom(...args),
+  }
+})
+
+vi.mock('../config/fetchRtcIceServers', () => ({
+  fetchRtcIceServers: () => fetchRtcIceServers(),
+}))
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogEpisodeQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('../auth/fanTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../auth/fanTokens')>()
+  return {
+    ...actual,
+    getFanAccessToken: () => null,
+  }
+})
+
+vi.mock('../config/wsUrl', () => ({
+  getPublicWsUrl: () => 'wss://ws.test.example',
+}))
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.test.example',
+}))
+
+vi.mock('../config/publicOrigin', () => ({
+  getPublicOrigin: () => 'https://www.test.example',
+}))
+
+vi.mock('../session/guestSession', () => ({
+  ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
+  setGuestDisplayName: (name: string) => name,
+  FAN_DISPLAY_NAME_MAX_LEN: 48,
+}))
+
+vi.mock('../room/cast/useCastAvailability', () => ({
+  useCastAvailability: () => 'available',
+}))
+
+vi.mock('../room/cast/useCastStartSession', () => ({
+  useCastStartSession: () => ({
+    castStartLifecycle: castStartLifecycle.value,
+    startCast,
+    stopCast,
+    castToTvButtonRef,
+    stopCastButtonRef,
+  }),
+}))
+
+vi.mock('../room/audio/theaterAudioMix', () => ({
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn(() => 'running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
+vi.mock('../room/sfu/mediasoupSharing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../room/sfu/mediasoupSharing')>()
+  return {
+    ...actual,
+    connectSfuUnifiedSession: vi.fn().mockResolvedValue({
+      close: vi.fn(),
+      replaceHostScreenProducer: vi.fn(),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+    }),
+    resolveSfuWsBaseForToken: vi.fn(() => 'wss://sfu.test.example'),
+  }
+})
+
+vi.mock('../api/webrtcSfuApi', () => ({
+  fetchSfuJoinToken: vi.fn().mockResolvedValue({
+    token: 'sfu-jwt',
+    wsUrl: 'wss://sfu.test.example',
+    role: 'consumer',
+    expiresInSeconds: 900,
+  }),
+}))
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+
+  constructor(url: string) {
+    void url
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+    })
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  send() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+}
+
+describe('RoomPage Cast active stage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    castStartLifecycle.value = 'idle'
+    startCast.mockReset()
+    stopCast.mockReset()
+    castToTvButtonRef.current = null
+    stopCastButtonRef.current = null
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+
+    fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
+    fetchRoom.mockResolvedValue({
+      roomId: 'room-test-1',
+      hostSub: 'host-sub',
+      catalogEpisodeId: 'ep-1',
+      youtubeVideoId: 'yt-1',
+      version: 1,
+      visibility: 'public',
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      roomMode: 'theater',
+      avDisabled: true,
+      broadcastCaptureActive: false,
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  async function openRoomTab() {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/room/room-test-1']}>
+          <RoomChromeProvider>
+            <Routes>
+              <Route path="/room/:roomId" element={<RoomPage />} />
+            </Routes>
+          </RoomChromeProvider>
+        </MemoryRouter>,
+      )
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
+    })
+
+    const roomTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find(
+      (node) => node.textContent?.trim() === 'Room',
+    )
+    act(() => {
+      ;(roomTab as HTMLButtonElement).click()
+    })
+  }
+
+  it('replaces the playback surface with Now Casting while casting', async () => {
+    castStartLifecycle.value = 'casting'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).not.toBeNull()
+    expect(container.textContent).toContain(CAST_ACTIVE_HEADING)
+    expect(container.textContent).toContain(CAST_ACTIVE_SUBCOPY)
+    expect(container.textContent).toContain(CAST_STOP_BUTTON_LABEL)
+    expect(container.querySelector('.riffsync-room-page__playback')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__guest-video')).toBeNull()
+  })
+
+  it('keeps the regular playback surface visible while Cast is starting', async () => {
+    castStartLifecycle.value = 'starting'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+  })
+
+  it('hides expanded view controls while casting', async () => {
+    castStartLifecycle.value = 'casting'
+    await openRoomTab()
+
+    expect(container.querySelector('.riffsync-room-page__expand-toggle')).toBeNull()
+  })
+
+  it('invokes stopCast when Stop Cast is clicked', async () => {
+    castStartLifecycle.value = 'casting'
+    await openRoomTab()
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    act(() => {
+      stopButton.click()
+    })
+
+    expect(stopCast).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show Cast to TV in the Room sidebar while casting', async () => {
+    castStartLifecycle.value = 'casting'
+    await openRoomTab()
+
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+})

--- a/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CastActiveStagePanel } from './CastActiveStagePanel'
+import {
+  CAST_ACTIVE_HEADING,
+  CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_BUTTON_LABEL,
+  RIFFSYNC_CAST_ACTIVE_STATUS_ID,
+} from './castActiveStatusCopy'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('CastActiveStagePanel', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('renders Now Casting copy and Stop Cast control', () => {
+    act(() => {
+      root.render(<CastActiveStagePanel onStopCast={vi.fn()} />)
+    })
+
+    expect(container.textContent).toContain(CAST_ACTIVE_HEADING)
+    expect(container.textContent).toContain(CAST_ACTIVE_SUBCOPY)
+    expect(container.textContent).toContain(CAST_STOP_BUTTON_LABEL)
+
+    const status = container.querySelector(`#${RIFFSYNC_CAST_ACTIVE_STATUS_ID}`)
+    expect(status?.getAttribute('role')).toBe('status')
+    expect(status?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('invokes onStopCast when Stop Cast is activated', () => {
+    const onStopCast = vi.fn()
+    act(() => {
+      root.render(<CastActiveStagePanel onStopCast={onStopCast} />)
+    })
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    act(() => {
+      stopButton.click()
+    })
+
+    expect(onStopCast).toHaveBeenCalledTimes(1)
+  })
+
+  it('associates Stop Cast with the Now Casting heading', () => {
+    act(() => {
+      root.render(<CastActiveStagePanel onStopCast={vi.fn()} />)
+    })
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    expect(stopButton.getAttribute('aria-describedby')).toBe('riffsync-cast-active-heading')
+  })
+})

--- a/apps/web/src/room/cast/CastActiveStagePanel.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.tsx
@@ -1,0 +1,43 @@
+import type { RefObject } from 'react'
+import {
+  CAST_ACTIVE_HEADING,
+  CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_BUTTON_LABEL,
+  RIFFSYNC_CAST_ACTIVE_STATUS_ID,
+} from './castActiveStatusCopy'
+
+type CastActiveStagePanelProps = {
+  onStopCast: () => void
+  stopCastButtonRef?: RefObject<HTMLButtonElement | null>
+}
+
+export function CastActiveStagePanel({ onStopCast, stopCastButtonRef }: CastActiveStagePanelProps) {
+  return (
+    <section
+      className="riffsync-room-page__cast-active-stage"
+      aria-labelledby="riffsync-cast-active-heading"
+      data-testid="cast-active-stage-panel"
+    >
+      <h2 id="riffsync-cast-active-heading" className="riffsync-room-page__cast-active-heading">
+        {CAST_ACTIVE_HEADING}
+      </h2>
+      <p
+        id={RIFFSYNC_CAST_ACTIVE_STATUS_ID}
+        className="riffsync-room-page__cast-active-subcopy"
+        role="status"
+        aria-live="polite"
+      >
+        {CAST_ACTIVE_SUBCOPY}
+      </p>
+      <button
+        ref={stopCastButtonRef}
+        type="button"
+        className="gen-button riffsync-room-page__cast-stop-button"
+        aria-describedby="riffsync-cast-active-heading"
+        onClick={onStopCast}
+      >
+        {CAST_STOP_BUTTON_LABEL}
+      </button>
+    </section>
+  )
+}

--- a/apps/web/src/room/cast/CastStartRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.test.tsx
@@ -66,4 +66,9 @@ describe('CastStartRoomActions', () => {
     const status = container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)
     expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
   })
+
+  it('hides Cast to TV while casting', () => {
+    renderActions('available', 'casting')
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
 })

--- a/apps/web/src/room/cast/castActiveStatusCopy.ts
+++ b/apps/web/src/room/cast/castActiveStatusCopy.ts
@@ -1,0 +1,7 @@
+export const CAST_ACTIVE_HEADING = 'Now Casting'
+
+export const CAST_ACTIVE_SUBCOPY = 'Casting to TV'
+
+export const CAST_STOP_BUTTON_LABEL = 'Stop Cast'
+
+export const RIFFSYNC_CAST_ACTIVE_STATUS_ID = 'riffsync-cast-active-status'

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -37,12 +37,18 @@ function TestHarness({ expandedViewActive = false }: { expandedViewActive?: bool
   return (
     <div>
       <span data-testid="lifecycle">{castStartLifecycle}</span>
-      <button ref={castToTvButtonRef} type="button" data-testid="cast-to-tv" onClick={() => void startCast()}>
-        Cast to TV
-      </button>
-      <button ref={stopCastButtonRef} type="button" data-testid="stop-cast" onClick={() => stopCast()}>
-        Stop Cast
-      </button>
+      {castStartLifecycle === 'idle' || castStartLifecycle === 'start_failed' ? (
+        <button ref={castToTvButtonRef} type="button" data-testid="cast-to-tv" onClick={() => void startCast()}>
+          Cast to TV
+        </button>
+      ) : castStartLifecycle === 'starting' ? (
+        <p data-testid="cast-starting-status">Starting Cast…</p>
+      ) : null}
+      {castStartLifecycle === 'casting' ? (
+        <button ref={stopCastButtonRef} type="button" data-testid="stop-cast" onClick={() => stopCast()}>
+          Stop Cast
+        </button>
+      ) : null}
     </div>
   )
 }
@@ -85,6 +91,7 @@ describe('useCastStartSession focus transfer', () => {
     })
 
     const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    expect(stopButton).not.toBeNull()
     expect(document.activeElement).toBe(stopButton)
   })
 
@@ -103,6 +110,36 @@ describe('useCastStartSession focus transfer', () => {
     await act(async () => {
       castButton.click()
       await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.activeElement).toBe(other)
+    other.remove()
+  })
+
+  it('does not steal focus when the viewer moves focus elsewhere during startup', async () => {
+    await renderHarness()
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    act(() => {
+      castButton.focus()
+    })
+
+    const other = document.createElement('button')
+    other.type = 'button'
+    other.textContent = 'Other'
+    document.body.appendChild(other)
+
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      other.focus()
+    })
+
+    await act(async () => {
       await Promise.resolve()
     })
 

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCastStartSession } from './useCastStartSession'
+
+function TestHarness({ expandedViewActive = false }: { expandedViewActive?: boolean }) {
+  const messageListeners = new Set<(message: unknown) => void>()
+
+  const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
+    useCastStartSession({
+      enabled: true,
+      expandedViewActive,
+      roomMode: 'theater',
+      youtubeVideoId: 'yt-1',
+      isPublisher: false,
+      hasHostCaptureStream: false,
+      hasGuestRelayStream: false,
+      chat: [],
+      chatMemberLabels: new Map(),
+      createSenderClient: () => ({
+        requestSession: vi.fn().mockResolvedValue({
+          sendMessage: async () => {
+            queueMicrotask(() => {
+              for (const listener of messageListeners) listener({ type: 'render_confirmed' })
+            })
+          },
+          addMessageListener: (handler: (message: unknown) => void) => {
+            messageListeners.add(handler)
+            return () => messageListeners.delete(handler)
+          },
+          end: vi.fn().mockResolvedValue(undefined),
+        }),
+      }),
+    })
+
+  return (
+    <div>
+      <span data-testid="lifecycle">{castStartLifecycle}</span>
+      <button ref={castToTvButtonRef} type="button" data-testid="cast-to-tv" onClick={() => void startCast()}>
+        Cast to TV
+      </button>
+      <button ref={stopCastButtonRef} type="button" data-testid="stop-cast" onClick={() => stopCast()}>
+        Stop Cast
+      </button>
+    </div>
+  )
+}
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('useCastStartSession focus transfer', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function renderHarness(expandedViewActive = false) {
+    act(() => {
+      root.render(<TestHarness expandedViewActive={expandedViewActive} />)
+    })
+  }
+
+  it('moves focus to Stop Cast when Cast to TV still owns focus at success', async () => {
+    await renderHarness()
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    act(() => {
+      castButton.focus()
+    })
+
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    expect(document.activeElement).toBe(stopButton)
+  })
+
+  it('does not steal focus when Cast to TV did not own focus at success', async () => {
+    await renderHarness()
+
+    const other = document.createElement('button')
+    other.type = 'button'
+    other.textContent = 'Other'
+    document.body.appendChild(other)
+    act(() => {
+      other.focus()
+    })
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.activeElement).toBe(other)
+    other.remove()
+  })
+
+  it('returns lifecycle to idle after stopCast', async () => {
+    await renderHarness()
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('casting')
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    await act(async () => {
+      stopButton.click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('idle')
+  })
+})

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -25,7 +25,9 @@ export type UseCastStartSessionInput = {
 export type UseCastStartSessionResult = {
   castStartLifecycle: CastStartLifecycle
   startCast: () => Promise<void>
+  stopCast: () => void
   castToTvButtonRef: RefObject<HTMLButtonElement | null>
+  stopCastButtonRef: RefObject<HTMLButtonElement | null>
 }
 
 export function useCastStartSession({
@@ -41,6 +43,7 @@ export function useCastStartSession({
   createSenderClient = createDefaultCastSenderClient,
 }: UseCastStartSessionInput): UseCastStartSessionResult {
   const castToTvButtonRef = useRef<HTMLButtonElement | null>(null)
+  const stopCastButtonRef = useRef<HTMLButtonElement | null>(null)
   const [controller] = useState<CastStartController>(() =>
     createCastStartController({ client: createSenderClient() }),
   )
@@ -101,9 +104,22 @@ export function useCastStartSession({
     castToTvButtonRef.current?.focus()
   }, [castStartLifecycle])
 
+  useEffect(() => {
+    if (castStartLifecycle !== 'casting') return
+    if (castToTvButtonRef.current === document.activeElement) {
+      stopCastButtonRef.current?.focus()
+    }
+  }, [castStartLifecycle])
+
+  const stopCast = useCallback(() => {
+    void controller.stopCast()
+  }, [controller])
+
   return {
     castStartLifecycle,
     startCast,
+    stopCast,
     castToTvButtonRef,
+    stopCastButtonRef,
   }
 }

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -44,6 +44,7 @@ export function useCastStartSession({
 }: UseCastStartSessionInput): UseCastStartSessionResult {
   const castToTvButtonRef = useRef<HTMLButtonElement | null>(null)
   const stopCastButtonRef = useRef<HTMLButtonElement | null>(null)
+  const shouldTransferFocusToStopRef = useRef(false)
   const [controller] = useState<CastStartController>(() =>
     createCastStartController({ client: createSenderClient() }),
   )
@@ -96,6 +97,10 @@ export function useCastStartSession({
       controller.resetStartFailure()
     }
 
+    shouldTransferFocusToStopRef.current =
+      castToTvButtonRef.current !== null &&
+      castToTvButtonRef.current === document.activeElement
+
     await controller.startCast(buildSnapshot())
   }, [buildSnapshot, controller, enabled, expandedViewActive])
 
@@ -105,10 +110,26 @@ export function useCastStartSession({
   }, [castStartLifecycle])
 
   useEffect(() => {
+    if (castStartLifecycle !== 'starting') return
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (!shouldTransferFocusToStopRef.current) return
+      const target = event.target
+      if (target instanceof HTMLElement && target !== castToTvButtonRef.current) {
+        shouldTransferFocusToStopRef.current = false
+      }
+    }
+
+    document.addEventListener('focusin', handleFocusIn, true)
+    return () => document.removeEventListener('focusin', handleFocusIn, true)
+  }, [castStartLifecycle])
+
+  useEffect(() => {
     if (castStartLifecycle !== 'casting') return
-    if (castToTvButtonRef.current === document.activeElement) {
+    if (shouldTransferFocusToStopRef.current) {
       stopCastButtonRef.current?.focus()
     }
+    shouldTransferFocusToStopRef.current = false
   }, [castStartLifecycle])
 
   const stopCast = useCallback(() => {

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2038,6 +2038,39 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   line-height: 1.35;
 }
 
+.riffsync-room-page__cast-active-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: min(52vh, 28rem);
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  background: rgb(13 17 23 / 0.72);
+  text-align: center;
+}
+
+.riffsync-room-page__cast-active-heading {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.riffsync-room-page__cast-active-subcopy {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  color: rgb(230 237 243 / 0.82);
+}
+
+.riffsync-room-page__cast-stop-button {
+  min-width: 11rem;
+  min-height: 2.75rem;
+  margin-top: 0.25rem;
+}
+
 .riffsync-cast-receiver {
   min-height: 100dvh;
   background: #0d1117;


### PR DESCRIPTION
## Summary

- After receiver render confirmation, the sender stage shows a local **Now Casting** panel with **Casting to TV** copy and a **Stop Cast** control that invokes the Cast controller only.
- Normal in-page playback stays visible during `starting`; the regular playback surface is hidden only while `casting` is active.
- Expanded view is suppressed while Cast is active (toggle hidden, layout not expanded).
- Focus moves from **Cast to TV** to **Stop Cast** only when the initiating button still owns focus at success.

Closes #274

## Test plan

- [x] `cd apps/web && npm ci && npm run build && npm test && npm run lint`
- [ ] Manual: simulate confirmed Cast start; verify Now Casting panel replaces playback surface
- [ ] Manual: confirm Stop Cast is keyboard reachable and does not affect room/SFU state
- [ ] Manual: confirm expanded view toggle is absent while casting