### PR TITLE
docs(ai): refine issue #301 contract updates

### DIFF
--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -23,14 +23,14 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 
 ### Cast sender availability gate (#272)
 
-The first Cast implementation slice may add a browser-local sender support detector. It reports whether the current normal room view may show **Cast to TV**; it does not start Cast and does not select the final receiver/source architecture.
+The first Cast implementation slice adds a browser-local sender support detector for the registered RiffSync Custom Web Receiver. It reports whether the current normal room view may show **Cast to TV**; it does not start Cast, render the receiver, or send presentation data.
 
 | Gate | Contract |
 | --- | --- |
 | **Runtime phase** | Run after normal room shell render/bootstrap. Detection must not block room snapshot, chat WebSocket, SFU bootstrap, normal playback, expanded view, or host controls. |
-| **Required support** | Show **Cast to TV** only when the browser/session exposes a usable sender capability for the chosen implementation path and the current context satisfies origin/security requirements. |
-| **Unsupported / unknown** | Omit the Cast entry while support is unknown or absent. If the detector fails after evaluation, map to local **`CAST_UNAVAILABLE`** copy in **`error_state.md`**. |
-| **No receiver architecture commitment** | #272 does not require custom receiver registration, receiver application id, receiver service identity, direct SFU subscribe authorization, YouTube-native Cast binding, or MediaStream Cast support. Those choices belong to the Cast-start slice. |
+| **Required support** | Show **Cast to TV** only when the browser/session exposes the Cast Framework sender API, the public **`VITE_CAST_RECEIVER_APP_ID`** is configured, and **`CastContext.setOptions({ receiverApplicationId, autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED })`** succeeds for the custom receiver. |
+| **Unsupported / unknown** | Omit the Cast entry while support is unknown or absent. Missing receiver app id, sender SDK load failure, callback timeout, absent **`ORIGIN_SCOPED`** policy, or failed **`CastContext`** configuration map to local **`CAST_UNAVAILABLE`** copy in **`error_state.md`**. |
+| **Sender module ownership** | **`apps/web/src/room/cast/castSenderSupportDetector.ts`** owns sender SDK script injection and **`window.__onGCastApiAvailable`** registration before script append. **`apps/web/src/room/cast/castSenderClient.ts`** owns receiver app id reads, **`CastContext.setOptions`**, and later **`requestSession()`** wrapping. **`useCastAvailability`** exposes the post-render React state used by normal room view. |
 | **No authority side effects** | Detection must not call RiffSync HTTP APIs, publish WebSocket messages, request SFU tokens, alter **`roomMode`**, alter **`share_state`**, or inspect/identify receiver devices in room state. |
 
 ### Cast start receiver boundary (#273)
@@ -147,9 +147,8 @@ The Cast-start slice uses a custom RiffSync Cast receiver page. The receiver ren
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-provider-boundary
-- Confirm the exact sender module ownership for SDK script injection, global callback registration, and idempotent **`CastContext.setOptions`** during `/refine-issue`.
 - Specify the exact receiver route bootstrap module and the test fixture that proves the custom namespace is configured before receiver context start.
