### PR TITLE
docs(ai): riffsync-seo-optimization contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -16,6 +16,13 @@ Business concepts and rules (language-agnostic). UI maps here via **`docs/archit
 - **Chat reaction (bounded retention):** emoji on a **`messageId`**; toggle per signed-in sender; active reaction rows persisted in **RoomChat** and replayed as aggregated chips in **`chat_history`**.
 - **Room admin:** signed-in participant whose **fan-pool Cognito `sub`** equals the room’s **`hostSub`** — **exclusive authority** to drive the **embedded player**, **start/stop broadcast capture**, select **`roomMode`**, operate the room-wide **`avDisabled`** kill switch, and mutate durable room playback metadata. **Anonymous users cannot host.** **Guest promotion** and token-based **admin reclaim** beyond normal Cognito re-login for the same user are **out of scope** for MVP. When the room admin enables a **participant camera**, they appear in Theater strip and Video Chat grid **like other signed-in fans** (not as a separate host-only surface).
 - **Operator (staff):** invite-only principal in the **staff** Cognito pool, provisioned **out-of-band** (console, CLI, or IaC). When authorized, carries **`cognito:groups`** including **`admin`** and/or **`curator`**. **Distinct** from **Participant** and **Room admin** — operator identity does **not** grant fan **`hostSub`** authority, room publisher role, or participant chat identity unless the same person also holds a separate **fan** session.
+- **Public discoverable surface:** the subset of routes that represent durable, indexable fan-facing content for search engines and social sharing, distinct from ephemeral, authenticated, or receiver-only surfaces that must stay out of search.
+
+  | Indexable | Not indexed (`noindex`) |
+  | --- | --- |
+  | **`/`**, **`/catalog`**, **`/watch/:catalogEpisodeId`**, **`/how-to-host-a-watchparty`**, **`/terms`**, **`/privacy`** | **`/room/:roomId`** (and **`/room/:roomId/experimental/:experimental`**), **`/lobby`**, **`/account`**, **`/admin/*`**, **`/cast/receiver`**, **`/privacy/data-removal`**, **`/auth/callback`**, **`/admin/auth/callback`** |
+
+  Ephemeral, authenticated, and receiver-only routes carry no durable identity worth surfacing to crawlers — this mirrors the existing **Identity modes** boundary below, not a new access rule. **`/watch/:catalogEpisodeId`** is indexable only for episodes satisfying the existing lawful-playback YouTube-link filter (**Invariant 1**) — an episode without a live YouTube link has no lawful surface to summarize or link to and is excluded from indexing and the sitemap until a link exists.
 
 ## Realtime session jurisdictions (watch-party client)
 
@@ -74,8 +81,9 @@ Three coexisting modes (see **`integration/authorization.md`**):
 6. **Video Chat layout:** the movie player region is **replaced** by a **grid of video-on participants** only. **Microphone-only** participants are **audible** but **not shown** in the grid (identity via People tab and chat). Camera-off removes grid tiles promptly; no frozen last-frame tiles. Entering **Video Chat** **fully stops** active host tab-capture (not suspend); returning to **Theater** requires the room admin to start **Share Source Tab** again.
 7. **Cast locality:** Chromecast is a viewer-local optional presentation. Cast start, stop, failure, unavailability, or receiver disconnect must not mutate **`roomMode`**, **`avDisabled`**, **`share_state`**, durable room playback fields, SFU permissions, host authority, participant roster authority, or any other participant's room experience.
 8. **Reconnect privacy:** after refresh or disconnect, each signed-in fan’s camera and microphone **default off**; the fan must manually re-enable.
-9. **Catalog title:** never replaced by TMDB **`title`** / **`original_title`**.
+9. **Catalog title:** never replaced by TMDB **`title`** / **`original_title`**. This extends to public search and share metadata — page titles, meta descriptions, and Open Graph/Twitter tags for **`/watch/:catalogEpisodeId`** always source the catalog **`title`** field, never TMDB's **`title`** or **`original_title`**.
 10. **Public catalog read** does not require authentication.
+11. **Public discoverability boundary:** only the durable public surfaces listed under **Public discoverable surface** are indexable. Ephemeral per-instance state (**rooms**, **lobby**) and authenticated or receiver-only surfaces (**account**, **admin**, **Cast receiver**, **auth callbacks**) never carry indexable metadata or sitemap entries, regardless of the rendering or build mechanism that produces them.
 
 ## Decisions (answered)
 
@@ -91,6 +99,7 @@ Three coexisting modes (see **`integration/authorization.md`**):
 | Operator onboarding (MVP)? | **Invite-only** — manual Cognito console invite and group assignment acceptable; no in-app “request access” flow. |
 | `admin` vs `curator` on routes? | **Deferred** until catalog/list handlers — auth slice treats either group as authorized for staff API probe. |
 | Operator moderation of rooms? | **Out of scope** for auth slice; when it ships, remains a **staff** capability separate from **room admin** capture authority. |
+| Public catalog SEO indexing scope? | Catalog, episode landing, host-help, and legal pages are indexable; rooms, lobby, account, admin, Cast receiver, and auth callbacks stay **`noindex`** — mirrors the existing lawful-playback and identity-mode boundaries, not a new access rule. |
 | Who may publish participant camera/mic? | **Signed-in fans only** — anonymous guests subscribe-only for participant A/V. |
 | Theater mic audio while movie plays? | **Yes** — participant microphones audible alongside host movie stream when **`avDisabled`** is false. |
 | Room mode durability? | **Durable** on room document — host **`PATCH`**; snapshot/join returns current mode; survives refresh and late join. |

--- a/.ai/business_logic/index.md
+++ b/.ai/business_logic/index.md
@@ -9,6 +9,7 @@ Scopes **domain concepts**, **user stories**, **errors** and recovery UX—not U
 
 - Record durable constraints and boundaries for this domain.
 - Covers **room layout mode** (**Theater** | **Video Chat**), **participant camera/microphone** eligibility and lifecycle, the host **AV kill switch**, and **realtime hardening** jurisdictions (**ChatSession**, **SfuMediaSession**, **TheaterPlayback**), decoupled lifecycles, and drawer-typed failures.
+- Covers **public discoverability**: which durable public routes (catalog, episode landing, host-help, legal) are indexable content vs ephemeral/authenticated/receiver-only surfaces that must stay out of search — see **`domain_model.md`** → *Public discoverable surface*.
 - Keep this file aligned with mapped child contracts.
 
 ## Primary code pointers (optional)

--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -51,6 +51,8 @@ MVP slice derived from **`vision.json`** + **`README.md`** — prioritized for s
 | US-P1-04 | operator | admin catalog + lists | I can curate without editing raw JSON in prod (**depends on US-P1-05**) |
 | US-P1-06 | signed-in fan in room | my **active** badge to persist across brief reconnects when I was recently engaged | late joiners and refresh see accurate engagement state on **People** |
 | US-P1-07 | Cast-capable room viewer | start a viewer-local Cast session from normal room view | I can watch the RiffSync room presentation on a TV while continuing to chat from my sender device |
+| US-P1-08 | search visitor | find a specific riffed episode via search engine | I can watch it without already knowing RiffSync exists |
+| US-P1-09 | fan | share a direct **`/watch/:id`** link on Discord or Reddit | the link preview shows the episode title and art instead of a generic site card |
 
 ## Out of scope (MVP)
 
@@ -69,6 +71,7 @@ MVP slice derived from **`vision.json`** + **`README.md`** — prioritized for s
 - **Guest join/leave system lines** (signed-in fans only; anonymous guests connect silently)
 - Room-wide Chromecast or host-controlled casting for all participants (Cast is viewer-local only)
 - Native media-only Cast or YouTube-only Cast as the current Cast maturity substitute; the current Cast scope is the custom RiffSync receiver presentation with chat overlay.
+- Search-engine indexing of **`/room/*`** or **`/lobby`** — ephemeral, per-instance state with no durable identity worth surfacing to crawlers (**`domain_model.md`** → *Public discoverable surface*).
 
 ## Decisions (answered — realtime hardening)
 

--- a/.ai/interface/accessibility.md
+++ b/.ai/interface/accessibility.md
@@ -9,6 +9,13 @@ Accessible-by-default contract for presentation and interaction surfaces.
 - **Color alone** must not be the only signal for on/off state on camera/mic toggles; pair with iconography and accessible name/state.
 - **Focus order** matches visual flow; see **`input_handling.md`**.
 
+## Public catalog and marketing surfaces
+
+- **Home route** (**`/`**) gets a static, visually-hidden (**`sr-only`**) **`<h1>`** so the document outline satisfies a landmark heading without changing visible hero markup (**`presentation.md`** → *Public site head tags and heading semantics*).
+- **Catalog card images** (**`CatalogGridCard`**) carry non-empty **`alt`** text describing the episode instead of **`alt=""`**.
+- **`/watch/:catalogEpisodeId`** keeps its existing **`sr-only`** **`<h1>{episode.title}</h1>`** — unaffected by this initiative beyond added head-tag metadata.
+- **Ephemeral/authenticated/receiver-only routes** (**`/room/:roomId`**, **`/lobby`**, **`/account`**, **`/admin/*`**, **`/cast/receiver`**) are unaffected — they keep the existing app-shell heading/landmark baseline, not a new accessibility commitment.
+
 ## Watch party participant AV
 
 ### Camera/microphone toggles
@@ -92,6 +99,9 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### chromecast-accessibility
 - No open implementation decisions remain for M25 Cast accessibility verification. See **Chromecast Cast status** and #279 verification requirements above.
+
+### public-site-seo
+- No open implementation decisions remain. The home **`sr-only`** H1 and catalog **`alt`** text are additive, non-visual fixes with no accessibility ambiguity — see **Public catalog and marketing surfaces** above.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/index.md
+++ b/.ai/interface/index.md
@@ -11,6 +11,7 @@ Scopes **inputs**, **presentation** states, **navigation/flow**, and **accessibi
 - Keep this file aligned with mapped child contracts.
 - **`/room/:roomId`** participant AV (camera/microphone), host **room mode** (**Theater** | **Video Chat**), and host **AV kill switch** are in scope; child docs define layout, flow, input, and accessibility boundaries.
 - **Realtime hardening:** **SFU-only** media path (no mesh UI), **drawer-independent** chat vs video-relay status surfaces (**#150** M19 ship gate), **guest host-screen SFU FSM copy** (**#151** M19 ship gate), **`producerClosed`** tile lifecycle (no frozen last frames), and thin **`RoomPage`** shell over **`ChatSession`** / **`SfuMediaSession`** / **`TheaterPlayback`** (**`runtime/execution_model.md`**).
+- **Public catalog, home, and marketing surfaces** (**`/`**, **`/catalog`**, **`/watch/:catalogEpisodeId`**, **`/how-to-host-a-watchparty`**, **`/terms`**, **`/privacy`**) are in scope for document-level head tags, heading semantics, and image alt text — see **`presentation.md`** → *Public site head tags and heading semantics* and **`business_logic/domain_model.md`** → *Public discoverable surface* for the indexable route boundary.
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -15,6 +15,35 @@ UI-level contract for layout states, honest failure surfaces, and **cost-conscio
 | **Rate / caps** | Server may return **429** / **WS business `error`** when limits hit (**`api_contracts.md`**); toast or inline message—**no** infinite retry storms. |
 | **Catalog era filters** | Public **`/catalog`** shows era chips for Joel, Mike, Jonah, Emily, Community, Movie Night, and **Riffable**. **`other`** is staff-only and must not appear on public filter chips. Default selected eras include **Riffable** with the core MST buckets. |
 
+## Public site head tags and heading semantics
+
+Document-level metadata for the durable public surfaces — **`/`**, **`/catalog`**, **`/watch/:catalogEpisodeId`**, **`/how-to-host-a-watchparty`**, **`/terms`**, **`/privacy`** — replacing today's single static **`index.html`** shell that applies the same meta to every route regardless of what renders. See **`business_logic/domain_model.md`** → *Public discoverable surface* for the indexable route boundary; this contract is **mechanism-agnostic** — it holds whether head tags are produced by build-time prerender (**`operations/build_packaging.md`**) or another rendering strategy.
+
+| Route | **`<title>`** | Meta description | Canonical | OG/Twitter image |
+| --- | --- | --- | --- | --- |
+| **`/`** | Site title framing (e.g. **`RiffSync — watch parties`**) | Fan-disclaimer framing copy (unofficial, non-trademark-claiming — same precedent as today's **`index.html`**) | **`https://riffsync.tv/`** | Static **`/og-card.png`** |
+| **`/catalog`** | Catalog framing (e.g. **`RiffSync Catalog — browse the library`**) | Catalog browsing framing copy | **`https://riffsync.tv/catalog`** | Static **`/og-card.png`** |
+| **`/watch/:catalogEpisodeId`** | Episode **`title`** + site framing | Composed from episode **`title`** (and **`tagline`** when present) | **`https://riffsync.tv/watch/{id}`** | Episode **`posterImageUrl`** / **`backdropImageUrl`** when present, else static **`/og-card.png`** |
+| **`/how-to-host-a-watchparty`** | Host-help framing | Host-help framing copy | **`https://riffsync.tv/how-to-host-a-watchparty`** | Static **`/og-card.png`** |
+| **`/terms`** | Legal framing | Legal framing copy | **`https://riffsync.tv/terms`** | Static **`/og-card.png`** |
+| **`/privacy`** | Legal framing | Legal framing copy | **`https://riffsync.tv/privacy`** | Static **`/og-card.png`** |
+
+**Ephemeral/authenticated/receiver-only routes** (**`/room/:roomId`** and its experimental variant, **`/lobby`**, **`/account`**, **`/admin/*`**, **`/cast/receiver`**, **`/privacy/data-removal`**, **`/auth/callback`**, **`/admin/auth/callback`**) keep the generic app-shell **`<title>RiffSync</title>`** and description plus a **`noindex`** robots meta tag — **no** per-instance head tags.
+
+Meta titles/descriptions/OG for **`/watch/:id`** always use the catalog **`title`** field, never TMDB's **`title`**/**`original_title`** (**`business_logic/domain_model.md`** Invariant 9).
+
+### Home route document outline (sr-only H1)
+
+**`/`** renders a static, visually-hidden (**`sr-only`**) **`<h1>`** ahead of **`HomeHeroBanner`** — matching the site title framing already used in **`<title>RiffSync</title>`** — rather than promoting the rotating hero carousel's **`h3`** slide title. A per-slide dynamic H1 would shift the document outline on every autorotate, which is a worse crawler and screen-reader signal than one stable heading. The hero, carousel, and spotlight banner keep their **existing visible markup and heading levels** (**`h3`**/**`h4`**) unchanged — no visible layout change.
+
+### Catalog card image alt text
+
+**`CatalogGridCard`** images carry non-empty **`alt`** text describing the episode (e.g. the episode **`title`**) instead of today's empty **`alt=""`**. Additive accessibility/SEO fix — no new interaction pattern, no visible layout change.
+
+### `/watch/:catalogEpisodeId` heading
+
+The existing **`sr-only`** **`<h1>{episode.title}</h1>`** on **`SoloWatchPage`** already satisfies the document-outline contract; this initiative adds only head-tag metadata (title/description/canonical/OG/Twitter per the table above) — no markup change to the existing heading.
+
 ## Chat & scrollback (watch party room)
 
 - **Surface:** **`/room/:roomId`** sidebar **Chat** tab (not solo watch).
