### PR TITLE
docs(ai): refine issue #326 contract updates

### DIFF
--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -21,12 +21,14 @@ Document-level metadata for the durable public surfaces — **`/`**, **`/catalog
 
 | Route | **`<title>`** | Meta description | Canonical | OG/Twitter image |
 | --- | --- | --- | --- | --- |
-| **`/`** | Site title framing (e.g. **`RiffSync — watch parties`**) | Fan-disclaimer framing copy (unofficial, non-trademark-claiming — same precedent as today's **`index.html`**) | **`https://riffsync.tv/`** | Static **`/og-card.png`** |
-| **`/catalog`** | Catalog framing (e.g. **`RiffSync Catalog — browse the library`**) | Catalog browsing framing copy | **`https://riffsync.tv/catalog`** | Static **`/og-card.png`** |
-| **`/watch/:catalogEpisodeId`** | Episode **`title`** + site framing | Composed from episode **`title`** (and **`tagline`** when present) | **`https://riffsync.tv/watch/{id}`** | Episode **`posterImageUrl`** / **`backdropImageUrl`** when present, else static **`/og-card.png`** |
-| **`/how-to-host-a-watchparty`** | Host-help framing | Host-help framing copy | **`https://riffsync.tv/how-to-host-a-watchparty`** | Static **`/og-card.png`** |
-| **`/terms`** | Legal framing | Legal framing copy | **`https://riffsync.tv/terms`** | Static **`/og-card.png`** |
-| **`/privacy`** | Legal framing | Legal framing copy | **`https://riffsync.tv/privacy`** | Static **`/og-card.png`** |
+| **`/`** | **`RiffSync — watch parties`** | **`RiffSync — fan watch parties with a curated MST3K-friendly catalog, shared viewing, and room chat. Unofficial fan project.`** | **`{origin}/`** | **`{origin}/og-card.png`** |
+| **`/catalog`** | **`RiffSync Catalog — browse the library`** | **`Browse the RiffSync catalog of riff-style episodes with lawful YouTube embeds. Filter by era, pick an experiment, and start a watch party. Unofficial fan project.`** | **`{origin}/catalog`** | **`{origin}/og-card.png`** |
+| **`/watch/:catalogEpisodeId`** | **`{episode.title} — RiffSync`** | With **`tagline`**: **`{tagline} — watch {episode.title} on RiffSync. Unofficial fan project with lawful YouTube embeds.`** Without **`tagline`**: **`Watch {episode.title} on RiffSync — fan watch parties with lawful YouTube embeds. Unofficial fan project.`** | **`{origin}/watch/{id}`** | Absolute **`posterImageUrl`**, else absolute **`backdropImageUrl`**, else **`{origin}/og-card.png`** |
+| **`/how-to-host-a-watchparty`** | **`How to host a watch party — RiffSync`** | **`Step-by-step help for hosting a RiffSync watch party: share your YouTube tab, keep guests in sync, and fix common screen-share issues.`** | **`{origin}/how-to-host-a-watchparty`** | **`{origin}/og-card.png`** |
+| **`/terms`** | **`Terms of Service — RiffSync`** | **`RiffSync Terms of Service — rules for using the fan watch-party site, catalog, chat, and related features. Unofficial fan project; not affiliated with MST3K or RiffTrax.`** | **`{origin}/terms`** | **`{origin}/og-card.png`** |
+| **`/privacy`** | **`Privacy Policy — RiffSync`** | **`RiffSync Privacy Policy — what we collect when you browse the catalog, join watch parties, or sign in, and how we use that information.`** | **`{origin}/privacy`** | **`{origin}/og-card.png`** |
+
+**`{origin}`** is the apex canonical build-time origin (**`VITE_PUBLIC_ORIGIN`** or **`https://riffsync.tv`** fallback). Episode art URLs that are root-relative in catalog data are prefixed with **`{origin}`** before emission; already-absolute **`https:`** values pass through unchanged.
 
 **Ephemeral/authenticated/receiver-only routes** (**`/room/:roomId`** and its experimental variant, **`/lobby`**, **`/account`**, **`/admin/*`**, **`/cast/receiver`**, **`/privacy/data-removal`**, **`/auth/callback`**, **`/admin/auth/callback`**) keep the generic app-shell **`<title>RiffSync</title>`** and description plus a **`noindex`** robots meta tag — **no** per-instance head tags.
 
