### PR TITLE
[M25] Verify Cast lifecycle and cleanup coverage

### DIFF
--- a/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
+++ b/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
@@ -286,6 +286,9 @@ const CAST_LIFECYCLE_PATHS: CastStartLifecycle[] = [
   'casting',
   'stopping',
   'start_failed',
+  'session_ended',
+  'playback_blocked',
+  'stop_failed',
 ]
 
 describe('RoomPage Cast room authority (#277)', () => {
@@ -392,7 +395,7 @@ describe('RoomPage Cast room authority (#277)', () => {
 
     const tokenCallsBefore = fetchSfuJoinToken.mock.calls.length
 
-    for (const lifecycle of ['starting', 'casting', 'stopping', 'start_failed', 'idle'] as const) {
+    for (const lifecycle of CAST_LIFECYCLE_PATHS) {
       await rerenderCastLifecycle(lifecycle)
     }
 
@@ -405,9 +408,9 @@ describe('RoomPage Cast room authority (#277)', () => {
 
     const messagesBefore = roomWsMessages().length
 
-    await rerenderCastLifecycle('casting')
-    await rerenderCastLifecycle('stopping')
-    await rerenderCastLifecycle('idle')
+    for (const lifecycle of CAST_LIFECYCLE_PATHS) {
+      await rerenderCastLifecycle(lifecycle)
+    }
 
     expect(roomWsMessages().length).toBe(messagesBefore)
   })
@@ -419,7 +422,7 @@ describe('RoomPage Cast room authority (#277)', () => {
     const chatBefore = chatDisconnectSpy.mock.calls.length
     const sfuBefore = sfuDisconnectSpy.mock.calls.length
 
-    for (const lifecycle of ['starting', 'casting', 'stopping', 'start_failed'] as const) {
+    for (const lifecycle of CAST_LIFECYCLE_PATHS) {
       await rerenderCastLifecycle(lifecycle)
     }
 

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -99,6 +99,19 @@ describe('createCastStartController', () => {
     vi.useRealTimers()
   })
 
+  it('maps receiver render failure during startup to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'receiver_render_error' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
   it('stopCast ends the Cast session without mutating snapshot input', async () => {
     const session = createMockSession({ confirmAfterSend: true })
     const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
@@ -179,6 +192,20 @@ describe('createCastStartController', () => {
     expect(session.end).toHaveBeenCalledTimes(1)
   })
 
+  it('resets recovery states to idle so Cast can be retried locally', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitSessionEnded()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    controller.resetStartFailure()
+
+    expect(controller.getState().lifecycle).toBe('idle')
+  })
+
   it('maps receiver render failure after active Cast to playback_blocked recovery', async () => {
     const session = createMockSession({ confirmAfterSend: true })
     const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
@@ -220,5 +247,20 @@ describe('createCastStartController', () => {
     await controller.stopCast()
 
     expect(controller.getState().lifecycle).toBe('session_ended')
+  })
+
+  it('detaches receiver listeners after successful cleanup', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    await controller.stopCast()
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'late_receiver_error' })
+    session.emitSessionEnded()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('idle')
+    expect(session.end).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -15,10 +15,18 @@ const snapshot: CastPresentationSnapshot = {
   },
 }
 
+type MockCastSession = CastSenderSessionHandle & {
+  emitSessionEnded: () => void
+  emitReceiverMessage: (message: unknown) => void
+  setActiveRoute: (active: boolean) => void
+  messageListenerCount: () => number
+  sessionEndedListenerCount: () => number
+}
+
 function createMockSession(handlers: {
   onSend?: (message: unknown) => void
   confirmAfterSend?: boolean
-}): CastSenderSessionHandle & { emitSessionEnded: () => void; emitReceiverMessage: (message: unknown) => void; setActiveRoute: (active: boolean) => void } {
+}): MockCastSession {
   const listeners = new Set<(message: unknown) => void>()
   const sessionEndedListeners = new Set<() => void>()
   let activeRoute = true
@@ -49,6 +57,8 @@ function createMockSession(handlers: {
     setActiveRoute: (active) => {
       activeRoute = active
     },
+    messageListenerCount: () => listeners.size,
+    sessionEndedListenerCount: () => sessionEndedListeners.size,
   }
 }
 
@@ -110,6 +120,33 @@ describe('createCastStartController', () => {
 
     expect(controller.getState().lifecycle).toBe('start_failed')
     expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears startup cleanup resources after receiver render failure', async () => {
+    vi.useFakeTimers()
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 50 })
+
+    await controller.startCast(snapshot)
+    expect(session.messageListenerCount()).toBe(1)
+    expect(session.sessionEndedListenerCount()).toBe(1)
+
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'receiver_render_error' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+    expect(session.messageListenerCount()).toBe(0)
+    expect(session.sessionEndedListenerCount()).toBe(0)
+
+    session.emitReceiverMessage({ type: 'render_confirmed' })
+    session.emitSessionEnded()
+    await vi.advanceTimersByTimeAsync(60)
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
   })
 
   it('stopCast ends the Cast session without mutating snapshot input', async () => {
@@ -192,6 +229,27 @@ describe('createCastStartController', () => {
     expect(session.end).toHaveBeenCalledTimes(1)
   })
 
+  it('cleans up active session-ended callbacks idempotently', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitSessionEnded()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.messageListenerCount()).toBe(0)
+    expect(session.sessionEndedListenerCount()).toBe(0)
+
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'late_receiver_error' })
+    session.emitSessionEnded()
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
   it('resets recovery states to idle so Cast can be retried locally', async () => {
     const session = createMockSession({ confirmAfterSend: true })
     const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
@@ -214,6 +272,27 @@ describe('createCastStartController', () => {
     session.emitReceiverMessage({ type: 'render_failed', reason: 'playback_blocked' })
     await Promise.resolve()
     await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('playback_blocked')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases active receiver bindings after playback-blocked cleanup', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({ type: 'render_failed', reason: 'playback_blocked' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('playback_blocked')
+    expect(session.messageListenerCount()).toBe(0)
+    expect(session.sessionEndedListenerCount()).toBe(0)
+
+    session.emitReceiverMessage({ type: 'render_confirmed' })
+    session.emitSessionEnded()
+    await controller.stopCast()
 
     expect(controller.getState().lifecycle).toBe('playback_blocked')
     expect(session.end).toHaveBeenCalledTimes(1)
@@ -247,6 +326,12 @@ describe('createCastStartController', () => {
     await controller.stopCast()
 
     expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.messageListenerCount()).toBe(0)
+    expect(session.sessionEndedListenerCount()).toBe(0)
+
+    await controller.stopCast()
+
+    expect(session.end).toHaveBeenCalledTimes(1)
   })
 
   it('detaches receiver listeners after successful cleanup', async () => {
@@ -262,5 +347,7 @@ describe('createCastStartController', () => {
 
     expect(controller.getState().lifecycle).toBe('idle')
     expect(session.end).toHaveBeenCalledTimes(1)
+    expect(session.messageListenerCount()).toBe(0)
+    expect(session.sessionEndedListenerCount()).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- Expands Cast controller lifecycle tests for receiver startup failure, recovery reset, and listener cleanup after stop.
- Adds cleanup-resource coverage for receiver render failure, external session end, playback-blocked recovery, route-gone stop failure, late Cast events, listener detachment, timer clearance, and idempotent stop cleanup.
- Keeps the branch scoped to viewer-local Cast behavior without room HTTP, WebSocket, SFU, diagnostics, or remote participant side effects.

## Test plan
- npm test --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web -- src/room/cast/castStartController.test.ts
- npm run build --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web
- npm test --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web
- npm run lint --prefix /Users/derrickanderson/Documents/code/alto9/alto9-core/riffsync/apps/web
- npm run verify:push

Closes #293
Closes #295
Refs #279