### PR TITLE
[M26] Render the Cast receiver presentation with chat overlay (#303)

### DIFF
--- a/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
@@ -3,9 +3,16 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CastReceiverPresentation } from './CastReceiverPresentation'
+import { CAST_RECEIVER_COPY } from './castReceiverCopy'
 import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const RECEIVER_VIEWPORTS = [
+  { label: '1280x720', width: 1280, height: 720 },
+  { label: '1920x1080', width: 1920, height: 1080 },
+  { label: '3840x2160', width: 3840, height: 2160 },
+] as const
 
 describe('CastReceiverPresentation', () => {
   let container: HTMLDivElement
@@ -28,36 +35,80 @@ describe('CastReceiverPresentation', () => {
     })
   }
 
-  it('renders stage-primary video and chat overlay from sender snapshot', () => {
-    const snapshot: CastPresentationSnapshot = {
-      roomMode: 'theater',
-      stagePrimary: {
-        kind: 'youtube_embed',
-        youtubeVideoId: 'abc123',
-        label: 'Party video',
-      },
-      chatOverlay: {
-        messages: [{ id: 'm1', kind: 'text', text: 'Fan: hello', senderLabel: 'Fan' }],
-      },
-    }
+  const youtubeSnapshot: CastPresentationSnapshot = {
+    roomMode: 'theater',
+    stagePrimary: {
+      kind: 'youtube_embed',
+      youtubeVideoId: 'abc123',
+      label: 'Party video',
+    },
+    chatOverlay: {
+      messages: [{ id: 'm1', kind: 'text', text: 'Fan: hello', senderLabel: 'Fan' }],
+    },
+  }
 
-    renderPresentation(snapshot)
+  it('shows waiting copy before the first sender snapshot', () => {
+    renderPresentation(null)
+    expect(container.textContent).toContain(CAST_RECEIVER_COPY.waitingForPresentation)
+  })
+
+  it('renders stage-primary video and chat overlay from sender snapshot', () => {
+    renderPresentation(youtubeSnapshot)
     expect(container.querySelector('[data-testid="cast-receiver-stage-primary"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="cast-receiver-chat-overlay"]')).not.toBeNull()
     expect(container.textContent).toContain('Fan: hello')
     expect(container.querySelector('iframe')?.getAttribute('src')).toContain('abc123')
   })
 
+  it('shows empty chat overlay copy when chat messages are absent', () => {
+    renderPresentation(youtubeSnapshot, [])
+    expect(container.textContent).toContain(CAST_RECEIVER_COPY.emptyChat)
+  })
+
+  it('maps waiting stage labels to receiver room-video copy', () => {
+    renderPresentation({
+      roomMode: 'theater',
+      stagePrimary: { kind: 'live_video_placeholder', label: 'Waiting for party video' },
+      chatOverlay: { messages: [] },
+    })
+
+    expect(container.textContent).toContain(CAST_RECEIVER_COPY.waitingForRoomVideo)
+  })
+
   it('does not render sidebar tabs or compose controls', () => {
-    const snapshot: CastPresentationSnapshot = {
+    renderPresentation({
       roomMode: 'theater',
       stagePrimary: { kind: 'live_video_placeholder', label: 'Party video' },
       chatOverlay: { messages: [] },
-    }
-
-    renderPresentation(snapshot)
+    })
     expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
     expect(container.querySelector('input[type="text"]')).toBeNull()
     expect(container.querySelector('button')).toBeNull()
   })
+
+  it.each(RECEIVER_VIEWPORTS)(
+    'keeps stage primary and chat overlay within TV layout constraints at $label',
+    ({ width, height }) => {
+      container.style.width = `${width}px`
+      container.style.height = `${height}px`
+      renderPresentation(youtubeSnapshot)
+
+      const stage = container.querySelector('.riffsync-cast-receiver__stage') as HTMLElement
+      const overlay = container.querySelector('.riffsync-cast-receiver__chat-overlay') as HTMLElement
+      const iframe = container.querySelector('.riffsync-cast-receiver__youtube') as HTMLElement
+
+      expect(stage).not.toBeNull()
+      expect(overlay).not.toBeNull()
+      expect(iframe).not.toBeNull()
+
+      const stageRect = stage.getBoundingClientRect()
+      const overlayRect = overlay.getBoundingClientRect()
+      const iframeRect = iframe.getBoundingClientRect()
+
+      expect(overlayRect.width).toBeLessThanOrEqual(stageRect.width * 0.4 + 1)
+      expect(overlayRect.height).toBeLessThanOrEqual(stageRect.height * 0.45 + 1)
+      expect(iframeRect.width).toBeLessThanOrEqual(stageRect.width + 1)
+      expect(iframeRect.height).toBeLessThanOrEqual(stageRect.height + 1)
+    },
+  )
 })

--- a/apps/web/src/pages/cast/CastReceiverPresentation.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.tsx
@@ -1,4 +1,5 @@
 import type { CastChatOverlayLine, CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+import { CAST_RECEIVER_COPY, resolveCastReceiverStagePlaceholder } from './castReceiverCopy'
 
 type CastReceiverChatOverlayProps = {
   messages: CastChatOverlayLine[]
@@ -11,16 +12,22 @@ export function CastReceiverChatOverlay({ messages }: CastReceiverChatOverlayPro
       aria-label="Chat overlay"
       data-testid="cast-receiver-chat-overlay"
     >
-      <ul className="riffsync-cast-receiver__chat-log">
-        {messages.map((line) => (
-          <li
-            key={line.id}
-            className={`riffsync-cast-receiver__chat-line riffsync-cast-receiver__chat-line--${line.kind}`}
-          >
-            {line.text}
-          </li>
-        ))}
-      </ul>
+      {messages.length === 0 ? (
+        <p className="riffsync-cast-receiver__chat-empty" role="status">
+          {CAST_RECEIVER_COPY.emptyChat}
+        </p>
+      ) : (
+        <ul className="riffsync-cast-receiver__chat-log">
+          {messages.map((line) => (
+            <li
+              key={line.id}
+              className={`riffsync-cast-receiver__chat-line riffsync-cast-receiver__chat-line--${line.kind}`}
+            >
+              {line.text}
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   )
 }
@@ -35,7 +42,10 @@ export function CastReceiverStagePrimary({ snapshot }: CastReceiverStagePrimaryP
   if (stagePrimary.kind === 'youtube_embed' && stagePrimary.youtubeVideoId) {
     const src = `https://www.youtube.com/embed/${encodeURIComponent(stagePrimary.youtubeVideoId)}?playsinline=1`
     return (
-      <div className="riffsync-cast-receiver__stage-primary" data-testid="cast-receiver-stage-primary">
+      <div
+        className="riffsync-cast-receiver__stage-primary riffsync-cast-receiver__stage-primary--youtube"
+        data-testid="cast-receiver-stage-primary"
+      >
         <iframe
           className="riffsync-cast-receiver__youtube"
           title="Party video"
@@ -60,14 +70,16 @@ export function CastReceiverStagePrimary({ snapshot }: CastReceiverStagePrimaryP
     )
   }
 
+  const placeholderCopy = resolveCastReceiverStagePlaceholder(stagePrimary)
+
   return (
     <div
       className="riffsync-cast-receiver__stage-primary riffsync-cast-receiver__stage-primary--live"
       data-testid="cast-receiver-stage-primary"
       role="img"
-      aria-label={stagePrimary.label ?? 'Party video'}
+      aria-label={placeholderCopy}
     >
-      <p className="riffsync-cast-receiver__stage-placeholder">{stagePrimary.label ?? 'Party video'}</p>
+      <p className="riffsync-cast-receiver__stage-placeholder">{placeholderCopy}</p>
     </div>
   )
 }
@@ -82,7 +94,7 @@ export function CastReceiverPresentation({ snapshot, chatMessages }: CastReceive
     return (
       <div className="riffsync-cast-receiver" aria-busy="true">
         <p className="riffsync-cast-receiver__waiting" role="status">
-          Waiting for party presentation…
+          {CAST_RECEIVER_COPY.waitingForPresentation}
         </p>
       </div>
     )

--- a/apps/web/src/pages/cast/castReceiverCopy.test.ts
+++ b/apps/web/src/pages/cast/castReceiverCopy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { CAST_RECEIVER_COPY, resolveCastReceiverStagePlaceholder } from './castReceiverCopy'
+
+describe('castReceiverCopy', () => {
+  it('maps waiting sender labels to receiver room-video copy', () => {
+    expect(
+      resolveCastReceiverStagePlaceholder({
+        kind: 'live_video_placeholder',
+        label: 'Waiting for party video',
+      }),
+    ).toBe(CAST_RECEIVER_COPY.waitingForRoomVideo)
+  })
+
+  it('preserves playback attention copy from the sender snapshot', () => {
+    expect(
+      resolveCastReceiverStagePlaceholder({
+        kind: 'live_video_placeholder',
+        label: CAST_RECEIVER_COPY.playbackNeedsAttention,
+      }),
+    ).toBe(CAST_RECEIVER_COPY.playbackNeedsAttention)
+  })
+
+  it('preserves active live video labels', () => {
+    expect(
+      resolveCastReceiverStagePlaceholder({
+        kind: 'live_video_placeholder',
+        label: 'Host shared stream',
+      }),
+    ).toBe('Host shared stream')
+  })
+})

--- a/apps/web/src/pages/cast/castReceiverCopy.ts
+++ b/apps/web/src/pages/cast/castReceiverCopy.ts
@@ -1,0 +1,29 @@
+import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
+
+export const CAST_RECEIVER_COPY = {
+  waitingForPresentation: 'Waiting for party presentation...',
+  waitingForRoomVideo: 'Waiting for room video...',
+  playbackNeedsAttention: 'Playback needs attention on the sender.',
+  emptyChat: 'Chat will appear here.',
+} as const
+
+export function resolveCastReceiverStagePlaceholder(
+  stagePrimary: CastPresentationSnapshot['stagePrimary'],
+): string {
+  if (stagePrimary.label === CAST_RECEIVER_COPY.playbackNeedsAttention) {
+    return CAST_RECEIVER_COPY.playbackNeedsAttention
+  }
+
+  if (
+    stagePrimary.kind === 'live_video_placeholder' &&
+    stagePrimary.label === 'Waiting for party video'
+  ) {
+    return CAST_RECEIVER_COPY.waitingForRoomVideo
+  }
+
+  if (stagePrimary.kind === 'live_video_placeholder' && !stagePrimary.label?.trim()) {
+    return CAST_RECEIVER_COPY.waitingForRoomVideo
+  }
+
+  return stagePrimary.label ?? CAST_RECEIVER_COPY.waitingForRoomVideo
+}

--- a/apps/web/src/pages/cast/castReceiverRenderConfirmation.test.ts
+++ b/apps/web/src/pages/cast/castReceiverRenderConfirmation.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { canConfirmCastReceiverRender } from './castReceiverRenderConfirmation'
+
+describe('canConfirmCastReceiverRender', () => {
+  it('requires both stage primary and chat overlay in the snapshot', () => {
+    expect(canConfirmCastReceiverRender(null)).toBe(false)
+    expect(
+      canConfirmCastReceiverRender({
+        roomMode: 'theater',
+        stagePrimary: { kind: 'youtube_embed', youtubeVideoId: 'abc123' },
+        chatOverlay: { messages: [] },
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/web/src/pages/cast/castReceiverRenderConfirmation.ts
+++ b/apps/web/src/pages/cast/castReceiverRenderConfirmation.ts
@@ -1,5 +1,5 @@
 import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
 
 export function canConfirmCastReceiverRender(snapshot: CastPresentationSnapshot | null): boolean {
-  return Boolean(snapshot?.stagePrimary)
+  return Boolean(snapshot?.stagePrimary && snapshot.chatOverlay)
 }

--- a/apps/web/src/pages/cast/castReceiverSession.test.ts
+++ b/apps/web/src/pages/cast/castReceiverSession.test.ts
@@ -100,12 +100,19 @@ describe('startCastReceiverSession', () => {
   it('accepts presentation snapshots delivered as Cast object payloads', async () => {
     const receiver = await startReceiver()
 
+    expect(receiver.context.addCustomMessageListener).toHaveBeenCalledWith(
+      RIFFSYNC_CAST_NAMESPACE,
+      expect.any(Function),
+    )
     expect(receiver.context.start).toHaveBeenCalledWith(
       expect.objectContaining({
         customNamespaces: {
           [RIFFSYNC_CAST_NAMESPACE]: 'json',
         },
       }),
+    )
+    expect(receiver.context.addCustomMessageListener.mock.invocationCallOrder[0]).toBeLessThan(
+      receiver.context.start.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
     )
     receiver.emitMessage({ type: 'presentation_snapshot', snapshot })
 

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2043,7 +2043,11 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 }
 
 .riffsync-cast-receiver {
-  min-height: 100dvh;
+  width: 100vw;
+  height: 100vh;
+  min-height: 100vh;
+  margin: 0;
+  overflow: hidden;
   background: #0d1117;
   color: #e6edf3;
 }
@@ -2055,18 +2059,28 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 
 .riffsync-cast-receiver__stage {
   position: relative;
-  min-height: 100dvh;
+  width: 100%;
+  height: 100%;
   background: #000;
 }
 
 .riffsync-cast-receiver__stage-primary {
   position: absolute;
   inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.riffsync-cast-receiver__stage-primary--youtube {
+  padding: 0;
 }
 
 .riffsync-cast-receiver__youtube {
-  width: 100%;
-  height: 100%;
+  width: min(100%, calc(100vh * 16 / 9));
+  height: min(100%, calc(100vw * 9 / 16));
+  max-width: 100%;
+  max-height: 100%;
   border: 0;
 }
 
@@ -2081,11 +2095,12 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 
 .riffsync-cast-receiver__chat-overlay {
   position: absolute;
-  right: clamp(0.75rem, 1.4vw, 1.1rem);
-  bottom: clamp(0.75rem, 1.4vw, 1.1rem);
+  right: 24px;
+  bottom: 24px;
   z-index: 2;
-  width: clamp(16rem, 30%, 24rem);
-  max-height: 40%;
+  width: clamp(22rem, 34vw, 42rem);
+  max-width: 40%;
+  max-height: 45%;
   min-height: 8rem;
   overflow: hidden;
   display: flex;
@@ -2095,6 +2110,29 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   border-radius: 8px;
   box-shadow: 0 14px 40px rgb(0 0 0 / 0.38);
   backdrop-filter: blur(6px);
+}
+
+@media (min-width: 1920px) {
+  .riffsync-cast-receiver__chat-overlay {
+    right: 32px;
+    bottom: 32px;
+  }
+}
+
+@media (min-width: 3840px) {
+  .riffsync-cast-receiver__chat-overlay {
+    right: 64px;
+    bottom: 64px;
+  }
+}
+
+.riffsync-cast-receiver__chat-empty {
+  margin: 0;
+  padding: 0.75rem;
+  font-size: 0.92rem;
+  line-height: 1.35;
+  color: rgb(255 255 255 / 0.72);
+  font-style: italic;
 }
 
 .riffsync-cast-receiver__chat-log {


### PR DESCRIPTION
## Summary

- Completes the Custom Web Receiver presentation at `/cast/receiver` with TV-safe layout, normative placeholder copy, and required chat overlay empty state.
- Tightens receiver bootstrap tests to prove the custom namespace listener and `customNamespaces` registration happen before `context.start(options)`.
- Gates render confirmation on both stage primary and chat overlay snapshot fields, with viewport coverage at 1280x720, 1920x1080, and 3840x2160.

Closes #303

## Test plan

- [x] `npm test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual Cast receiver smoke on physical hardware (documented in issue; out of CI scope)