### PR TITLE
[M28] Build-time robots.txt and sitemap.xml generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,6 @@ jobs:
           cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
       - run: npm run build
+      - run: npm run verify:seo-artifacts
       - run: npm test
       - run: npm run lint

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -305,4 +305,10 @@ jobs:
           DIST="$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
             --query "Stacks[0].Outputs[?OutputKey=='DistributionId'].OutputValue" --output text)"
           aws s3 sync ./dist/ "s3://${BUCKET}/" --delete
+          aws s3 cp ./dist/robots.txt "s3://${BUCKET}/robots.txt" \
+            --cache-control "public, max-age=3600" \
+            --content-type "text/plain"
+          aws s3 cp ./dist/sitemap.xml "s3://${BUCKET}/sitemap.xml" \
+            --cache-control "public, max-age=3600" \
+            --content-type "application/xml"
           aws cloudfront create-invalidation --distribution-id "$DIST" --paths "/*"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && vite-node scripts/generate-seo-artifacts.mjs",
+    "verify:seo-artifacts": "vite-node scripts/verify-seo-artifacts.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/web/scripts/generate-seo-artifacts.mjs
+++ b/apps/web/scripts/generate-seo-artifacts.mjs
@@ -1,0 +1,62 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  buildRobotsTxt,
+  buildSitemapXml,
+  resolveCanonicalOrigin,
+} from '../src/seo/generateSeoArtifacts.ts'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '../..')
+const catalogPath = resolve(repoRoot, 'data/catalog/episodes.json')
+const distDir = resolve(webRoot, 'dist')
+
+async function loadCatalogEntries() {
+  let raw
+  try {
+    raw = await readFile(catalogPath, 'utf8')
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Catalog file missing: ${catalogPath}`)
+    }
+    throw error
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error(`Catalog file is not valid JSON: ${catalogPath}`)
+  }
+
+  const entries = parsed?.entries
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`Catalog entries missing or empty in ${catalogPath}`)
+  }
+
+  return entries
+}
+
+async function main() {
+  const origin = resolveCanonicalOrigin(process.env.VITE_PUBLIC_ORIGIN)
+  const episodes = await loadCatalogEntries()
+
+  const robotsTxt = buildRobotsTxt(origin)
+  const sitemapXml = buildSitemapXml(origin, episodes)
+
+  await mkdir(distDir, { recursive: true })
+  const robotsPath = resolve(distDir, 'robots.txt')
+  const sitemapPath = resolve(distDir, 'sitemap.xml')
+  await writeFile(robotsPath, robotsTxt, 'utf8')
+  await writeFile(sitemapPath, sitemapXml, 'utf8')
+
+  console.log(`Wrote ${robotsPath}`)
+  console.log(`Wrote ${sitemapPath}`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/web/scripts/verify-seo-artifacts.mjs
+++ b/apps/web/scripts/verify-seo-artifacts.mjs
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { countSitemapUrls } from '../src/seo/generateSeoArtifacts.ts'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '../..')
+const catalogPath = resolve(repoRoot, 'data/catalog/episodes.json')
+const distDir = resolve(webRoot, 'dist')
+
+async function loadCatalogEntries() {
+  const raw = await readFile(catalogPath, 'utf8')
+  const parsed = JSON.parse(raw)
+  const entries = parsed?.entries
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`Catalog entries missing or empty in ${catalogPath}`)
+  }
+  return entries
+}
+
+function countUrlTags(xml) {
+  const matches = xml.match(/<url>/g)
+  return matches ? matches.length : 0
+}
+
+async function main() {
+  const robotsPath = resolve(distDir, 'robots.txt')
+  const sitemapPath = resolve(distDir, 'sitemap.xml')
+
+  const [robotsTxt, sitemapXml, episodes] = await Promise.all([
+    readFile(robotsPath, 'utf8'),
+    readFile(sitemapPath, 'utf8'),
+    loadCatalogEntries(),
+  ])
+
+  if (!robotsTxt.includes('Sitemap:')) {
+    throw new Error('robots.txt is missing a Sitemap directive')
+  }
+
+  const expectedUrlCount = countSitemapUrls(episodes)
+  const actualUrlCount = countUrlTags(sitemapXml)
+  if (actualUrlCount !== expectedUrlCount) {
+    throw new Error(
+      `sitemap.xml has ${actualUrlCount} <url> entries; expected ${expectedUrlCount}`,
+    )
+  }
+
+  console.log(`SEO artifacts verified (${actualUrlCount} sitemap URLs).`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/web/src/seo/generateSeoArtifacts.test.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import {
+  DEFAULT_PUBLIC_ORIGIN,
+  ROBOTS_DISALLOW_PATHS,
+  STATIC_SITEMAP_PATHS,
+  absoluteUrl,
+  buildRobotsTxt,
+  buildSitemapXml,
+  countSitemapUrls,
+  resolveCanonicalOrigin,
+} from './generateSeoArtifacts'
+
+function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>): CatalogEpisode {
+  return {
+    experimentNumber: 101,
+    title: 'Fixture',
+    era: 'joel',
+    youtubeVideoId: 'abc123',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc123',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    ...overrides,
+  }
+}
+
+describe('resolveCanonicalOrigin', () => {
+  it('uses VITE_PUBLIC_ORIGIN when set', () => {
+    expect(resolveCanonicalOrigin('https://staging.example.com/')).toBe('https://staging.example.com')
+  })
+
+  it('falls back to apex production origin', () => {
+    expect(resolveCanonicalOrigin(undefined)).toBe(DEFAULT_PUBLIC_ORIGIN)
+    expect(resolveCanonicalOrigin('   ')).toBe(DEFAULT_PUBLIC_ORIGIN)
+  })
+})
+
+describe('buildRobotsTxt', () => {
+  it('disallows ephemeral and authenticated paths and publishes the sitemap line', () => {
+    const robots = buildRobotsTxt('https://riffsync.tv')
+    expect(robots).toMatch(/^User-agent: \*\n/)
+    for (const path of ROBOTS_DISALLOW_PATHS) {
+      expect(robots).toContain(`Disallow: ${path}`)
+    }
+    expect(robots).toContain('Sitemap: https://riffsync.tv/sitemap.xml')
+  })
+
+  it('uses the resolved canonical origin for the sitemap line', () => {
+    const robots = buildRobotsTxt('https://preview.riffsync.tv')
+    expect(robots).toContain('Sitemap: https://preview.riffsync.tv/sitemap.xml')
+  })
+})
+
+describe('buildSitemapXml', () => {
+  const entries = [
+    episode({ id: '101-the-crawling-eye' }),
+    episode({ id: 'no-youtube', youtubeVideoId: null, youtubeWatchUrl: null }),
+    episode({ id: 'blank-youtube', youtubeVideoId: '   ' }),
+  ]
+
+  it('includes static routes and only YouTube-linked watch URLs', () => {
+    const xml = buildSitemapXml('https://riffsync.tv', entries)
+    for (const path of STATIC_SITEMAP_PATHS) {
+      expect(xml).toContain(`<loc>${absoluteUrl('https://riffsync.tv', path)}</loc>`)
+    }
+    expect(xml).toContain('<loc>https://riffsync.tv/watch/101-the-crawling-eye</loc>')
+    expect(xml).not.toContain('/watch/no-youtube')
+    expect(xml).not.toContain('/watch/blank-youtube')
+  })
+
+  it('escapes XML entities in loc values', () => {
+    const xml = buildSitemapXml('https://riffsync.tv', [
+      episode({ id: 'episode-with-"quotes"' }),
+    ])
+    expect(xml).toContain('<loc>https://riffsync.tv/watch/episode-with-&quot;quotes&quot;</loc>')
+  })
+})
+
+describe('countSitemapUrls', () => {
+  it('counts static routes plus YouTube-linked episodes', () => {
+    const entries = [
+      episode({ id: 'linked-a' }),
+      episode({ id: 'linked-b' }),
+      episode({ id: 'missing', youtubeVideoId: null, youtubeWatchUrl: null }),
+    ]
+    expect(countSitemapUrls(entries)).toBe(STATIC_SITEMAP_PATHS.length + 2)
+  })
+})

--- a/apps/web/src/seo/generateSeoArtifacts.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.ts
@@ -1,0 +1,79 @@
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
+
+export const DEFAULT_PUBLIC_ORIGIN = 'https://riffsync.tv'
+
+export const ROBOTS_DISALLOW_PATHS = [
+  '/room/',
+  '/lobby',
+  '/account',
+  '/admin/',
+  '/cast/receiver',
+  '/privacy/data-removal',
+  '/auth/callback',
+  '/admin/auth/callback',
+] as const
+
+export const STATIC_SITEMAP_PATHS = [
+  '/',
+  '/catalog',
+  '/how-to-host-a-watchparty',
+  '/terms',
+  '/privacy',
+] as const
+
+/** Canonical origin for absolute SEO URLs at build time. */
+export function resolveCanonicalOrigin(envOrigin: string | undefined): string {
+  const trimmed = envOrigin?.trim()
+  if (trimmed && trimmed.length > 0) {
+    return trimmed.replace(/\/$/, '')
+  }
+  return DEFAULT_PUBLIC_ORIGIN
+}
+
+export function absoluteUrl(origin: string, path: string): string {
+  const normalizedOrigin = origin.replace(/\/$/, '')
+  if (path === '/') {
+    return `${normalizedOrigin}/`
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedOrigin}${normalizedPath}`
+}
+
+export function buildRobotsTxt(origin: string): string {
+  const lines = ['User-agent: *', ...ROBOTS_DISALLOW_PATHS.map((path) => `Disallow: ${path}`)]
+  lines.push(`Sitemap: ${absoluteUrl(origin, '/sitemap.xml')}`)
+  return `${lines.join('\n')}\n`
+}
+
+export function buildSitemapXml(origin: string, episodes: CatalogEpisode[]): string {
+  const locs: string[] = STATIC_SITEMAP_PATHS.map((path) => absoluteUrl(origin, path))
+  for (const episode of catalogEntriesWithYoutubeLink(episodes)) {
+    locs.push(absoluteUrl(origin, `/watch/${episode.id}`))
+  }
+
+  const urlEntries = locs
+    .map((loc) => `  <url>\n    <loc>${escapeXml(loc)}</loc>\n  </url>`)
+    .join('\n')
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urlEntries,
+    '</urlset>',
+    '',
+  ].join('\n')
+}
+
+export function countSitemapUrls(episodes: CatalogEpisode[]): number {
+  return STATIC_SITEMAP_PATHS.length + catalogEntriesWithYoutubeLink(episodes).length
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}


### PR DESCRIPTION
## Summary

- Add `generateSeoArtifacts.ts` with pure builders for `robots.txt` and `sitemap.xml` sourced from committed `data/catalog/episodes.json` and the existing `episodeHasYoutubeLink` filter.
- Wire `apps/web` build to emit both artifacts into `dist/` after Vite, with `verify:seo-artifacts` guarding sitemap URL counts in CI.
- Re-upload `robots.txt` and `sitemap.xml` in `deploy-prod.yml` with `Cache-Control: public, max-age=3600` and correct content types.

Closes #325

## Test plan

- [x] `cd apps/web && npm run build` writes `dist/robots.txt` and `dist/sitemap.xml`
- [x] `npm run verify:seo-artifacts` passes (140 sitemap URLs = 5 static + YouTube-linked episodes)
- [x] `npm test -- src/seo/generateSeoArtifacts.test.ts` passes
- [x] `npm run verify:push:web` passes from repo root
- [ ] Post-deploy smoke: `curl -sI https://riffsync.tv/robots.txt` and `https://riffsync.tv/sitemap.xml` return 200 (M31)