### PR TITLE
[M26] Configure Google Cast sender availability for the custom receiver (#301)

### DIFF
--- a/apps/web/src/room/cast/castSenderClient.test.ts
+++ b/apps/web/src/room/cast/castSenderClient.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createDefaultCastSenderClient } from './castSenderClient'
+import { createDefaultCastSenderClient, prepareDefaultCastSenderClient } from './castSenderClient'
 
 type CastSenderTestWindow = Window & {
   chrome?: {
@@ -82,6 +82,43 @@ function installCastFramework({
 
   return { context, currentSession, session }
 }
+
+describe('prepareDefaultCastSenderClient', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    document.head.innerHTML = ''
+    delete (window as CastSenderTestWindow).chrome
+    delete (window as CastSenderTestWindow).cast
+    delete (window as Window & { __onGCastApiAvailable?: (isAvailable: boolean) => void }).__onGCastApiAvailable
+  })
+
+  it('configures CastContext for availability without requesting a session', async () => {
+    vi.stubEnv('VITE_CAST_RECEIVER_APP_ID', 'receiver-app-id')
+    const { context } = installCastFramework()
+
+    await expect(prepareDefaultCastSenderClient()).resolves.toBe(true)
+
+    expect(context.setOptions).toHaveBeenCalledWith({
+      receiverApplicationId: 'receiver-app-id',
+      autoJoinPolicy: 'origin_scoped',
+    })
+    expect(context.requestSession).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the receiver application id is missing', async () => {
+    installCastFramework()
+
+    await expect(prepareDefaultCastSenderClient()).resolves.toBe(false)
+  })
+
+  it('returns false when CastContext configuration fails', async () => {
+    vi.stubEnv('VITE_CAST_RECEIVER_APP_ID', 'receiver-app-id')
+    const { context } = installCastFramework({ includeAutoJoinPolicy: false })
+
+    await expect(prepareDefaultCastSenderClient()).resolves.toBe(false)
+    expect(context.requestSession).not.toHaveBeenCalled()
+  })
+})
 
 describe('createDefaultCastSenderClient', () => {
   afterEach(() => {

--- a/apps/web/src/room/cast/castSenderSupportDetector.test.ts
+++ b/apps/web/src/room/cast/castSenderSupportDetector.test.ts
@@ -104,4 +104,36 @@ describe('detectCastSenderSupport', () => {
 
     await expect(promise).resolves.toBe(false)
   })
+
+  it('returns false when the Cast availability callback times out', async () => {
+    vi.useFakeTimers()
+
+    const promise = detectCastSenderSupport()
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).resolves.toBe(false)
+    expect(prepareDefaultCastSenderClient).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('does not append duplicate Cast sender scripts on repeated probes', async () => {
+    vi.useFakeTimers()
+
+    const first = detectCastSenderSupport()
+    await Promise.resolve()
+    expect(document.querySelectorAll('script[data-riffsync-cast-framework="true"]')).toHaveLength(1)
+
+    const second = detectCastSenderSupport()
+    await Promise.resolve()
+    expect(document.querySelectorAll('script[data-riffsync-cast-framework="true"]')).toHaveLength(1)
+
+    ;(window as Window & { __onGCastApiAvailable?: (isAvailable: boolean) => void }).__onGCastApiAvailable?.(
+      true,
+    )
+
+    await Promise.all([first, second])
+    vi.useRealTimers()
+  })
 })

--- a/apps/web/src/room/cast/castSenderSupportDetector.ts
+++ b/apps/web/src/room/cast/castSenderSupportDetector.ts
@@ -64,7 +64,7 @@ function ensureCastFrameworkScript(): void {
   document.head.appendChild(script)
 }
 
-/** Post-render Google Cast sender support probe for #272 availability only. */
+/** Post-render Google Cast sender availability probe for #301. */
 export const detectCastSenderSupport: CastSenderSupportDetector = async () => {
   if (typeof window === 'undefined') return false
 


### PR DESCRIPTION
## Summary

- Completes issue #301 test coverage for Google Cast sender availability on the custom receiver path.
- Sender availability loads `cast_sender.js?loadCastFramework=1`, registers `__onGCastApiAvailable` before script append, configures `CastContext.setOptions` with `VITE_CAST_RECEIVER_APP_ID` and `ORIGIN_SCOPED`, and gates **Cast to TV** in normal room view without calling `requestSession()`.
- Adds unit tests for callback timeout, idempotent SDK injection, missing receiver app id, availability-only `setOptions`, and room-authority isolation already covered by existing wiring and RoomPage tests.

Closes #301

## Test plan

- [x] `cd apps/web && npm ci && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] Manual: on a Cast-capable browser with `VITE_CAST_RECEIVER_APP_ID` set, confirm **Cast to TV** appears in normal room view and is omitted in expanded view