### PR TITLE
[M27] Canonical apex hostname alignment (config, CDK, www redirect)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,18 +12,18 @@
       name="description"
       content="RiffSync — fan watch parties with a curated MST3K-friendly catalog, shared viewing, and room chat. Unofficial fan project."
     />
-    <link rel="canonical" href="https://www.riffsync.tv/" />
+    <link rel="canonical" href="https://riffsync.tv/" />
 
     <!-- Open Graph (Slack, Discord, iMessage, Facebook, LinkedIn, etc.) -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="RiffSync" />
-    <meta property="og:url" content="https://www.riffsync.tv/" />
+    <meta property="og:url" content="https://riffsync.tv/" />
     <meta property="og:title" content="RiffSync — watch parties" />
     <meta
       property="og:description"
       content="Fan watch parties with a curated catalog, shared viewing, and room chat. Unofficial fan project."
     />
-    <meta property="og:image" content="https://www.riffsync.tv/og-card.png" />
+    <meta property="og:image" content="https://riffsync.tv/og-card.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -36,7 +36,7 @@
       name="twitter:description"
       content="Fan watch parties with a curated catalog, shared viewing, and room chat."
     />
-    <meta name="twitter:image" content="https://www.riffsync.tv/og-card.png" />
+    <meta name="twitter:image" content="https://riffsync.tv/og-card.png" />
 
     <link rel="stylesheet" href="/design/css/bootstrap.min.css" />
     <link rel="stylesheet" href="/design/css/style.css" />

