### PR TITLE
[M26] Launch the RiffSync Custom Web Receiver from normal room view (#302)

### DIFF
--- a/apps/web/src/pages/RoomPageCastActive.test.tsx
+++ b/apps/web/src/pages/RoomPageCastActive.test.tsx
@@ -217,7 +217,7 @@ describe('RoomPage Cast active stage', () => {
   })
 
   it('keeps the regular playback surface visible while Cast is starting', async () => {
-    castStartLifecycle.value = 'starting'
+    castStartLifecycle.value = 'launching'
     await openRoomTab()
 
     expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()

--- a/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
+++ b/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
@@ -282,7 +282,8 @@ class MockWebSocket {
 
 const CAST_LIFECYCLE_PATHS: CastStartLifecycle[] = [
   'idle',
-  'starting',
+  'launching',
+  'session_pending_render',
   'casting',
   'stopping',
   'start_failed',

--- a/apps/web/src/pages/RoomPageCastStart.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStart.test.tsx
@@ -196,7 +196,15 @@ describe('RoomPage Cast start', () => {
   }
 
   it('shows local starting status when Cast start is in progress', async () => {
-    castStartLifecycle.value = 'starting'
+    castStartLifecycle.value = 'launching'
+    await openRoomTab()
+
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_STARTING_MESSAGE)
+  })
+
+  it('shows local starting status while session render is pending', async () => {
+    castStartLifecycle.value = 'session_pending_render'
     await openRoomTab()
 
     const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)

--- a/apps/web/src/room/cast/CastStartRoomActions.test.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.test.tsx
@@ -51,7 +51,14 @@ describe('CastStartRoomActions', () => {
   })
 
   it('shows starting status without replacing playback surfaces', () => {
-    renderActions('available', 'starting')
+    renderActions('available', 'launching')
+    const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
+    expect(status?.textContent).toBe(CAST_STARTING_MESSAGE)
+    expect(container.textContent).not.toContain('Cast to TV')
+  })
+
+  it('shows starting status while session render is pending', () => {
+    renderActions('available', 'session_pending_render')
     const status = container.querySelector(`#${RIFFSYNC_CAST_START_STATUS_ID}`)
     expect(status?.textContent).toBe(CAST_STARTING_MESSAGE)
     expect(container.textContent).not.toContain('Cast to TV')

--- a/apps/web/src/room/cast/CastStartRoomActions.tsx
+++ b/apps/web/src/room/cast/CastStartRoomActions.tsx
@@ -41,7 +41,7 @@ export function CastStartRoomActions({
     )
   }
 
-  if (castStartLifecycle === 'starting') {
+  if (castStartLifecycle === 'launching' || castStartLifecycle === 'session_pending_render') {
     return (
       <p
         id={RIFFSYNC_CAST_START_STATUS_ID}

--- a/apps/web/src/room/cast/castChannelProtocol.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.ts
@@ -4,7 +4,8 @@ export const RIFFSYNC_CAST_NAMESPACE = 'urn:x-cast:com.riffsync.presentation'
 
 export type CastStartLifecycle =
   | 'idle'
-  | 'starting'
+  | 'launching'
+  | 'session_pending_render'
   | 'casting'
   | 'stopping'
   | 'start_failed'

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -69,16 +69,90 @@ function createMockClient(session: CastSenderSessionHandle): CastSenderClient {
 }
 
 describe('createCastStartController', () => {
-  it('transitions to casting after receiver render confirmation', async () => {
-    const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+  it('maps launch timeout to start_failed without an active session handle', async () => {
+    vi.useFakeTimers()
+    let resolveSession: ((session: CastSenderSessionHandle) => void) | undefined
+    const session = createMockSession({})
+    const client: CastSenderClient = {
+      requestSession: vi.fn(
+        () =>
+          new Promise<CastSenderSessionHandle>((resolve) => {
+            resolveSession = resolve
+          }),
+      ),
+    }
+    const controller = createCastStartController({
+      client,
+      launchTimeoutMs: 50,
+      confirmationTimeoutMs: 1000,
+    })
+
+    const promise = controller.startCast(snapshot)
+    await vi.advanceTimersByTimeAsync(50)
+    await promise
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).not.toHaveBeenCalled()
+    resolveSession?.(session)
+    vi.useRealTimers()
+  })
+
+  it('enters session_pending_render after requestSession without transitioning to casting', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      launchTimeoutMs: 1000,
+      confirmationTimeoutMs: 1000,
+    })
 
     const states: string[] = []
     controller.subscribe((state) => states.push(state.lifecycle))
 
     await controller.startCast(snapshot)
 
-    expect(states).toEqual(['starting', 'casting'])
+    expect(states).toEqual(['launching', 'session_pending_render'])
+    expect(controller.getState().lifecycle).toBe('session_pending_render')
+  })
+
+  it('ignores late requestSession resolve after launch timeout', async () => {
+    vi.useFakeTimers()
+    let resolveSession: ((session: CastSenderSessionHandle) => void) | undefined
+    const session = createMockSession({})
+    const client: CastSenderClient = {
+      requestSession: vi.fn(
+        () =>
+          new Promise<CastSenderSessionHandle>((resolve) => {
+            resolveSession = resolve
+          }),
+      ),
+    }
+    const controller = createCastStartController({
+      client,
+      launchTimeoutMs: 50,
+      confirmationTimeoutMs: 1000,
+    })
+
+    const promise = controller.startCast(snapshot)
+    await vi.advanceTimersByTimeAsync(60)
+    await promise
+
+    resolveSession?.(session)
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    vi.useRealTimers()
+  })
+
+  it('transitions to casting after receiver render confirmation', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    const states: string[] = []
+    controller.subscribe((state) => states.push(state.lifecycle))
+
+    await controller.startCast(snapshot)
+
+    expect(states).toEqual(['launching', 'session_pending_render', 'casting'])
     expect(session.end).not.toHaveBeenCalled()
   })
 
@@ -111,7 +185,7 @@ describe('createCastStartController', () => {
 
   it('maps receiver render failure during startup to start_failed', async () => {
     const session = createMockSession({})
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitReceiverMessage({ type: 'render_failed', reason: 'receiver_render_error' })
@@ -151,7 +225,7 @@ describe('createCastStartController', () => {
 
   it('stopCast ends the Cast session without mutating snapshot input', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     await controller.stopCast()
@@ -162,7 +236,7 @@ describe('createCastStartController', () => {
 
   it('transitions through stopping before idle on stopCast', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
 
@@ -182,7 +256,7 @@ describe('createCastStartController', () => {
           resolveEnd = resolve
         }),
     )
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     const firstStop = controller.stopCast()
@@ -200,7 +274,7 @@ describe('createCastStartController', () => {
       confirmAfterSend: true,
       onSend: (message) => sent.push(message),
     })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     await controller.sendChatOverlayUpdate({
@@ -218,7 +292,7 @@ describe('createCastStartController', () => {
 
   it('maps active session-ended callbacks to session_ended recovery', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitSessionEnded()
@@ -231,7 +305,7 @@ describe('createCastStartController', () => {
 
   it('cleans up active session-ended callbacks idempotently', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitSessionEnded()
@@ -252,7 +326,7 @@ describe('createCastStartController', () => {
 
   it('resets recovery states to idle so Cast can be retried locally', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitSessionEnded()
@@ -266,7 +340,7 @@ describe('createCastStartController', () => {
 
   it('maps receiver render failure after active Cast to playback_blocked recovery', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitReceiverMessage({ type: 'render_failed', reason: 'playback_blocked' })
@@ -279,7 +353,7 @@ describe('createCastStartController', () => {
 
   it('releases active receiver bindings after playback-blocked cleanup', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     session.emitReceiverMessage({ type: 'render_failed', reason: 'playback_blocked' })
@@ -301,7 +375,7 @@ describe('createCastStartController', () => {
   it('keeps Stop Cast retryable when stop fails and the route is still active', async () => {
     const session = createMockSession({ confirmAfterSend: true })
     session.end = vi.fn().mockRejectedValue(new Error('stop rejected'))
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     await controller.stopCast()
@@ -320,7 +394,7 @@ describe('createCastStartController', () => {
     const session = createMockSession({ confirmAfterSend: true })
     session.end = vi.fn().mockRejectedValue(new Error('route already gone'))
     session.setActiveRoute(false)
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     await controller.stopCast()
@@ -336,7 +410,7 @@ describe('createCastStartController', () => {
 
   it('detaches receiver listeners after successful cleanup', async () => {
     const session = createMockSession({ confirmAfterSend: true })
-    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000 })
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
     await controller.startCast(snapshot)
     await controller.stopCast()

--- a/apps/web/src/room/cast/castStartController.ts
+++ b/apps/web/src/room/cast/castStartController.ts
@@ -2,7 +2,8 @@ import type { CastPresentationSnapshot, CastStartLifecycle } from './castChannel
 import { parseCastReceiverOutboundMessage } from './castChannelProtocol'
 import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
 
-export const CAST_RENDER_CONFIRMATION_TIMEOUT_MS = 15000
+export const CAST_LAUNCH_TIMEOUT_MS = 45_000
+export const CAST_RENDER_CONFIRMATION_TIMEOUT_MS = 30_000
 
 export type CastStartControllerState = {
   lifecycle: CastStartLifecycle
@@ -19,23 +20,33 @@ export type CastStartController = {
 
 type CreateCastStartControllerOptions = {
   client: CastSenderClient
+  launchTimeoutMs?: number
   confirmationTimeoutMs?: number
 }
 
 export function createCastStartController({
   client,
+  launchTimeoutMs = CAST_LAUNCH_TIMEOUT_MS,
   confirmationTimeoutMs = CAST_RENDER_CONFIRMATION_TIMEOUT_MS,
 }: CreateCastStartControllerOptions): CastStartController {
   let lifecycle: CastStartLifecycle = 'idle'
   let session: CastSenderSessionHandle | null = null
   let removeMessageListener: (() => void) | null = null
   let removeSessionEndedListener: (() => void) | null = null
+  let launchTimer: ReturnType<typeof setTimeout> | null = null
   let confirmationTimer: ReturnType<typeof setTimeout> | null = null
   const listeners = new Set<(state: CastStartControllerState) => void>()
 
   const emit = () => {
     const state = { lifecycle }
     for (const listener of listeners) listener(state)
+  }
+
+  const clearLaunchTimer = () => {
+    if (launchTimer !== null) {
+      clearTimeout(launchTimer)
+      launchTimer = null
+    }
   }
 
   const clearConfirmationTimer = () => {
@@ -67,6 +78,7 @@ export function createCastStartController({
   }
 
   const failStart = async () => {
+    clearLaunchTimer()
     await cleanupSession()
     lifecycle = 'start_failed'
     emit()
@@ -88,11 +100,11 @@ export function createCastStartController({
     const message = parseCastReceiverOutboundMessage(raw)
     if (!message) return
     if (message.type === 'render_confirmed') {
-      if (lifecycle === 'starting') confirmStart()
+      if (lifecycle === 'session_pending_render') confirmStart()
       return
     }
     if (message.type === 'render_failed') {
-      if (lifecycle === 'starting') {
+      if (lifecycle === 'session_pending_render') {
         void failStart()
         return
       }
@@ -100,6 +112,21 @@ export function createCastStartController({
         void recoverFromActiveSession('playback_blocked')
       }
     }
+  }
+
+  const attachSession = (nextSession: CastSenderSessionHandle) => {
+    session = nextSession
+
+    removeMessageListener = nextSession.addMessageListener(handleReceiverMessage)
+    removeSessionEndedListener = nextSession.addSessionEndedListener(() => {
+      if (lifecycle === 'session_pending_render') {
+        void failStart()
+        return
+      }
+      if (lifecycle === 'casting' || lifecycle === 'stopping' || lifecycle === 'stop_failed') {
+        void recoverFromActiveSession('session_ended')
+      }
+    })
   }
 
   const stopActiveSession = async (): Promise<'idle' | 'session_ended' | 'stop_failed'> => {
@@ -133,21 +160,37 @@ export function createCastStartController({
       return () => listeners.delete(listener)
     },
     startCast: async (snapshot) => {
-      if (lifecycle === 'starting' || lifecycle === 'casting' || lifecycle === 'stopping' || lifecycle === 'stop_failed') return
+      if (
+        lifecycle === 'launching' ||
+        lifecycle === 'session_pending_render' ||
+        lifecycle === 'casting' ||
+        lifecycle === 'stopping' ||
+        lifecycle === 'stop_failed'
+      ) {
+        return
+      }
 
-      lifecycle = 'starting'
+      lifecycle = 'launching'
       emit()
 
-      try {
-        const nextSession = await client.requestSession()
-        session = nextSession
+      let launchAbortReject: ((error: Error) => void) | undefined
+      const launchAbortPromise = new Promise<never>((_, reject) => {
+        launchAbortReject = reject
+      })
 
-        removeMessageListener = nextSession.addMessageListener(handleReceiverMessage)
-        removeSessionEndedListener = nextSession.addSessionEndedListener(() => {
-          if (lifecycle === 'casting' || lifecycle === 'stopping' || lifecycle === 'stop_failed') {
-            void recoverFromActiveSession('session_ended')
-          }
-        })
+      launchTimer = setTimeout(() => {
+        launchAbortReject?.(new Error('Cast launch timed out'))
+      }, launchTimeoutMs)
+
+      try {
+        const nextSession = await Promise.race([client.requestSession(), launchAbortPromise])
+        clearLaunchTimer()
+        if (lifecycle !== 'launching') return
+
+        lifecycle = 'session_pending_render'
+        emit()
+
+        attachSession(nextSession)
 
         confirmationTimer = setTimeout(() => {
           void failStart()
@@ -158,6 +201,8 @@ export function createCastStartController({
           snapshot,
         })
       } catch {
+        clearLaunchTimer()
+        if (lifecycle !== 'launching') return
         await failStart()
       }
     },
@@ -180,7 +225,8 @@ export function createCastStartController({
     stopCast: async () => {
       if (
         lifecycle === 'idle' ||
-        lifecycle === 'starting' ||
+        lifecycle === 'launching' ||
+        lifecycle === 'session_pending_render' ||
         lifecycle === 'start_failed' ||
         lifecycle === 'session_ended' ||
         lifecycle === 'playback_blocked'

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -87,7 +87,7 @@ function TestHarness({
         <button ref={castToTvButtonRef} type="button" data-testid="cast-to-tv" onClick={() => void startCast()}>
           Cast to TV
         </button>
-      ) : castStartLifecycle === 'starting' ? (
+      ) : castStartLifecycle === 'launching' || castStartLifecycle === 'session_pending_render' ? (
         <p data-testid="cast-starting-status">Starting Cast…</p>
       ) : null}
       {castStartLifecycle === 'casting' || castStartLifecycle === 'stopping' || castStartLifecycle === 'stop_failed' ? (

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -141,7 +141,7 @@ export function useCastStartSession({
   }, [castStartLifecycle])
 
   useEffect(() => {
-    if (castStartLifecycle !== 'starting') return
+    if (castStartLifecycle !== 'launching') return
 
     const handleFocusIn = (event: FocusEvent) => {
       if (!shouldTransferFocusToStopRef.current) return


### PR DESCRIPTION
## Summary

- Split Cast launch into `launching` and `session_pending_render` lifecycle states per the viewer-local-cast contract.
- Added a 45-second `requestSession()` launch timeout with chooser cancel/reject recovery to `start_failed` and `CAST_START_REJECTED` copy.
- Kept **Starting Cast…** visible through launch and pending render while normal playback stays on screen; **Now Casting** remains gated on receiver render confirmation (#304).

Closes #302

## Test plan

- [x] `cd apps/web && npm ci && npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual Cast hardware smoke: **Cast to TV** opens the RiffSync custom receiver chooser; cancel/reject/timeout restores retry without room side effects