-- Specify how Google Cast sender error objects and session state callbacks map into local Cast status codes without exposing receiver identifiers or provider internals in room surfaces.
+- No open decisions remain for sender availability provider errors. Availability-time sender failures map to local **`CAST_UNAVAILABLE`**; later start/session failures map to local Cast start/lifecycle statuses in the issue that owns that path. Provider errors, receiver identifiers, and device names are not exposed in room surfaces or room diagnostics.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/interaction_flow.md
+++ b/.ai/interface/interaction_flow.md
@@ -125,6 +125,14 @@ Implementation note: the expanded toggle is client-local React state in `RoomPag
 9. **Room authority preservation (#277):** Every Cast lifecycle path is sender-local. Starting, activating, stopping, failing, disconnecting, or clearing Cast must not send room WebSocket messages, change **`share_state`**, call room HTTP mutation APIs, change **`roomMode`** / **`avDisabled`**, alter SFU token eligibility, or change another participant's stage, controls, drawer status, chat state, presence, or playback.
 10. **Verification (#279):** Automated and manual checks cover the lifecycle from availability through cleanup: support detection, start, active, stop, unavailable, failed-start, receiver-ended, playback-blocked, stop-failed, cleanup completion, room leave, navigation, and reload. Each path preserves sender chat/sidebar/room state and proves other participants receive no Cast-induced UI, messaging, or media change.
 
+### Cast sender availability flow (#301)
+
+1. **Probe timing:** After the normal room shell exists, the sender availability hook loads the Google Cast sender SDK, installs **`window.__onGCastApiAvailable`** before script append, and attempts to configure **`CastContext`** for the custom receiver app id.
+2. **Available:** Render **Cast to TV** only in the normal-view **Room** sidebar action group when the SDK reports availability and **`CastContext.setOptions`** succeeds with **`VITE_CAST_RECEIVER_APP_ID`** and **`ORIGIN_SCOPED`** auto-join policy.
+3. **Checking / unavailable:** While checking, render no Cast action. When unavailable because the SDK is absent, blocked, timed out, missing **`VITE_CAST_RECEIVER_APP_ID`**, or cannot configure **`CastContext`**, show only local **`CAST_UNAVAILABLE`** copy at the Cast surface if the implementation renders evaluated status. Do not use chat drawer, video-relay status, host feedback, room error boundaries, or global announcer copy for availability failure.
+4. **No launch in this slice:** #301 does not call **`CastContext.requestSession()`** as part of availability detection. User gesture launch, chooser cancellation, start rejection, receiver render timeout, active **`Now Casting`**, stop, and cleanup focus behavior are handled by later M26 slices.
+5. **Room isolation:** Availability probing does not call room HTTP APIs, publish room WebSocket messages, request SFU tokens, change **`share_state`**, alter **`roomMode`** / **`avDisabled`**, change presence, reset chat/sidebar state, or expose receiver/device identifiers to the room.
+
 ### Cast-active sender flow (#274)
 
 1. **Active entry:** #274 begins when the local Cast controller reaches active Cast after receiver render confirmation. Do not show **`Now Casting`** before that confirmation.
@@ -231,7 +239,7 @@ Mesh-only strings (**`negotiating_ice`**, **`recovering_ice`**, **`Establishing 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-interaction-flow
-- Specify local copy and status placement for unsupported sender, missing app id, starting, chooser cancel, start rejected, receiver render timeout, session ended, playback blocked, stop failed, and cleanup complete.
+- Specify local copy and status placement for starting, chooser cancel, start rejected, receiver render timeout, session ended, playback blocked, stop failed, and cleanup complete.
 - Specify focus behavior for chooser cancel, receiver confirmation success, Stop Cast success, stop failure, navigation, reload, and external receiver end.
 - Specify tests that prove **`Now Casting`** is absent until receiver render confirmation and removed on cleanup without resetting sidebar/chat state.
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -276,15 +276,16 @@ The Cast-start slice proves an actual custom receiver view, not just a sender-si
 
 ### Cast availability in normal room view (#272)
 
-The first Cast slice exposes availability only after the normal room shell has rendered and local sender support is confirmed.
+The Cast availability slice exposes availability only after the normal room shell has rendered and local sender support is confirmed for the configured RiffSync Custom Web Receiver.
 
 | Concern | Contract |
 | --- | --- |
 | **Primary placement** | Place **Cast to TV** in the normal-view **Room** sidebar action group near existing room actions such as **Copy Party Link** and **Leave Party**. It is a viewer-local room action, not a host-authoritative control. |
 | **Host control separation** | Do **not** place Cast availability in **`HostControlBar`** or gate it on **`JWT.sub === hostSub`**. Room admins and guests follow the same local sender-support rule. |
 | **Expanded view** | Do not render a Cast start action in expanded view. If normal-view state changes while expanded, the expanded toggle and overlay remain unchanged; the viewer exits expanded view before using Cast. |
-| **Unsupported sender default** | When sender support is absent, unknown, blocked by platform policy, or still checking, omit **Cast to TV**. Normal playback, chat, expanded view, host controls, and participant A/V remain unchanged. |
-| **Explainable unavailable state** | If an implementation briefly renders or evaluates the Cast affordance and then learns Cast is unavailable, show a local status line at the Cast surface with copy such as **Cast is not available in this browser or device.** Do not use the chat drawer banner, video-relay status, room error, or host feedback surfaces. |
+| **Required ready state** | Render **Cast to TV** only when the Cast sender SDK reports availability and the sender can configure **`CastContext`** with **`VITE_CAST_RECEIVER_APP_ID`** and **`chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED`** for the custom receiver. |
+| **Unsupported sender default** | When sender support is absent, unknown, blocked by platform policy, missing receiver app id, unable to configure **`CastContext`**, or still checking, omit **Cast to TV**. Normal playback, chat, expanded view, host controls, and participant A/V remain unchanged. |
+| **Explainable unavailable state** | If an implementation briefly renders or evaluates the Cast affordance and then learns Cast is unavailable, show a local status line at the Cast surface with copy **Cast is not available in this browser or device.** Do not use the chat drawer banner, video-relay status, room error, global announcer, or host feedback surfaces. |
 | **Stage impact** | #272 does not replace the stage, hide the player, or show **`Now Casting`**. The regular **`RoomPlaybackPanel`** remains the active playback surface until a later start-Cast slice confirms a Cast session. |
 
 ## Accessibility & motion (baseline)

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -47,9 +47,10 @@ The SPA build includes the custom receiver route and public receiver app id conf
 | Concern | Contract |
 | --- | --- |
 | **Receiver route** | **`/cast/receiver`** is part of the same Vite SPA artifact and must be reachable from the production CloudFront origin over HTTPS. |
