### PR TITLE
Restore interactive chat in regular Expanded View (#318)

### DIFF
--- a/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
+++ b/apps/web/src/pages/RoomPage.drawerStatusBanners.test.tsx
@@ -516,7 +516,7 @@ describe('RoomPage drawer status banner integration (#209)', () => {
     expect(container.querySelector('.riffsync-room-page__chat-column')).toBeNull()
     expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
     expect(chatBanner()?.closest('.riffsync-room-page__chat--overlay')).not.toBeNull()
-    expect(overlay?.querySelector('.riffsync-room-chat-compose')).toBeNull()
+    expect(overlay?.querySelector('.riffsync-room-chat-compose')).not.toBeNull()
     expect(overlay?.querySelector('.riffsync-room-chat-reaction-add')).toBeNull()
 
     act(() => {

--- a/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
+++ b/apps/web/src/pages/cast/CastReceiverPresentation.test.tsx
@@ -103,7 +103,7 @@ describe('CastReceiverPresentation', () => {
     expect(container.textContent).not.toContain(CAST_RECEIVER_COPY.waitingForRoomVideo)
   })
 
-  it('does not render sidebar tabs or compose controls', () => {
+  it('keeps Chromecast receiver presentation read-only without compose or reactions (#318)', () => {
     renderPresentation({
       snapshotId: 'snap-waiting-1',
       roomMode: 'theater',

--- a/apps/web/src/room/RoomPageSidebar.expandedOverlay.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.expandedOverlay.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { RoomPageSidebar } from './RoomPageSidebar'
+import type { ParticipantAvController } from './sfu/participantAvSession'
+import type { ChatLine } from './roomPageTypes'
+import { RIFFSYNC_CHAT_DRAWER_STATUS_ID } from './drawerErrorPresentation'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function createParticipantAvControllerStub(): ParticipantAvController {
+  const state = {
+    cameraEnabled: false,
+    micEnabled: false,
+    micMuted: false,
+    canPublish: true,
+    needsProducerToken: false,
+    error: null,
+    busy: false,
+  }
+  return {
+    getState: () => state,
+    getLocalPreviewStream: () => null,
+    subscribe: () => () => undefined,
+    refreshPublishGate: vi.fn(),
+    attachSession: vi.fn(),
+    resetOnReconnect: vi.fn(),
+    teardownPublishing: vi.fn(),
+    enableCamera: vi.fn().mockResolvedValue(undefined),
+    disableCamera: vi.fn(),
+    enableMic: vi.fn().mockResolvedValue(undefined),
+    disableMic: vi.fn(),
+    toggleMicMute: vi.fn(),
+    failPublish: vi.fn(),
+    clearError: vi.fn(),
+  }
+}
+
+const sampleChat: ChatLine[] = [
+  {
+    kind: 'text',
+    messageId: 'msg-1',
+    sessionId: 'sess-other',
+    displayName: 'Fan',
+    text: 'hello from chat',
+    ts: 1,
+  },
+]
+
+function buildSidebarProps(overrides: Partial<Parameters<typeof RoomPageSidebar>[0]> = {}) {
+  return {
+    presentation: 'overlay' as const,
+    wsBase: 'wss://ws.test.example',
+    fanToken: 'fan-jwt',
+    roomId: 'room-test-1',
+    sessionId: 'sess-test-1',
+    myAvatarUrl: null,
+    activeSidebarTab: 'chat' as const,
+    setRoomSidebarTab: vi.fn(),
+    viewerCount: 2,
+    chat: sampleChat,
+    chatReactions: {},
+    remoteTyping: [],
+    chatMemberLabels: new Map<string, string>(),
+    chatDraft: '',
+    setChatDraft: vi.fn(),
+    notifyComposeBlur: vi.fn(),
+    chatLogRef: { current: null },
+    chatInputRef: { current: null },
+    showJumpToLatest: true,
+    jumpToLatestLabel: 'New messages (2)',
+    jumpToLatest: vi.fn(),
+    chatDrawerBanner: 'Reconnecting chat…',
+    chatComposeStatus: { message: null, disableSubmit: false },
+    sendChat: vi.fn(),
+    sendChatGif: vi.fn(),
+    toggleChatReaction: vi.fn(),
+    peopleShown: [],
+    participantProducerBySessionId: new Map(),
+    speakingBySessionId: new Map(),
+    isPublisher: false,
+    experimentalFeatures: true,
+    shareHint: null,
+    onCopyShare: vi.fn(),
+    onOpenRenameModal: vi.fn(),
+    avDisabled: false,
+    participantAvController: createParticipantAvControllerStub(),
+    announceRoomA11y: vi.fn(),
+    profileDraft: '',
+    setProfileDraft: vi.fn(),
+    profileSaveErr: null,
+    profileSaving: false,
+    profileAvatarUrl: null,
+    profileAvatarLoading: false,
+    profileAvatarUploading: false,
+    profileAvatarErr: null,
+    profileAvatarInputRef: { current: null },
+    saveProfileDisplayName: vi.fn(),
+    onProfileAvatarSelected: vi.fn(),
+    castAvailability: 'checking' as const,
+    castStartLifecycle: 'idle' as const,
+    onCastToTvClick: vi.fn(),
+    castToTvButtonRef: { current: null },
+    ...overrides,
+  }
+}
+
+describe('RoomPageSidebar expanded overlay chat (#318)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderSidebar(overrides: Partial<Parameters<typeof RoomPageSidebar>[0]> = {}) {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPageSidebar {...buildSidebarProps(overrides)} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('keeps regular expanded overlay chat interactive with compose, reactions, and jump-to-latest', () => {
+    renderSidebar()
+
+    const overlay = container.querySelector('.riffsync-room-page__chat--overlay')
+    expect(overlay).not.toBeNull()
+    expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
+    expect(overlay?.querySelector('.riffsync-room-chat-compose')).not.toBeNull()
+    expect(overlay?.querySelector('.riffsync-room-chat-reaction-add')).not.toBeNull()
+    expect(overlay?.querySelector('.riffsync-room-chat-jump-latest')?.textContent).toBe('New messages (2)')
+    expect(overlay?.querySelector(`#${RIFFSYNC_CHAT_DRAWER_STATUS_ID}`)?.textContent).toBe(
+      'Reconnecting chat…',
+    )
+    expect(container.textContent).toContain('hello from chat')
+  })
+
+  it('shows participant A/V toggles in expanded overlay for signed-in fans', () => {
+    renderSidebar()
+
+    expect(container.querySelector('.riffsync-room-page__chat--overlay .riffsync-room-av')).not.toBeNull()
+  })
+
+  it('keeps anonymous expanded overlay readable with the existing sign-in gate', () => {
+    renderSidebar({ fanToken: null })
+
+    const overlay = container.querySelector('.riffsync-room-page__chat--overlay')
+    expect(overlay?.querySelector('.riffsync-room-chat-signin-overlay')).not.toBeNull()
+    expect(overlay?.querySelector('.riffsync-room-chat-compose-send')?.hasAttribute('disabled')).toBe(true)
+    expect(overlay?.querySelector('.riffsync-room-chat-reaction-add')).toBeNull()
+    expect(container.textContent).toContain('hello from chat')
+  })
+
+  it('invokes sendChat from expanded overlay compose when enabled', () => {
+    const sendChat = vi.fn()
+    renderSidebar({ sendChat, chatDraft: 'expanded hello' })
+
+    const input = container.querySelector('input[placeholder="Say something…"]') as HTMLInputElement
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(sendChat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -22,7 +22,6 @@ import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
   RIFFSYNC_CHAT_DRAWER_STATUS_ID,
 } from './drawerErrorPresentation'
-import { ChatOverlayMessageList, type ChatOverlayMessage } from './ChatOverlayMessageList'
 import { CastStartRoomActions } from './cast/CastStartRoomActions'
 import type { CastAvailabilityState } from './cast/castAvailabilityTypes'
 import type { CastStartLifecycle } from './cast/castChannelProtocol'
@@ -82,61 +81,6 @@ type RoomPageSidebarProps = {
   castToTvButtonRef: RefObject<HTMLButtonElement | null>
 }
 
-function toReadOnlyOverlayMessage(params: {
-  line: ChatLine
-  index: number
-  chat: ChatLine[]
-  chatMemberLabels: Map<string, string>
-  sessionId: string
-  myAvatarUrl: string | null
-}): ChatOverlayMessage {
-  const { line, index, chat, chatMemberLabels, sessionId, myAvatarUrl } = params
-  if (line.kind === 'system') {
-    return {
-      id: line.messageId,
-      kind: 'system',
-      text: formatChatSystemText(line.displayName, line.systemEvent),
-    }
-  }
-
-  const senderLabel =
-    (line.displayName && line.displayName.trim() !== ''
-      ? line.displayName
-      : chatMemberLabels.get(line.sessionId)) ??
-    `${line.sessionId.slice(0, 6)}...`
-  const avatarUrl = resolveMemberAvatarUrl(line.sessionId, line.avatarUrl, sessionId, myAvatarUrl)
-  const isContinued = isContinuedChatLine(chat, index)
-  const isMine = line.sessionId === sessionId
-
-  if (line.kind === 'gif') {
-    return {
-      id: line.messageId,
-      kind: 'gif',
-      text: `${senderLabel}: GIF`,
-      senderLabel,
-      avatarUrl,
-      isMine,
-      isContinued,
-      gif: {
-        src: line.renditionUrl,
-        alt: line.title?.trim() || 'GIF',
-        width: line.width,
-        height: line.height,
-      },
-    }
-  }
-
-  return {
-    id: line.messageId,
-    kind: 'text',
-    text: line.text,
-    senderLabel,
-    avatarUrl,
-    isMine,
-    isContinued,
-  }
-}
-
 export function RoomPageSidebar({
   presentation = 'sidebar',
   wsBase,
@@ -191,16 +135,6 @@ export function RoomPageSidebar({
   onCastToTvClick,
   castToTvButtonRef,
 }: RoomPageSidebarProps) {
-  const readOnlyOverlayMessages = chat.map((line, index) =>
-    toReadOnlyOverlayMessage({
-      line,
-      index,
-      chat,
-      chatMemberLabels,
-      sessionId,
-      myAvatarUrl,
-    }),
-  )
   const chatPlane = (
     <section
       className={`riffsync-room-page__chat${presentation === 'overlay' ? ' riffsync-room-page__chat--overlay' : ''}`}
@@ -266,14 +200,6 @@ export function RoomPageSidebar({
 
         {activeSidebarTab === 'chat' ? (
           <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--chat">
-            {presentation === 'overlay' ? (
-              <ChatOverlayMessageList
-                ref={chatLogRef}
-                variant="room"
-                messages={readOnlyOverlayMessages}
-                typingEntries={remoteTyping}
-              />
-            ) : (
               <ul ref={chatLogRef} className="riffsync-room-chat-log">
                 {chat.map((m, index) => {
                   if (m.kind === 'system') {
@@ -364,7 +290,6 @@ export function RoomPageSidebar({
                   </li>
                 ))}
               </ul>
-            )}
           </div>
         ) : null}
 
@@ -534,7 +459,7 @@ export function RoomPageSidebar({
           </div>
         ) : null}
 
-        {presentation === 'sidebar' ? <div className="riffsync-room-page__sidebar-footer">
+        <div className="riffsync-room-page__sidebar-footer">
           {fanToken && experimentalFeatures ? (
             <ParticipantAvToggles
               controller={participantAvController}
@@ -617,7 +542,7 @@ export function RoomPageSidebar({
               ) : null}
             </div>
           ) : null}
-        </div> : null}
+        </div>
       </section>
   )
 


### PR DESCRIPTION
## Summary

- Restore the regular `/room/:roomId` Expanded View chat overlay to the interactive room chat plane (compose, GIF picker, reactions, jump-to-latest, typing, drawer status, participant A/V toggles).
- Keep the Chromecast receiver presentation (`/cast/receiver`) read-only with stage-primary content and chat overlay only.
- Add regression coverage that distinguishes room expanded overlay interactivity from Cast receiver read-only behavior.

Closes #318

## Test plan

- [x] `cd apps/web && npm run build`
- [x] `cd apps/web && npm test`
- [x] `cd apps/web && npm run lint`
- [ ] Manual: enter Expanded View on desktop, send chat/GIF/reaction as signed-in fan
- [ ] Manual: confirm anonymous Expanded View stays readable with sign-in gate
- [ ] Manual: confirm `/cast/receiver` has no compose, reactions, or sidebar tabs