### PR TITLE
docs(ai): refine issue #279 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -233,15 +233,17 @@ Three coexisting modes (see **`integration/authorization.md`**):
 | Does active Cast emit diagnostics or telemetry? | **No aggregate telemetry or drawer diagnostics for #274.** Local controller state and test-only hooks may prove active/stop behavior, but Cast must not appear in **`RoomRealtimeSdk.getDiagnostics().drawers.*`**, room activity metrics, or receiver-identifying logs. |
 | What does #277 own? | Guardrails and regression coverage that prove local Cast does not mutate **`roomMode`**, **`avDisabled`**, **`share_state`**, durable room playback fields, host authority, SFU permissions, participant roster authority, or any other participant's room experience. |
 | What does #278 own? | Sender-local recovery when Cast is unavailable, start fails after support was shown, an active receiver disconnects or ends externally, receiver playback becomes blocked, or Stop Cast fails. Recovery keeps room participation, chat, SFU, and authoritative room state intact while restoring or keeping normal in-page playback visible whenever the sender is no longer actively casting. |
+| What does #279 own? | Milestone-wide Cast verification across #272-#278. It proves local Cast lifecycle paths, accessibility/focus/status behavior, and sender cleanup preserve the viewer-local boundary without adding new product behavior. |
+| #279 lifecycle coverage | Cover availability, start, active, stop, unavailable, failed-start, receiver-ended, playback-blocked, stop-failed, cleanup completion, room leave, navigation, and reload paths at the most practical automated or manual layer for browser Cast constraints. |
+| #279 negative side effects | Verification must prove Cast lifecycle and cleanup do not write room state, mutate **`roomMode`**, **`avDisabled`**, **`share_state`**, alter host authority, change SFU permission or token state, fan out room messages, affect participant roster authority, or change any other participant's room presentation. |
 
-## Open implementation decisions
+## Decisions (answered - Cast verification #279)
 
-Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
-
-### chromecast-local-cast-lifecycle
-- **Resolved for #274:** active Cast uses sender-local stage state only: **`Now Casting`** plus Stop Cast. It produces no aggregate telemetry and no **`RoomRealtimeSdk`** drawer diagnostics.
-- **Resolved for #277:** local Cast lifecycle transitions must not create room authority or participant-visible side effects. Tests should cover sender start/active/stop/failure paths without any room document write, room WebSocket fan-out, **`share_state`** mutation, SFU permission change, or remote participant stage/status change.
-- **Resolved for #278:** local Cast recovery owns unavailable, failed-start, receiver-disconnected, externally-ended, playback-blocked, and stop-failed states. These states are browser-session state only and must not update durable room documents, room snapshots, lobby rows, **`share_state`**, SFU token claims, or other participants' presentation.
+| Topic | Decision |
+| --- | --- |
+| Verification posture | #279 is a verification umbrella for M25 Cast behavior. It adds test and review coverage for existing contracts rather than introducing a room-wide Cast mode or new authority surface. |
+| Test boundary | Tests may use controller-local state hooks, fake Cast sender clients, receiver-channel stubs, and manual Cast-capable device checks. These verification hooks must remain local to Cast surfaces and must not appear in room diagnostics, active realtime error codes, or room authority payloads. |
+| Completion signal | #279 is complete when lifecycle, accessibility, and cleanup coverage collectively prove the sender-local Cast contract across peer issues #272-#278 and no stale **`Now Casting`**, sender handles, listeners, timers, receiver bindings, or room side effects remain after cleanup paths. |
 
 ## Decisions (theater mic mix on host_screen close — #145)
 

--- a/.ai/business_logic/error_state.md
+++ b/.ai/business_logic/error_state.md
@@ -50,6 +50,10 @@ The availability, Cast-start, and local recovery slices define local Cast status
 
 Cast status codes must not appear in chat drawer status, video-relay status, room-level alerts, or **`RoomRealtimeSdk.getDiagnostics().drawers.*`**. They are local UI status for the viewer's browser/session only.
 
+### Cast status verification (#279)
+
+Issue #279 verifies the full local status taxonomy above across availability, start, active, stop, failure, disconnect, blocked playback, cleanup completion, room leave, navigation, and reload paths. Coverage must assert correct user-facing copy surface, stale status removal, retryability where contracted, and absence of Cast codes from room drawer health, room alerts, chat messages, WebSocket fan-out, and other participants' UI.
+
 ## Auth — fan
 
 | State | UX |