-| **Receiver app id** | Public build-time value, expected as **`VITE_CAST_RECEIVER_APP_ID`** unless refinement chooses a repo-consistent alternative. It is safe in the bundle and must not be handled as a secret. |
+| **Receiver app id** | Public build-time value **`VITE_CAST_RECEIVER_APP_ID`**. Production deploy wiring reads the Cast Developer Console app id from a non-secret GitHub Actions variable such as **`PROD_CAST_RECEIVER_APP_ID`** and exports it as **`VITE_CAST_RECEIVER_APP_ID`** for the SPA build. It is safe in the bundle and must not be handled as a secret. |
 | **Sender SDK** | The production bundle may load Google's Cast sender SDK from **`www.gstatic.com`** with **`loadCastFramework=1`**. Build and CSP policy must permit the required script path where Cast is enabled. |
 | **Custom receiver** | Release readiness requires the Cast SDK Developer Console app id to point at the deployed receiver URL and any applicable sender origin allowlist to include **`https://riffsync.tv`**. |
+| **Missing prod app id** | Missing production **`VITE_CAST_RECEIVER_APP_ID`** does not fail unrelated room deploys. The SPA must hide or locally fail Cast availability, and #306 release readiness records the missing app id as a blocker before announcing Cast-ready production behavior. |
 
 ### Deploy ordering vs build
 
@@ -251,6 +252,4 @@ The informal **SFU deploy checklist — hardening deltas** table above is supers
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-build-packaging
-- Specify deploy workflow wiring for the public receiver app id and placeholder CI value.
-- Specify whether production deploy fails when receiver app id is missing or records a release-check failure while hiding Cast.
-- Specify the web-app test split for Cast: SDK loader unit tests, receiver route rendering tests, and manual physical-device smoke evidence.
+- No open decisions remain for sender availability build packaging. Production wiring uses a non-secret GitHub Actions variable exported as **`VITE_CAST_RECEIVER_APP_ID`** for the SPA build; missing app id hides or locally fails Cast and blocks release readiness, not unrelated room deploys; #301 web-app tests cover SDK loader, app id, **`CastContext.setOptions`**, availability UI, and no room-authority side effects. Receiver route rendering tests belong to #303, and physical-device smoke evidence belongs to #306.

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -54,9 +54,9 @@ The Cast receiver application id is public build-time configuration for the SPA.
 
 | Config | Contract |
 | --- | --- |
-| **Receiver app id** | A public Vite value, expected to be named **`VITE_CAST_RECEIVER_APP_ID`** unless refinement finds an existing naming convention conflict. Missing or invalid prod configuration hides or locally fails Cast; it must not degrade room bootstrap, chat, SFU media, or host controls. |
-| **Receiver URL** | Production registration points to the Custom Web Receiver route on **`https://riffsync.tv/cast/receiver`**. Local/dev receiver URLs may be used only where Cast device reachability and TLS requirements are satisfied. |
-| **Sender SDK** | The sender loads the Google Cast sender SDK with **`loadCastFramework=1`** and configures **`CastContext`** from build-time receiver app id before opening the chooser. |
+| **Receiver app id** | The public Vite value is **`VITE_CAST_RECEIVER_APP_ID`**. Missing or invalid configuration hides or locally fails Cast; it must not degrade room bootstrap, chat, SFU media, host controls, expanded view, or normal playback. |
+| **Receiver URL** | Production registration points to the Custom Web Receiver route on **`https://riffsync.tv/cast/receiver`**. Local/dev physical Cast tests require a Cast-device-reachable HTTPS origin; ordinary **`localhost`** Vite dev is suitable for unit/component tests but is not a physical receiver target unless tunneled or otherwise exposed over trusted TLS. |
+| **Sender SDK** | The sender loads the Google Cast sender SDK with **`loadCastFramework=1`**, assigns **`window.__onGCastApiAvailable`** before appending the SDK script, and configures **`CastContext`** from the build-time receiver app id with **`chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED`** before exposing the normal-view **Cast to TV** start action. |
 | **No secrets** | Receiver app id and public origin values may appear in the browser bundle. They must not be treated as credentials or included in private secret rotation plans. |
 
 ## Secrets
