### PR TITLE
[M25] Restore normal in-page playback after Stop Cast (#276)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -230,6 +230,7 @@ export function RoomPage() {
   const activeSidebarTab =
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
   const viewportWide = useViewportWide()
+  const expandToggleRef = useRef<HTMLButtonElement>(null)
   const castAvailability = useCastAvailability(Boolean(room))
   const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
     useCastStartSession({
@@ -242,9 +243,10 @@ export function RoomPage() {
       hasGuestRelayStream: Boolean(guestRemote),
       chat,
       chatMemberLabels,
+      stageFocusRestoreRef: expandToggleRef,
     })
-  const castActive = castStartLifecycle === 'casting'
-  const expandedViewActive = expandedView && viewportWide && !castActive
+  const castStageActive = castStartLifecycle === 'casting' || castStartLifecycle === 'stopping'
+  const expandedViewActive = expandedView && viewportWide && !castStageActive
   const onCastToTvClick = useCallback(() => {
     void startCast()
   }, [startCast])
@@ -442,8 +444,9 @@ export function RoomPage() {
           data-expanded-view={expandedViewActive ? 'true' : 'false'}
         >
           <div className={`riffsync-room-page__theater${expandedViewActive ? ' riffsync-room-page__theater--expanded' : ''}`}>
-            {viewportWide && !castActive ? (
+            {viewportWide && !castStageActive ? (
               <button
+                ref={expandToggleRef}
                 type="button"
                 className="riffsync-room-page__expand-toggle"
                 aria-pressed={expandedViewActive}
@@ -461,10 +464,11 @@ export function RoomPage() {
               avSurfacesEnabled={avSurfacesEnabled}
               expandedView={expandedViewActive}
               playback={
-                castActive ? (
+                castStageActive ? (
                   <CastActiveStagePanel
                     onStopCast={onStopCastClick}
                     stopCastButtonRef={stopCastButtonRef}
+                    stopping={castStartLifecycle === 'stopping'}
                   />
                 ) : (
                   <RoomPlaybackPanel

--- a/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomPage } from './RoomPage'
+import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import {
+  CAST_ACTIVE_HEADING,
+  CAST_STOPPING_SUBCOPY,
+} from '../room/cast/castActiveStatusCopy'
+import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
+
+const fetchRoom = vi.fn()
+const fetchRtcIceServers = vi.fn()
+const castStartLifecycle = vi.hoisted(() => ({ value: 'idle' as CastStartLifecycle }))
+const startCast = vi.hoisted(() => vi.fn())
+const stopCast = vi.hoisted(() => vi.fn())
+const castToTvButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
+const stopCastButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    fetchRoom: (...args: unknown[]) => fetchRoom(...args),
+  }
+})
+
+vi.mock('../config/fetchRtcIceServers', () => ({
+  fetchRtcIceServers: () => fetchRtcIceServers(),
+}))
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogEpisodeQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('../auth/fanTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../auth/fanTokens')>()
+  return {
+    ...actual,
+    getFanAccessToken: () => null,
+  }
+})
+
+vi.mock('../config/wsUrl', () => ({
+  getPublicWsUrl: () => 'wss://ws.test.example',
+}))
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.test.example',
+}))
+
+vi.mock('../config/publicOrigin', () => ({
+  getPublicOrigin: () => 'https://www.test.example',
+}))
+
+vi.mock('../session/guestSession', () => ({
+  ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
+  setGuestDisplayName: (name: string) => name,
+  FAN_DISPLAY_NAME_MAX_LEN: 48,
+}))
+
+vi.mock('../room/cast/useCastAvailability', () => ({
+  useCastAvailability: () => 'available',
+}))
+
+vi.mock('../room/cast/useCastStartSession', () => ({
+  useCastStartSession: () => ({
+    castStartLifecycle: castStartLifecycle.value,
+    startCast,
+    stopCast,
+    castToTvButtonRef,
+    stopCastButtonRef,
+  }),
+}))
+
+vi.mock('../room/audio/theaterAudioMix', () => ({
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn(() => 'running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
+vi.mock('../room/sfu/mediasoupSharing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../room/sfu/mediasoupSharing')>()
+  return {
+    ...actual,
+    connectSfuUnifiedSession: vi.fn().mockResolvedValue({
+      close: vi.fn(),
+      replaceHostScreenProducer: vi.fn(),
+    }),
+  }
+})
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+      this.onopen?.(new Event('open'))
+    })
+  }
+
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+
+  addEventListener(type: string, listener: EventListener) {
+    if (type === 'open') this.onopen = listener as (event: Event) => void
+    if (type === 'message') this.onmessage = listener as (event: MessageEvent) => void
+    if (type === 'error') this.onerror = listener as (event: Event) => void
+    if (type === 'close') this.onclose = listener as (event: CloseEvent) => void
+  }
+
+  removeEventListener() {}
+  send() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+}
+
+describe('RoomPage Cast stop restoration', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    castStartLifecycle.value = 'idle'
+    startCast.mockReset()
+    stopCast.mockReset()
+    castToTvButtonRef.current = null
+    stopCastButtonRef.current = null
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+
+    fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
+    fetchRoom.mockResolvedValue({
+      roomId: 'room-test-1',
+      hostSub: 'host-sub',
+      catalogEpisodeId: 'ep-1',
+      youtubeVideoId: 'yt-1',
+      version: 1,
+      visibility: 'public',
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      roomMode: 'theater',
+      avDisabled: true,
+      broadcastCaptureActive: false,
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  async function openRoomTab() {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/room/room-test-1']}>
+          <RoomChromeProvider>
+            <Routes>
+              <Route path="/room/:roomId" element={<RoomPage />} />
+            </Routes>
+          </RoomChromeProvider>
+        </MemoryRouter>,
+      )
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
+    })
+  }
+
+  it('keeps the Cast stage panel visible while stopping', async () => {
+    castStartLifecycle.value = 'stopping'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).not.toBeNull()
+    expect(container.textContent).toContain(CAST_ACTIVE_HEADING)
+    expect(container.textContent).toContain(CAST_STOPPING_SUBCOPY)
+    expect(container.querySelector('.riffsync-room-page__playback')).toBeNull()
+  })
+
+  it('restores the normal playback surface after stop completes to idle', async () => {
+    castStartLifecycle.value = 'idle'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+  })
+
+  it('shows the expand toggle again after stop restoration to idle', async () => {
+    castStartLifecycle.value = 'idle'
+    await openRoomTab()
+
+    expect(container.querySelector('.riffsync-room-page__expand-toggle')).not.toBeNull()
+  })
+})

