### PR TITLE
[M26] Gate Now Casting on receiver render confirmation (#304)

### DIFF
--- a/apps/web/src/pages/cast/CastReceiverPage.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { CastChatOverlayLine, CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
 import {
   CastReceiverPresentation,
@@ -6,15 +6,15 @@ import {
 import { canConfirmCastReceiverRender } from './castReceiverRenderConfirmation'
 import {
   getCastReceiverContextForTests,
-  sendCastReceiverRenderConfirmed,
   sendCastReceiverRenderFailed,
+  sendCastReceiverRendered,
   startCastReceiverSession,
 } from './castReceiverSession'
 
 export function CastReceiverPage() {
   const [snapshot, setSnapshot] = useState<CastPresentationSnapshot | null>(null)
   const [chatMessages, setChatMessages] = useState<CastChatOverlayLine[]>([])
-  const renderConfirmedRef = useRef(false)
+  const confirmedSnapshotIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -39,15 +39,19 @@ export function CastReceiverPage() {
     }
   }, [])
 
-  useEffect(() => {
-    if (renderConfirmedRef.current) return
-    if (!canConfirmCastReceiverRender(snapshot)) return
+  useLayoutEffect(() => {
+    if (!snapshot || !canConfirmCastReceiverRender(snapshot)) return
+    if (confirmedSnapshotIdRef.current === snapshot.snapshotId) return
+
+    const stagePrimary = document.querySelector('[data-testid="cast-receiver-stage-primary"]')
+    const chatOverlay = document.querySelector('[data-testid="cast-receiver-chat-overlay"]')
+    if (!stagePrimary || !chatOverlay) return
 
     const context = getCastReceiverContextForTests()
     if (!context) return
 
-    renderConfirmedRef.current = true
-    sendCastReceiverRenderConfirmed(context)
+    confirmedSnapshotIdRef.current = snapshot.snapshotId
+    sendCastReceiverRendered(context, snapshot.snapshotId)
   }, [snapshot, chatMessages])
 
   return <CastReceiverPresentation snapshot={snapshot} chatMessages={chatMessages} />

--- a/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
@@ -36,6 +36,7 @@ describe('CastReceiverPresentation', () => {
   }
 
   const youtubeSnapshot: CastPresentationSnapshot = {
+    snapshotId: 'snap-youtube-1',
     roomMode: 'theater',
     stagePrimary: {
       kind: 'youtube_embed',
@@ -67,6 +68,7 @@ describe('CastReceiverPresentation', () => {
 
   it('maps waiting stage labels to receiver room-video copy', () => {
     renderPresentation({
+      snapshotId: 'snap-waiting-1',
       roomMode: 'theater',
       stagePrimary: { kind: 'live_video_placeholder', label: 'Waiting for party video' },
       chatOverlay: { messages: [] },
@@ -77,6 +79,7 @@ describe('CastReceiverPresentation', () => {
 
   it('does not render sidebar tabs or compose controls', () => {
     renderPresentation({
+      snapshotId: 'snap-waiting-1',
       roomMode: 'theater',
       stagePrimary: { kind: 'live_video_placeholder', label: 'Party video' },
       chatOverlay: { messages: [] },

--- a/apps/web/src/pages/cast/castReceiverRenderConfirmation.test.ts
+++ b/apps/web/src/pages/cast/castReceiverRenderConfirmation.test.ts
@@ -6,6 +6,7 @@ describe('canConfirmCastReceiverRender', () => {
     expect(canConfirmCastReceiverRender(null)).toBe(false)
     expect(
       canConfirmCastReceiverRender({
+        snapshotId: 'snap-1',
         roomMode: 'theater',
         stagePrimary: { kind: 'youtube_embed', youtubeVideoId: 'abc123' },
         chatOverlay: { messages: [] },

--- a/apps/web/src/pages/cast/castReceiverSession.test.ts
+++ b/apps/web/src/pages/cast/castReceiverSession.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { CastPresentationSnapshot } from '../../room/cast/castChannelProtocol'
 import { RIFFSYNC_CAST_NAMESPACE } from '../../room/cast/castChannelProtocol'
-import { startCastReceiverSession } from './castReceiverSession'
+import { startCastReceiverSession, sendCastReceiverRendered } from './castReceiverSession'
 
 type ReceiverMessageHandler = (event: { data?: unknown }) => void
 
@@ -27,6 +27,7 @@ type CastReceiverTestWindow = Window & {
 }
 
 const snapshot: CastPresentationSnapshot = {
+  snapshotId: 'snap-receiver-1',
   roomMode: 'theater',
   stagePrimary: {
     kind: 'youtube_embed',
@@ -126,5 +127,22 @@ describe('startCastReceiverSession', () => {
     receiver.emitMessage(JSON.stringify({ type: 'chat_overlay_update', messages }))
 
     expect(receiver.onChatOverlayUpdate).toHaveBeenCalledWith(messages)
+  })
+
+  it('sendCastReceiverRendered emits receiver_rendered with snapshotId and render flags', async () => {
+    const receiver = await startReceiver()
+
+    sendCastReceiverRendered(receiver.context, 'snap-receiver-1')
+
+    expect(receiver.context.sendCustomMessage).toHaveBeenCalledWith(
+      RIFFSYNC_CAST_NAMESPACE,
+      JSON.stringify({
+        type: 'receiver_rendered',
+        schemaVersion: 1,
+        snapshotId: 'snap-receiver-1',
+        stagePrimaryRendered: true,
+        chatOverlayRendered: true,
+      }),
+    )
   })
 })

--- a/apps/web/src/pages/cast/castReceiverSession.ts
+++ b/apps/web/src/pages/cast/castReceiverSession.ts
@@ -129,8 +129,17 @@ export async function startCastReceiverSession(
   }
 }
 
-export function sendCastReceiverRenderConfirmed(context: CastReceiverContextInstance): void {
-  context.sendCustomMessage(RIFFSYNC_CAST_NAMESPACE, JSON.stringify({ type: 'render_confirmed' }))
+export function sendCastReceiverRendered(context: CastReceiverContextInstance, snapshotId: string): void {
+  context.sendCustomMessage(
+    RIFFSYNC_CAST_NAMESPACE,
+    JSON.stringify({
+      type: 'receiver_rendered',
+      schemaVersion: 1,
+      snapshotId,
+      stagePrimaryRendered: true,
+      chatOverlayRendered: true,
+    }),
+  )
 }
 
 export function sendCastReceiverRenderFailed(

--- a/apps/web/src/room/cast/buildCastPresentationSnapshot.test.ts
+++ b/apps/web/src/room/cast/buildCastPresentationSnapshot.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { buildCastPresentationSnapshot } from './buildCastPresentationSnapshot'
+import { resetCastSnapshotIdCounterForTests } from './castChannelProtocol'
 
 describe('buildCastPresentationSnapshot', () => {
+  it('assigns a snapshotId to each presentation snapshot', () => {
+    resetCastSnapshotIdCounterForTests()
+    const snapshot = buildCastPresentationSnapshot({
+      roomMode: 'theater',
+      youtubeVideoId: 'abc123',
+      isPublisher: false,
+      hasHostCaptureStream: false,
+      hasGuestRelayStream: false,
+      chat: [],
+      chatMemberLabels: new Map(),
+    })
+
+    expect(snapshot.snapshotId).toBe('cast-snapshot-1')
+  })
+
   it('uses youtube embed metadata for theater guests without relay video', () => {
     const snapshot = buildCastPresentationSnapshot({
       roomMode: 'theater',

--- a/apps/web/src/room/cast/buildCastPresentationSnapshot.ts
+++ b/apps/web/src/room/cast/buildCastPresentationSnapshot.ts
@@ -3,6 +3,7 @@ import type { ChatLine } from '../roomPageTypes'
 import { formatChatSystemText } from '../chatSystemLine'
 import { isEmojiOnlyChatMessage } from '../chatEmojiDisplay'
 import type { CastChatOverlayLine, CastPresentationSnapshot } from './castChannelProtocol'
+import { createCastSnapshotId } from './castChannelProtocol'
 
 export type BuildCastPresentationSnapshotInput = {
   roomMode: RoomMode
@@ -83,12 +84,14 @@ function toOverlayLine(line: ChatLine, chatMemberLabels: Map<string, string>): C
 
 export function buildCastPresentationSnapshot(
   input: BuildCastPresentationSnapshotInput,
+  options?: { snapshotId?: string },
 ): CastPresentationSnapshot {
   const messages = input.chat
     .map((line) => toOverlayLine(line, input.chatMemberLabels))
     .filter((line): line is CastChatOverlayLine => line !== null)
 
   return {
+    snapshotId: options?.snapshotId ?? createCastSnapshotId(),
     roomMode: input.roomMode,
     stagePrimary: resolveStagePrimary(input),
     chatOverlay: { messages },

--- a/apps/web/src/room/cast/castChannelProtocol.test.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildReceiverRenderedAcknowledgement,
+  createCastSnapshotId,
+  isPositiveReceiverRenderedAcknowledgement,
+  parseCastReceiverOutboundMessage,
+  resetCastSnapshotIdCounterForTests,
+} from './castChannelProtocol'
+
+describe('parseCastReceiverOutboundMessage', () => {
+  it('accepts a valid receiver_rendered acknowledgement', () => {
+    const ack = buildReceiverRenderedAcknowledgement('snap-1')
+    expect(parseCastReceiverOutboundMessage(ack)).toEqual(ack)
+  })
+
+  it('returns unrecognized for unknown acknowledgement types', () => {
+    expect(parseCastReceiverOutboundMessage({ type: 'render_confirmed' })).toBe('unrecognized')
+  })
+
+  it('returns null for non-object payloads', () => {
+    expect(parseCastReceiverOutboundMessage(null)).toBeNull()
+    expect(parseCastReceiverOutboundMessage('bad')).toBeNull()
+  })
+})
+
+describe('isPositiveReceiverRenderedAcknowledgement', () => {
+  it('requires schemaVersion, snapshotId, and both render flags', () => {
+    const ack = buildReceiverRenderedAcknowledgement('snap-1')
+    expect(isPositiveReceiverRenderedAcknowledgement(ack, 'snap-1')).toBe(true)
+    expect(isPositiveReceiverRenderedAcknowledgement(ack, 'snap-2')).toBe(false)
+    expect(isPositiveReceiverRenderedAcknowledgement({ ...ack, stagePrimaryRendered: false }, 'snap-1')).toBe(
+      false,
+    )
+    expect(isPositiveReceiverRenderedAcknowledgement({ ...ack, chatOverlayRendered: false }, 'snap-1')).toBe(
+      false,
+    )
+    expect(isPositiveReceiverRenderedAcknowledgement({ ...ack, schemaVersion: 2 }, 'snap-1')).toBe(false)
+  })
+})
+
+describe('createCastSnapshotId', () => {
+  it('returns unique ids for successive snapshots', () => {
+    resetCastSnapshotIdCounterForTests()
+    expect(createCastSnapshotId()).toBe('cast-snapshot-1')
+    expect(createCastSnapshotId()).toBe('cast-snapshot-2')
+  })
+})

--- a/apps/web/src/room/cast/castChannelProtocol.ts
+++ b/apps/web/src/room/cast/castChannelProtocol.ts
@@ -1,6 +1,7 @@
 import type { RoomMode } from '../../api/roomsApi'
 
 export const RIFFSYNC_CAST_NAMESPACE = 'urn:x-cast:com.riffsync.presentation'
+export const CAST_RECEIVER_RENDERED_SCHEMA_VERSION = 1
 
 export type CastStartLifecycle =
   | 'idle'
@@ -23,6 +24,7 @@ export type CastChatOverlayLine = {
 }
 
 export type CastPresentationSnapshot = {
+  snapshotId: string
   roomMode: RoomMode
   stagePrimary: {
     kind: CastStagePrimaryKind
@@ -38,17 +40,85 @@ export type CastSenderOutboundMessage =
   | { type: 'presentation_snapshot'; snapshot: CastPresentationSnapshot }
   | { type: 'chat_overlay_update'; messages: CastChatOverlayLine[] }
 
+export type CastReceiverRenderedAcknowledgement = {
+  type: 'receiver_rendered'
+  schemaVersion: number
+  snapshotId: string
+  stagePrimaryRendered: boolean
+  chatOverlayRendered: boolean
+}
+
 export type CastReceiverOutboundMessage =
-  | { type: 'render_confirmed' }
+  | CastReceiverRenderedAcknowledgement
   | { type: 'render_failed'; reason?: string }
 
-export function parseCastReceiverOutboundMessage(raw: unknown): CastReceiverOutboundMessage | null {
+let castSnapshotIdCounter = 0
+
+export function createCastSnapshotId(): string {
+  castSnapshotIdCounter += 1
+  return `cast-snapshot-${castSnapshotIdCounter}`
+}
+
+export function resetCastSnapshotIdCounterForTests(): void {
+  castSnapshotIdCounter = 0
+}
+
+export function buildReceiverRenderedAcknowledgement(
+  snapshotId: string,
+): CastReceiverRenderedAcknowledgement {
+  return {
+    type: 'receiver_rendered',
+    schemaVersion: CAST_RECEIVER_RENDERED_SCHEMA_VERSION,
+    snapshotId,
+    stagePrimaryRendered: true,
+    chatOverlayRendered: true,
+  }
+}
+
+export function isPositiveReceiverRenderedAcknowledgement(
+  message: CastReceiverOutboundMessage,
+  expectedSnapshotId: string | null,
+): message is CastReceiverRenderedAcknowledgement {
+  return (
+    message.type === 'receiver_rendered' &&
+    message.schemaVersion === CAST_RECEIVER_RENDERED_SCHEMA_VERSION &&
+    typeof message.snapshotId === 'string' &&
+    message.snapshotId.length > 0 &&
+    expectedSnapshotId !== null &&
+    message.snapshotId === expectedSnapshotId &&
+    message.stagePrimaryRendered === true &&
+    message.chatOverlayRendered === true
+  )
+}
+
+export function parseCastReceiverOutboundMessage(
+  raw: unknown,
+): CastReceiverOutboundMessage | 'unrecognized' | null {
   if (!raw || typeof raw !== 'object') return null
+
   const type = (raw as { type?: unknown }).type
-  if (type === 'render_confirmed') return { type: 'render_confirmed' }
   if (type === 'render_failed') {
     const reason = (raw as { reason?: unknown }).reason
     return { type: 'render_failed', reason: typeof reason === 'string' ? reason : undefined }
   }
+
+  if (type === 'receiver_rendered') {
+    const schemaVersion = (raw as { schemaVersion?: unknown }).schemaVersion
+    const snapshotId = (raw as { snapshotId?: unknown }).snapshotId
+    const stagePrimaryRendered = (raw as { stagePrimaryRendered?: unknown }).stagePrimaryRendered
+    const chatOverlayRendered = (raw as { chatOverlayRendered?: unknown }).chatOverlayRendered
+    return {
+      type: 'receiver_rendered',
+      schemaVersion:
+        schemaVersion === CAST_RECEIVER_RENDERED_SCHEMA_VERSION
+          ? CAST_RECEIVER_RENDERED_SCHEMA_VERSION
+          : (Number(schemaVersion) as typeof CAST_RECEIVER_RENDERED_SCHEMA_VERSION),
+      snapshotId: typeof snapshotId === 'string' ? snapshotId : '',
+      stagePrimaryRendered: stagePrimaryRendered === true ? true : (false as true),
+      chatOverlayRendered: chatOverlayRendered === true ? true : (false as true),
+    }
+  }
+
+  if (type !== undefined) return 'unrecognized'
   return null
 }

--- a/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
+++ b/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { buildReceiverRenderedAcknowledgement } from './castChannelProtocol'
 import { createCastStartController } from './castStartController'
 import type { CastPresentationSnapshot } from './castChannelProtocol'
 import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
 
 const snapshot: CastPresentationSnapshot = {
+  snapshotId: 'snap-authority-1',
   roomMode: 'theater',
   stagePrimary: {
     kind: 'youtube_embed',
@@ -26,8 +28,12 @@ function createMockSession(handlers: {
   return {
     sendMessage: async (message) => {
       handlers.onSend?.(message)
-      if (handlers.confirmAfterSend) {
-        for (const listener of listeners) listener({ type: 'render_confirmed' })
+      if (handlers.confirmAfterSend && typeof message === 'object' && message !== null) {
+        const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+        if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+          const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+          for (const listener of listeners) listener(ack)
+        }
       }
       if (handlers.failAfterSend) {
         for (const listener of listeners) listener({ type: 'render_failed' })
@@ -131,8 +137,13 @@ describe('createCastStartController room authority (#277)', () => {
       sendMessage: vi
         .fn()
         .mockImplementationOnce(async (message) => {
-          for (const listener of listeners) listener({ type: 'render_confirmed' })
-          void message
+          if (typeof message === 'object' && message !== null) {
+            const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+            if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+              const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+              for (const listener of listeners) listener(ack)
+            }
+          }
         })
         .mockRejectedValueOnce(new Error('receiver disconnected')),
       addMessageListener: (handler) => {

--- a/apps/web/src/room/cast/castStartController.test.ts
+++ b/apps/web/src/room/cast/castStartController.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { buildReceiverRenderedAcknowledgement } from './castChannelProtocol'
 import { createCastStartController } from './castStartController'
 import type { CastPresentationSnapshot } from './castChannelProtocol'
 import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
 
 const snapshot: CastPresentationSnapshot = {
+  snapshotId: 'snap-test-1',
   roomMode: 'theater',
   stagePrimary: {
     kind: 'youtube_embed',
@@ -33,8 +35,12 @@ function createMockSession(handlers: {
   return {
     sendMessage: async (message) => {
       handlers.onSend?.(message)
-      if (handlers.confirmAfterSend) {
-        for (const listener of listeners) listener({ type: 'render_confirmed' })
+      if (handlers.confirmAfterSend && typeof message === 'object' && message !== null) {
+        const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+        if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+          const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+          for (const listener of listeners) listener(ack)
+        }
       }
     },
     addMessageListener: (handler) => {
@@ -143,7 +149,7 @@ describe('createCastStartController', () => {
     vi.useRealTimers()
   })
 
-  it('transitions to casting after receiver render confirmation', async () => {
+  it('transitions to casting after a valid receiver_rendered acknowledgement', async () => {
     const session = createMockSession({ confirmAfterSend: true })
     const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
 
@@ -183,6 +189,83 @@ describe('createCastStartController', () => {
     vi.useRealTimers()
   })
 
+  it('maps stale snapshotId acknowledgement to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage(buildReceiverRenderedAcknowledgement('stale-id'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps missing stagePrimaryRendered to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({
+      type: 'receiver_rendered',
+      schemaVersion: 1,
+      snapshotId: snapshot.snapshotId,
+      chatOverlayRendered: true,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+
+  it('maps missing chatOverlayRendered to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({
+      type: 'receiver_rendered',
+      schemaVersion: 1,
+      snapshotId: snapshot.snapshotId,
+      stagePrimaryRendered: true,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+
+  it('maps false render flags to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({
+      type: 'receiver_rendered',
+      schemaVersion: 1,
+      snapshotId: snapshot.snapshotId,
+      stagePrimaryRendered: false,
+      chatOverlayRendered: true,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+
+  it('maps unknown acknowledgement type to start_failed during pending render', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitReceiverMessage({ type: 'render_confirmed' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+
   it('maps receiver render failure during startup to start_failed', async () => {
     const session = createMockSession({})
     const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
@@ -214,13 +297,25 @@ describe('createCastStartController', () => {
     expect(session.messageListenerCount()).toBe(0)
     expect(session.sessionEndedListenerCount()).toBe(0)
 
-    session.emitReceiverMessage({ type: 'render_confirmed' })
+    session.emitReceiverMessage(buildReceiverRenderedAcknowledgement(snapshot.snapshotId))
     session.emitSessionEnded()
     await vi.advanceTimersByTimeAsync(60)
 
     expect(controller.getState().lifecycle).toBe('start_failed')
     expect(session.end).toHaveBeenCalledTimes(1)
     vi.useRealTimers()
+  })
+
+  it('maps Cast channel close before active Cast to start_failed', async () => {
+    const session = createMockSession({})
+    const controller = createCastStartController({ client: createMockClient(session), confirmationTimeoutMs: 1000, launchTimeoutMs: 1000 })
+
+    await controller.startCast(snapshot)
+    session.emitSessionEnded()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('start_failed')
   })
 
   it('stopCast ends the Cast session without mutating snapshot input', async () => {
@@ -364,7 +459,7 @@ describe('createCastStartController', () => {
     expect(session.messageListenerCount()).toBe(0)
     expect(session.sessionEndedListenerCount()).toBe(0)
 
-    session.emitReceiverMessage({ type: 'render_confirmed' })
+    session.emitReceiverMessage(buildReceiverRenderedAcknowledgement(snapshot.snapshotId))
     session.emitSessionEnded()
     await controller.stopCast()
 

--- a/apps/web/src/room/cast/castStartController.ts
+++ b/apps/web/src/room/cast/castStartController.ts
@@ -1,5 +1,8 @@
 import type { CastPresentationSnapshot, CastStartLifecycle } from './castChannelProtocol'
-import { parseCastReceiverOutboundMessage } from './castChannelProtocol'
+import {
+  isPositiveReceiverRenderedAcknowledgement,
+  parseCastReceiverOutboundMessage,
+} from './castChannelProtocol'
 import type { CastSenderClient, CastSenderSessionHandle } from './castSenderClient'
 
 export const CAST_LAUNCH_TIMEOUT_MS = 45_000
@@ -31,6 +34,7 @@ export function createCastStartController({
 }: CreateCastStartControllerOptions): CastStartController {
   let lifecycle: CastStartLifecycle = 'idle'
   let session: CastSenderSessionHandle | null = null
+  let pendingSnapshotId: string | null = null
   let removeMessageListener: (() => void) | null = null
   let removeSessionEndedListener: (() => void) | null = null
   let launchTimer: ReturnType<typeof setTimeout> | null = null
@@ -79,6 +83,7 @@ export function createCastStartController({
 
   const failStart = async () => {
     clearLaunchTimer()
+    pendingSnapshotId = null
     await cleanupSession()
     lifecycle = 'start_failed'
     emit()
@@ -92,17 +97,29 @@ export function createCastStartController({
 
   const confirmStart = () => {
     clearConfirmationTimer()
+    pendingSnapshotId = null
     lifecycle = 'casting'
     emit()
   }
 
   const handleReceiverMessage = (raw: unknown) => {
     const message = parseCastReceiverOutboundMessage(raw)
-    if (!message) return
-    if (message.type === 'render_confirmed') {
-      if (lifecycle === 'session_pending_render') confirmStart()
+    if (message === 'unrecognized') {
+      if (lifecycle === 'session_pending_render') void failStart()
       return
     }
+    if (!message) return
+
+    if (message.type === 'receiver_rendered') {
+      if (lifecycle !== 'session_pending_render') return
+      if (isPositiveReceiverRenderedAcknowledgement(message, pendingSnapshotId)) {
+        confirmStart()
+      } else {
+        void failStart()
+      }
+      return
+    }
+
     if (message.type === 'render_failed') {
       if (lifecycle === 'session_pending_render') {
         void failStart()
@@ -188,6 +205,7 @@ export function createCastStartController({
         if (lifecycle !== 'launching') return
 
         lifecycle = 'session_pending_render'
+        pendingSnapshotId = snapshot.snapshotId
         emit()
 
         attachSession(nextSession)

--- a/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
@@ -2,6 +2,8 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildReceiverRenderedAcknowledgement } from './castChannelProtocol'
+import type { CastPresentationSnapshot } from './castChannelProtocol'
 import { useCastStartSession } from './useCastStartSession'
 
 function TestHarness({ enabled = true }: { enabled?: boolean }) {
@@ -23,9 +25,15 @@ function TestHarness({ enabled = true }: { enabled?: boolean }) {
     chatMemberLabels: new Map(),
     createSenderClient: () => ({
       requestSession: vi.fn().mockResolvedValue({
-        sendMessage: async () => {
+        sendMessage: async (message: unknown) => {
           queueMicrotask(() => {
-            for (const listener of messageListeners) listener({ type: 'render_confirmed' })
+            if (typeof message === 'object' && message !== null) {
+              const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+              if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+                const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+                for (const listener of messageListeners) listener(ack)
+              }
+            }
           })
         },
         addMessageListener: (handler: (message: unknown) => void) => {

--- a/apps/web/src/room/cast/useCastStartSession.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.test.tsx
@@ -2,11 +2,13 @@
 import { act, useRef, type RefObject } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildReceiverRenderedAcknowledgement } from './castChannelProtocol'
+import type { CastPresentationSnapshot } from './castChannelProtocol'
 import { useCastStartSession } from './useCastStartSession'
 
 type HarnessSession = {
   end: ReturnType<typeof vi.fn>
-  sendMessage: () => Promise<void>
+  sendMessage: (message: unknown) => Promise<void>
   addMessageListener: (handler: (message: unknown) => void) => () => void
   addSessionEndedListener: (handler: () => void) => () => void
   hasActiveRoute: () => boolean
@@ -26,9 +28,15 @@ function createHarnessSession(): HarnessSession {
   })
 
   return {
-    sendMessage: async () => {
+    sendMessage: async (message: unknown) => {
       queueMicrotask(() => {
-        for (const listener of messageListeners) listener({ type: 'render_confirmed' })
+        if (typeof message === 'object' && message !== null) {
+          const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+          if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+            const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+            for (const listener of messageListeners) listener(ack)
+          }
+        }
       })
     },
     addMessageListener: (handler: (message: unknown) => void) => {

--- a/apps/web/src/room/cast/useCastStartSession.ts
+++ b/apps/web/src/room/cast/useCastStartSession.ts
@@ -141,7 +141,7 @@ export function useCastStartSession({
   }, [castStartLifecycle])
 
   useEffect(() => {
-    if (castStartLifecycle !== 'launching') return
+    if (castStartLifecycle !== 'launching' && castStartLifecycle !== 'session_pending_render') return
 
     const handleFocusIn = (event: FocusEvent) => {
       if (!shouldTransferFocusToStopRef.current) return


### PR DESCRIPTION
## Summary

- Gate active Cast on a validated `receiver_rendered` acknowledgement over `urn:x-cast:com.riffsync.presentation` with `schemaVersion: 1`, matching `snapshotId`, and both render flags set to true.
- Assign `snapshotId` to each sender presentation snapshot and keep normal playback visible through `session_pending_render` until confirmation, timeout, invalid ack, or channel close returns to retryable `start_failed`.
- Emit the acknowledgement from the custom receiver after stage-primary and chat overlay DOM render, and extend focus-transfer tracking through pending render.

Closes #304

## Test plan

- [x] `cd apps/web && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] Manual Cast smoke on physical hardware (release readiness, #306)