### PR TITLE
Gate broken Cast to TV button behind experimental flag (#317)

### DIFF
--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -233,10 +233,10 @@ export function RoomPage() {
     !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
   const viewportWide = useViewportWide()
   const expandToggleRef = useRef<HTMLButtonElement>(null)
-  const castAvailability = useCastAvailability(Boolean(room))
+  const castAvailability = useCastAvailability(Boolean(room) && experimentalFeatures)
   const { castStartLifecycle, startCast, stopCast, castToTvButtonRef, stopCastButtonRef } =
     useCastStartSession({
-      enabled: Boolean(room) && castAvailability === 'available',
+      enabled: Boolean(room) && experimentalFeatures && castAvailability === 'available',
       expandedViewActive: expandedView && viewportWide,
       roomMode,
       roomId: canonicalRoomId,

--- a/apps/web/src/pages/RoomPageCastActive.test.tsx
+++ b/apps/web/src/pages/RoomPageCastActive.test.tsx
@@ -21,6 +21,10 @@ const stopCast = vi.hoisted(() => vi.fn())
 const castToTvButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
 const stopCastButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
 
+vi.mock('../room/experimentalRoomFeatures', () => ({
+  detectExperimentalRoomFeatures: () => true,
+}))
+
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
   return {

--- a/apps/web/src/pages/RoomPageCastAvailability.test.tsx
+++ b/apps/web/src/pages/RoomPageCastAvailability.test.tsx
@@ -16,6 +16,11 @@ const fetchRtcIceServers = vi.fn()
 const castAvailabilityState = vi.hoisted(() => ({
   value: 'checking' as CastAvailabilityState,
 }))
+const experimentalEnabled = vi.hoisted(() => ({ value: true }))
+
+vi.mock('../room/experimentalRoomFeatures', () => ({
+  detectExperimentalRoomFeatures: () => experimentalEnabled.value,
+}))
 
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
@@ -152,6 +157,7 @@ describe('RoomPage Cast availability', () => {
   let webSocketCtor: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    experimentalEnabled.value = true
     castAvailabilityState.value = 'checking'
     MockWebSocket.instances = []
     webSocketCtor = vi.fn((url: string) => new MockWebSocket(url))
@@ -275,5 +281,37 @@ describe('RoomPage Cast availability', () => {
     expect(container.textContent?.includes(CAST_UNAVAILABLE_MESSAGE)).toBe(true)
     const chatDrawerStatus = container.querySelector('#riffsync-chat-drawer-status')
     expect(chatDrawerStatus?.textContent ?? '').not.toContain(CAST_UNAVAILABLE_MESSAGE)
+  })
+
+  it('omits Cast to TV when experimental features are disabled', async () => {
+    experimentalEnabled.value = false
+    castAvailabilityState.value = 'available'
+    renderRoom()
+    await openRoomTab()
+
+    expect(container.textContent).not.toContain('Cast to TV')
+    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
+  })
+
+  it('omits Cast unavailable copy when experimental features are disabled', async () => {
+    experimentalEnabled.value = false
+    castAvailabilityState.value = 'unavailable'
+    renderRoom()
+    await openRoomTab()
+
+    expect(container.textContent).not.toContain('Cast to TV')
+    expect(container.textContent).not.toContain(CAST_UNAVAILABLE_MESSAGE)
+    expect(container.querySelector(`#${RIFFSYNC_CAST_AVAILABILITY_STATUS_ID}`)).toBeNull()
+  })
+
+  it('keeps non-Cast room controls when experimental features are disabled', async () => {
+    experimentalEnabled.value = false
+    castAvailabilityState.value = 'available'
+    renderRoom()
+    await openRoomTab()
+
+    expect(container.textContent).toContain('Copy Party Link')
+    expect(container.textContent).toContain('Leave Party')
+    expect(container.textContent).not.toContain('Cast to TV')
   })
 })

--- a/apps/web/src/pages/RoomPageCastStart.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStart.test.tsx
@@ -18,6 +18,10 @@ const fetchRtcIceServers = vi.fn()
 const castStartLifecycle = vi.hoisted(() => ({ value: 'idle' as CastStartLifecycle }))
 const startCast = vi.hoisted(() => vi.fn())
 
+vi.mock('../room/experimentalRoomFeatures', () => ({
+  detectExperimentalRoomFeatures: () => true,
+}))
+
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
   return {

--- a/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
+++ b/apps/web/src/pages/RoomPageCastStopRestoration.test.tsx
@@ -23,6 +23,10 @@ const stopCast = vi.hoisted(() => vi.fn())
 const castToTvButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
 const stopCastButtonRef = vi.hoisted(() => ({ current: null as HTMLButtonElement | null }))
 
+vi.mock('../room/experimentalRoomFeatures', () => ({
+  detectExperimentalRoomFeatures: () => true,
+}))
+
 vi.mock('../api/roomsApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/roomsApi')>()
   return {

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -449,12 +449,14 @@ export function RoomPageSidebar({
                 Hosting Guide
               </Link>
             ) : null}
-            <CastStartRoomActions
-              castAvailability={castAvailability}
-              castStartLifecycle={castStartLifecycle}
-              onCastToTvClick={onCastToTvClick}
-              castToTvButtonRef={castToTvButtonRef}
-            />
+            {experimentalFeatures ? (
+              <CastStartRoomActions
+                castAvailability={castAvailability}
+                castStartLifecycle={castStartLifecycle}
+                onCastToTvClick={onCastToTvClick}
+                castToTvButtonRef={castToTvButtonRef}
+              />
+            ) : null}
             <Link className="gen-button gen-button-wide" to="/">
               Leave Party
             </Link>


### PR DESCRIPTION
## Summary

- Gate `Cast to TV` behind the existing `experimentalFeatures` opt-in from `detectExperimentalRoomFeatures()`.
- Skip Cast availability probing and session start hooks when experimental features are disabled, so `CastContext.requestSession()` cannot run in normal room sessions.
- Add focused RoomPage tests for experimental disabled/enabled paths and non-Cast control regressions.

Closes #317

## Test plan

- [x] `cd apps/web && npm test -- RoomPage`
- [x] `cd apps/web && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] CI green on `web-app` job