### PR TITLE
fix(admin): allow catalog delete when only stale rooms reference episode

### DIFF
--- a/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.test.ts
+++ b/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.test.ts
@@ -4,13 +4,13 @@ import { formatCatalogEpisodeInUseMessage } from './formatCatalogEpisodeInUseMes
 describe('formatCatalogEpisodeInUseMessage', () => {
   it('includes room and list counts when present', () => {
     expect(formatCatalogEpisodeInUseMessage({ rooms: 3, lists: 1 })).toBe(
-      'Cannot delete — this episode is used by 3 room(s) and/or 1 list(s).',
+      'Cannot delete — this episode is used by 3 active watch party room(s) and/or 1 list(s).',
     )
   })
 
   it('omits zero reference counts', () => {
     expect(formatCatalogEpisodeInUseMessage({ rooms: 2, lists: 0 })).toBe(
-      'Cannot delete — this episode is used by 2 room(s).',
+      'Cannot delete — this episode is used by 2 active watch party room(s).',
     )
   })
 })

--- a/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.ts
+++ b/apps/web/src/catalog/formatCatalogEpisodeInUseMessage.ts
@@ -4,7 +4,7 @@ export function formatCatalogEpisodeInUseMessage(references: {
 }): string {
   const segments: string[] = []
   if (references.rooms > 0) {
-    segments.push(`${references.rooms} room(s)`)
+    segments.push(`${references.rooms} active watch party room(s)`)
   }
   if (references.lists > 0) {
     segments.push(`${references.lists} list(s)`)

--- a/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogDeleteControl.tsx
@@ -104,8 +104,8 @@ export function AdminCatalogDeleteControl({
         Danger zone
       </h2>
       <p className="riffsync-admin-catalog-delete__lede">
-        Permanently remove this episode from the catalog. Deletion is blocked while rooms or lists
-        reference the episode.
+        Permanently remove this episode from the catalog. Deletion is blocked while active watch
+        parties or lists reference the episode.
       </p>
       <button type="button" className="btn btn-danger" onClick={openDialog} disabled={deleting}>
         Delete episode
@@ -130,8 +130,8 @@ export function AdminCatalogDeleteControl({
               Delete episode?
             </h2>
             <p className="riffsync-admin-modal__lede">
-              This action is permanent. You cannot delete while rooms or lists still reference this
-              episode.
+              This action is permanent. You cannot delete while active watch parties or lists still
+              reference this episode.
             </p>
             <div className="riffsync-admin-modal__form">
               <label className="riffsync-admin-modal__label" htmlFor={confirmInputId}>

--- a/infra/cdk/lambda/admin-catalog-delete-shared.test.ts
+++ b/infra/cdk/lambda/admin-catalog-delete-shared.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isActiveCatalogEpisodeRoomReference } from './admin-catalog-delete-shared';
+
+describe('isActiveCatalogEpisodeRoomReference', () => {
+  const staleMs = 45 * 60 * 1000;
+  const nowMs = 1_000_000;
+
+  afterEach(() => {
+    delete process.env.STALE_ROOM_MS;
+  });
+
+  it('returns true for matching episode within stale window', () => {
+    expect(
+      isActiveCatalogEpisodeRoomReference(
+        { catalogEpisodeId: 'ep-1', lastActivityAt: nowMs - 1_000 },
+        'ep-1',
+        nowMs,
+        staleMs,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for matching episode past stale window', () => {
+    expect(
+      isActiveCatalogEpisodeRoomReference(
+        { catalogEpisodeId: 'ep-1', lastActivityAt: nowMs - staleMs - 1 },
+        'ep-1',
+        nowMs,
+        staleMs,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when episode id differs', () => {
+    expect(
+      isActiveCatalogEpisodeRoomReference(
+        { catalogEpisodeId: 'ep-2', lastActivityAt: nowMs - 1_000 },
+        'ep-1',
+        nowMs,
+        staleMs,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when lastActivityAt is missing or invalid', () => {
+    expect(isActiveCatalogEpisodeRoomReference({ catalogEpisodeId: 'ep-1' }, 'ep-1', nowMs, staleMs)).toBe(
+      false,
+    );
+    expect(
+      isActiveCatalogEpisodeRoomReference(
+        { catalogEpisodeId: 'ep-1', lastActivityAt: '2026-01-01' },
+        'ep-1',
+        nowMs,
+        staleMs,
+      ),
+    ).toBe(false);
+  });
+});

--- a/infra/cdk/lambda/admin-catalog-delete-shared.ts
+++ b/infra/cdk/lambda/admin-catalog-delete-shared.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { defaultStaleRoomMs } from './room-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -24,12 +25,34 @@ async function countScanMatches(
   return typeof out.Count === 'number' ? out.Count : 0;
 }
 
+/** True when a room row still references an episode in an active watch party window. */
+export function isActiveCatalogEpisodeRoomReference(
+  row: Record<string, unknown>,
+  episodeId: string,
+  nowMs: number,
+  staleMs: number = defaultStaleRoomMs(),
+): boolean {
+  if (row.catalogEpisodeId !== episodeId) return false;
+  const lastActivityAt = row.lastActivityAt;
+  if (typeof lastActivityAt !== 'number' || !Number.isFinite(lastActivityAt)) {
+    return false;
+  }
+  return lastActivityAt > nowMs - staleMs;
+}
+
 export async function countCatalogEpisodeReferences(
   episodeId: string,
   roomsTableName: string,
   listsTableName?: string,
+  nowMs: number = Date.now(),
+  staleMs: number = defaultStaleRoomMs(),
 ): Promise<CatalogEpisodeReferences> {
-  const rooms = await countScanMatches(roomsTableName, 'catalogEpisodeId = :id', { ':id': episodeId });
+  const activeRoomCutoff = nowMs - staleMs;
+  const rooms = await countScanMatches(
+    roomsTableName,
+    'catalogEpisodeId = :id AND lastActivityAt > :cutoff',
+    { ':id': episodeId, ':cutoff': activeRoomCutoff },
+  );
   const lists =
     listsTableName && listsTableName.length > 0
       ? await countScanMatches(listsTableName, 'catalogEpisodeId = :id', { ':id': episodeId })

--- a/infra/cdk/lambda/admin-catalog-delete.test.ts
+++ b/infra/cdk/lambda/admin-catalog-delete.test.ts
@@ -29,6 +29,7 @@ vi.mock('./riffsync-observability', async (importOriginal) => {
   };
 });
 
+import { ScanCommand } from '@aws-sdk/lib-dynamodb';
 import { handler as deleteHandler } from './admin-catalog-delete';
 
 function deleteEvent(
@@ -125,7 +126,7 @@ describe('admin-catalog-delete handler', () => {
     );
   });
 
-  it('returns 409 when room scan returns matches', async () => {
+  it('returns 409 when active room scan returns matches', async () => {
     mocks.docSend
       .mockResolvedValueOnce({ Item: { id: 'ep-1' } })
       .mockResolvedValueOnce({ Count: 2 });
@@ -146,6 +147,11 @@ describe('admin-catalog-delete handler', () => {
       code: 'catalog_episode_in_use',
       references: { rooms: 2, lists: 0 },
     });
+    expect(ScanCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        FilterExpression: 'catalogEpisodeId = :id AND lastActivityAt > :cutoff',
+      }),
+    );
     expect(mocks.recordAdminCatalogRoute).toHaveBeenCalledWith(
       'AdminCatalogDelete',
       'conflict',


### PR DESCRIPTION
Room documents persist after watch parties end, so counting every room row with a matching catalogEpisodeId falsely blocked deletion. Only count rooms whose lastActivityAt is still within the stale-room window.