@@ -143,9 +143,7 @@ When mediasoup signaling cannot be reached, the SPA surfaces an **honest configu
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### chromecast-configuration
-- Confirm the final Vite env var name for the public receiver app id and update **`apps/web/.env.example`**, CI placeholders, and deploy workflow output wiring consistently.
-- Specify the production behavior when the receiver app id is absent: build failure, deploy checklist failure with hidden Cast UI, or explicit runtime local failure copy.
-- Specify local development guidance for Cast testing where physical receivers require reachable TLS origins rather than ordinary localhost.
+- No open decisions remain for sender availability configuration. The public app id env var is **`VITE_CAST_RECEIVER_APP_ID`**; missing prod configuration keeps Cast hidden or locally unavailable and is a release-readiness blocker before announcing Cast-ready behavior, not a room bootstrap failure; local physical Cast testing requires reachable TLS rather than ordinary **`localhost`**.
 
 ## Primary code pointers (optional)
 

--- a/.ai/specs/viewer-local-cast.spec.md
+++ b/.ai/specs/viewer-local-cast.spec.md
@@ -20,6 +20,10 @@ Every lifecycle outcome is local and recoverable: unavailable sender, chooser ca
 
 The web sender uses the current Google Cast Web Sender Framework. It loads `https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1`, assigns `window.__onGCastApiAvailable` before the SDK script loads, calls `cast.framework.CastContext.getInstance().setOptions(...)` with the configured receiver application id and `autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED`, and invokes `CastContext.requestSession()` to open the Cast chooser.
 
+Sender availability is owned by the room Cast modules under `apps/web/src/room/cast/`. `castSenderSupportDetector.ts` owns one-time SDK script injection, the `data-riffsync-cast-framework="true"` script marker, callback registration order, callback timeout handling, and conversion of SDK load/configuration failures into unavailable sender support. `castSenderClient.ts` owns reading public `VITE_CAST_RECEIVER_APP_ID`, configuring `CastContext`, wrapping later `requestSession()` calls, and hiding provider internals from room UI. `useCastAvailability` runs after normal room bootstrap and exposes only `checking`, `available`, or `unavailable` to React room surfaces.
+
+The public receiver application id is `VITE_CAST_RECEIVER_APP_ID`. Missing or invalid configuration is local Cast unavailability, not a room configuration failure. It must not block room snapshot loading, chat WebSocket bootstrap, SFU media bootstrap, host controls, expanded view, or normal playback.
+
 The receiver is a Custom Web Receiver registered in the Cast SDK Developer Console. It is launched by the configured app id, served from a public HTTPS receiver URL, and configures custom namespace `urn:x-cast:com.riffsync.presentation` in receiver options before `context.start(options)`.
 
 The receiver remains sender-proxied only. It must not call RiffSync room HTTP APIs, open room WebSockets, request SFU tokens, create presence rows, publish chat, subscribe to room media services, mutate `share_state`, or change durable room fields. A future direct-joining receiver would require a separate integration and authorization review.
@@ -31,6 +35,8 @@ Relevant repository versions from package metadata: `@riffsync/web` uses React `
 ## Testing Strategy
 
 Unit and component tests prove sender SDK bootstrap order, support gating, `CastContext.setOptions`, `requestSession()` use, local status mapping, focus behavior, `Now Casting` gating on receiver render confirmation, stop restoration, failed stop behavior, and idempotent cleanup.
+
+The sender availability slice specifically verifies that the SDK callback is installed before script append, duplicate SDK scripts are not appended, script load failure or callback timeout resolves to unavailable, missing `VITE_CAST_RECEIVER_APP_ID` resolves to unavailable, `CastContext.setOptions` receives the configured receiver app id and `ORIGIN_SCOPED` auto-join policy, `Cast to TV` is hidden while checking or unavailable, unavailable copy stays at the normal-view Cast surface, expanded view exposes no Cast start action, and availability probing does not call room HTTP APIs, room WebSocket send paths, SFU token paths, or room mutation callbacks.
 
 Receiver tests or stubs prove the custom namespace is configured before receiver context start, the receiver renders the stage-primary plus chat-overlay shell, and sender-proxied updates do not introduce direct room API, room WebSocket, SFU token, presence, or chat publishing behavior.
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #301
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.