--- a/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
@@ -6,6 +6,7 @@ import { CastActiveStagePanel } from './CastActiveStagePanel'
 import {
   CAST_ACTIVE_HEADING,
   CAST_ACTIVE_SUBCOPY,
+  CAST_STOPPING_SUBCOPY,
   CAST_STOP_BUTTON_LABEL,
   RIFFSYNC_CAST_ACTIVE_STATUS_ID,
 } from './castActiveStatusCopy'
@@ -62,5 +63,18 @@ describe('CastActiveStagePanel', () => {
 
     const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
     expect(stopButton.getAttribute('aria-describedby')).toBe('riffsync-cast-active-heading')
+  })
+
+  it('shows stopping copy and disables Stop Cast while stopping', () => {
+    act(() => {
+      root.render(<CastActiveStagePanel onStopCast={vi.fn()} stopping />)
+    })
+
+    expect(container.textContent).toContain(CAST_STOPPING_SUBCOPY)
+    expect(container.textContent).not.toContain(CAST_ACTIVE_SUBCOPY)
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    expect(stopButton.disabled).toBe(true)
+    expect(stopButton.getAttribute('aria-disabled')).toBe('true')
   })
 })

--- a/apps/web/src/room/cast/CastActiveStagePanel.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from 'react'
 import {
   CAST_ACTIVE_HEADING,
   CAST_ACTIVE_SUBCOPY,
+  CAST_STOPPING_SUBCOPY,
   CAST_STOP_BUTTON_LABEL,
   RIFFSYNC_CAST_ACTIVE_STATUS_ID,
 } from './castActiveStatusCopy'