@@ -431,9 +433,20 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - No open decisions remain for #303 receiver presentation. The receiver shell uses the route and component contracts above, TV-safe 720p/1080p/4K overlay constraints, explicit waiting/blocked playback copy, and component or screenshot coverage proving native media-only and YouTube-only Cast paths do not satisfy the required RiffSync stage-primary plus chat-overlay presentation.
 
 ### public-site-seo
-- Exact per-route **`<title>`** / meta description copy strings for each public route — defer to **`/refine-issue`**.
-- Whether the home **`sr-only`** H1 text is fully static or interpolates a dynamic catalog fact — static is the safer default absent a stated need.
-- Exact **`alt`** text template for catalog cards (**`{title}`** vs **`{title} poster`** vs including era).
+- No open decisions remain for M29 per-route head tags (#326). Normative copy is in the table above and **Decisions (M29 — per-route head tags — #326)** below.
+- Home **`sr-only`** H1 wording and catalog card **`alt`** template remain **M30 #327** scope.
+
+## Decisions (M29 — per-route head tags — #326)
+
+| Topic | Decision |
+| --- | --- |
+| **Static route copy** | Use the exact **`<title>`** and meta description strings in the *Public site head tags* table above for **`/`**, **`/catalog`**, **`/how-to-host-a-watchparty`**, **`/terms`**, and **`/privacy`**. |
+| **`/watch/:id` title** | **`{episode.title} — RiffSync`** using catalog **`title`** only (Invariant 9). Apply **`trimTabTitleSegment`** only when the composed string exceeds **70** characters for the HTML **`<title>`** element; OG/Twitter **`og:title`** / **`twitter:title`** use the untrimmed catalog title. |
+| **`/watch/:id` description** | When **`tagline`** is non-empty after trim: **`{tagline} — watch {episode.title} on RiffSync. Unofficial fan project with lawful YouTube embeds.`** Otherwise: **`Watch {episode.title} on RiffSync — fan watch parties with lawful YouTube embeds. Unofficial fan project.`** |
+| **`/watch/:id` OG image** | Prefer absolute **`posterImageUrl`**, then absolute **`backdropImageUrl`**, else **`{origin}/og-card.png`**. Do **not** use YouTube thumbnail URLs for OG/Twitter image tags. |
+| **OG/Twitter parity** | Each indexable route emits matching **`og:title`**, **`og:description`**, **`og:url`**, **`og:image`**, **`twitter:card=summary_large_image`**, **`twitter:title`**, **`twitter:description`**, and **`twitter:image`** alongside **`<title>`**, meta description, and canonical **`<link>`**. Reuse today's **`index.html`** **`og:site_name`**, **`og:type=website`**, **`og:locale`**, and **`og:image`** width/height/type tags on static routes. |
+| **Generic noindex shell** | Ephemeral/authenticated/receiver-only routes and the SPA fallback artifact use **`<title>RiffSync</title>`**, description **`RiffSync — fan watch parties with a curated MST3K-friendly catalog, shared viewing, and room chat. Unofficial fan project.`**, **`<meta name="robots" content="noindex">`**, and **no** canonical **`<link>`**. |
+| **Home H1 / catalog alt** | **Out of scope** — **M30 #327**. |
 
 ## Primary code pointers (optional)
 

--- a/.ai/operations/build_packaging.md
+++ b/.ai/operations/build_packaging.md
@@ -101,12 +101,28 @@ No hosted staging/dev SEO footprint — consistent with the prod-only environmen
 | **S3 cache-control** | In **`deploy-prod.yml`** SPA publish phase, after bulk **`aws s3 sync`**, re-upload **`robots.txt`** and **`sitemap.xml`** with **`Cache-Control: public, max-age=3600`** and correct **`Content-Type`** (**`text/plain`**, **`application/xml`**). These objects must **not** inherit any **`index.html`** no-cache/no-store policy. Full-path CloudFront invalidation (**`/*`**) on deploy still refreshes them immediately after catalog updates. |
 | **CI assertion** | **`web-app`** job (or **`npm run verify:seo-artifacts`** invoked from it) asserts both files exist post-build and sitemap **`<url>`** count equals **5 static routes + `catalogEntriesWithYoutubeLink(entries).length`**. |
 
+### Decisions (M29 — per-route head tags and prerender — #326)
+
+| Topic | Decision |
+| --- | --- |
+| **Tooling** | **Custom Node prerender step** inside **`apps/web` `npm run build`** — **not** a Vite prerender plugin and **not** a second build pipeline. Reuse the M28 pattern: pure TypeScript in **`apps/web/src/seo/`** plus a thin CLI under **`apps/web/scripts/`**. |
+| **Build order** | **`tsc -b && vite build && node scripts/generate-seo-artifacts.mjs && node scripts/prerender-indexable-routes.mjs`**. Prerender runs **after** Vite emits **`dist/`** so it can clone the built shell (hashed asset URLs intact). |
+| **Module layout** | **`apps/web/src/seo/indexableRoutes.ts`** — shared static path list. **`routeHeadTags.ts`** — pure head-tag builders per **`.ai/interface/presentation.md`**. **`buildPrerenderDocument.ts`** — inject head tags into the Vite-built HTML template. **`prerender-indexable-routes.mjs`** — load catalog, write artifacts, emit **`spa-shell.html`**. |
+| **Prerender outputs** | Overwrite **`dist/index.html`** with home head tags. Write **`dist/catalog/index.html`**, **`dist/how-to-host-a-watchparty/index.html`**, **`dist/terms/index.html`**, **`dist/privacy/index.html`**, and **`dist/watch/{catalogEpisodeId}/index.html`** for each episode passing **`episodeHasYoutubeLink`**. Write **`dist/spa-shell.html`** (generic **`noindex`** shell). |
+| **Body markup** | Prerendered files keep the same **`<div id="root">` + module script** SPA shell as today's Vite output — **no** visible layout change. Head tags (and existing watch-page **`sr-only` H1** in React after hydration) supply crawler/unfurler signal; M29 does **not** add prerendered visible body content beyond the shell. |
+| **Catalog source / filter** | Same as M28: committed **`data/catalog/episodes.json`**; **`episodeHasYoutubeLink`** only. Episodes without a YouTube link get **no** prerender object; direct **`/watch/{id}`** requests fall through to **`spa-shell.html`**. |
+| **Origin** | **`process.env.VITE_PUBLIC_ORIGIN`** when set at build, else **`https://riffsync.tv`**. |
+| **CloudFront SPA fallback** | Update **`infra/cdk/lib/static-site-stack.ts`** custom error responses (**403** / **404** → **`/spa-shell.html`**, **200**, **ttl 0**) so ephemeral deep links do not serve home canonical metadata from **`index.html`**. **No** new CloudFront Function or Lambda@Edge. |
+| **S3 cache-control** | Prerendered route HTML follows the same cache policy as the rest of the SPA static sync unless a future milestone pins per-route headers; full-path CloudFront invalidation on deploy refreshes prerender output after catalog updates. |
+| **CI assertion** | Extend **`npm run verify:seo-artifacts`** (or add **`verify:prerender`**) so **`web-app`** asserts: **`spa-shell.html`** exists with **`noindex`**; static indexable paths have **`index.html`** at the S3 keys above; watch prerender count equals **`catalogEntriesWithYoutubeLink(entries).length`**; sample files contain expected **`<title>`** / canonical for **`/`** and one known **`/watch/{id}`** fixture episode. |
+| **Unit tests** | **`apps/web/src/seo/routeHeadTags.test.ts`** covers all six static route shapes plus **`/watch/:id`** with and without **`tagline`** / poster art. |
+
 ## CI expectations
 
 | Job | Scope | Blocking |
 | --- | --- | --- |
 | **`infra-cdk`** | **`cdk synth`**, **`cfn-lint`** on **`cdk.out`** | PR |
-| **`web-app`** | **`apps/web`** **`npm run build`** + unit tests + lint (may use placeholder env in CI; production deploy reads live Cfn outputs). Build step must produce **`robots.txt`** and **`sitemap.xml`** (M28); missing catalog data or a sitemap count mismatch fails the build rather than shipping stale SEO artifacts. Prerendered HTML for indexable routes is M29 scope. | PR |
+| **`web-app`** | **`apps/web`** **`npm run build`** + unit tests + lint (may use placeholder env in CI; production deploy reads live Cfn outputs). Build step must produce **`robots.txt`** and **`sitemap.xml`** (M28) and prerendered HTML for each indexable route plus **`spa-shell.html`** (M29); missing catalog data, sitemap count mismatch, or missing prerender objects fails the build rather than shipping stale SEO artifacts. | PR |
 | **`realtime-conformance`** | Disposable SFU + TURN integration harness (see below) | **PR** when path filters match |
 
 Viewer-local Cast browser/unit tests live under the **`web-app`** job. Physical Google Cast discovery and receiver launch are manual smoke checks because CI cannot reliably emulate Cast devices.
@@ -293,6 +309,6 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 - No open decisions remain for sender availability build packaging. Production wiring uses a non-secret GitHub Actions variable exported as **`VITE_CAST_RECEIVER_APP_ID`** for the SPA build; the current pre-release UI additionally requires the existing room experimental feature opt-in; missing app id or disabled experimental opt-in hides or locally fails Cast and blocks release readiness, not unrelated room deploys; #301 web-app tests cover SDK loader, app id, **`CastContext.setOptions`**, availability UI, and no room-authority side effects, while #317 adds focused web coverage for the experimental exposure gate. Receiver route rendering tests belong to #303, and physical-device smoke evidence belongs to #306.
 
 ### public-site-seo
-- No open decisions remain for **`robots.txt`** / **`sitemap.xml`** generation (M28 — #325). Node build step in **`apps/web`**, catalog read from **`data/catalog/episodes.json`**, S3 **`max-age=3600`** cache-control on deploy — see *Decisions (M28 — robots.txt and sitemap.xml — #325)* above.
-- Exact prerender tooling choice (custom Node script rendering routes to static HTML vs a Vite prerender plugin) — must integrate with the existing single **`npm run build`**, not a second build pipeline (M29 scope).
-- Whether the Search Console / Bing verification DNS record is added to the existing Route 53 zone via CDK or documented as a manual operator step (**[`deployment_environments.md`](deployment_environments.md)**) (M31 scope).
+- No open decisions remain for **`robots.txt`** / **`sitemap.xml`** generation (M28 — #325). See *Decisions (M28 — robots.txt and sitemap.xml — #325)* above.
+- No open decisions remain for per-route head tags and build-time prerender (M29 — #326). See *Decisions (M29 — per-route head tags and prerender — #326)* above.
+- Whether the Search Console / Bing verification DNS record is added to the existing Route 53 zone via CDK or documented as a manual operator step (**[`deployment_environments.md`](deployment_environments.md)**) (M31 #328 scope).

--- a/.ai/specs/public-site-seo.spec.md
+++ b/.ai/specs/public-site-seo.spec.md
@@ -64,6 +64,21 @@ Search Console / Bing Webmaster verification uses a DNS TXT record on the existi
 
 Full detail: `.ai/operations/build_packaging.md` → *Decisions (M28 — robots.txt and sitemap.xml — #325)*.
 
+**M29 (per-route head tags + prerender — #326):**
+
+| Concern | Contract |
+| --- | --- |
+| **Module layout** | Shared **`indexableRoutes.ts`**, **`routeHeadTags.ts`**, **`buildPrerenderDocument.ts`** under **`apps/web/src/seo/`**; CLI **`apps/web/scripts/prerender-indexable-routes.mjs`**. |
+| **Build order** | Last step after M28 SEO artifact generation: **`… && node scripts/generate-seo-artifacts.mjs && node scripts/prerender-indexable-routes.mjs`**. |
+| **Head-tag copy** | Normative strings in **`.ai/interface/presentation.md`** → *Public site head tags* table and *Decisions (M29 — per-route head tags — #326)*. |
+| **Prerender paths** | **`dist/index.html`** (home), **`dist/{route}/index.html`** for static indexable paths, **`dist/watch/{catalogEpisodeId}/index.html`** per YouTube-linked episode, **`dist/spa-shell.html`** (generic **`noindex`** fallback). |
+| **SPA fallback** | **`static-site-stack.ts`** maps **403/404** to **`/spa-shell.html`** so **`/room/*`**, **`/lobby`**, and other non-prerendered paths do not inherit home canonical metadata. |
+| **Catalog / filter** | Same committed catalog file and **`episodeHasYoutubeLink`** filter as M28. |
+| **Origin** | **`VITE_PUBLIC_ORIGIN`** at build when set, else **`https://riffsync.tv`**. |
+| **CI** | **`web-app`** verifies prerender file count and spot-checks head tags on **`/`** plus a fixture **`/watch/{id}`**; unit tests cover **`routeHeadTags`** for all indexable route shapes. |
+
+Full detail: `.ai/operations/build_packaging.md` → *Decisions (M29 — per-route head tags and prerender — #326)*.
+
 **Canonical origin sourcing:** the same `public_domain` / `PUBLIC_WEB_ORIGIN` build-time value already used for `VITE_PUBLIC_ORIGIN` (`.ai/runtime/configuration.md`) is the single source for all absolute URLs this capability emits.
 
 **Canonical hostname redirect:** GitHub Actions repository variables (`PROD_FAN_WEB_HOSTNAME`, `PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES`, `PROD_FAN_WEB_CANONICAL_HOSTNAME`) and matching CDK context on `RiffSyncStatic-prod` (`infra/cdk/lib/static-site-stack.ts`) set apex `riffsync.tv` as canonical with `www.riffsync.tv` as an alternate. The existing `cloudfront-canonical-redirect.ts` CloudFront Function **301**-redirects any non-canonical custom alias (including `www.riffsync.tv`) to apex, preserving path and query. Change redirect status from **302** to **301** in `viewerRequestRedirectToCanonicalSource` as part of M27. No new CDK construct is required.
@@ -76,11 +91,11 @@ Full detail: `.ai/operations/build_packaging.md` → *Decisions (M28 — robots.
 
 ## Testing Strategy
 
-**Unit/component:** home `sr-only` H1 renders exactly once; catalog card `alt` text is non-empty; the per-route head-tag generator produces the expected title/description/canonical/OG for each indexable route, including `/watch/:id` cases with and without `tagline`/poster art.
+**Unit/component:** home `sr-only` H1 renders exactly once (M30); catalog card `alt` text is non-empty (M30); **`routeHeadTags`** produces expected title/description/canonical/OG/Twitter for each indexable route, including `/watch/:id` with and without `tagline`/poster art (M29).
 
 **Build/CI (M28):** the `web-app` CI job asserts `robots.txt` and `sitemap.xml` exist after `npm run build`; sitemap `<url>` count equals 5 static indexable routes plus the count of catalog episodes passing `episodeHasYoutubeLink`; the build fails when catalog data is unavailable or counts mismatch.
 
-**Build/CI (M29):** prerendered HTML exists for each indexable route (separate milestone).
+**Build/CI (M29):** after `npm run build`, `web-app` (via `verify:seo-artifacts` or dedicated verify script) asserts `spa-shell.html` contains `noindex`; prerendered `index.html` exists for `/`, `/catalog`, `/how-to-host-a-watchparty`, `/terms`, `/privacy`; `watch/{id}/index.html` count matches YouTube-linked catalog episodes; spot checks validate apex canonical on `/` and episode title/canonical on a fixture watch route.
 
 **Manual/smoke (post-deploy, production only):** apex canonical reachable; `www` → apex redirect returns **301** to the matching apex path and query; `robots.txt`/`sitemap.xml` return 200 (M28+); the canonical `<link>` on `/` matches apex `https://riffsync.tv/`; `curl -sI https://www.riffsync.tv/lobby` shows `location: https://riffsync.tv/lobby`; shipped `index.html` contains no `www.riffsync.tv` absolute URLs. Search Console DNS verification confirmed (M31). Peer prior art for the smoke-check shape: `control9/control9-www`'s `smoke-production.mjs` (reference only — riffsync's static-hosting shape differs enough that it is not a template to copy wholesale).
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #326
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.