--- a/apps/web/src/config/publicSiteShell.test.ts
+++ b/apps/web/src/config/publicSiteShell.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const indexHtmlPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../index.html')
+
+describe('public site shell (index.html)', () => {
+  it('uses apex riffsync.tv and never www.riffsync.tv in absolute URLs', () => {
+    const html = readFileSync(indexHtmlPath, 'utf8')
+    expect(html).not.toMatch(/www\.riffsync\.tv/)
+    expect(html).toMatch(/https:\/\/riffsync\.tv\//)
+    expect(html).toMatch(/https:\/\/riffsync\.tv\/og-card\.png/)
+  })
+})

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -96,22 +96,22 @@ JSON response shapes: **`docs/api.catalog.md`**.
 
 ### Extra SPA hostname (e.g. `www`)
 
-**Typical pattern (same as most public sites):** one **CloudFront** distribution with **two (or more) alternate domain names** on the **same ACM certificate**, and **Route 53 alias A (and AAAA) records** for each name pointing at that distribution. Optional: a **viewer-request CloudFront Function** returns **302** from non-canonical hosts (e.g. apex → `www`) so bookmarks and links consolidate on one hostname; this repo uses optional CDK context **`fanWebCanonicalHostname`** for that redirect.
+**Typical pattern (same as most public sites):** one **CloudFront** distribution with **two (or more) alternate domain names** on the **same ACM certificate**, and **Route 53 alias A (and AAAA) records** for each name pointing at that distribution. Optional: a **viewer-request CloudFront Function** returns **301** from non-canonical hosts (e.g. `www` → apex) so bookmarks and links consolidate on one hostname; this repo uses optional CDK context **`fanWebCanonicalHostname`** for that redirect.
 
 **You must list both names** in CDK: **`fanWebCustomDomain`** is always set to one hostname, and **`fanWebAlternateDomainNames`** lists the rest (comma-separated). CDK merges them for CloudFront **and** creates **one Route 53 record per name** when **`RIFFSYNC_ROUTE53_*`** is set.
 
-**Production (apex + `www`, canonical `www`, apex 302 → `www`):**
+**Production (apex + `www`, canonical apex, `www` 301 → apex):**
 
 | GitHub Actions variable | Example value |
 | --- | --- |
-| **`PROD_FAN_WEB_HOSTNAME`** | **`www.riffsync.tv`** |
-| **`PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES`** | **`riffsync.tv`** |
-| **`PROD_FAN_WEB_CANONICAL_HOSTNAME`** | **`www.riffsync.tv`** |
+| **`PROD_FAN_WEB_HOSTNAME`** | **`riffsync.tv`** |
+| **`PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES`** | **`www.riffsync.tv`** |
+| **`PROD_FAN_WEB_CANONICAL_HOSTNAME`** | **`riffsync.tv`** |
 
 Same **`us-east-1`** ACM cert must include **both** DNS names. **`FanWebSiteUrl`** (and CI **`VITE_PUBLIC_ORIGIN`**) follow **`PROD_FAN_WEB_CANONICAL_HOSTNAME`** when set, otherwise **`PROD_FAN_WEB_HOSTNAME`**.
 
 **Local / CLI:**  
-`--context fanWebAlternateDomainNames=riffsync.tv --context fanWebCanonicalHostname=www.riffsync.tv` (with **`fanWebCustomDomain=www.riffsync.tv`**).
+`--context fanWebAlternateDomainNames=www.riffsync.tv --context fanWebCanonicalHostname=riffsync.tv` (with **`fanWebCustomDomain=riffsync.tv`**).
 
 CORS and Cognito callback allowlists include prod **`https` origins**, **localhost** dev URLs, and **`fanWebAlternateDomainNames`** from context.
 
@@ -471,8 +471,8 @@ Prefer **OIDC federation** (**GitHub → AWS**) over long-lived access keys (**`
 | --- | --- |
 | **`PROD_FAN_WEB_HOSTNAME`** | e.g. **`riffsync.tv`** or **`www.riffsync.tv`** (production deploy workflow) |
 | **`PROD_FAN_WEB_CERTIFICATE_ARN`** | **`us-east-1`** ACM ARN covering production hostname(s) |
-| **`PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES`** | Optional; comma-separated extra hostnames on the **same** cert (e.g. apex **`riffsync.tv`** when **`PROD_FAN_WEB_HOSTNAME`** is **`www.riffsync.tv`**) — CloudFront aliases, Route 53 A, CORS, Cognito URLs |
-| **`PROD_FAN_WEB_CANONICAL_HOSTNAME`** | Optional; when set (e.g. **`www.riffsync.tv`**), CloudFront **302** from any **other** custom alias to this host (**`FanWebSiteUrl`** / **`VITE_PUBLIC_ORIGIN`** use this too) |
+| **`PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES`** | Optional; comma-separated extra hostnames on the **same** cert (e.g. **`www.riffsync.tv`** when **`PROD_FAN_WEB_HOSTNAME`** is apex **`riffsync.tv`**) — CloudFront aliases, Route 53 A, CORS, Cognito URLs |
+| **`PROD_FAN_WEB_CANONICAL_HOSTNAME`** | Optional; when set (e.g. apex **`riffsync.tv`**), CloudFront **301** from any **other** custom alias to this host (**`FanWebSiteUrl`** / **`VITE_PUBLIC_ORIGIN`** use this too) |
 | **`RIFFSYNC_ROUTE53_HOSTED_ZONE_ID`** | Public hosted zone for **`RIFFSYNC_ROUTE53_ZONE_NAME`** (optional) |
 | **`RIFFSYNC_ROUTE53_ZONE_NAME`** | e.g. **`riffsync.tv`** — with zone id; CDK creates Route 53 alias **A** records for **`fanWebCustomDomain`** and each **`fanWebAlternateDomainNames`** host |
 | **`PROD_TURN_HOST`** | Public **`turn:`** hostname or IP for coturn. See **Self-hosted TURN** — omit until EC2 + secret are ready. |
@@ -494,12 +494,12 @@ Local deploy with custom hostname:
 
 ```bash
 npx cdk deploy --all --context environment=prod \
-  --context fanWebCustomDomain=www.riffsync.tv \
+  --context fanWebCustomDomain=riffsync.tv \
   --context fanWebCertificateArn=arn:aws:acm:us-east-1:ACCOUNT:certificate/UUID \
   --context fanWebHostedZoneId=Z0123456789ABCDEFGHIJ \
   --context fanWebZoneName=riffsync.tv
-# Optional apex on the same ACM cert (see README § Extra SPA hostname):
-#   --context fanWebAlternateDomainNames=riffsync.tv --context fanWebCanonicalHostname=www.riffsync.tv
+# Optional www on the same ACM cert (see README § Extra SPA hostname):
+#   --context fanWebAlternateDomainNames=www.riffsync.tv --context fanWebCanonicalHostname=riffsync.tv
 ```
 
 IAM trust policy (**sketch**) for each role (`sts:AssumeRoleWithWebIdentity`):

--- a/infra/cdk/lib/cloudfront-canonical-redirect.test.ts
+++ b/infra/cdk/lib/cloudfront-canonical-redirect.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { viewerRequestRedirectToCanonicalSource } from './cloudfront-canonical-redirect'
+
+describe('viewerRequestRedirectToCanonicalSource', () => {
+  it('returns 301 Moved Permanently for non-canonical hosts', () => {
+    const source = viewerRequestRedirectToCanonicalSource('riffsync.tv')
+    expect(source).toContain('statusCode: 301')
+    expect(source).toContain("statusDescription: 'Moved Permanently'")
+    expect(source).not.toContain('statusCode: 302')
+  })
+})

--- a/infra/cdk/lib/cloudfront-canonical-redirect.ts
+++ b/infra/cdk/lib/cloudfront-canonical-redirect.ts
@@ -1,5 +1,5 @@
 /**
- * Viewer-request function: send browsers to the canonical hostname (302) while
+ * Viewer-request function: send browsers to the canonical hostname (301) while
  * leaving `*.cloudfront.net` and the canonical host unchanged.
  */
 export function viewerRequestRedirectToCanonicalSource(canonicalHost: string): string {
@@ -33,8 +33,8 @@ export function viewerRequestRedirectToCanonicalSource(canonicalHost: string): s
     if (parts.length) tail = '?' + parts.join('&');
   }
   return {
-    statusCode: 302,
-    statusDescription: 'Found',
+    statusCode: 301,
+    statusDescription: 'Moved Permanently',
     headers: { location: { value: 'https://' + canonical + uri + tail } }
   };
 }

--- a/infra/cdk/lib/static-site-stack.ts
+++ b/infra/cdk/lib/static-site-stack.ts
@@ -34,7 +34,7 @@ export interface StaticSiteStackProps extends cdk.StackProps {
    */
   readonly fanWebAlternateDomainNames?: string[];
   /**
-   * If set (e.g. `www.riffsync.tv`), CloudFront returns **302** for any other custom alias so the browser
+   * If set (e.g. `riffsync.tv`), CloudFront returns **301** for any other custom alias so the browser
    * lands on this host (path + query preserved). Must be one of **fanWebCustomDomain** + **fanWebAlternateDomainNames**.
    * Leave unset for no host-based redirects.
    */


### PR DESCRIPTION
## Summary

- Switch `apps/web/index.html` canonical, Open Graph, and Twitter absolute URLs from `www.riffsync.tv` to apex `https://riffsync.tv`.
- Change the CloudFront canonical redirect function from **302** to **301** (`Moved Permanently`) for non-canonical hosts such as `www`.
- Update `infra/cdk/README.md` to document the apex-canonical GitHub Actions variable pattern (`PROD_FAN_WEB_HOSTNAME=riffsync.tv`, `PROD_FAN_WEB_ALTERNATE_DOMAIN_NAMES=www.riffsync.tv`, `PROD_FAN_WEB_CANONICAL_HOSTNAME=riffsync.tv`).
- Add CI guards: `publicSiteShell.test.ts` (no `www` in `index.html`) and `cloudfront-canonical-redirect.test.ts` (301 status).

Closes #324

## Operator follow-up (post-merge)

After merge, update GitHub Actions repository variables to the apex-canonical values above and run `deploy-prod.yml` so CDK context, OAuth/CORS refresh, and `VITE_PUBLIC_ORIGIN` bake apex into production.

## Test plan

- [x] `npm run verify:push:web` passes
- [x] `cd apps/web && npm run lint && npm run build`
- [x] `cd infra/cdk && npm test` (includes new redirect + shell guard tests)
- [ ] Post-deploy: `curl -sI https://www.riffsync.tv/lobby?x=1` returns **301** with `Location: https://riffsync.tv/lobby?x=1`
- [ ] Post-deploy: shipped `index.html` contains no `www.riffsync.tv` absolute URLs