@@ -9,9 +10,14 @@ import {
 type CastActiveStagePanelProps = {
   onStopCast: () => void
   stopCastButtonRef?: RefObject<HTMLButtonElement | null>
+  stopping?: boolean
 }
 
-export function CastActiveStagePanel({ onStopCast, stopCastButtonRef }: CastActiveStagePanelProps) {
+export function CastActiveStagePanel({
+  onStopCast,
+  stopCastButtonRef,
+  stopping = false,
+}: CastActiveStagePanelProps) {
   return (
     <section
       className="riffsync-room-page__cast-active-stage"
@@ -27,7 +33,7 @@ export function CastActiveStagePanel({ onStopCast, stopCastButtonRef }: CastActi
         role="status"
         aria-live="polite"
       >
-        {CAST_ACTIVE_SUBCOPY}
+        {stopping ? CAST_STOPPING_SUBCOPY : CAST_ACTIVE_SUBCOPY}
       </p>
       <button
         ref={stopCastButtonRef}
@@ -35,6 +41,8 @@ export function CastActiveStagePanel({ onStopCast, stopCastButtonRef }: CastActi
         className="gen-button riffsync-room-page__cast-stop-button"
         aria-describedby="riffsync-cast-active-heading"
         onClick={onStopCast}
+        disabled={stopping}
+        aria-disabled={stopping ? 'true' : undefined}
       >
         {CAST_STOP_BUTTON_LABEL}
       </button>

--- a/apps/web/src/room/cast/CastStartRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.test.tsx
@@ -29,7 +29,7 @@ describe('CastStartRoomActions', () => {
 
   function renderActions(
     castAvailability: 'checking' | 'available' | 'unavailable',
-    castStartLifecycle: 'idle' | 'starting' | 'casting' | 'start_failed' = 'idle',
+    castStartLifecycle: 'idle' | 'starting' | 'casting' | 'stopping' | 'start_failed' = 'idle',
   ) {
     act(() => {
       root.render(
@@ -69,6 +69,11 @@ describe('CastStartRoomActions', () => {
 
   it('hides Cast to TV while casting', () => {
     renderActions('available', 'casting')
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('hides Cast to TV while stopping', () => {
+    renderActions('available', 'stopping')
     expect(container.textContent).not.toContain('Cast to TV')
   })
 })

--- a/apps/web/src/room/cast/CastStartRoomActions.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.tsx
@@ -75,7 +75,7 @@ export function CastStartRoomActions({
     )
   }
 
-  if (castStartLifecycle === 'casting') {
+  if (castStartLifecycle === 'casting' || castStartLifecycle === 'stopping') {
     return null
   }
 

--- a/apps/web/src/room/cast/castActiveParticipationWiring.test.ts
+++ b/apps/web/src/room/cast/castActiveParticipationWiring.test.ts
@@ -52,8 +52,8 @@ describe('Cast active participation wiring (#275)', () => {
     expect(src).toContain('useCastStartSession')
     expect(src).toContain('useRoomMediaEngine')
     expect(mediaEngineCall).not.toContain('castStartLifecycle')
-    expect(mediaEngineCall).not.toContain('castActive')
-    expect(src).toMatch(/castActive \? \([\s\S]*CastActiveStagePanel/)
+    expect(mediaEngineCall).not.toContain('castStageActive')
+    expect(src).toMatch(/castStageActive \? \([\s\S]*CastActiveStagePanel/)
     expect(src).toMatch(/const roomSidebarProps = \{[\s\S]*castStartLifecycle,/)
   })
 
@@ -77,6 +77,6 @@ describe('Cast active participation wiring (#275)', () => {
     expect(src).toMatch(/disabled=\{!fanToken \|\| chatComposeStatus\.disableSubmit\}/)
     expect(src).not.toMatch(/disableSubmit[\s\S]{0,80}castStartLifecycle/)
     expect(src).not.toMatch(/castStartLifecycle[\s\S]{0,80}disableSubmit/)
-    expect(src).not.toMatch(/castActive/)
+    expect(src).not.toMatch(/castStageActive/)
   })
 })

--- a/apps/web/src/room/cast/castActiveStatusCopy.ts
+++ b/apps/web/src/room/cast/castActiveStatusCopy.ts
@@ -2,6 +2,8 @@ export const CAST_ACTIVE_HEADING = 'Now Casting'
 
 export const CAST_ACTIVE_SUBCOPY = 'Casting to TV'
 
+export const CAST_STOPPING_SUBCOPY = 'Stopping Cast…'
+
 export const CAST_STOP_BUTTON_LABEL = 'Stop Cast'
 
 export const RIFFSYNC_CAST_ACTIVE_STATUS_ID = 'riffsync-cast-active-status'

--- a/apps/web/src/room/cast/castChannelProtocol.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.ts
@@ -2,7 +2,7 @@ import type { RoomMode } from '../../api/roomsApi'
 
 export const RIFFSYNC_CAST_NAMESPACE = 'urn:x-cast:com.riffsync.presentation'
 
-export type CastStartLifecycle = 'idle' | 'starting' | 'casting' | 'start_failed'
+export type CastStartLifecycle = 'idle' | 'starting' | 'casting' | 'stopping' | 'start_failed'
 
 export type CastStagePrimaryKind = 'youtube_embed' | 'live_video_placeholder' | 'video_chat_grid'
 

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -93,6 +93,40 @@ describe('createCastStartController', () => {
     expect(session.end).toHaveBeenCalledTimes(1)
   })
 
+  it('transitions through stopping before idle on stopCast', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+
+    const states: string[] = []
+    controller.subscribe((state) => states.push(state.lifecycle))
+    await controller.stopCast()
+
+    expect(states).toEqual(['stopping', 'idle'])
+  })
+
+  it('stopCast is idempotent while stopping', async () => {
+    let resolveEnd: (() => void) | undefined
+    const session = createMockSession({ confirmAfterSend: true })
+    session.end = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEnd = resolve
+        }),
+    )
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    const firstStop = controller.stopCast()
+    await controller.stopCast()
+    resolveEnd?.()
+    await firstStop
+
+    expect(controller.getState().lifecycle).toBe('idle')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
   it('proxies chat overlay updates while casting', async () => {
     const sent: unknown[] = []
     const session = createMockSession({

--- a/apps/web/src/room/cast/castStartController.ts
+++ b/apps/web/src/room/cast/castStartController.ts
@@ -128,6 +128,12 @@ export function createCastStartController({
       emit()
     },
     stopCast: async () => {
+      if (lifecycle === 'idle' || lifecycle === 'starting' || lifecycle === 'start_failed') return
+      if (lifecycle === 'stopping') return
+
+      lifecycle = 'stopping'
+      emit()
+
       await cleanupSession()
       lifecycle = 'idle'
       emit()

--- a/apps/web/src/room/cast/castStopRestorationWiring.test.ts
+++ b/apps/web/src/room/cast/castStopRestorationWiring.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const castDir = path.dirname(fileURLToPath(import.meta.url))
+const pagesDir = path.join(castDir, '../../pages')
+
+function readCast(relativePath: string): string {
+  return fs.readFileSync(path.join(castDir, relativePath), 'utf8')
+}
+
+function readPage(relativePath: string): string {
+  return fs.readFileSync(path.join(pagesDir, relativePath), 'utf8')
+}
+
+describe('Cast stop restoration wiring (#276)', () => {
+  it('castStartController stopCast enters stopping before idle cleanup', () => {
+    const src = readCast('castStartController.ts')
+    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*lifecycle = 'stopping'[\s\S]*cleanupSession/)
+    expect(src).toMatch(/cleanupSession\(\)[\s\S]*lifecycle = 'idle'/)
+  })
+
+  it('useCastStartSession restores focus only after stopping completes to idle', () => {
+    const src = readCast('useCastStartSession.ts')
+    expect(src).toContain('shouldRestoreFocusFromCastStageRef')
+    expect(src).toMatch(/previousLifecycle !== 'stopping'/)
+    expect(src).toContain('stageFocusRestoreRef')
+    expect(src).not.toContain('sendChat(')
+    expect(src).not.toContain('setChatDraft')
+  })
+
+  it('RoomPage keeps Cast stage mounted through stopping and restores playback after', () => {
+    const src = readPage('RoomPage.tsx')
+    expect(src).toContain("castStartLifecycle === 'casting' || castStartLifecycle === 'stopping'")
+    expect(src).toMatch(/stopping=\{castStartLifecycle === 'stopping'\}/)
+    expect(src).toMatch(/castStageActive \? \([\s\S]*CastActiveStagePanel[\s\S]*RoomPlaybackPanel/)
+  })
+
+  it('CastActiveStagePanel exposes stopping feedback on the stage-local status surface', () => {
+    const src = readCast('CastActiveStagePanel.tsx')
+    expect(src).toContain('CAST_STOPPING_SUBCOPY')
+    expect(src).toMatch(/disabled=\{stopping\}/)
+  })
+})

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -1,10 +1,16 @@
 // @vitest-environment happy-dom
-import { act } from 'react'
+import { act, useRef, type RefObject } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCastStartSession } from './useCastStartSession'
 
-function TestHarness({ expandedViewActive = false }: { expandedViewActive?: boolean }) {
+function TestHarness({
+  expandedViewActive = false,
+  stageFocusRestoreRef,
+}: {
+  expandedViewActive?: boolean
+  stageFocusRestoreRef?: RefObject<HTMLButtonElement | null>
+}) {
   const messageListeners = new Set<(message: unknown) => void>()
 
   const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
@@ -18,6 +24,7 @@ function TestHarness({ expandedViewActive = false }: { expandedViewActive?: bool
       hasGuestRelayStream: false,
       chat: [],
       chatMemberLabels: new Map(),
+      stageFocusRestoreRef,
       createSenderClient: () => ({
         requestSession: vi.fn().mockResolvedValue({
           sendMessage: async () => {
@@ -44,9 +51,14 @@ function TestHarness({ expandedViewActive = false }: { expandedViewActive?: bool
       ) : castStartLifecycle === 'starting' ? (
         <p data-testid="cast-starting-status">Starting Cast…</p>
       ) : null}
-      {castStartLifecycle === 'casting' ? (
+      {castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' ? (
         <button ref={stopCastButtonRef} type="button" data-testid="stop-cast" onClick={() => stopCast()}>
           Stop Cast
+        </button>
+      ) : null}
+      {stageFocusRestoreRef ? (
+        <button ref={stageFocusRestoreRef} type="button" data-testid="stage-restore">
+          Expand view
         </button>
       ) : null}
     </div>
@@ -70,9 +82,19 @@ describe('useCastStartSession focus transfer', () => {
     container.remove()
   })
 
-  async function renderHarness(expandedViewActive = false) {
+  async function renderHarness(expandedViewActive = false, withStageRestore = false) {
+    function HarnessWrapper() {
+      const stageFocusRestoreRef = useRef<HTMLButtonElement | null>(null)
+      return (
+        <TestHarness
+          expandedViewActive={expandedViewActive}
+          stageFocusRestoreRef={withStageRestore ? stageFocusRestoreRef : undefined}
+        />
+      )
+    }
+
     act(() => {
-      root.render(<TestHarness expandedViewActive={expandedViewActive} />)
+      root.render(withStageRestore ? <HarnessWrapper /> : <TestHarness expandedViewActive={expandedViewActive} />)
     })
   }
 
@@ -166,5 +188,66 @@ describe('useCastStartSession focus transfer', () => {
     })
 
     expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('idle')
+  })
+
+  it('restores focus to the stage control when Stop Cast still owns focus at success', async () => {
+    await renderHarness(false, true)
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    act(() => {
+      stopButton.focus()
+    })
+
+    await act(async () => {
+      stopButton.click()
+      await Promise.resolve()
+    })
+
+    const stageRestore = container.querySelector('[data-testid="stage-restore"]') as HTMLButtonElement
+    expect(document.activeElement).toBe(stageRestore)
+  })
+
+  it('preserves focus when the viewer moves away from the Cast stage during stopping', async () => {
+    await renderHarness(false, true)
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    act(() => {
+      stopButton.focus()
+    })
+
+    const other = document.createElement('button')
+    other.type = 'button'
+    other.textContent = 'Chat compose'
+    document.body.appendChild(other)
+
+    await act(async () => {
+      stopButton.click()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      other.focus()
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(document.activeElement).toBe(other)
+    other.remove()
   })
 })

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -9,6 +9,20 @@ import type { CastStartLifecycle } from './castChannelProtocol'
 import { createCastStartController, type CastStartController } from './castStartController'
 import { createDefaultCastSenderClient, type CastSenderClientFactory } from './castSenderClient'
 
+function isFocusRestoreTargetVisible(element: HTMLElement): boolean {
+  if (!element.isConnected) return false
+  const style = window.getComputedStyle(element)
+  return style.visibility !== 'hidden' && style.display !== 'none'
+}
+
+function isCastStageFocusTarget(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false
+  return (
+    element.matches('[data-testid="cast-active-stage-panel"], [data-testid="cast-active-stage-panel"] *') ||
+    element.classList.contains('riffsync-room-page__cast-stop-button')
+  )
+}
+
 export type UseCastStartSessionInput = {
   enabled: boolean
   expandedViewActive: boolean
@@ -20,6 +34,7 @@ export type UseCastStartSessionInput = {
   chat: ChatLine[]
   chatMemberLabels: Map<string, string>
   createSenderClient?: CastSenderClientFactory
+  stageFocusRestoreRef?: RefObject<HTMLElement | null>
 }
 
 export type UseCastStartSessionResult = {
@@ -41,10 +56,13 @@ export function useCastStartSession({
   chat,
   chatMemberLabels,
   createSenderClient = createDefaultCastSenderClient,
+  stageFocusRestoreRef,
 }: UseCastStartSessionInput): UseCastStartSessionResult {
   const castToTvButtonRef = useRef<HTMLButtonElement | null>(null)
   const stopCastButtonRef = useRef<HTMLButtonElement | null>(null)
   const shouldTransferFocusToStopRef = useRef(false)
+  const shouldRestoreFocusFromCastStageRef = useRef(false)
+  const previousLifecycleRef = useRef<CastStartLifecycle>('idle')
   const [controller] = useState<CastStartController>(() =>
     createCastStartController({ client: createSenderClient() }),
   )
@@ -132,7 +150,48 @@ export function useCastStartSession({
     shouldTransferFocusToStopRef.current = false
   }, [castStartLifecycle])
 
+  useEffect(() => {
+    if (castStartLifecycle !== 'stopping') return
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (!shouldRestoreFocusFromCastStageRef.current) return
+      const target = event.target
+      if (target instanceof HTMLElement && !isCastStageFocusTarget(target)) {
+        shouldRestoreFocusFromCastStageRef.current = false
+      }
+    }
+
+    document.addEventListener('focusin', handleFocusIn, true)
+    return () => document.removeEventListener('focusin', handleFocusIn, true)
+  }, [castStartLifecycle])
+
+  useEffect(() => {
+    const previousLifecycle = previousLifecycleRef.current
+    previousLifecycleRef.current = castStartLifecycle
+
+    if (castStartLifecycle !== 'idle' || previousLifecycle !== 'stopping') return
+    if (!shouldRestoreFocusFromCastStageRef.current) return
+
+    shouldRestoreFocusFromCastStageRef.current = false
+
+    const stageTarget = stageFocusRestoreRef?.current
+    if (stageTarget && isFocusRestoreTargetVisible(stageTarget)) {
+      stageTarget.focus()
+      return
+    }
+
+    const castToTvTarget = castToTvButtonRef.current
+    if (castToTvTarget && isFocusRestoreTargetVisible(castToTvTarget)) {
+      castToTvTarget.focus()
+    }
+  }, [castStartLifecycle, stageFocusRestoreRef])
+
   const stopCast = useCallback(() => {
+    const active = document.activeElement
+    const stopButton = stopCastButtonRef.current
+    shouldRestoreFocusFromCastStageRef.current =
+      (stopButton !== null && (active === stopButton || stopButton.contains(active))) ||
+      isCastStageFocusTarget(active)
     void controller.stopCast()
   }, [controller])
 


### PR DESCRIPTION
## Summary

- Adds a `stopping` Cast lifecycle state with idempotent session cleanup in `castStartController`.
- Keeps the sender `Now Casting` stage mounted through stop cleanup, shows stage-local stopping feedback, and restores `RoomPlaybackPanel` when lifecycle returns to `idle`.
- Restores keyboard focus to the expand toggle or Cast to TV only when focus still belongs to the removed Cast stage surface.

Closes #276

## Test plan

- [x] `npm test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual: start Cast, activate Stop Cast, confirm normal playback returns with chat draft, sidebar tab, and room state intact