### PR TITLE
test(room): lock Cast room authority guardrails (#277)

### DIFF
--- a/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
+++ b/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
@@ -26,14 +26,6 @@ vi.mock('../room/experimentalRoomFeatures', () => ({
   detectExperimentalRoomFeatures: () => false,
 }))
 
-function mockFanJwt(sub = 'fan-sub-1'): string {
-  const payload = btoa(JSON.stringify({ sub }))
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-  return `eyJhbGciOiJIUzI1NiJ9.${payload}.sig`
-}
-
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
   return {

--- a/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
+++ b/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
@@ -1,0 +1,481 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomPage } from './RoomPage'
+import { RoomChromeProvider } from '../room/RoomChromeProvider'
+import { ChatSession } from '../room/sessions/ChatSession'
+import { SfuMediaSession } from '../room/sessions/SfuMediaSession'
+import {
+  CAST_ACTIVE_HEADING,
+  RIFFSYNC_CAST_ACTIVE_STATUS_ID,
+} from '../room/cast/castActiveStatusCopy'
+import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
+import type { RoomRealtimeDiagnostics } from '../room/sessions/RoomRealtimeSdk'
+
+const fetchRoom = vi.fn()
+const fetchRtcIceServers = vi.fn()
+const fetchFanProfile = vi.fn()
+const patchRoom = vi.fn()
+const fetchSfuJoinToken = vi.fn()
+const castStartLifecycle = vi.hoisted(() => ({ value: 'idle' as CastStartLifecycle }))
+const stopCast = vi.hoisted(() => vi.fn())
+
+vi.mock('../room/experimentalRoomFeatures', () => ({
+  detectExperimentalRoomFeatures: () => false,
+}))
+
+function mockFanJwt(sub = 'fan-sub-1'): string {
+  const payload = btoa(JSON.stringify({ sub }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+  return `eyJhbGciOiJIUzI1NiJ9.${payload}.sig`
+}
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    fetchRoom: (...args: unknown[]) => fetchRoom(...args),
+    patchRoom: (...args: unknown[]) => patchRoom(...args),
+  }
+})
+
+vi.mock('../api/fanProfileApi', () => ({
+  fetchFanProfile: (...args: unknown[]) => fetchFanProfile(...args),
+}))
+
+vi.mock('../config/fetchRtcIceServers', () => ({
+  fetchRtcIceServers: () => fetchRtcIceServers(),
+}))
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogEpisodeQuery: () => ({ data: undefined }),
+}))
+
+const fanTokenState = vi.hoisted(() => ({ value: null as string | null }))
+
+vi.mock('../auth/fanTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../auth/fanTokens')>()
+  return {
+    ...actual,
+    getFanAccessToken: () => fanTokenState.value,
+  }
+})
+
+vi.mock('../config/wsUrl', () => ({
+  getPublicWsUrl: () => 'wss://ws.test.example',
+}))
+
+vi.mock('../config/apiBaseUrl', () => ({
+  getPublicApiBaseUrl: () => 'https://api.test.example',
+}))
+
+vi.mock('../config/publicOrigin', () => ({
+  getPublicOrigin: () => 'https://www.test.example',
+}))
+
+vi.mock('../session/guestSession', () => ({
+  ensureGuestSession: () => ({ sessionId: 'sess-test-1', displayName: 'Guest' }),
+  setGuestDisplayName: (name: string) => name,
+  FAN_DISPLAY_NAME_MAX_LEN: 48,
+}))
+
+vi.mock('../room/cast/useCastAvailability', () => ({
+  useCastAvailability: () => 'available',
+}))
+
+vi.mock('../room/cast/useCastStartSession', () => ({
+  useCastStartSession: () => ({
+    castStartLifecycle: castStartLifecycle.value,
+    startCast: vi.fn(),
+    stopCast,
+    castToTvButtonRef: { current: null },
+    stopCastButtonRef: { current: null },
+  }),
+}))
+
+vi.mock('../room/audio/theaterAudioMix', () => ({
+  createTheaterAudioMix: vi.fn(() => ({
+    dispose: vi.fn(),
+    setAvDisabled: vi.fn(),
+    setHostVideoElement: vi.fn(),
+    onConsumerEvent: vi.fn(),
+    resumeIfSuspended: vi.fn().mockResolvedValue(undefined),
+    getAudioContextState: vi.fn(() => 'running'),
+    watchAudioContextState: vi.fn((listener: (state: AudioContextState | undefined) => void) => {
+      listener('running')
+      return () => undefined
+    }),
+  })),
+}))
+
+vi.mock('../room/sfu/mediasoupSharing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../room/sfu/mediasoupSharing')>()
+  return {
+    ...actual,
+    connectSfuUnifiedSession: vi.fn().mockResolvedValue({
+      close: vi.fn(),
+      replaceHostScreenProducer: vi.fn(),
+      unpublishProducerKind: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+    }),
+    resolveSfuWsBaseForToken: vi.fn(() => 'wss://sfu.test.example'),
+  }
+})
+
+vi.mock('../api/webrtcSfuApi', () => ({
+  fetchSfuJoinToken: (...args: unknown[]) => fetchSfuJoinToken(...args),
+}))
+
+const sendControlSpy = vi.hoisted(() => vi.fn(() => true))
+
+const defaultDrawerDiagnostics = vi.hoisted(
+  () =>
+    ({
+      roomId: 'room-test-1',
+      sessionId: 'sess-test-1',
+      asOf: new Date(0).toISOString(),
+      drawers: {
+        chat: { state: 'connected' },
+        sfuSignaling: {
+          state: 'connected',
+          health: {
+            connectivity: { state: 'connected' },
+            produceConsume: {
+              state: 'connected',
+              producerCount: 0,
+              consumerCount: 0,
+              hostScreenAttached: false,
+              participantAvPublishActive: false,
+            },
+          },
+        },
+        theaterPlayback: { state: 'connected' },
+      },
+      activeErrorCodes: [],
+    }) satisfies RoomRealtimeDiagnostics,
+)
+
+const drawerStatusMockConfig = vi.hoisted(() => {
+  type MockConfig = {
+    diagnostics: RoomRealtimeDiagnostics
+    guestShareFsm: 'idle' | 'verifying_media' | 'running'
+  }
+
+  let config: MockConfig = {
+    diagnostics: defaultDrawerDiagnostics,
+    guestShareFsm: 'running',
+  }
+
+  class MockRoomRealtimeSdk {
+    sendControl = sendControlSpy
+
+    join(_roomId: string, options: { onDiagnosticsChange?: (diagnostics: MockConfig['diagnostics']) => void }) {
+      options.onDiagnosticsChange?.(config.diagnostics)
+    }
+
+    subscribe() {}
+    teardown() {}
+
+    onTheaterSnapshotChange(listener: (snapshot: {
+      guestShareFsm: MockConfig['guestShareFsm']
+      guestPlayHint: boolean
+      hostCapturePlayHint: boolean
+    }) => void) {
+      listener({
+        guestShareFsm: config.guestShareFsm,
+        guestPlayHint: false,
+        hostCapturePlayHint: false,
+      })
+      return () => undefined
+    }
+
+    getTheaterSnapshot() {
+      return {
+        guestShareFsm: config.guestShareFsm,
+        guestPlayHint: false,
+        hostCapturePlayHint: false,
+      }
+    }
+
+    getDiagnostics() {
+      return config.diagnostics
+    }
+
+    getChatStatus() {
+      return 'open' as const
+    }
+
+    getParticipantAvController() {
+      return null
+    }
+
+    buildParticipantProducerSnapshots() {
+      return new Map()
+    }
+
+    onParticipantProducerRegistryChange() {
+      return () => undefined
+    }
+
+    setCaptureStreamForTheater() {}
+    setYoutubeVideoIdForTheater() {}
+    setRoomMode() {}
+    setAvDisabled() {}
+    updateFanToken() {}
+    getSfuStatus() {
+      return 'open' as const
+    }
+    syncHostScreenPublish() {
+      return () => undefined
+    }
+    unpublishHostScreen() {}
+    playGuestVideo() {
+      return Promise.resolve()
+    }
+    playHostCapturePreview() {
+      return Promise.resolve()
+    }
+    bindGuestVideo() {}
+    bindHostCaptureVideo() {}
+    notifyComposeDraftChange() {}
+  }
+
+  return {
+    get: () => config,
+    set: (next: MockConfig) => {
+      config = next
+    },
+    MockRoomRealtimeSdk,
+  }
+})
+
+vi.mock('../room/sessions/RoomRealtimeSdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../room/sessions/RoomRealtimeSdk')>()
+  return {
+    ...actual,
+    RoomRealtimeSdk: drawerStatusMockConfig.MockRoomRealtimeSdk,
+  }
+})
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  sent: string[] = []
+
+  constructor(url: string) {
+    void url
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+    })
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+}
+
+const CAST_LIFECYCLE_PATHS: CastStartLifecycle[] = [
+  'idle',
+  'starting',
+  'casting',
+  'stopping',
+  'start_failed',
+]
+
+describe('RoomPage Cast room authority (#277)', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let chatDisconnectSpy: ReturnType<typeof vi.spyOn>
+  let sfuDisconnectSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    castStartLifecycle.value = 'idle'
+    fanTokenState.value = null
+    stopCast.mockReset()
+    patchRoom.mockReset()
+    sendControlSpy.mockClear()
+    drawerStatusMockConfig.set({
+      diagnostics: defaultDrawerDiagnostics,
+      guestShareFsm: 'running',
+    })
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+
+    chatDisconnectSpy = vi.spyOn(ChatSession.prototype, 'disconnect')
+    sfuDisconnectSpy = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+
+    fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
+    fetchFanProfile.mockResolvedValue({ displayName: 'Fan One', avatarUrl: null })
+    fetchSfuJoinToken.mockResolvedValue({
+      token: 'sfu-jwt',
+      wsUrl: 'wss://sfu.test.example',
+      role: 'consumer',
+      expiresInSeconds: 900,
+    })
+    fetchRoom.mockResolvedValue({
+      roomId: 'room-test-1',
+      hostSub: 'host-sub',
+      catalogEpisodeId: 'ep-1',
+      youtubeVideoId: 'yt-1',
+      version: 1,
+      visibility: 'public',
+      lastActivityAt: '2026-01-01T00:00:00.000Z',
+      roomMode: 'theater',
+      avDisabled: false,
+      broadcastCaptureActive: false,
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    act(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  function renderRoom(initialPath = '/room/room-test-1') {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={[initialPath]}>
+          <RoomChromeProvider>
+            <Routes>
+              <Route path="/room/:roomId" element={<RoomPage />} />
+            </Routes>
+          </RoomChromeProvider>
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  async function waitForSidebarTabs() {
+    await vi.waitFor(() => {
+      expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
+    })
+  }
+
+  async function rerenderCastLifecycle(lifecycle: CastStartLifecycle) {
+    castStartLifecycle.value = lifecycle
+    renderRoom()
+    await waitForSidebarTabs()
+  }
+
+  function roomWsMessages(): string[] {
+    return MockWebSocket.instances.flatMap((socket) => socket.sent)
+  }
+
+  it.each(CAST_LIFECYCLE_PATHS)(
+    'does not call patchRoom or sendControl when Cast lifecycle is %s',
+    async (lifecycle) => {
+      castStartLifecycle.value = lifecycle
+      renderRoom()
+      await waitForSidebarTabs()
+
+      expect(patchRoom).not.toHaveBeenCalled()
+      expect(sendControlSpy).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not issue extra SFU token requests across Cast lifecycle re-renders', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const tokenCallsBefore = fetchSfuJoinToken.mock.calls.length
+
+    for (const lifecycle of ['starting', 'casting', 'stopping', 'start_failed', 'idle'] as const) {
+      await rerenderCastLifecycle(lifecycle)
+    }
+
+    expect(fetchSfuJoinToken.mock.calls.length).toBe(tokenCallsBefore)
+  })
+
+  it('does not emit room WebSocket traffic when Cast lifecycle changes', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const messagesBefore = roomWsMessages().length
+
+    await rerenderCastLifecycle('casting')
+    await rerenderCastLifecycle('stopping')
+    await rerenderCastLifecycle('idle')
+
+    expect(roomWsMessages().length).toBe(messagesBefore)
+  })
+
+  it('does not disconnect chat or SFU sessions across Cast lifecycle re-renders', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const chatBefore = chatDisconnectSpy.mock.calls.length
+    const sfuBefore = sfuDisconnectSpy.mock.calls.length
+
+    for (const lifecycle of ['starting', 'casting', 'stopping', 'start_failed'] as const) {
+      await rerenderCastLifecycle(lifecycle)
+    }
+
+    expect(chatDisconnectSpy.mock.calls.length).toBe(chatBefore)
+    expect(sfuDisconnectSpy.mock.calls.length).toBe(sfuBefore)
+  })
+
+  it('keeps drawer diagnostics unchanged when Cast becomes active on the sender', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const diagnosticsBefore = drawerStatusMockConfig.get().diagnostics
+
+    await rerenderCastLifecycle('casting')
+
+    expect(drawerStatusMockConfig.get().diagnostics).toEqual(diagnosticsBefore)
+    expect(container.querySelector(`#${RIFFSYNC_CAST_ACTIVE_STATUS_ID}`)).not.toBeNull()
+  })
+
+  it('remote participant view stays Cast-free when local Cast lifecycle is idle', async () => {
+    castStartLifecycle.value = 'idle'
+    renderRoom()
+    await waitForSidebarTabs()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.textContent).not.toContain(CAST_ACTIVE_HEADING)
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+  })
+
+  it('invokes local stopCast without room mutation or websocket fan-out', async () => {
+    castStartLifecycle.value = 'casting'
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const patchBefore = patchRoom.mock.calls.length
+    const messagesBefore = roomWsMessages().length
+    const chatBefore = chatDisconnectSpy.mock.calls.length
+    const sfuBefore = sfuDisconnectSpy.mock.calls.length
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    act(() => {
+      stopButton.click()
+    })
+
+    expect(stopCast).toHaveBeenCalledTimes(1)
+    expect(patchRoom.mock.calls.length).toBe(patchBefore)
+    expect(roomWsMessages().length).toBe(messagesBefore)
+    expect(chatDisconnectSpy.mock.calls.length).toBe(chatBefore)
+    expect(sfuDisconnectSpy.mock.calls.length).toBe(sfuBefore)
+  })
+})

