### PR TITLE
[M26] Preserve room authority across Cast lifecycle paths (#305)

### DIFF
--- a/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
+++ b/apps/web/src/pages/RoomPageCastRoomAuthority.test.tsx
@@ -7,6 +7,7 @@ import { RoomPage } from './RoomPage'
 import { RoomChromeProvider } from '../room/RoomChromeProvider'
 import { ChatSession } from '../room/sessions/ChatSession'
 import { SfuMediaSession } from '../room/sessions/SfuMediaSession'
+import { TheaterPlayback } from '../room/sessions/TheaterPlayback'
 import {
   CAST_ACTIVE_HEADING,
   RIFFSYNC_CAST_ACTIVE_STATUS_ID,
@@ -292,11 +293,12 @@ const CAST_LIFECYCLE_PATHS: CastStartLifecycle[] = [
   'stop_failed',
 ]
 
-describe('RoomPage Cast room authority (#277)', () => {
+describe('RoomPage Cast room authority (#305)', () => {
   let container: HTMLDivElement
   let root: Root
   let chatDisconnectSpy: ReturnType<typeof vi.spyOn>
   let sfuDisconnectSpy: ReturnType<typeof vi.spyOn>
+  let theaterDisposeSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     castStartLifecycle.value = 'idle'
@@ -313,6 +315,7 @@ describe('RoomPage Cast room authority (#277)', () => {
 
     chatDisconnectSpy = vi.spyOn(ChatSession.prototype, 'disconnect')
     sfuDisconnectSpy = vi.spyOn(SfuMediaSession.prototype, 'disconnect')
+    theaterDisposeSpy = vi.spyOn(TheaterPlayback.prototype, 'dispose')
 
     fetchRtcIceServers.mockResolvedValue([{ urls: 'stun:stun.test' }])
     fetchFanProfile.mockResolvedValue({ displayName: 'Fan One', avatarUrl: null })
@@ -453,6 +456,38 @@ describe('RoomPage Cast room authority (#277)', () => {
     expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
   })
 
+  it('does not dispose TheaterPlayback across Cast lifecycle re-renders', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const disposeBefore = theaterDisposeSpy.mock.calls.length
+
+    for (const lifecycle of CAST_LIFECYCLE_PATHS) {
+      await rerenderCastLifecycle(lifecycle)
+    }
+
+    expect(theaterDisposeSpy.mock.calls.length).toBe(disposeBefore)
+  })
+
+  it('keeps activeErrorCodes empty across Cast lifecycle re-renders', async () => {
+    renderRoom()
+    await waitForSidebarTabs()
+
+    for (const lifecycle of CAST_LIFECYCLE_PATHS) {
+      await rerenderCastLifecycle(lifecycle)
+    }
+
+    expect(drawerStatusMockConfig.get().diagnostics.activeErrorCodes).toEqual([])
+  })
+
+  it('does not show Now Casting stage while session_pending_render', async () => {
+    await rerenderCastLifecycle('session_pending_render')
+
+    expect(container.querySelector('[data-testid="cast-active-stage-panel"]')).toBeNull()
+    expect(container.textContent).not.toContain(CAST_ACTIVE_HEADING)
+    expect(container.querySelector('.riffsync-room-page__playback')).not.toBeNull()
+  })
+
   it('invokes local stopCast without room mutation or websocket fan-out', async () => {
     castStartLifecycle.value = 'casting'
     renderRoom()
@@ -473,5 +508,24 @@ describe('RoomPage Cast room authority (#277)', () => {
     expect(roomWsMessages().length).toBe(messagesBefore)
     expect(chatDisconnectSpy.mock.calls.length).toBe(chatBefore)
     expect(sfuDisconnectSpy.mock.calls.length).toBe(sfuBefore)
+  })
+
+  it('allows repeated Stop Cast clicks without room mutation side effects', async () => {
+    castStartLifecycle.value = 'casting'
+    renderRoom()
+    await waitForSidebarTabs()
+
+    const patchBefore = patchRoom.mock.calls.length
+    const messagesBefore = roomWsMessages().length
+
+    const stopButton = container.querySelector('.riffsync-room-page__cast-stop-button') as HTMLButtonElement
+    act(() => {
+      stopButton.click()
+      stopButton.click()
+    })
+
+    expect(stopCast).toHaveBeenCalledTimes(2)
+    expect(patchRoom.mock.calls.length).toBe(patchBefore)
+    expect(roomWsMessages().length).toBe(messagesBefore)
   })
 })

--- a/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
+++ b/apps/web/src/room/cast/castRoomAuthorityWiring.test.ts
@@ -60,7 +60,7 @@ const FORBIDDEN_CAST_SIDE_EFFECTS = [
   'WebSocket',
 ]
 
-describe('Cast room authority wiring (#277)', () => {
+describe('Cast room authority wiring (#305)', () => {
   it('keeps Cast runtime modules free of room mutation and fan-out hooks', () => {
     for (const file of CAST_RUNTIME_SOURCES) {
       const src = readCast(file)

--- a/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
+++ b/apps/web/src/room/cast/castStartController.roomAuthority.test.ts
@@ -58,7 +58,7 @@ function createMockClient(session: CastSenderSessionHandle): CastSenderClient {
   }
 }
 
-describe('createCastStartController room authority (#277)', () => {
+describe('createCastStartController room authority (#305)', () => {
   it('active Cast sends only Cast channel overlay updates', async () => {
     const sent: unknown[] = []
     const session = createMockSession({
@@ -175,5 +175,79 @@ describe('createCastStartController room authority (#277)', () => {
     await controller.startCast(snapshot)
 
     expect(controller.getState().lifecycle).toBe('start_failed')
+  })
+
+  it('playback_blocked recovery ends Cast session without room side effects', async () => {
+    const listeners = new Set<(message: unknown) => void>()
+    const session: CastSenderSessionHandle = {
+      sendMessage: vi
+        .fn()
+        .mockImplementationOnce(async (message) => {
+          if (typeof message === 'object' && message !== null) {
+            const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+            if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+              const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+              for (const listener of listeners) listener(ack)
+            }
+          }
+        }),
+      addMessageListener: (handler) => {
+        listeners.add(handler)
+        return () => listeners.delete(handler)
+      },
+      addSessionEndedListener: () => () => undefined,
+      hasActiveRoute: () => true,
+      end: vi.fn().mockResolvedValue(undefined),
+    }
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    for (const listener of listeners) listener({ type: 'render_failed', reason: 'playback_blocked' })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(controller.getState().lifecycle).toBe('playback_blocked')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('stop_failed keeps Cast session handle for retry without room side effects', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    session.end = vi.fn().mockRejectedValue(new Error('stop rejected'))
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('stop_failed')
+    expect(session.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('repeated cleanup after session_ended is idempotent', async () => {
+    const session = createMockSession({ confirmAfterSend: true })
+    const sessionEndedListeners = new Set<() => void>()
+    const originalAddSessionEnded = session.addSessionEndedListener.bind(session)
+    session.addSessionEndedListener = (handler) => {
+      sessionEndedListeners.add(handler)
+      return originalAddSessionEnded(handler)
+    }
+    const controller = createCastStartController({
+      client: createMockClient(session),
+      confirmationTimeoutMs: 1000,
+    })
+
+    await controller.startCast(snapshot)
+    for (const listener of sessionEndedListeners) listener()
+    await Promise.resolve()
+    await controller.stopCast()
+    await controller.stopCast()
+
+    expect(controller.getState().lifecycle).toBe('session_ended')
+    expect(session.end).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
+++ b/apps/web/src/room/cast/useCastStartSession.roomAuthority.test.tsx
@@ -69,7 +69,7 @@ function TestHarness({ enabled = true }: { enabled?: boolean }) {
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-describe('useCastStartSession room authority (#277)', () => {
+describe('useCastStartSession room authority (#305)', () => {
   let container: HTMLDivElement
   let root: Root
 
@@ -183,6 +183,259 @@ describe('useCastStartSession room authority (#277)', () => {
     })
 
     expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('start_failed')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('session_ended recovery stays sender-local without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+    const messageListeners = new Set<(message: unknown) => void>()
+    const sessionEndedListeners = new Set<() => void>()
+
+    function SessionEndedHarness() {
+      const { castStartLifecycle, startCast } = useCastStartSession({
+        enabled: true,
+        expandedViewActive: false,
+        roomMode: 'theater',
+        youtubeVideoId: 'yt-1',
+        isPublisher: false,
+        hasHostCaptureStream: false,
+        hasGuestRelayStream: false,
+        chat: [],
+        chatMemberLabels: new Map(),
+        createSenderClient: () => ({
+          requestSession: vi.fn().mockResolvedValue({
+            sendMessage: async (message: unknown) => {
+              queueMicrotask(() => {
+                if (typeof message === 'object' && message !== null) {
+                  const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+                  if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+                    const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+                    for (const listener of messageListeners) listener(ack)
+                  }
+                }
+              })
+            },
+            addMessageListener: (handler: (message: unknown) => void) => {
+              messageListeners.add(handler)
+              return () => messageListeners.delete(handler)
+            },
+            addSessionEndedListener: (handler: () => void) => {
+              sessionEndedListeners.add(handler)
+              return () => sessionEndedListeners.delete(handler)
+            },
+            hasActiveRoute: () => true,
+            end: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+      })
+
+      return (
+        <div>
+          <span data-testid="lifecycle">{castStartLifecycle}</span>
+          <button type="button" data-testid="start" onClick={() => void startCast()}>
+            Start
+          </button>
+        </div>
+      )
+    }
+
+    act(() => {
+      root.render(<SessionEndedHarness />)
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      for (const listener of sessionEndedListeners) listener()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('session_ended')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('playback_blocked recovery stays sender-local without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+    const messageListeners = new Set<(message: unknown) => void>()
+
+    function PlaybackBlockedHarness() {
+      const { castStartLifecycle, startCast } = useCastStartSession({
+        enabled: true,
+        expandedViewActive: false,
+        roomMode: 'theater',
+        youtubeVideoId: 'yt-1',
+        isPublisher: false,
+        hasHostCaptureStream: false,
+        hasGuestRelayStream: false,
+        chat: [],
+        chatMemberLabels: new Map(),
+        createSenderClient: () => ({
+          requestSession: vi.fn().mockResolvedValue({
+            sendMessage: async (message: unknown) => {
+              queueMicrotask(() => {
+                if (typeof message === 'object' && message !== null) {
+                  const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+                  if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+                    const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+                    for (const listener of messageListeners) listener(ack)
+                    for (const listener of messageListeners) listener({ type: 'render_failed' })
+                  }
+                }
+              })
+            },
+            addMessageListener: (handler: (message: unknown) => void) => {
+              messageListeners.add(handler)
+              return () => messageListeners.delete(handler)
+            },
+            addSessionEndedListener: () => () => undefined,
+            hasActiveRoute: () => true,
+            end: vi.fn().mockResolvedValue(undefined),
+          }),
+        }),
+      })
+
+      return (
+        <div>
+          <span data-testid="lifecycle">{castStartLifecycle}</span>
+          <button type="button" data-testid="start" onClick={() => void startCast()}>
+            Start
+          </button>
+        </div>
+      )
+    }
+
+    act(() => {
+      root.render(<PlaybackBlockedHarness />)
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('playback_blocked')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('stop_failed recovery stays sender-local without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+    const messageListeners = new Set<(message: unknown) => void>()
+
+    function StopFailedHarness() {
+      const { castStartLifecycle, startCast, stopCast } = useCastStartSession({
+        enabled: true,
+        expandedViewActive: false,
+        roomMode: 'theater',
+        youtubeVideoId: 'yt-1',
+        isPublisher: false,
+        hasHostCaptureStream: false,
+        hasGuestRelayStream: false,
+        chat: [],
+        chatMemberLabels: new Map(),
+        createSenderClient: () => ({
+          requestSession: vi.fn().mockResolvedValue({
+            sendMessage: async (message: unknown) => {
+              queueMicrotask(() => {
+                if (typeof message === 'object' && message !== null) {
+                  const outbound = message as { type?: string; snapshot?: CastPresentationSnapshot }
+                  if (outbound.type === 'presentation_snapshot' && outbound.snapshot?.snapshotId) {
+                    const ack = buildReceiverRenderedAcknowledgement(outbound.snapshot.snapshotId)
+                    for (const listener of messageListeners) listener(ack)
+                  }
+                }
+              })
+            },
+            addMessageListener: (handler: (message: unknown) => void) => {
+              messageListeners.add(handler)
+              return () => messageListeners.delete(handler)
+            },
+            addSessionEndedListener: () => () => undefined,
+            hasActiveRoute: () => true,
+            end: vi.fn().mockRejectedValue(new Error('stop rejected')),
+          }),
+        }),
+      })
+
+      return (
+        <div>
+          <span data-testid="lifecycle">{castStartLifecycle}</span>
+          <button type="button" data-testid="start" onClick={() => void startCast()}>
+            Start
+          </button>
+          <button type="button" data-testid="stop" onClick={() => stopCast()}>
+            Stop
+          </button>
+        </div>
+      )
+    }
+
+    act(() => {
+      root.render(<StopFailedHarness />)
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="stop"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="lifecycle"]')?.textContent).toBe('stop_failed')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(WebSocketSpy).not.toHaveBeenCalled()
+
+    fetchSpy.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  it('repeated unmount cleanup is idempotent without room fetch or websocket usage', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not fetch'))
+    const WebSocketSpy = vi.fn()
+    vi.stubGlobal('WebSocket', WebSocketSpy)
+
+    await renderHarness()
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="start"]') as HTMLButtonElement).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      root.unmount()
+    })
+    act(() => {
+      root.unmount()
+    })
+
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(WebSocketSpy).not.toHaveBeenCalled()
 


### PR DESCRIPTION
## Summary

- Expands Cast lifecycle room-authority regression coverage for #305 across controller, hook, wiring, and RoomPage integration tests.
- Verifies every Cast lifecycle path (`launching`, `session_pending_render`, `casting`, stop, `session_ended`, `playback_blocked`, `stop_failed`, cleanup) leaves room HTTP mutations, WebSocket fan-out, SFU token requests, `TheaterPlayback` teardown, drawer diagnostics, and `activeErrorCodes` unchanged.
- Confirms pending render keeps normal playback visible (no **Now Casting** stage) and Stop Cast remains sender-local with idempotent cleanup.

Closes #305

## Test plan

- [x] `cd apps/web && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`