@@ -400,6 +429,11 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### chromecast-presentation
 - No open decisions remain for #303 receiver presentation. The receiver shell uses the route and component contracts above, TV-safe 720p/1080p/4K overlay constraints, explicit waiting/blocked playback copy, and component or screenshot coverage proving native media-only and YouTube-only Cast paths do not satisfy the required RiffSync stage-primary plus chat-overlay presentation.
+
+### public-site-seo
+- Exact per-route **`<title>`** / meta description copy strings for each public route — defer to **`/refine-issue`**.
+- Whether the home **`sr-only`** H1 text is fully static or interpolates a dynamic catalog fact — static is the safer default absent a stated need.
+- Exact **`alt`** text template for catalog cards (**`{title}`** vs **`{title} poster`** vs including era).
 
 ## Primary code pointers (optional)
 

--- a/.ai/knowledge_map.json
+++ b/.ai/knowledge_map.json
@@ -78,7 +78,8 @@
           "primary_doc": ".ai/specs/index.md",
           "description": "Durable capability-level architecture and behavior specifications.",
           "children": [
-            ".ai/specs/viewer-local-cast.spec.md"
+            ".ai/specs/viewer-local-cast.spec.md",
+            ".ai/specs/public-site-seo.spec.md"
           ]
         }
       ]

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -63,12 +63,35 @@ Staff Cognito outputs must exist **before** the SPA build that includes admin ro
 
 See **[`deployment_environments.md`](deployment_environments.md)** for the full production sequence.
 