--- a/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
+++ b/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const castDir = path.dirname(fileURLToPath(import.meta.url))
+const pagesDir = path.join(castDir, '../../pages')
+const castReceiverDir = path.join(pagesDir, 'cast')
+
+function readCast(relativePath: string): string {
+  return fs.readFileSync(path.join(castDir, relativePath), 'utf8')
+}
+
+function readPage(relativePath: string): string {
+  return fs.readFileSync(path.join(pagesDir, relativePath), 'utf8')
+}
+
+function readCastReceiver(relativePath: string): string {
+  return fs.readFileSync(path.join(castReceiverDir, relativePath), 'utf8')
+}
+
+const CAST_RUNTIME_SOURCES = [
+  'castStartController.ts',
+  'useCastStartSession.ts',
+  'castSenderClient.ts',
+  'buildCastPresentationSnapshot.ts',
+  'CastStartRoomActions.tsx',
+  'CastActiveStagePanel.tsx',
+  'useCastAvailability.ts',
+  'castSenderSupportDetector.ts',
+  'castChannelProtocol.ts',
+  'CastAvailabilityRoomActions.tsx',
+]
+
+const CAST_RECEIVER_SOURCES = [
+  'CastReceiverPage.tsx',
+  'CastReceiverPresentation.tsx',
+  'castReceiverSession.ts',
+  'castReceiverRenderConfirmation.ts',
+]
+
+const FORBIDDEN_CAST_SIDE_EFFECTS = [
+  'ChatSession',
+  'SfuMediaSession',
+  'TheaterPlayback',
+  'RoomRealtimeSdk',
+  'patchRoom(',
+  'sendControl(',
+  'fetchSfuJoinToken',
+  'getDiagnostics(',
+  'activeErrorCodes',
+  'share_state',
+  'localStorage',
+  'sessionStorage',
+  'setRoomMode',
+  'setAvDisabled',
+  'unpublishHostScreen',
+  'disconnect(',
+  'teardown(',
+  'WebSocket',
+]
+
+describe('Cast room authority wiring (#277)', () => {
+  it('keeps Cast runtime modules free of room mutation and fan-out hooks', () => {
+    for (const file of CAST_RUNTIME_SOURCES) {
+      const src = readCast(file)
+      for (const token of FORBIDDEN_CAST_SIDE_EFFECTS) {
+        expect(src, `${file} must not reference ${token}`).not.toContain(token)
+      }
+    }
+  })
+
+  it('keeps Cast receiver modules free of room session integration', () => {
+    for (const file of CAST_RECEIVER_SOURCES) {
+      const src = readCastReceiver(file)
+      for (const token of FORBIDDEN_CAST_SIDE_EFFECTS) {
+        expect(src, `${file} must not reference ${token}`).not.toContain(token)
+      }
+    }
+  })
+
+  it('castChannelProtocol defines session-only lifecycle without persistence fields', () => {
+    const src = readCast('castChannelProtocol.ts')
+    expect(src).toContain("export type CastStartLifecycle = 'idle'")
+    expect(src).not.toMatch(/castStartLifecycle[\s\S]{0,120}localStorage/)
+    expect(src).not.toContain('castLifecycle')
+    expect(src).not.toContain('share_state')
+  })
+
+  it('buildCastPresentationSnapshot reads room presentation only, not Cast lifecycle', () => {
+    const src = readCast('buildCastPresentationSnapshot.ts')
+    expect(src).toContain('roomMode')
+    expect(src).not.toContain('castStartLifecycle')
+    expect(src).not.toContain('castStageActive')
+    expect(src).not.toContain('CastStartLifecycle')
+  })
+
+  it('useCastAvailability probes sender support without room APIs', () => {
+    const src = readCast('useCastAvailability.ts')
+    expect(src).toContain('detectCastSenderSupport')
+    expect(src).not.toContain('fetch(')
+    expect(src).not.toContain('patchRoom')
+  })
+
+  it('RoomPage routes Cast lifecycle only to sender-local stage and sidebar actions', () => {
+    const src = readPage('RoomPage.tsx')
+    const mediaEngineCall = src.match(/useRoomMediaEngine\(\{[\s\S]*?\}\)/)?.[0] ?? ''
+    expect(src).toContain('useCastStartSession')
+    expect(mediaEngineCall).not.toContain('castStartLifecycle')
+    expect(mediaEngineCall).not.toContain('castStageActive')
+    expect(mediaEngineCall).not.toContain('castAvailability')
+    expect(src).toMatch(/castStageActive \? \([\s\S]*CastActiveStagePanel/)
+    expect(src).toMatch(/const roomSidebarProps = \{[\s\S]*castStartLifecycle,/)
+    expect(src).not.toMatch(/castStartLifecycle[\s\S]{0,120}patchRoom/)
+    expect(src).not.toMatch(/castStartLifecycle[\s\S]{0,120}announceRoomA11y/)
+  })
+
+  it('useCastStartSession cleans up Cast on unmount without room session hooks', () => {
+    const src = readCast('useCastStartSession.ts')
+    expect(src).toMatch(/return \(\) => \{[\s\S]*controller\.stopCast\(\)/)
+    expect(src).not.toContain('patchRoom')
+    expect(src).not.toContain('sendControl')
+    expect(src).not.toContain('fetchSfuJoinToken')
+    expect(src).not.toContain('localStorage')
+  })
+
+  it('castStartController lifecycle paths use Cast channel only', () => {
+    const src = readCast('castStartController.ts')
+    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*cleanupSession/)
+    expect(src).not.toContain('fetch(')
+    expect(src).not.toContain('WebSocket')
+    expect(src).not.toContain('share_state')
+  })
+})

--- a/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
+++ b/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createCastStartController } from './castStartController'
+import type { CastPresentationSnapshot } from './castChannelProtocol'
+import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
+
+const snapshot: CastPresentationSnapshot = {
+  roomMode: 'theater',
+  stagePrimary: {
+    kind: 'youtube_embed',
+    youtubeVideoId: 'abc123',
+    label: 'Party video',
+  },
+  chatOverlay: {
+    messages: [{ id: 'm1', kind: 'text', text: 'Host: hello', senderLabel: 'Host' }],
+  },
+}
+
+function createMockSession(handlers: {
+  onSend?: (message: unknown) => void
+  confirmAfterSend?: boolean
+  failAfterSend?: boolean
+}): CastSenderSessionHandle {
+  const listeners = new Set<(message: unknown) => void>()
+  return {
+    sendMessage: async (message) => {
+      handlers.onSend?.(message)
+      if (handlers.confirmAfterSend) {
+        for (const listener of listeners) listener({ type: 'render_confirmed' })
+      }
+      if (handlers.failAfterSend) {
+        for (const listener of listeners) listener({ type: 'render_failed' })
+      }
+    },
+    addMessageListener: (handler) => {
+      listeners.add(handler)
+      return () => listeners.delete(handler)
+    },
+    end: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createMockClient(session: CastSenderSessionHandle): CastSenderClient {
+  return {
+    requestSession: vi.fn().mockResolvedValue(session),
+  }
+}
+
+describe('createCastStartController room authority (#277)', () => {
+  it('active Cast sends only Cast channel overlay updates', async () => {
+    const sent: unknown[] = []
+    const session = createMockSession({
+      confirmAfterSend: true,
+      onSend: (message) => sent.push(message),
+    })
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    await controller.sendChatOverlayUpdate({
+      ...snapshot,
+      chatOverlay: {
+        messages: [{ id: 'm2', kind: 'text', text: 'Host: updated', senderLabel: 'Host' }],
+      },
+    })
+
+    expect(sent).toHaveLength(2)
+    expect(sent[0]).toEqual({ type: 'presentation_snapshot', snapshot })
+    expect(sent[1]).toEqual({
+      type: 'chat_overlay_update',
+      messages: [{ id: 'm2', kind: 'text', text: 'Host: updated', senderLabel: 'Host' }],
+    })
+    expect(session.end).not.toHaveBeenCalled()
+  })
+
+  it('stop intent ends the Cast session without room side effects', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('idle')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('start failure cleans up Cast session only', async () => {
+    const session = createMockSession({ failAfterSend: true })
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('render confirmation timeout cleans up Cast session only', async () => {
+    vi.useFakeTimers()
+    const session = createMockSession({})
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 50,
+    })
+
+    const promise = controller.startCast(snapshot)
+    await vi.advanceTimersByTimeAsync(60)
+    await promise
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
+  it('overlay update failure during active Cast is silent', async () => {
+    const listeners = new Set<(message: unknown) => void>()
+    const session: CastSenderSessionHandle = {
+      sendMessage: vi
+        .fn()
+        .mockImplementationOnce(async (message) => {
+          for (const listener of listeners) listener({ type: 'render_confirmed' })
+          void message
+        })
+        .mockRejectedValueOnce(new Error('receiver disconnected')),
+      addMessageListener: (handler) => {
+        listeners.add(handler)
+        return () => listeners.delete(handler)
+      },
+      end: vi.fn().mockResolvedValue(undefined),
+    }
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    await controller.sendChatOverlayUpdate(snapshot)
+
+    expect(controller.getState().lifecycle).toBe('casting')
+    expect(session.end).not.toHaveBeenCalled()
+  })
+
+  it('launch rejection maps to start_failed without an active session handle', async () => {
+    const client: CastSenderClient = {
+      requestSession: vi.fn().mockRejectedValue(new Error('user cancelled')),
+    }
+    const controller = createCastStartController({ client, confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+})

--- a/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCastStartSession } from './useCastStartSession'
+
+function TestHarness({ enabled = true }: { enabled?: boolean }) {
+  const stopCastSpy = vi.fn()
+  const sessionEndSpy = vi.fn().mockResolvedValue(undefined)
+  const messageListeners = new Set<(message: unknown) => void>()
+
+  const { castStartLifecycle, startCast, stopCast } = useCastStartSession({
+    enabled,
+    expandedViewActive: false,
+    roomMode: 'theater',
+    youtubeVideoId: 'yt-1',
+    isPublisher: false,
+    hasHostCaptureStream: false,
+    hasGuestRelayStream: false,
+    chat: [],
+    chatMemberLabels: new Map(),
+    createSenderClient: () => ({
+      requestSession: vi.fn().mockResolvedValue({
+        sendMessage: async () => {
+          queueMicrotask(() => {
+            for (const listener of messageListeners) listener({ type: 'render_confirmed' })
+          })
+        },
+        addMessageListener: (handler: (message: unknown) => void) => {
+          messageListeners.add(handler)
+          return () => messageListeners.delete(handler)
+        },
+        end: sessionEndSpy,
+      }),
+    }),
+  })
+
+  stopCastSpy.mockImplementation(() => {
+    stopCast()
+  })
+
+  return (
+    <div>
+      <span data-testid="lifecycle">{castStartLifecycle}</span>
+      <button type="button" data-testid="start" onClick={() => void startCast()}>
+        Start
+      </button>
+      <button type="button" data-testid="stop" onClick={() => stopCastSpy()}>
+        Stop
+      </button>
+    </div>
+  )
+}
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('useCastStartSession room authority (#277)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function renderHarness(enabled = true) {
+    act(() => {
+      root.render(<TestHarness enabled={enabled} />)
+    })
+  }
+
+  it('route leave cleanup stops Cast without touching room integration surfaces', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+
+    await renderHarness()
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('casting')
+
+    act(() => {
+      root.unmount()
+    })
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('stop intent returns lifecycle to idle without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+
+    await renderHarness()
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="stop"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('idle')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('start failure stays sender-local without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+
+    function FailureHarness() {
+      const { castStartLifecycle, startCast } = useCastStartSession({
+        enabled: true,
+        expandedViewActive: false,
+        roomMode: 'theater',
+        youtubeVideoId: 'yt-1',
+        isPublisher: false,
+        hasHostCaptureStream: false,
+        hasGuestRelayStream: false,
+        chat: [],
+        chatMemberLabels: new Map(),
+        createSenderClient: () => ({
+          requestSession: vi.fn().mockRejectedValue(new Error('Cast unavailable')),
+        }),
+      })
+
+      return (
+        <div>
+          <span data-testid="lifecycle">{castStartLifecycle}</span>
+          <button type="button" data-testid="start" onClick={() => void startCast()}>
+            Start
+          </button>
+        </div>
+      )
+    }
+
+    act(() => {
+      root.render(<FailureHarness />)
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('start_failed')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds static wiring guardrails for Cast runtime and receiver modules proving no room HTTP, WebSocket, `share_state`, SFU token, drawer diagnostics, or persistence integration.
- Adds controller and hook lifecycle tests covering active Cast, stop intent, start failure, overlay disconnect, route-leave cleanup, and unavailable launch paths with negative assertions for room side effects.
- Adds RoomPage integration tests across all Cast lifecycle states verifying `patchRoom`, `sendControl`, SFU token requests, room WebSocket traffic, session teardown, drawer diagnostics, and remote participant presentation stay unchanged.

Closes #277

## Test plan

- [x] `npm run verify:push:web`
- [x] `npm run verify:push`
- [x] New tests: `castRoomAuthorityWiring`, `castStartController.roomAuthority`, `useCastStartSession.roomAuthority`, `RoomPageCastRoomAuthority`