@@ -176,11 +180,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Kill-switch toggle affordance:** visible-disabled with host explanation per **`presentation.md`** (resolved).
 
 ### chromecast-local-errors
-- **Resolved for #273:** start uses **`CAST_STARTING`** while waiting for custom receiver render confirmation and **`CAST_START_REJECTED`** when launch is rejected, canceled, or the receiver does not confirm stage-primary video plus chat overlay rendering.
-- **Resolved for #274:** active Cast may use **`CAST_ACTIVE`** for the sender-local **`Now Casting`** stage. It remains local UI status only and must not appear in chat/video-relay drawer health.
-- **Resolved for #278:** active-session disconnect, SDK-ended sessions, receiver app close, external TV stop, blocked receiver playback, and failed stop map to **`CAST_SESSION_ENDED`**, **`CAST_PLAYBACK_BLOCKED`**, or **`CAST_STOP_FAILED`**. All remain sender-local and keep normal room participation available.
-- **Resolved for #278:** **`CAST_SESSION_ENDED`** and **`CAST_PLAYBACK_BLOCKED`** restore or keep in-page playback visible after local cleanup. **`CAST_STOP_FAILED`** leaves Stop Cast retryable only while the sender still believes a Cast session is active.
-- **Resolved for #273:** start feedback uses local Cast status near the Cast action or stage-local Cast surface and must not merge with chat drawer or video-relay drawer health.
+- No open implementation decisions remain for M25 Cast error/status verification. See **Local Cast status taxonomy** and **Cast status verification (#279)** above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -109,6 +109,7 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 | Client vs CDK mesh retirement order? | **#134** removes SPA mesh handlers and modules first; **#135** removes API Gateway **`signaling`** route. After **#134** the SPA ignores inbound **`signaling`** envelopes; orphaned route is harmless until **#135**. |
 | Chromecast room API? | **None.** Viewer-local Cast state does not add HTTP fields, WebSocket routes, `share_state` payload fields, SFU token claims, lobby fields, or room snapshot fields. |
 | Chromecast side effects for #277? | **None.** Local Cast lifecycle paths must not call **`PATCH /v1/rooms/{roomId}`**, add room snapshot fields, emit room WebSocket payloads, alter **`share_state`**, request different SFU token claims, or change other participants' room diagnostics/status through integration surfaces. |
+| Chromecast verification for #279? | Tests must assert Cast lifecycle, failure, and cleanup paths keep Cast out of HTTP room fields, lobby payloads, room WebSocket routes/fan-out, **`share_state`**, SFU token claims, **`activeErrorCodes`**, and **`RoomRealtimeSdk.getDiagnostics().drawers.*`**. |
 
 ## Decisions (answered — #101 HTTP room AV)
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -19,6 +19,8 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 
 **Boundary:** Cast state is not written to RiffSync HTTP APIs, not sent over the room WebSocket, not represented in **`share_state`**, and not used for SFU token authorization. The M25 receiver is sender-proxied only: the sender remains the sole room participant for this Cast session and owns the room snapshot, chat log, and overlay updates it forwards to the receiver. If a future receiver joins RiffSync services directly, that is a new integration/auth review rather than an implied part of this contract.
 
+**Verification (#279):** Cast lifecycle, failure, and cleanup tests must assert the integration boundary above. The receiver must not call room HTTP APIs, open room WebSockets, request SFU tokens, create presence rows, or introduce room-wide Cast payloads. Sender lifecycle and cleanup must not emit room WebSocket messages, mutate **`share_state`**, or change SFU authorization claims.
+
 ### Cast sender availability gate (#272)
 
 The first Cast implementation slice may add a browser-local sender support detector. It reports whether the current normal room view may show **Cast to TV**; it does not start Cast and does not select the final receiver/source architecture.
@@ -143,9 +145,7 @@ The Cast-start slice uses a custom RiffSync Cast receiver page. The receiver ren
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-provider-boundary
-- **Resolved for #273:** custom RiffSync receiver page with sender-proxied local state. Native YouTube Cast, sender media-element Cast, and tab mirroring are outside #273.
-- **Resolved for #273:** the receiver does not join room services directly, so no receiver identity, room access token, SFU subscribe authorization, or receiver presence row is introduced for M25.
-- **Resolved for #273:** Google Cast receiver registration, application ID, origin allowlist, CSP, and iframe policy are required configuration for the custom receiver path and must preserve sender-only room authority.
+- No open implementation decisions remain for M25 Cast provider-boundary verification. See **Google Cast / Chromecast** and **Verification (#279)** above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/messaging_async.md
+++ b/.ai/integration/messaging_async.md
@@ -41,6 +41,7 @@ Scheduled work, durable events, and side effects that are not synchronous reques
 | `share_state: stopped` tears down SFU for guests? | **No** — **`host_screen` consumer detach only**; preserve SFU session and **`participant_av`**. |
 | Chat outbound retry before **`CHAT_SEND_DROPPED`**? | **No retry queue** — first failed send while chat plane unavailable emits **`CHAT_SEND_DROPPED`** (**#140** / **`api_contracts.md`**). |
 | Cast fan-out? | **No.** Cast is local client state and never posted to room members. #277 verifies this across start, active, stop, failure, disconnect, and cleanup paths. |
+| Cast fan-out verification for #279? | Lifecycle and cleanup tests must assert no room message, durable event, late-join replay, **`share_state`** variant, presence update, drawer status update, or SFU permission message is produced by local Cast paths. |
 
 ## Decisions (answered — presence and AV maturity)
 

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -61,6 +61,7 @@ Accessible-by-default contract for presentation and interaction surfaces.
 - For #276 successful Stop Cast, the restored normal stage playback surface is perceivable as normal room content again and the removed **`Now Casting`** panel is absent from the accessibility tree.
 - If focus remains on **Stop Cast** or stage-local stopping status when successful cleanup completes, restore focus to a visible normal-room control near the restored stage or Room action group. If focus moved elsewhere during stopping, preserve that focus.
 - Post-stop announcements use the restored stage or local Cast status surface only when useful; they must not duplicate chat drawer, video-relay, host feedback, or global room announcer output.
+- For #279 verification, automated and manual checks must cover accessible names for **Cast to TV** and **Stop Cast**, keyboard reachability, local **`role="status"`** / stage-local announcement behavior, focus transfer and restoration across success/failure/cleanup, removal of stale Cast controls from the accessibility tree, and absence of Cast-induced live regions or focus movement for other participants.
 
 ### Keyboard verification matrix (#106)
 
@@ -90,15 +91,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **`THEATER_AUDIO_SUSPENDED` a11y:** whether resume uses implicit gesture only or a keyboard-focusable explicit control with accessible name (pairs with **`presentation.md`** theater audio item).
 
 ### chromecast-accessibility
-- **Resolved for #273:** local Cast starting and start-failed text uses a visible **`role="status"`** with polite announcement near the Cast action or stage-local Cast surface. It must not duplicate chat drawer, video-relay, or global room announcer output.
-- **Resolved for #273:** **Cast to TV** has a visible label or accessible name; receiver/device name is omitted from app-authored accessible copy for privacy.
-- **Resolved for #273:** failed start returns focus to **Cast to TV** when still rendered, or to the nearest normal-view Room action.
-- **Resolved for #274:** persistent active state exposes **`Now Casting`** text plus an associated **Stop Cast** control, with stage-local polite status only.
-- **Resolved for #274:** focus moves from **Cast to TV** to **Stop Cast** only when the initiating action still owns focus at success; expanded-view controls are inaccessible while casting.
-- **Resolved for #276:** successful post-stop restoration removes the Cast-active panel from the accessibility tree, makes the normal stage perceivable again, and restores focus only when focus still belongs to the removed Cast stage surface.
-- **Resolved for #277:** remote participants receive no Cast-induced live region update, focus movement, drawer status, stage control, or room-mode announcement because another viewer starts, stops, fails, or disconnects Cast.
-- **Resolved for #278:** unavailable, failed-start, receiver-ended, playback-blocked, and stop-failed states use the same local Cast **`role="status"`** / stage-local status family. They must not duplicate chat drawer, video-relay, host feedback, global room announcer, or remote participant live regions.
-- **Resolved for #278:** receiver-ended and playback-blocked cleanup removes stale **`Now Casting`** and receiver-bound controls from the accessibility tree once the sender returns to normal in-page playback. Stop failure keeps **Stop Cast** accessible only while retry remains possible.
+- No open implementation decisions remain for M25 Cast accessibility verification. See **Chromecast Cast status** and #279 verification requirements above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/input_handling.md
+++ b/.ai/interface/input_handling.md
@@ -82,18 +82,14 @@ Keyboard, pointer, and permission input contract for room and catalog surfaces.
 - While local Cast is active, the expanded-view toggle is not rendered or is inert and unavailable to assistive technology. **Stop Cast** remains the primary stage action and uses the same minimum **44×44** CSS px target posture as other room controls.
 - After successful Stop Cast, if focus is still on **Stop Cast** or on stage-local stopping status, move focus to the restored normal stage's first meaningful control or back to the normal-view Room action group near **Cast to TV**. If the viewer moved focus into chat, sidebar tabs, participant A/V controls, or another room control while stopping, do not steal focus.
 - Post-stop focus restoration must not focus a hidden Cast source, a detached video element, a removed **`Now Casting`** panel, or an expanded-view control that is not currently available.
+- #279 verification covers click, **Enter**, and **Space** activation for rendered Cast controls; tab-order absence when Cast is unsupported, unknown, expanded, or inactive; focus transfer from **Cast to TV** to **Stop Cast** only when appropriate; focus preservation when the viewer moves elsewhere; and focus safety after failed, ended, blocked, stop-failed, cleanup, room leave, navigation, and reload paths.
 
 ## Open implementation decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-input-handling
-- **Resolved for #273:** focus remains on **Cast to TV** during receiver launch; start status uses local status text rather than forced focus movement.
-- **Resolved for #274:** after active Cast appears, focus moves to **Stop Cast** only when focus is still on the initiating **Cast to TV** action; otherwise do not steal focus.
-- **Resolved for #274:** expanded-view toggle is unavailable while casting, and Stop Cast keeps a keyboard-operable **44×44** minimum target posture.
-- **Resolved for #276:** successful Stop Cast restores focus only when it still belongs to the removed Cast stage surface; otherwise it preserves the viewer's current focus in chat/sidebar/room controls and never targets hidden Cast or unavailable expanded-view elements.
-- **Resolved for #278:** failed start, unavailable Cast, receiver-ended cleanup, and playback-blocked cleanup restore focus only if focus still belongs to removed Cast chrome or stage-local recovery text. Prefer the normal-view Cast action or nearest Room action; otherwise preserve current focus in chat, sidebar tabs, participant A/V controls, or other room controls.
-- **Resolved for #278:** stop failure keeps focus on **Stop Cast** when the control remains visible and retryable. If cleanup discovers the receiver has already ended, follow the receiver-ended focus rule instead of focusing hidden or detached Cast controls.
+- No open implementation decisions remain for M25 Cast input verification. See **Chromecast Cast controls** and #279 verification requirements above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -123,6 +123,7 @@ Implementation note: the expanded toggle is client-local React state in `RoomPag
 7. **Stop Cast:** Successful intentional Stop Cast returns the sender to normal in-page playback. Room session, chat state, selected sidebar tab, and latest authoritative room state remain intact.
 8. **Failure / unavailable:** Start rejection, platform policy block, receiver loss before active Cast, or unsupported sender state returns to normal in-page playback with local recoverable status only. Do not leave the room, reset chat, or tear down healthy SFU/video relay state.
 9. **Room authority preservation (#277):** Every Cast lifecycle path is sender-local. Starting, activating, stopping, failing, disconnecting, or clearing Cast must not send room WebSocket messages, change **`share_state`**, call room HTTP mutation APIs, change **`roomMode`** / **`avDisabled`**, alter SFU token eligibility, or change another participant's stage, controls, drawer status, chat state, presence, or playback.
+10. **Verification (#279):** Automated and manual checks cover the lifecycle from availability through cleanup: support detection, start, active, stop, unavailable, failed-start, receiver-ended, playback-blocked, stop-failed, cleanup completion, room leave, navigation, and reload. Each path preserves sender chat/sidebar/room state and proves other participants receive no Cast-induced UI, messaging, or media change.
 
 ### Cast-active sender flow (#274)
 
@@ -230,15 +231,7 @@ Mesh-only strings (**`negotiating_ice`**, **`recovering_ice`**, **`Establishing 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-interaction-flow
-- **Resolved for #273:** detect support, set local starting state, attempt Cast, and swap to active Cast only after receiver render confirmation.
-- **Resolved for #273:** failed start resets to local failed/idle state, keeps normal playback visible, keeps chat draft/session state intact, and exposes retryable local error.
-- **Resolved for #274:** active Cast replaces the sender stage with **`Now Casting`** and Stop Cast after confirmed success. Stop activation sends local stop intent only; full normal-playback restoration remains #276.
-- **Resolved for #274:** expanded view is unavailable while local Cast is active, and stale expanded-view state is cleared when active Cast begins.
-- **Resolved for #276:** successful intentional Stop Cast restores the sender's normal in-page stage playback and preserves chat, sidebar, room membership, presence, participant A/V, and authoritative room state.
-- **Resolved for #277:** other participants receive no Cast status, stage replacement, stop affordance, room mode change, playback change, chat/sidebar reset, participant A/V change, or drawer-status change because of another viewer's Cast lifecycle.
-- **Resolved for #278:** unavailable support keeps or returns the viewer to the normal Room Cast action with local unavailable copy. Start failure after the chooser or receiver handshake clears starting state, preserves normal playback/chat/sidebar state, and allows retry when support is still available.
-- **Resolved for #278:** receiver disconnect, SDK-ended active sessions, receiver app close, external TV stop, and blocked receiver playback all end active sender Cast locally, run idempotent cleanup, restore or keep in-page playback visible, and leave room membership, chat, SFU, participant A/V, and authoritative room state unchanged.
-- **Resolved for #278:** stop failure transitions to a retryable local stop-failed state only while the sender still has an active session handle. If the active route is gone, cleanup completes as **`CAST_SESSION_ENDED`** instead of preserving stale active Cast UI.
+- No open implementation decisions remain for M25 Cast interaction-flow verification. See **Chromecast Cast flow** and peer slice flows #274, #276, #278 above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -232,6 +232,7 @@ Optional Chromecast support is a local room presentation layer for Cast-capable 
 | **Stop Cast** | Stop returns the sender to normal in-page playback without clearing chat scrollback, compose state, selected sidebar tab, presence, room membership, or authoritative room snapshot state. |
 | **Failure / unavailable** | Cast unavailable, blocked, rejected, or failed start surfaces honest local status and leaves normal in-page playback/chat intact. It never implies the room failed or that other participants changed state. |
 | **Other participants (#277)** | Other participants see no Cast status, **`Now Casting`** panel, Stop Cast control, room mode indicator, playback change, drawer status change, chat reset, sidebar reset, participant A/V change, or stage layout change caused by another viewer's local Cast session. |
+| **Verification (#279)** | Cast presentation coverage must assert normal-view availability, receiver-start feedback, active **`Now Casting`**, Stop Cast restoration, failure/recovery copy, and cleanup removal of stale Cast surfaces. Checks must also prove sidebar/chat state and other participants' presentation remain unchanged. |
 
 ### Cast stop restoration (#276)
 
@@ -351,12 +352,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Telemetry / UX story event names** for layout transition timeout — deferred; per-drawer reconnect and tile lifecycle client log **`event`** names are normative in **`operations/observability.md`** Decisions.
 
 ### chromecast-presentation
-- **Resolved for #274:** persistent Cast-active sender stage uses a stage-local **`Now Casting`** panel with Stop Cast, no receiver-device naming, and no room-wide framing.
-- **Resolved for #274:** expanded view is unavailable while local Cast is active; stale expanded-view state is cleared when active Cast begins.
-- **Resolved for #276:** successful intentional Stop Cast removes the active Cast panel, restores the normal room stage playback surface, and preserves sender sidebar/chat state without notifying other viewers.
-- **Resolved for #277:** Cast presentation state is never rendered from room snapshot fields, room WebSocket payloads, SFU diagnostics, or another participant's local Cast controller. Remote participants keep their current room presentation and status surfaces unchanged.
-- **Resolved for #278:** unavailable and failed-start feedback appears only at the normal-view Cast action or stage-local Cast surface. Receiver disconnected, SDK-ended, externally stopped, and playback-blocked states remove or replace the **`Now Casting`** panel with local recovery copy and keep the normal room stage/playback path visible.
-- **Resolved for #278:** stop failure keeps **Stop Cast** visible and retryable while the sender still believes an active route exists. If cleanup determines the receiver already ended, the UI transitions to the normal room stage with **`CAST_SESSION_ENDED`** instead of leaving stale active Cast chrome.
+- No open implementation decisions remain for M25 Cast presentation verification. See **Chromecast Cast view**, peer slice sections #272-#278, and #279 verification requirements above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/execution_model.md
+++ b/.ai/runtime/execution_model.md
@@ -101,6 +101,17 @@ The #276 slice completes the intentional sender Stop Cast path after active Cast
 | **Sibling boundary** | Receiver disconnects, sender SDK-ended sessions outside explicit Stop Cast success, start/stop failure copy, and blocked/unavailable recovery are refined by #278. #276 may share the cleanup helper but does not define those failure states. |
 | **Diagnostics** | Stop restoration remains local controller state. It must not add Cast drawer diagnostics, active realtime error codes, room WebSocket messages, room HTTP mutations, or SFU token changes. |
 
+### Cast verification controller hooks (#279)
+
+The #279 verification slice may add test-only hooks or fakes around the local Cast controller, Cast sender client, and receiver channel to exercise lifecycle paths that browser Cast APIs cannot reliably drive in CI.
+
+| Concern | Contract |
+| --- | --- |
+| **Covered states** | Availability checking, unavailable, idle, starting, start-failed, casting/active, stopping, stop-failed, session-ended, playback-blocked, cleaned-up, room leave, navigation, and reload. |
+| **Allowed test seams** | Controller-local state inspection, fake sender clients, fake receiver-channel acknowledgements/errors, fake timer control, and receiver presentation stubs. |
+| **Forbidden promotion** | Test hooks must not become fan-visible drawer diagnostics, **`activeErrorCodes`**, room WebSocket payloads, room HTTP fields, SFU token claims, or persistent room state. |
+| **Side-effect assertions** | Tests assert no destructive calls into **`ChatSession`**, **`SfuMediaSession`**, **`TheaterPlayback`**, room mutation APIs, room WebSocket send paths, **`share_state`**, or remote participant presentation/state. |
+
 ### Application SDK surface (narrow public API)
 
 Room code outside these modules calls only:
@@ -465,16 +476,7 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - **Harness extension** — **`realtime-conformance`** steps for typing routes, **`lastActiveAt`** / **active** fan-out after **`presence_request`**, and drawer-isolation matrix extensions documented in **`.ai/operations/observability.md`**.
 
 ### chromecast-runtime-controller
-- **Resolved for #273:** the controller is room-shell local and launches a custom RiffSync receiver page with sender-proxied state.
-- **Resolved for #273:** local lifecycle must cover **`idle`**, **`starting`**, **`casting`**, and **`start_failed`**; stop/disconnect refinements extend this in sibling issues.
-- **Resolved for #273:** the receiver reconstructs the expanded-view-like presentation from sender-proxied snapshots and updates; provider-native media Cast and tab mirroring are outside this slice.
-- **Resolved for #273:** normal in-page playback remains visible during **`starting`** and the #274 sender-stage replacement owns the full **`Now Casting`** placeholder behavior.
-- **Resolved for #273:** Cast-specific launch/render test hooks may be local to the Cast controller or receiver harness, but they must not overload **`getDiagnostics().drawers.*`**.
-- **Resolved for #274:** active Cast renders **`CAST_ACTIVE`** / **`Now Casting`** on the sender stage, exposes local Stop Cast intent, clears/suppresses expanded view, and still does not add drawer diagnostics or active realtime error codes.
-- **Resolved for #276:** successful intentional Stop Cast uses local, idempotent cleanup and restores the normal in-page stage without clearing room, chat, SFU, theater playback, sidebar, or authoritative room state.
-- **Resolved for #277:** Cast controller tests should assert the absence of room HTTP mutations, room WebSocket sends, **`share_state`** changes, SFU token/permission changes, drawer diagnostic changes, and remote participant presentation changes for local Cast lifecycle paths.
-- **Resolved for #278:** extend the local Cast controller lifecycle with distinct unavailable, start-failed, session-ended, playback-blocked, stopping, stop-failed, and cleaned-up states. Receiver disconnect, sender SDK **session-ended**, receiver app close, external TV stop, and blocked receiver playback must drive local cleanup and retry behavior without touching **`ChatSession`**, **`SfuMediaSession`**, **`TheaterPlayback`**, room HTTP APIs, room WebSocket sends, or **`RoomRealtimeSdk.getDiagnostics().drawers.*`**.
-- **Resolved for #278:** tests may use controller-local hooks, fake sender clients, and receiver-channel stubs to simulate unavailable support, launch rejection, active disconnect, playback blocked, stop rejection, and cleanup completion. These hooks must remain outside aggregate room diagnostics and active realtime error codes.
+- No open implementation decisions remain for M25 Cast runtime-controller verification. See **Local Cast controller**, peer controller sections #272-#276, and **Cast verification controller hooks (#279)** above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/runtime/lifecycle_shutdown.md
+++ b/.ai/runtime/lifecycle_shutdown.md
@@ -65,6 +65,7 @@ Local Cast state follows the same independence rule: Cast stop, failure, or rece
 - **Custom receiver launch failure (#273):** if the sender SDK rejects launch, the user cancels the chooser, or the receiver does not confirm rendering stage-primary video plus chat overlay, clear **`CAST_STARTING`**, surface **`CAST_START_REJECTED`**, and keep normal playback visible.
 - **Expanded view state:** Cast starts only from normal view. If stale expanded-view local state exists internally, cleanup must not re-enter expanded view after Cast stop unless a later interface contract permits it.
 - **Participant isolation (#277):** local Cast cleanup must be idempotent and sender-only. It must not close room WebSocket, close SFU signaling, stop participant **`getUserMedia`**, clear remote consumers, change **`share_state`**, mutate room state, clear other viewers' stage/chrome, or broadcast room cleanup messages.
+- **Verification (#279):** cleanup tests cover successful stop, failed stop, receiver disconnect, SDK-ended active sessions, blocked playback, start failure, unavailable Cast, room leave, navigation, and reload. They assert idempotent release of sender-side Cast session handles, Cast channel listeners, receiver presentation bindings, hidden/detached Cast source bindings, timers, and stale UI state while preserving healthy room modules and authority.
 
 ## Participant A/V errors (client)
 
@@ -102,11 +103,7 @@ Local Cast state follows the same independence rule: Cast stop, failure, or rece
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-lifecycle-shutdown
-- **Resolved for #273:** launch failure and route leave clear local start state and keep/restore normal playback without closing healthy room, chat, SFU, or theater playback modules.
-- **Resolved for #274:** active Cast cleanup begins with local stop intent only; the Stop Cast control must not tear down healthy room, chat, SFU, or theater playback modules by itself.
-- **Resolved for #276:** successful intentional Stop Cast clears local Cast-active UI, releases sender-side Cast resources best-effort, and restores normal in-page playback while preserving room membership, chat, SFU, theater playback, selected sidebar tab, and authoritative room state.
-- **Resolved for #277:** cleanup and teardown tests must prove local Cast cleanup is idempotent and does not close room WebSocket, close SFU signaling, stop participant A/V, clear remote consumers, mutate **`share_state`**, write room state, or broadcast room cleanup messages.
-- **Resolved for #278:** receiver disconnect after active Cast, sender SDK-ended active sessions outside successful user stop, receiver playback blocked, start-failed recovery after a visible Cast affordance, unavailable Cast, and stop failure use sender-local cleanup/status paths only. They must preserve room membership, chat draft/session state, selected sidebar tab, SFU signaling, participant A/V state, theater playback ownership, and authoritative room state.
+- No open implementation decisions remain for M25 Cast lifecycle cleanup verification. See **SPA local Cast** and **Verification (#279)** above.
 
 ## Primary code pointers (optional)
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #279
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.