+## Public site SEO artifacts
+
+Search-engine and social-share surfaces for the fan SPA — **`robots.txt`**, **`sitemap.xml`**, per-route prerendered HTML, and per-route head tags — are **build-time generated artifacts**, not hand-maintained static files or a new runtime component. They ship through the **existing** **`apps/web`** → **`RiffSyncStatic-prod`** S3 sync + CloudFront invalidation pipeline (Artifacts table above) — no new publish target, no new CI job.
+
+| Artifact | Generation | Source |
+| --- | --- | --- |
+| **`robots.txt`** | New step in **`apps/web`** **`npm run build`**, emitted into **`dist/`** | Static policy (below), keyed to the route matrix in **[`business_logic/domain_model.md`](../business_logic/domain_model.md)** → *Public discoverable surface* |
+| **`sitemap.xml`** | Same build step; enumerates the static indexable routes plus one **`<url>`** entry per catalog episode passing **`episodeHasYoutubeLink`** | **`data/catalog/episodes.json`** (or **`GET /v1/catalog`** at build time) |
+| **Per-route prerendered HTML** | Build-time prerender step renders static HTML snapshots for each indexable route into **`dist/`** alongside the SPA shell — served directly by the existing S3 + CloudFront static pipeline; **no** CloudFront Function / Lambda@Edge bot detection, **no** new edge compute surface | Vite build output plus the indexable route list |
+| **Per-route head tags** (**`<title>`**, description, canonical, OG/Twitter) | Baked into each prerendered route's HTML at the same build step | **[`interface/presentation.md`](../interface/presentation.md)** → *Public site head tags and heading semantics* |
+
+All absolute URLs in these artifacts (canonical links, **`Sitemap:`** line, OG/Twitter **`url`**/**`image`**) use the canonical production origin — **`https://riffsync.tv`** (apex) — sourced from the same **`public_domain`** / **`PUBLIC_WEB_ORIGIN`** build-time value already used for SPA absolute URLs (**[`runtime/configuration.md`](../runtime/configuration.md)**). Non-canonical **`www.riffsync.tv`** redirects to apex (**[`deployment_environments.md`](deployment_environments.md)** → *Public site SEO deployment readiness*); no artifact emits **`www`** absolute URLs.
+
+**`robots.txt`** policy:
+
+| Directive | Paths |
+| --- | --- |
+| **Disallow** | **`/room/`**, **`/lobby`**, **`/account`**, **`/admin/`**, **`/cast/receiver`**, **`/privacy/data-removal`**, **`/auth/callback`**, **`/admin/auth/callback`** |
+| **Allow** (default) | **`/`**, **`/catalog`**, **`/watch/`**, **`/how-to-host-a-watchparty`**, **`/terms`**, **`/privacy`** |
+| **`Sitemap:`** | **`https://riffsync.tv/sitemap.xml`** |
+
+No hosted staging/dev SEO footprint — consistent with the prod-only environment policy in **[`deployment_environments.md`](deployment_environments.md)**; these artifacts ship only to **`RiffSyncStatic-prod`**.
+
 ## CI expectations
 
 | Job | Scope | Blocking |
 | --- | --- | --- |
 | **`infra-cdk`** | **`cdk synth`**, **`cfn-lint`** on **`cdk.out`** | PR |
-| **`web-app`** | **`apps/web`** **`npm run build`** + unit tests + lint (may use placeholder env in CI; production deploy reads live Cfn outputs) | PR |
+| **`web-app`** | **`apps/web`** **`npm run build`** + unit tests + lint (may use placeholder env in CI; production deploy reads live Cfn outputs). Build step must also produce **`robots.txt`**, **`sitemap.xml`**, and prerendered HTML for indexable routes without failing; missing catalog data at build time fails the build rather than shipping an empty or stale sitemap. | PR |
 | **`realtime-conformance`** | Disposable SFU + TURN integration harness (see below) | **PR** when path filters match |
 
 Viewer-local Cast browser/unit tests live under the **`web-app`** job. Physical Google Cast discovery and receiver launch are manual smoke checks because CI cannot reliably emulate Cast devices.
@@ -253,3 +276,9 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### chromecast-build-packaging
 - No open decisions remain for sender availability build packaging. Production wiring uses a non-secret GitHub Actions variable exported as **`VITE_CAST_RECEIVER_APP_ID`** for the SPA build; the current pre-release UI additionally requires the existing room experimental feature opt-in; missing app id or disabled experimental opt-in hides or locally fails Cast and blocks release readiness, not unrelated room deploys; #301 web-app tests cover SDK loader, app id, **`CastContext.setOptions`**, availability UI, and no room-authority side effects, while #317 adds focused web coverage for the experimental exposure gate. Receiver route rendering tests belong to #303, and physical-device smoke evidence belongs to #306.
+
+### public-site-seo
+- Exact sitemap/robots generation script location and tooling (Node script inside the **`apps/web`** build vs a small CDK custom resource).
+- Exact prerender tooling choice (custom Node script rendering routes to static HTML vs a Vite prerender plugin) — must integrate with the existing single **`npm run build`**, not a second build pipeline.
+- CloudFront/S3 response headers and cache-control for **`robots.txt`** / **`sitemap.xml`** (bypass the SPA's aggressive **`index.html`** no-cache pattern vs a short TTL for post-catalog-update freshness).
+- Whether the Search Console / Bing verification DNS record is added to the existing Route 53 zone via CDK or documented as a manual operator step (**[`deployment_environments.md`](deployment_environments.md)**).

--- a/.ai/operations/deployment_environments.md
+++ b/.ai/operations/deployment_environments.md
@@ -51,6 +51,17 @@ Viewer-local Cast uses the production SPA origin and a Google Cast Custom Web Re
 | **CSP / headers** | CloudFront and SPA headers must permit the Google Cast sender/receiver scripts, receiver route loading, necessary frame/script policies, and YouTube/player resources needed for the receiver presentation. |
 | **Smoke band** | Physical Cast-device smoke testing is a production release-readiness check. CI verifies local controller behavior and receiver route rendering but does not replace device discovery and receiver launch tests. |
 
+## Public site SEO deployment readiness
+
+Search-engine and social-share readiness for the fan SPA reuses the existing **`RiffSyncStatic-prod`** CloudFront/S3 origin and Route 53 hosted zone. It does not add a hosted backend stack or a room-authoritative service.
+
+| Check | Contract |
+| --- | --- |
+| **Canonical hostname redirect** | **`fanWebCanonicalHostname`** CDK context on **`RiffSyncStatic-prod`** (**[`infra/cdk/lib/static-site-stack.ts`](../../infra/cdk/lib/static-site-stack.ts)**) is set to the apex hostname **`riffsync.tv`**; **`www.riffsync.tv`** is a **`fanWebAlternateDomainNames`** entry that the existing **[`cloudfront-canonical-redirect.ts`](../../infra/cdk/lib/cloudfront-canonical-redirect.ts)** CloudFront Function redirects to apex, preserving path and query. |
+| **`robots.txt` / `sitemap.xml` reachable** | **`https://riffsync.tv/robots.txt`** and **`https://riffsync.tv/sitemap.xml`** return **200** from the production CloudFront distribution after SPA publish. |
+| **Search Console / Bing verification** | A DNS **TXT** record is added to the **existing** Route 53 hosted zone (**`fanWebZoneName`**) already managed in **`static-site-stack.ts`** — not an HTML file upload or meta-tag verification step. |
+| **Smoke band** | Post-deploy smoke verifies the apex canonical origin, the **`www`** → apex redirect, **`robots.txt`**/**`sitemap.xml`** returning **200**, and the canonical **`<link>`** tag on **`/`** matching apex — see **[`build_packaging.md`](build_packaging.md)** CI vs prod verification bands for where each check runs. |
+
 ## GitHub Actions and OIDC
 
 - **CI:** **[`ci.yml`](../../.github/workflows/ci.yml)** — synth + lint; **no** AWS deploy credentials.
@@ -164,6 +175,10 @@ Back-of-envelope for **8** concurrent fan publishers (camera + mic) in one room 
 - Specify where the Cast SDK Developer Console registration details are recorded for maintainers without committing secrets or private device information.
 - Specify the exact CloudFront response header/CSP changes needed for the sender SDK, receiver SDK, receiver route, and embedded playback resources.
 - Specify the physical-device smoke test matrix across Chrome sender, Cast-capable receiver, signed-in sender, anonymous sender, and active room media source.
+
+### public-site-seo
+- Where the Search Console / Bing verification DNS record value is recorded for maintainers (**`docs/`** vs CDK context) without committing secrets.
+- Whether an automated post-deploy smoke script (peer pattern: **`control9-www`**'s **`smoke-production.mjs`**) is added under **`apps/web`** or a root **`scripts/`** directory, and its exact check list.
 
 ## Primary code pointers (optional)
 

--- a/.ai/operations/index.md
+++ b/.ai/operations/index.md
@@ -4,6 +4,8 @@ Scopes **build/deploy** (**AWS CDK**, TypeScript Lambdas, serverless-first packa
 
 Participant camera/microphone in watch-party rooms extends the existing **`RiffSyncTurn`** mediasoup SFU + coturn footprint; **no** new deployment tier or hosted staging stack. **Realtime hardening:** SFU-only media path (mesh retired), PR-blocking **`realtime-conformance`** harness on isolated disposable SFU + TURN, drawer-labeled observability.
 
+Public site discoverability (**`robots.txt`**, **`sitemap.xml`**, build-time prerender, canonical hostname alignment) extends the existing **`apps/web`** → **`RiffSyncStatic-prod`** static build/publish pipeline; **no** new deployment tier, edge compute surface, or hosted staging footprint.
+
 - Child contracts: **`build_packaging.md`**, **`deployment_environments.md`**, **`observability.md`**, **`security.md`**.
 
 ## Scope

--- a/.ai/runtime/configuration.md
+++ b/.ai/runtime/configuration.md
@@ -23,6 +23,12 @@ There is **no hosted `dev`** stack and **no hosted staging** stack—**local dev
 
 SPA builds for **prod** should inject **`https://riffsync.tv`** (or derive it from **`public_domain`**) for absolute share links and OAuth redirect configuration.
 
+## Public site SEO build-time config
+
+**`robots.txt`**, **`sitemap.xml`**, prerendered route HTML, and per-route canonical/OG/Twitter URLs (**`operations/build_packaging.md`**, **`interface/presentation.md`**) source the canonical origin from the **same** **`public_domain`** / **`PUBLIC_WEB_ORIGIN`** build-time value above — **`https://riffsync.tv`** (apex) in prod. There is **no** second, parallel "public origin" config value for SEO artifacts. Non-canonical **`https://www.riffsync.tv`** redirects to apex at the edge (**`deployment_environments.md`** → *Public site SEO deployment readiness*); no SEO artifact emits **`www`** absolute URLs.
+
+These artifacts are static or build-time-generated content served by the existing CloudFront/S3 static-hosting runtime — they introduce **no** new runtime process, execution boundary, or secret.
+
 ## Parameters (non-secret)
 
 Illustrative—final list in IaC:
@@ -55,7 +61,7 @@ The Cast receiver application id is public build-time configuration for the SPA.
 | Config | Contract |
 | --- | --- |
 | **Receiver app id** | The public Vite value is **`VITE_CAST_RECEIVER_APP_ID`**. Missing or invalid configuration hides or locally fails Cast; it must not degrade room bootstrap, chat, SFU media, host controls, expanded view, or normal playback. |
-| **Receiver URL** | Production registration points to the Custom Web Receiver route on the canonical production origin, currently **`https://www.riffsync.tv/cast/receiver`**. Local/dev physical Cast tests require a Cast-device-reachable HTTPS origin; ordinary **`localhost`** Vite dev is suitable for unit/component tests but is not a physical receiver target unless tunneled or otherwise exposed over trusted TLS. |
+| **Receiver URL** | Production registration points to the Custom Web Receiver route on the canonical apex origin, **`https://riffsync.tv/cast/receiver`**. Local/dev physical Cast tests require a Cast-device-reachable HTTPS origin; ordinary **`localhost`** Vite dev is suitable for unit/component tests but is not a physical receiver target unless tunneled or otherwise exposed over trusted TLS. |
 | **Sender SDK** | The sender loads the Google Cast sender SDK with **`loadCastFramework=1`**, assigns **`window.__onGCastApiAvailable`** before appending the SDK script, and configures **`CastContext`** from the build-time receiver app id with **`chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED`** before exposing the normal-view **Cast to TV** start action. |
 | **Experimental exposure gate** | Until Cast is repaired and release-ready, **Cast to TV** also requires the existing room experimental feature opt-in from **`detectExperimentalRoomFeatures()`**. `?experimental=true` or `/experimental/true` enables and persists the opt-in; `?experimental=false` or `/experimental/false` clears it. This flag gates only the Cast entry point and other experimental room UI, not room bootstrap, chat, SFU media, host controls, expanded view, or normal playback. |
 | **No secrets** | Receiver app id and public origin values may appear in the browser bundle. They must not be treated as credentials or included in private secret rotation plans. |
@@ -145,6 +151,9 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 
 ### chromecast-configuration
 - No open decisions remain for sender availability configuration. The public app id env var is **`VITE_CAST_RECEIVER_APP_ID`**; the current pre-release exposure gate is the existing room experimental feature opt-in from **`detectExperimentalRoomFeatures()`**; missing prod configuration or disabled experimental opt-in keeps Cast hidden or locally unavailable and is a release-readiness blocker before announcing Cast-ready behavior, not a room bootstrap failure; local physical Cast testing requires reachable TLS rather than ordinary **`localhost`**.
+
+### public-site-seo
+- Exact wiring of the build-time origin value into the sitemap/prerender generation script (reading the same env var already baked for **`VITE_PUBLIC_ORIGIN`** vs a separate Node-side read of **`public_domain`**) — mechanical, defer to **`/refine-issue`**.
 
 ## Primary code pointers (optional)
 

--- a/.ai/specs/index.md
+++ b/.ai/specs/index.md
@@ -5,3 +5,4 @@ Durable capability-level architecture and behavior specifications for RiffSync.
 | Slug | Title | Purpose | Status |
 | --- | --- | --- | --- |
 | `viewer-local-cast` | Viewer-local Cast | Defines optional Google Cast sender and custom receiver behavior for local room presentation without room authority. | draft |
+| `public-site-seo` | Public Site SEO | Defines the indexable route boundary, per-route head tags, and build-time sitemap/robots/prerender generation for search and social discoverability. | draft |

--- a/.ai/specs/public-site-seo.spec.md
+++ b/.ai/specs/public-site-seo.spec.md
@@ -1,0 +1,77 @@
+# Public Site SEO
+
+## Introduction
+
+RiffSync's public catalog and marketing surfaces — home, catalog, episode watch pages, host-help, and legal pages — are discoverable by search engines and shareable with rich social previews (Discord, Reddit, Mastodon, and similar unfurlers), without changing the SPA's existing visual design and without extending discoverability to live, ephemeral room state.
+
+**Audience:** fans searching for riff-style watch parties and episode discovery; community sharers posting catalog and watch links.
+
+**Related capability:** `viewer-local-cast` (separate optional per-viewer presentation layer; not part of this capability).
+
+**Non-goals:** indexing `/room/*` or `/lobby`; a server-side rendering framework migration; CloudFront-based bot-detection or edge compute for dynamic rendering; dedicated per-era catalog routes (`/catalog` remains the single canonical catalog entry).
+
+## Functional Specification
+
+### Indexable vs noindex route matrix
+
+| Indexable | `noindex` |
+| --- | --- |
+| `/`, `/catalog`, `/watch/:catalogEpisodeId`, `/how-to-host-a-watchparty`, `/terms`, `/privacy` | `/room/:roomId` (+ `/room/:roomId/experimental/:experimental`), `/lobby`, `/account`, `/admin/*`, `/cast/receiver`, `/privacy/data-removal`, `/auth/callback`, `/admin/auth/callback` |
+
+`/watch/:catalogEpisodeId` is indexable only for episodes with a live YouTube link (the existing `episodeHasYoutubeLink` filter) — an episode without a lawful embed carries no surface worth summarizing or linking to and is excluded from indexing and the sitemap until a link exists.
+
+### Per-route head tags
+
+Each indexable route gets a unique `<title>`, meta description, canonical `<link>`, and Open Graph/Twitter tags, replacing today's single static `index.html` shell applied to every route. `/watch/:catalogEpisodeId` sources title/description/OG from the catalog `title` field (never TMDB `title`/`original_title`) plus `tagline`, `posterImageUrl`, and `backdropImageUrl` when present. All other routes carry the generic app-shell title/description plus a `noindex` robots meta tag — no per-instance head tags. Full per-route table: `.ai/interface/presentation.md` → *Public site head tags and heading semantics*.
+
+### `robots.txt` and `sitemap.xml`
+
+Both are build-time-generated artifacts reflecting the current catalog, not hand-maintained static files. `robots.txt` disallows ephemeral/authenticated/receiver-only paths and allows the indexable set; it publishes a `Sitemap:` line pointing at `sitemap.xml`. `sitemap.xml` enumerates the static indexable routes plus one `<url>` entry per YouTube-linked catalog episode. Full policy table: `.ai/operations/build_packaging.md` → *Public site SEO artifacts*.
+
+### Build-time prerender
+
+A build step renders static HTML snapshots for each indexable route into `dist/` alongside the SPA shell. Crawlers and unfurlers that do not execute JavaScript receive meaningful HTML; users still get the interactive React SPA. No CloudFront Function or Lambda@Edge bot-detection is introduced — the artifact ships through the existing S3 + CloudFront static pipeline with no new edge compute surface.
+
+### Canonical hostname alignment
+
+The canonical production origin is the apex hostname `https://riffsync.tv`. Non-canonical `https://www.riffsync.tv` redirects to apex at the edge, preserving path and query. Every absolute URL this capability produces — canonical `<link>`, sitemap entries, OG/Twitter `url`/`image` — uses apex; none emit `www`.
+
+### Home heading and catalog image accessibility
+
+`/` gets a static, visually-hidden (`sr-only`) `<h1>` ahead of the hero banner — no visible layout change to the hero, carousel, or spotlight banner. Catalog card images get non-empty `alt` text describing the episode. `/watch/:catalogEpisodeId`'s existing `sr-only` `<h1>{episode.title}</h1>` is unchanged.
+
+### Search Console verification
+
+Search Console / Bing Webmaster verification uses a DNS TXT record on the existing Route 53 hosted zone already managing `riffsync.tv` — not an HTML file upload or meta-tag step.
+
+## Technical Specification
+
+**Stack:** `apps/web` — React 19.2, Vite 8, react-router-dom 7, single Vite build (`npm run build` → `dist/`) published to the `RiffSyncStatic-prod` private S3 + CloudFront (OAC) origin via the existing GitHub Actions `deploy-prod.yml` pipeline (Node/CI toolchain per `.ai/operations/build_packaging.md`).
+
+**Build pipeline:** the SEO artifact generation (robots/sitemap/prerender/head-tags) is a new step inside the existing `apps/web` `npm run build` invocation — not a second build pipeline, not a new CI job. Sitemap and robots generation reads `data/catalog/episodes.json` (or `GET /v1/catalog`) filtered by the existing `episodeHasYoutubeLink` predicate (`apps/web/src/catalog/mockCatalog.ts`).
+
+**Canonical origin sourcing:** the same `public_domain` / `PUBLIC_WEB_ORIGIN` build-time value already used for `VITE_PUBLIC_ORIGIN` (`.ai/runtime/configuration.md`) is the single source for all absolute URLs this capability emits.
+
+**Canonical hostname redirect:** the existing `fanWebCanonicalHostname` CDK context on `RiffSyncStatic-prod` (`infra/cdk/lib/static-site-stack.ts`) drives the existing `cloudfront-canonical-redirect.ts` CloudFront Function, which 301-redirects any configured `fanWebAlternateDomainNames` (including `www.riffsync.tv`) to the canonical apex host. No new CDK construct is required — only ensuring the context value is set to apex.
+
+**Publish target:** artifacts ship through the existing `apps/web` → `RiffSyncStatic-prod` S3 sync + CloudFront invalidation (`deploy-prod.yml` phase 5). No new stack, no new environment tier, no hosted staging footprint.
+
+**Search Console verification:** a DNS TXT record added to the existing Route 53 hosted zone (`fanWebZoneName`) already managed in `static-site-stack.ts`.
+
+## Testing Strategy
+
+**Unit/component:** home `sr-only` H1 renders exactly once; catalog card `alt` text is non-empty; the per-route head-tag generator produces the expected title/description/canonical/OG for each indexable route, including `/watch/:id` cases with and without `tagline`/poster art.
+
+**Build/CI:** the `web-app` CI job asserts `robots.txt`, `sitemap.xml`, and prerendered HTML exist for each indexable route after `npm run build`; sitemap entry count matches the count of catalog episodes passing `episodeHasYoutubeLink`; the build fails rather than shipping an empty or stale sitemap when catalog data is unavailable.
+
+**Manual/smoke (post-deploy, production only):** apex canonical reachable; `www` → apex redirect returns a 3xx to the apex host; `robots.txt`/`sitemap.xml` return 200; the canonical `<link>` on `/` and a sample `/watch/:id` matches apex; Search Console DNS verification confirmed. Peer prior art for the smoke-check shape: `control9/control9-www`'s `smoke-production.mjs` (reference only — riffsync's static-hosting shape differs enough that it is not a template to copy wholesale).
+
+## References
+
+- `.ai/business_logic/domain_model.md` — Public discoverable surface, Invariant 1 (lawful playback), Invariant 9 (catalog title), Invariant 11 (public discoverability boundary)
+- `.ai/business_logic/user_stories.md` — US-P1-08, US-P1-09
+- `.ai/interface/presentation.md` — Public site head tags and heading semantics
+- `.ai/interface/accessibility.md` — Public catalog and marketing surfaces
+- `.ai/operations/build_packaging.md` — Public site SEO artifacts
+- `.ai/operations/deployment_environments.md` — Public site SEO deployment readiness
+- `.ai/runtime/configuration.md` — Public hostname, Public site SEO build-time config


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** riffsync-seo-optimization
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and cross-repo coherence before merge

Adds the `public-site-seo` capability spec and aligns `business_logic`, `interface`, `operations`, and `runtime` contracts on:
- the indexable vs `noindex` route boundary
- per-route head tags (title/description/canonical/OG/Twitter), including `/watch/:id` from catalog fields
- build-time `robots.txt`/`sitemap.xml` generation from the catalog
- build-time prerender scope integrated into the existing Vite build
- apex (`https://riffsync.tv`) canonical hostname alignment, fixing the prior apex/`www` contradiction across `runtime/configuration.md`
- home `sr-only` H1 and catalog alt-text fixes with no visible layout change
- Search Console DNS verification and release smoke checks

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.