### PR TITLE
Handle local Cast recovery states

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -245,7 +245,8 @@ export function RoomPage() {
       chatMemberLabels,
       stageFocusRestoreRef: expandToggleRef,
     })
-  const castStageActive = castStartLifecycle === 'casting' || castStartLifecycle === 'stopping'
+  const castStageActive =
+    castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' || castStartLifecycle === 'stop_failed'
   const expandedViewActive = expandedView && viewportWide && !castStageActive
   const onCastToTvClick = useCallback(() => {
     void startCast()
@@ -469,6 +470,7 @@ export function RoomPage() {
                     onStopCast={onStopCastClick}
                     stopCastButtonRef={stopCastButtonRef}
                     stopping={castStartLifecycle === 'stopping'}
+                    stopFailed={castStartLifecycle === 'stop_failed'}
                   />
                 ) : (
                   <RoomPlaybackPanel

--- a/apps/web/src/pages/RoomPageCastActive.test.tsx
+++ b/apps/web/src/pages/RoomPageCastActive.test.tsx
@@ -8,6 +8,7 @@ import { RoomChromeProvider } from '../room/RoomChromeProvider'
 import {
   CAST_ACTIVE_HEADING,
   CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_FAILED_SUBCOPY,
   CAST_STOP_BUTTON_LABEL,
 } from '../room/cast/castActiveStatusCopy'
 import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
@@ -247,5 +248,23 @@ describe('RoomPage Cast active stage', () => {
     await openRoomTab()
 
     expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('keeps Stop Cast retryable while stop failure is local and active', async () => {
+    castStartLifecycle.value = 'stop_failed'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).not.toBeNull()
+    expect(container.textContent).toContain(CAST_STOP_FAILED_SUBCOPY)
+    expect(container.querySelector('.riffsync-room-page__playback')).toBeNull()
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    expect(stopButton.disabled).toBe(false)
+
+    act(() => {
+      stopButton.click()
+    })
+
+    expect(stopCast).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
@@ -9,6 +9,10 @@ import {
   CAST_ACTIVE_HEADING,
   CAST_STOPPING_SUBCOPY,
 } from '../room/cast/castActiveStatusCopy'
+import {
+  CAST_PLAYBACK_BLOCKED_MESSAGE,
+  CAST_SESSION_ENDED_MESSAGE,
+} from '../room/cast/castStartStatusCopy'
 import type { CastStartLifecycle } from '../room/cast/castChannelProtocol'
 
 const fetchRoom = vi.fn()
@@ -195,6 +199,13 @@ describe('RoomPage Cast stop restoration', () => {
     await vi.waitFor(() => {
       expect(container.querySelector('.riffsync-room-page__tab')).not.toBeNull()
     })
+
+    const roomTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find(
+      (node) => node.textContent?.trim() === 'Room',
+    )
+    act(() => {
+      ;(roomTab as HTMLButtonElement).click()
+    })
   }
 
   it('keeps the Cast stage panel visible while stopping', async () => {
@@ -220,5 +231,25 @@ describe('RoomPage Cast stop restoration', () => {
     await openRoomTab()
 
     expect(container.querySelector('.riffsync-room-page__expand-toggle')).not.toBeNull()
+  })
+
+  it('restores playback and local status after an active Cast session ends externally', async () => {
+    castStartLifecycle.value = 'session_ended'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+    expect(container.textContent).toContain(CAST_SESSION_ENDED_MESSAGE)
+    expect(container.textContent).toContain('Cast to TV')
+  })
+
+  it('restores playback and local status after receiver playback is blocked', async () => {
+    castStartLifecycle.value = 'playback_blocked'
+    await openRoomTab()
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+    expect(container.textContent).toContain(CAST_PLAYBACK_BLOCKED_MESSAGE)
+    expect(container.textContent).toContain('Cast to TV')
   })
 })

--- a/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.test.tsx
@@ -6,6 +6,7 @@ import { CastActiveStagePanel } from './CastActiveStagePanel'
 import {
   CAST_ACTIVE_HEADING,
   CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_FAILED_SUBCOPY,
   CAST_STOPPING_SUBCOPY,
   CAST_STOP_BUTTON_LABEL,
   RIFFSYNC_CAST_ACTIVE_STATUS_ID,
@@ -76,5 +77,18 @@ describe('CastActiveStagePanel', () => {
     const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
     expect(stopButton.disabled).toBe(true)
     expect(stopButton.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('shows stop-failed copy and keeps Stop Cast retryable', () => {
+    act(() => {
+      root.render(<CastActiveStagePanel onStopCast={vi.fn()} stopFailed />)
+    })
+
+    expect(container.textContent).toContain(CAST_STOP_FAILED_SUBCOPY)
+    expect(container.textContent).not.toContain(CAST_ACTIVE_SUBCOPY)
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    expect(stopButton.disabled).toBe(false)
+    expect(stopButton.getAttribute('aria-disabled')).toBeNull()
   })
 })

--- a/apps/web/src/room/cast/CastActiveStagePanel.tsx
+++ b/apps/web/src/room/cast/CastActiveStagePanel.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from 'react'
 import {
   CAST_ACTIVE_HEADING,
   CAST_ACTIVE_SUBCOPY,
+  CAST_STOP_FAILED_SUBCOPY,
   CAST_STOPPING_SUBCOPY,
   CAST_STOP_BUTTON_LABEL,
   RIFFSYNC_CAST_ACTIVE_STATUS_ID,
@@ -11,13 +12,17 @@ type CastActiveStagePanelProps = {
   onStopCast: () => void
   stopCastButtonRef?: RefObject<HTMLButtonElement | null>
   stopping?: boolean
+  stopFailed?: boolean
 }
 
 export function CastActiveStagePanel({
   onStopCast,
   stopCastButtonRef,
   stopping = false,
+  stopFailed = false,
 }: CastActiveStagePanelProps) {
+  const statusCopy = stopFailed ? CAST_STOP_FAILED_SUBCOPY : stopping ? CAST_STOPPING_SUBCOPY : CAST_ACTIVE_SUBCOPY
+
   return (
     <section
       className="riffsync-room-page__cast-active-stage"
@@ -33,7 +38,7 @@ export function CastActiveStagePanel({
         role="status"
         aria-live="polite"
       >
-        {stopping ? CAST_STOPPING_SUBCOPY : CAST_ACTIVE_SUBCOPY}
+        {statusCopy}
       </p>
       <button
         ref={stopCastButtonRef}

--- a/apps/web/src/room/cast/CastStartRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.test.tsx
@@ -4,11 +4,14 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CastStartRoomActions } from './CastStartRoomActions'
 import {
+  CAST_PLAYBACK_BLOCKED_MESSAGE,
+  CAST_SESSION_ENDED_MESSAGE,
   CAST_STARTING_MESSAGE,
   CAST_START_REJECTED_MESSAGE,
   RIFFSYNC_CAST_START_STATUS_ID,
 } from './castStartStatusCopy'
 import { CAST_UNAVAILABLE_MESSAGE, RIFFSYNC_CAST_AVAILABILITY_STATUS_ID } from './castAvailabilityTypes'
+import type { CastStartLifecycle } from './castChannelProtocol'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -29,7 +32,7 @@ describe('CastStartRoomActions', () => {
 
   function renderActions(
     castAvailability: 'checking' | 'available' | 'unavailable',
-    castStartLifecycle: 'idle' | 'starting' | 'casting' | 'stopping' | 'start_failed' = 'idle',
+    castStartLifecycle: CastStartLifecycle = 'idle',
   ) {
     act(() => {
       root.render(
@@ -67,6 +70,20 @@ describe('CastStartRoomActions', () => {
     expect(status?.textContent).toBe(CAST_UNAVAILABLE_MESSAGE)
   })
 
+  it('shows session-ended status and retry button', () => {
+    renderActions('available', 'session_ended')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_SESSION_ENDED_MESSAGE)
+    expect(container.textContent).toContain('Cast to TV')
+  })
+
+  it('shows playback-blocked status and retry button', () => {
+    renderActions('available', 'playback_blocked')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_PLAYBACK_BLOCKED_MESSAGE)
+    expect(container.textContent).toContain('Cast to TV')
+  })
+
   it('hides Cast to TV while casting', () => {
     renderActions('available', 'casting')
     expect(container.textContent).not.toContain('Cast to TV')
@@ -74,6 +91,11 @@ describe('CastStartRoomActions', () => {
 
   it('hides Cast to TV while stopping', () => {
     renderActions('available', 'stopping')
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('hides Cast to TV while stop failure is retryable on the active stage', () => {
+    renderActions('available', 'stop_failed')
     expect(container.textContent).not.toContain('Cast to TV')
   })
 })

--- a/apps/web/src/room/cast/CastStartRoomActions.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.tsx
@@ -1,6 +1,8 @@
 import type { RefObject } from 'react'
 import {
   CAST_STARTING_MESSAGE,
+  CAST_PLAYBACK_BLOCKED_MESSAGE,
+  CAST_SESSION_ENDED_MESSAGE,
   CAST_START_REJECTED_MESSAGE,
   RIFFSYNC_CAST_START_STATUS_ID,
 } from './castStartStatusCopy'
@@ -52,7 +54,16 @@ export function CastStartRoomActions({
     )
   }
 
-  if (castStartLifecycle === 'start_failed') {
+  const recoveryMessage =
+    castStartLifecycle === 'start_failed'
+      ? CAST_START_REJECTED_MESSAGE
+      : castStartLifecycle === 'session_ended'
+        ? CAST_SESSION_ENDED_MESSAGE
+        : castStartLifecycle === 'playback_blocked'
+          ? CAST_PLAYBACK_BLOCKED_MESSAGE
+          : null
+
+  if (recoveryMessage) {
     return (
       <>
         <p
@@ -61,7 +72,7 @@ export function CastStartRoomActions({
           role="status"
           aria-live="polite"
         >
-          {CAST_START_REJECTED_MESSAGE}
+          {recoveryMessage}
         </p>
         <button
           ref={castToTvButtonRef}
@@ -75,7 +86,7 @@ export function CastStartRoomActions({
     )
   }
 
-  if (castStartLifecycle === 'casting' || castStartLifecycle === 'stopping') {
+  if (castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' || castStartLifecycle === 'stop_failed') {
     return null
   }
 

--- a/apps/web/src/room/cast/castActiveParticipationWiring.test.ts
+++ b/apps/web/src/room/cast/castActiveParticipationWiring.test.ts
@@ -67,7 +67,7 @@ describe('Cast active participation wiring (#275)', () => {
 
   it('castStartController stop path ends Cast session without room APIs', () => {
     const src = readCast('castStartController.ts')
-    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*cleanupSession/)
+    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*stopActiveSession/)
     expect(src).not.toContain('fetch(')
     expect(src).not.toContain('WebSocket')
   })

--- a/apps/web/src/room/cast/castActiveStatusCopy.ts
+++ b/apps/web/src/room/cast/castActiveStatusCopy.ts
@@ -4,6 +4,9 @@ export const CAST_ACTIVE_SUBCOPY = 'Casting to TV'
 
 export const CAST_STOPPING_SUBCOPY = 'Stopping Cast…'
 
+export const CAST_STOP_FAILED_SUBCOPY =
+  'Cast could not stop from this tab. Try Stop Cast again or use your TV controls.'
+
 export const CAST_STOP_BUTTON_LABEL = 'Stop Cast'
 
 export const RIFFSYNC_CAST_ACTIVE_STATUS_ID = 'riffsync-cast-active-status'

--- a/apps/web/src/room/cast/castChannelProtocol.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.ts
@@ -2,7 +2,15 @@ import type { RoomMode } from '../../api/roomsApi'
 
 export const RIFFSYNC_CAST_NAMESPACE = 'urn:x-cast:com.riffsync.presentation'
 
-export type CastStartLifecycle = 'idle' | 'starting' | 'casting' | 'stopping' | 'start_failed'
+export type CastStartLifecycle =
+  | 'idle'
+  | 'starting'
+  | 'casting'
+  | 'stopping'
+  | 'start_failed'
+  | 'session_ended'
+  | 'playback_blocked'
+  | 'stop_failed'
 
 export type CastStagePrimaryKind = 'youtube_embed' | 'live_video_placeholder' | 'video_chat_grid'
 

--- a/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
+++ b/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
@@ -81,7 +81,9 @@ describe('Cast room authority wiring (#277)', () => {
 
   it('castChannelProtocol defines session-only lifecycle without persistence fields', () => {
     const src = readCast('castChannelProtocol.ts')
-    expect(src).toContain("export type CastStartLifecycle = 'idle'")
+    expect(src).toContain('export type CastStartLifecycle =')
+    expect(src).toContain("| 'idle'")
+    expect(src).toContain("| 'session_ended'")
     expect(src).not.toMatch(/castStartLifecycle[\s\S]{0,120}localStorage/)
     expect(src).not.toContain('castLifecycle')
     expect(src).not.toContain('share_state')
@@ -126,7 +128,7 @@ describe('Cast room authority wiring (#277)', () => {
 
   it('castStartController lifecycle paths use Cast channel only', () => {
     const src = readCast('castStartController.ts')
-    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*cleanupSession/)
+    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*stopActiveSession/)
     expect(src).not.toContain('fetch(')
     expect(src).not.toContain('WebSocket')
     expect(src).not.toContain('share_state')

--- a/apps/web/src/room/cast/castSenderClient.ts
+++ b/apps/web/src/room/cast/castSenderClient.ts
@@ -3,6 +3,8 @@ import { RIFFSYNC_CAST_NAMESPACE } from './castChannelProtocol'
 export type CastSenderSessionHandle = {
   sendMessage: (message: unknown) => Promise<void>
   addMessageListener: (handler: (message: unknown) => void) => () => void
+  addSessionEndedListener: (handler: () => void) => () => void
+  hasActiveRoute: () => boolean
   end: () => Promise<void>
 }
 
@@ -55,6 +57,8 @@ type CastSessionInstance = {
   endSession: (stopCasting?: boolean) => void
 }
 
+type CastFramework = NonNullable<NonNullable<CastFrameworkWindow['cast']>['framework']>
+
 function readCastFramework(): CastFrameworkWindow['cast'] | undefined {
   if (typeof window === 'undefined') return undefined
   return (window as CastFrameworkWindow).cast
@@ -100,8 +104,14 @@ async function waitForCastFramework(): Promise<NonNullable<CastFrameworkWindow['
   })
 }
 
-function wrapCastSession(session: CastSessionInstance): CastSenderSessionHandle {
+function wrapCastSession(
+  session: CastSessionInstance,
+  context: CastContextInstance,
+  framework: CastFramework,
+): CastSenderSessionHandle {
   const listeners = new Set<(message: unknown) => void>()
+  const sessionEndedListeners = new Set<() => void>()
+  let activeRoute = true
 
   const frameworkListener = (_namespace: string, message: string) => {
     try {
@@ -114,6 +124,15 @@ function wrapCastSession(session: CastSessionInstance): CastSenderSessionHandle 
 
   session.addMessageListener(RIFFSYNC_CAST_NAMESPACE, frameworkListener)
 
+  const sessionStateListener = (event: { sessionState?: string }) => {
+    if (event.sessionState !== framework.SessionState.SESSION_ENDED) return
+    if (!activeRoute) return
+    activeRoute = false
+    for (const listener of sessionEndedListeners) listener()
+  }
+
+  context.addEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, sessionStateListener)
+
   return {
     sendMessage: async (message) => {
       await session.sendMessage(RIFFSYNC_CAST_NAMESPACE, message)
@@ -122,8 +141,15 @@ function wrapCastSession(session: CastSessionInstance): CastSenderSessionHandle 
       listeners.add(handler)
       return () => listeners.delete(handler)
     },
+    addSessionEndedListener: (handler) => {
+      sessionEndedListeners.add(handler)
+      return () => sessionEndedListeners.delete(handler)
+    },
+    hasActiveRoute: () => activeRoute,
     end: async () => {
       session.removeMessageListener(RIFFSYNC_CAST_NAMESPACE, frameworkListener)
+      context.removeEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, sessionStateListener)
+      activeRoute = false
       session.endSession(true)
     },
   }
@@ -169,7 +195,7 @@ export function createDefaultCastSenderClient(): CastSenderClient {
             if (settled) return
             settled = true
             context.removeEventListener(framework.CastContextEventType.SESSION_STATE_CHANGED, onSessionStateChanged)
-            resolve(wrapCastSession(session))
+            resolve(wrapCastSession(session, context, framework))
           })
           .catch((error: unknown) => {
             if (settled) return

--- a/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
+++ b/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
@@ -21,6 +21,8 @@ function createMockSession(handlers: {
   failAfterSend?: boolean
 }): CastSenderSessionHandle {
   const listeners = new Set<(message: unknown) => void>()
+  const sessionEndedListeners = new Set<() => void>()
+  const activeRoute = true
   return {
     sendMessage: async (message) => {
       handlers.onSend?.(message)
@@ -35,6 +37,11 @@ function createMockSession(handlers: {
       listeners.add(handler)
       return () => listeners.delete(handler)
     },
+    addSessionEndedListener: (handler) => {
+      sessionEndedListeners.add(handler)
+      return () => sessionEndedListeners.delete(handler)
+    },
+    hasActiveRoute: () => activeRoute,
     end: vi.fn().mockResolvedValue(undefined),
   }
 }
@@ -132,6 +139,8 @@ describe('createCastStartController room authority (#277)', () => {
         listeners.add(handler)
         return () => listeners.delete(handler)
       },
+      addSessionEndedListener: () => () => undefined,
+      hasActiveRoute: () => true,
       end: vi.fn().mockResolvedValue(undefined),
     }
     const controller = createCastStartController({
@@ -142,8 +151,8 @@ describe('createCastStartController room authority (#277)', () => {
     await controller.startCast(snapshot)
     await controller.sendChatOverlayUpdate(snapshot)
 
-    expect(controller.getState().lifecycle).toBe('casting')
-    expect(session.end).not.toHaveBeenCalled()
+    expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.end).toHaveBeenCalledTimes(1)
   })
 
   it('launch rejection maps to start_failed without an active session handle', async () => {

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -18,8 +18,10 @@ const snapshot: CastPresentationSnapshot = {
 function createMockSession(handlers: {
   onSend?: (message: unknown) => void
   confirmAfterSend?: boolean
-}): CastSenderSessionHandle {
+}): CastSenderSessionHandle & { emitSessionEnded: () => void; emitReceiverMessage: (message: unknown) => void; setActiveRoute: (active: boolean) => void } {
   const listeners = new Set<(message: unknown) => void>()
+  const sessionEndedListeners = new Set<() => void>()
+  let activeRoute = true
   return {
     sendMessage: async (message) => {
       handlers.onSend?.(message)
@@ -31,7 +33,22 @@ function createMockSession(handlers: {
       listeners.add(handler)
       return () => listeners.delete(handler)
     },
+    addSessionEndedListener: (handler) => {
+      sessionEndedListeners.add(handler)
+      return () => sessionEndedListeners.delete(handler)
+    },
+    hasActiveRoute: () => activeRoute,
     end: vi.fn().mockResolvedValue(undefined),
+    emitSessionEnded: () => {
+      activeRoute = false
+      for (const listener of sessionEndedListeners) listener()
+    },
+    emitReceiverMessage: (message) => {
+      for (const listener of listeners) listener(message)
+    },
+    setActiveRoute: (active) => {
+      activeRoute = active
+    },
   }
 }
 
@@ -147,5 +164,61 @@ describe('createCastStartController', () => {
       type: 'chat_overlay_update',
       messages: [{ id: 'm2', kind: 'text', text: 'Host: updated', senderLabel: 'Host' }],
     })
+  })
+
+  it('maps active session-ended callbacks to session_ended recovery', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitSessionEnded()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps receiver render failure after active Cast to playback_blocked recovery', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'playback_blocked' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('playback_blocked')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps Stop Cast retryable when stop fails and the route is still active', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    session.end = vi.fn().mockRejectedValue(new Error('stop rejected'))
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('stop_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+
+    session.end = vi.fn().mockResolvedValue(undefined)
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('idle')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps stop failure to session_ended when cleanup observes that the route is gone', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    session.end = vi.fn().mockRejectedValue(new Error('route already gone'))
+    session.setActiveRoute(false)
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('session_ended')
   })
 })

--- a/apps/web/src/room/cast/castStartController.ts
+++ b/apps/web/src/room/cast/castStartController.ts
@@ -29,6 +29,7 @@ export function createCastStartController({
   let lifecycle: CastStartLifecycle = 'idle'
   let session: CastSenderSessionHandle | null = null
   let removeMessageListener: (() => void) | null = null
+  let removeSessionEndedListener: (() => void) | null = null
   let confirmationTimer: ReturnType<typeof setTimeout> | null = null
   const listeners = new Set<(state: CastStartControllerState) => void>()
 
@@ -44,10 +45,16 @@ export function createCastStartController({
     }
   }
 
-  const cleanupSession = async () => {
+  const detachSessionListeners = () => {
     clearConfirmationTimer()
     removeMessageListener?.()
     removeMessageListener = null
+    removeSessionEndedListener?.()
+    removeSessionEndedListener = null
+  }
+
+  const cleanupSession = async () => {
+    detachSessionListeners()
     const activeSession = session
     session = null
     if (activeSession) {
@@ -65,10 +72,58 @@ export function createCastStartController({
     emit()
   }
 
+  const recoverFromActiveSession = async (nextLifecycle: Extract<CastStartLifecycle, 'session_ended' | 'playback_blocked'>) => {
+    await cleanupSession()
+    lifecycle = nextLifecycle
+    emit()
+  }
+
   const confirmStart = () => {
     clearConfirmationTimer()
     lifecycle = 'casting'
     emit()
+  }
+
+  const handleReceiverMessage = (raw: unknown) => {
+    const message = parseCastReceiverOutboundMessage(raw)
+    if (!message) return
+    if (message.type === 'render_confirmed') {
+      if (lifecycle === 'starting') confirmStart()
+      return
+    }
+    if (message.type === 'render_failed') {
+      if (lifecycle === 'starting') {
+        void failStart()
+        return
+      }
+      if (lifecycle === 'casting' || lifecycle === 'stop_failed') {
+        void recoverFromActiveSession('playback_blocked')
+      }
+    }
+  }
+
+  const stopActiveSession = async (): Promise<'idle' | 'session_ended' | 'stop_failed'> => {
+    clearConfirmationTimer()
+    const activeSession = session
+    if (!activeSession) {
+      detachSessionListeners()
+      return 'session_ended'
+    }
+
+    try {
+      await activeSession.end()
+    } catch {
+      if (activeSession.hasActiveRoute()) {
+        return 'stop_failed'
+      }
+      detachSessionListeners()
+      session = null
+      return 'session_ended'
+    }
+
+    detachSessionListeners()
+    session = null
+    return 'idle'
   }
 
   return {
@@ -78,7 +133,7 @@ export function createCastStartController({
       return () => listeners.delete(listener)
     },
     startCast: async (snapshot) => {
-      if (lifecycle === 'starting' || lifecycle === 'casting') return
+      if (lifecycle === 'starting' || lifecycle === 'casting' || lifecycle === 'stopping' || lifecycle === 'stop_failed') return
 
       lifecycle = 'starting'
       emit()
@@ -87,15 +142,10 @@ export function createCastStartController({
         const nextSession = await client.requestSession()
         session = nextSession
 
-        removeMessageListener = nextSession.addMessageListener((raw) => {
-          const message = parseCastReceiverOutboundMessage(raw)
-          if (!message) return
-          if (message.type === 'render_confirmed') {
-            confirmStart()
-            return
-          }
-          if (message.type === 'render_failed') {
-            void failStart()
+        removeMessageListener = nextSession.addMessageListener(handleReceiverMessage)
+        removeSessionEndedListener = nextSession.addSessionEndedListener(() => {
+          if (lifecycle === 'casting' || lifecycle === 'stopping' || lifecycle === 'stop_failed') {
+            void recoverFromActiveSession('session_ended')
           }
         })
 
@@ -119,23 +169,30 @@ export function createCastStartController({
           messages: snapshot.chatOverlay.messages,
         })
       } catch {
-        /* Receiver disconnect handling belongs to later slices. */
+        await recoverFromActiveSession('session_ended')
       }
     },
     resetStartFailure: () => {
-      if (lifecycle !== 'start_failed') return
+      if (lifecycle !== 'start_failed' && lifecycle !== 'session_ended' && lifecycle !== 'playback_blocked') return
       lifecycle = 'idle'
       emit()
     },
     stopCast: async () => {
-      if (lifecycle === 'idle' || lifecycle === 'starting' || lifecycle === 'start_failed') return
+      if (
+        lifecycle === 'idle' ||
+        lifecycle === 'starting' ||
+        lifecycle === 'start_failed' ||
+        lifecycle === 'session_ended' ||
+        lifecycle === 'playback_blocked'
+      ) {
+        return
+      }
       if (lifecycle === 'stopping') return
 
       lifecycle = 'stopping'
       emit()
 
-      await cleanupSession()
-      lifecycle = 'idle'
+      lifecycle = await stopActiveSession()
       emit()
     },
   }

--- a/apps/web/src/room/cast/castStartStatusCopy.ts
+++ b/apps/web/src/room/cast/castStartStatusCopy.ts
@@ -3,4 +3,9 @@ export const CAST_STARTING_MESSAGE = 'Starting Cast…'
 export const CAST_START_REJECTED_MESSAGE =
   'Cast could not start. Try again from this browser or device.'
 
+export const CAST_SESSION_ENDED_MESSAGE = 'Cast ended. Playback is back in this tab.'
+
+export const CAST_PLAYBACK_BLOCKED_MESSAGE =
+  'Cast playback was interrupted. Playback is available in this tab.'
+
 export const RIFFSYNC_CAST_START_STATUS_ID = 'riffsync-cast-start-status'

--- a/apps/web/src/room/cast/castStopRestorationWiring.test.ts
+++ b/apps/web/src/room/cast/castStopRestorationWiring.test.ts
@@ -17,8 +17,8 @@ function readPage(relativePath: string): string {
 describe('Cast stop restoration wiring (#276)', () => {
   it('castStartController stopCast enters stopping before idle cleanup', () => {
     const src = readCast('castStartController.ts')
-    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*lifecycle = 'stopping'[\s\S]*cleanupSession/)
-    expect(src).toMatch(/cleanupSession\(\)[\s\S]*lifecycle = 'idle'/)
+    expect(src).toMatch(/stopCast: async \(\) => \{[\s\S]*lifecycle = 'stopping'[\s\S]*stopActiveSession/)
+    expect(src).toMatch(/stopActiveSession[\s\S]*return 'idle'/)
   })
 
   it('useCastStartSession restores focus only after stopping completes to idle', () => {
@@ -32,7 +32,9 @@ describe('Cast stop restoration wiring (#276)', () => {
 
   it('RoomPage keeps Cast stage mounted through stopping and restores playback after', () => {
     const src = readPage('RoomPage.tsx')
-    expect(src).toContain("castStartLifecycle === 'casting' || castStartLifecycle === 'stopping'")
+    expect(src).toContain("castStartLifecycle === 'casting'")
+    expect(src).toContain("castStartLifecycle === 'stopping'")
+    expect(src).toContain("castStartLifecycle === 'stop_failed'")
     expect(src).toMatch(/stopping=\{castStartLifecycle === 'stopping'\}/)
     expect(src).toMatch(/castStageActive \? \([\s\S]*CastActiveStagePanel[\s\S]*RoomPlaybackPanel/)
   })

--- a/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
@@ -8,6 +8,8 @@ function TestHarness({ enabled = true }: { enabled?: boolean }) {
   const stopCastSpy = vi.fn()
   const sessionEndSpy = vi.fn().mockResolvedValue(undefined)
   const messageListeners = new Set<(message: unknown) => void>()
+  const sessionEndedListeners = new Set<() => void>()
+  const activeRoute = true
 
   const { castStartLifecycle, startCast, stopCast } = useCastStartSession({
     enabled,
@@ -30,6 +32,11 @@ function TestHarness({ enabled = true }: { enabled?: boolean }) {
           messageListeners.add(handler)
           return () => messageListeners.delete(handler)
         },
+        addSessionEndedListener: (handler: () => void) => {
+          sessionEndedListeners.add(handler)
+          return () => sessionEndedListeners.delete(handler)
+        },
+        hasActiveRoute: () => activeRoute,
         end: sessionEndSpy,
       }),
     }),

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -4,15 +4,65 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCastStartSession } from './useCastStartSession'
 
+type HarnessSession = {
+  end: ReturnType<typeof vi.fn>
+  sendMessage: () => Promise<void>
+  addMessageListener: (handler: (message: unknown) => void) => () => void
+  addSessionEndedListener: (handler: () => void) => () => void
+  hasActiveRoute: () => boolean
+  emitReceiverMessage: (message: unknown) => void
+  emitSessionEnded: () => void
+  setActiveRoute: (active: boolean) => void
+}
+
+let latestSession: HarnessSession | null = null
+
+function createHarnessSession(): HarnessSession {
+  const messageListeners = new Set<(message: unknown) => void>()
+  const sessionEndedListeners = new Set<() => void>()
+  const route = { active: true }
+  const end = vi.fn().mockImplementation(async () => {
+    route.active = false
+  })
+
+  return {
+    sendMessage: async () => {
+      queueMicrotask(() => {
+        for (const listener of messageListeners) listener({ type: 'render_confirmed' })
+      })
+    },
+    addMessageListener: (handler: (message: unknown) => void) => {
+      messageListeners.add(handler)
+      return () => messageListeners.delete(handler)
+    },
+    addSessionEndedListener: (handler: () => void) => {
+      sessionEndedListeners.add(handler)
+      return () => sessionEndedListeners.delete(handler)
+    },
+    hasActiveRoute: () => route.active,
+    end,
+    emitReceiverMessage: (message) => {
+      for (const listener of messageListeners) listener(message)
+    },
+    emitSessionEnded: () => {
+      route.active = false
+      for (const listener of sessionEndedListeners) listener()
+    },
+    setActiveRoute: (active) => {
+      route.active = active
+    },
+  }
+}
+
 function TestHarness({
   expandedViewActive = false,
   stageFocusRestoreRef,
+  session,
 }: {
   expandedViewActive?: boolean
   stageFocusRestoreRef?: RefObject<HTMLButtonElement | null>
+  session: HarnessSession
 }) {
-  const messageListeners = new Set<(message: unknown) => void>()
-
   const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
     useCastStartSession({
       enabled: true,
@@ -26,18 +76,7 @@ function TestHarness({
       chatMemberLabels: new Map(),
       stageFocusRestoreRef,
       createSenderClient: () => ({
-        requestSession: vi.fn().mockResolvedValue({
-          sendMessage: async () => {
-            queueMicrotask(() => {
-              for (const listener of messageListeners) listener({ type: 'render_confirmed' })
-            })
-          },
-          addMessageListener: (handler: (message: unknown) => void) => {
-            messageListeners.add(handler)
-            return () => messageListeners.delete(handler)
-          },
-          end: vi.fn().mockResolvedValue(undefined),
-        }),
+        requestSession: vi.fn().mockResolvedValue(session),
       }),
     })
 
@@ -51,8 +90,15 @@ function TestHarness({
       ) : castStartLifecycle === 'starting' ? (
         <p data-testid="cast-starting-status">Starting Cast…</p>
       ) : null}
-      {castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' ? (
-        <button ref={stopCastButtonRef} type="button" data-testid="stop-cast" onClick={() => stopCast()}>
+      {castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' || castStartLifecycle === 'stop_failed' ? (
+        <button
+          ref={stopCastButtonRef}
+          type="button"
+          data-testid="stop-cast"
+          className="riffsync-room-page__cast-stop-button"
+          disabled={castStartLifecycle === 'stopping'}
+          onClick={() => stopCast()}
+        >
           Stop Cast
         </button>
       ) : null}
@@ -72,6 +118,7 @@ describe('useCastStartSession focus transfer', () => {
   let root: Root
 
   beforeEach(() => {
+    latestSession = null
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -83,10 +130,14 @@ describe('useCastStartSession focus transfer', () => {
   })
 
   async function renderHarness(expandedViewActive = false, withStageRestore = false) {
+    const session = createHarnessSession()
+    latestSession = session
+
     function HarnessWrapper() {
       const stageFocusRestoreRef = useRef<HTMLButtonElement | null>(null)
       return (
         <TestHarness
+          session={session}
           expandedViewActive={expandedViewActive}
           stageFocusRestoreRef={withStageRestore ? stageFocusRestoreRef : undefined}
         />
@@ -94,7 +145,13 @@ describe('useCastStartSession focus transfer', () => {
     }
 
     act(() => {
-      root.render(withStageRestore ? <HarnessWrapper /> : <TestHarness expandedViewActive={expandedViewActive} />)
+      root.render(
+        withStageRestore ? (
+          <HarnessWrapper />
+        ) : (
+          <TestHarness session={session} expandedViewActive={expandedViewActive} />
+        ),
+      )
     })
   }
 
@@ -249,5 +306,62 @@ describe('useCastStartSession focus transfer', () => {
 
     expect(document.activeElement).toBe(other)
     other.remove()
+  })
+
+  it('restores focus to the stage control when active Cast ends externally', async () => {
+    await renderHarness(false, true)
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    act(() => {
+      stopButton.focus()
+    })
+
+    await act(async () => {
+      latestSession?.emitSessionEnded()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const stageRestore = container.querySelector('[data-testid="stage-restore"]') as HTMLButtonElement
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('session_ended')
+    expect(document.activeElement).toBe(stageRestore)
+  })
+
+  it('keeps focus on retryable Stop Cast when stop fails with an active route', async () => {
+    await renderHarness(false, true)
+
+    const castButton = container.querySelector('[data-testid="cast-to-tv"]') as HTMLButtonElement
+    await act(async () => {
+      castButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    latestSession?.end.mockRejectedValueOnce(new Error('stop rejected'))
+
+    const stopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    act(() => {
+      stopButton.focus()
+    })
+
+    await act(async () => {
+      stopButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const retryStopButton = container.querySelector('[data-testid="stop-cast"]') as HTMLButtonElement
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('stop_failed')
+    expect(retryStopButton.disabled).toBe(false)
+    expect(document.activeElement).toBe(retryStopButton)
   })
 })

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -94,7 +94,20 @@ export function useCastStartSession({
     [snapshotInput],
   )
 
-  useEffect(() => controller.subscribe((state) => setCastStartLifecycle(state.lifecycle)), [controller])
+  useEffect(
+    () =>
+      controller.subscribe((state) => {
+        const currentLifecycle = previousLifecycleRef.current
+        if (
+          (currentLifecycle === 'casting' || currentLifecycle === 'stopping' || currentLifecycle === 'stop_failed') &&
+          (state.lifecycle === 'session_ended' || state.lifecycle === 'playback_blocked')
+        ) {
+          shouldRestoreFocusFromCastStageRef.current = isCastStageFocusTarget(document.activeElement)
+        }
+        setCastStartLifecycle(state.lifecycle)
+      }),
+    [controller],
+  )
 
   useEffect(() => {
     if (!enabled) return
@@ -169,7 +182,27 @@ export function useCastStartSession({
     const previousLifecycle = previousLifecycleRef.current
     previousLifecycleRef.current = castStartLifecycle
 
-    if (castStartLifecycle !== 'idle' || previousLifecycle !== 'stopping') return
+    if (castStartLifecycle === 'stop_failed' && previousLifecycle === 'stopping') {
+      if (shouldRestoreFocusFromCastStageRef.current) {
+        stopCastButtonRef.current?.focus()
+      }
+      return
+    }
+
+    if (
+      castStartLifecycle !== 'idle' &&
+      castStartLifecycle !== 'session_ended' &&
+      castStartLifecycle !== 'playback_blocked'
+    ) {
+      return
+    }
+    if (
+      previousLifecycle !== 'stopping' &&
+      previousLifecycle !== 'casting' &&
+      previousLifecycle !== 'stop_failed'
+    ) {
+      return
+    }
     if (!shouldRestoreFocusFromCastStageRef.current) return
 
     shouldRestoreFocusFromCastStageRef.current = false


### PR DESCRIPTION
## Summary
- Adds sender-local Cast recovery states for active session end, receiver playback blocked, and stop failure.
- Restores normal in-tab playback for ended/blocked recovery while keeping Stop Cast retryable only when the active route remains.
- Extends controller, hook, stage/sidebar UI, focus handling, and guardrail tests for local-only recovery behavior.

## Test plan
- `npm ci --prefix apps/web`
- `npm run build --prefix apps/web`
- `npm test --prefix apps/web`
- `npm run lint --prefix apps/web` (passes with existing `CatalogPage.tsx` warning)
- `npm run verify:push`

Closes #278