### PR TITLE
[M29] Per-route head tags and build-time prerender

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build && vite-node scripts/generate-seo-artifacts.mjs",
+    "build": "tsc -b && vite build && vite-node scripts/generate-seo-artifacts.mjs && vite-node scripts/prerender-indexable-routes.mjs",
     "verify:seo-artifacts": "vite-node scripts/verify-seo-artifacts.mjs",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/apps/web/scripts/prerender-indexable-routes.mjs
+++ b/apps/web/scripts/prerender-indexable-routes.mjs
@@ -1,0 +1,83 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildPrerenderDocument } from '../src/seo/buildPrerenderDocument.ts'
+import { STATIC_INDEXABLE_ROUTES, staticRouteDistPath } from '../src/seo/indexableRoutes.ts'
+import { catalogEntriesWithYoutubeLink } from '../src/catalog/mockCatalog.ts'
+import {
+  buildSpaShellHeadTags,
+  buildStaticRouteHeadTags,
+  buildWatchRouteHeadTags,
+  resolveSeoOrigin,
+} from '../src/seo/routeHeadTags.ts'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(webRoot, '../..')
+const catalogPath = resolve(repoRoot, 'data/catalog/episodes.json')
+const distDir = resolve(webRoot, 'dist')
+
+async function loadCatalogEntries() {
+  let raw
+  try {
+    raw = await readFile(catalogPath, 'utf8')
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Catalog file missing: ${catalogPath}`)
+    }
+    throw error
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error(`Catalog file is not valid JSON: ${catalogPath}`)
+  }
+
+  const entries = parsed?.entries
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`Catalog entries missing or empty in ${catalogPath}`)
+  }
+
+  return entries
+}
+
+async function writePrerenderedHtml(relativePath, html) {
+  const outputPath = resolve(distDir, relativePath)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, html, 'utf8')
+  console.log(`Wrote ${outputPath}`)
+}
+
+async function main() {
+  const origin = resolveSeoOrigin(process.env.VITE_PUBLIC_ORIGIN)
+  const templatePath = resolve(distDir, 'index.html')
+  const templateHtml = await readFile(templatePath, 'utf8')
+  const episodes = await loadCatalogEntries()
+  const youtubeLinked = catalogEntriesWithYoutubeLink(episodes)
+
+  for (const route of STATIC_INDEXABLE_ROUTES) {
+    const head = buildStaticRouteHeadTags(route, origin)
+    const html = buildPrerenderDocument(templateHtml, head)
+    await writePrerenderedHtml(staticRouteDistPath(route), html)
+  }
+
+  for (const episode of youtubeLinked) {
+    const head = buildWatchRouteHeadTags(episode, origin)
+    const html = buildPrerenderDocument(templateHtml, head)
+    await writePrerenderedHtml(`watch/${episode.id}/index.html`, html)
+  }
+
+  const spaShell = buildPrerenderDocument(templateHtml, buildSpaShellHeadTags())
+  await writePrerenderedHtml('spa-shell.html', spaShell)
+
+  console.log(
+    `Prerendered ${STATIC_INDEXABLE_ROUTES.length} static routes, ${youtubeLinked.length} watch pages, and spa-shell.html`,
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/web/scripts/verify-seo-artifacts.mjs
+++ b/apps/web/scripts/verify-seo-artifacts.mjs
@@ -1,13 +1,17 @@
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { catalogEntriesWithYoutubeLink } from '../src/catalog/mockCatalog.ts'
 import { countSitemapUrls } from '../src/seo/generateSeoArtifacts.ts'
+import { STATIC_INDEXABLE_ROUTES, staticRouteDistPath } from '../src/seo/indexableRoutes.ts'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const webRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(webRoot, '../..')
 const catalogPath = resolve(repoRoot, 'data/catalog/episodes.json')
 const distDir = resolve(webRoot, 'dist')
+
+const WATCH_FIXTURE_ID = '101-the-crawling-eye'
 
 async function loadCatalogEntries() {
   const raw = await readFile(catalogPath, 'utf8')
@@ -24,9 +28,17 @@ function countUrlTags(xml) {
   return matches ? matches.length : 0
 }
 
+async function assertFileContains(relativePath, needle) {
+  const content = await readFile(resolve(distDir, relativePath), 'utf8')
+  if (!content.includes(needle)) {
+    throw new Error(`${relativePath} is missing expected content: ${needle}`)
+  }
+}
+
 async function main() {
   const robotsPath = resolve(distDir, 'robots.txt')
   const sitemapPath = resolve(distDir, 'sitemap.xml')
+  const spaShellPath = resolve(distDir, 'spa-shell.html')
 
   const [robotsTxt, sitemapXml, episodes] = await Promise.all([
     readFile(robotsPath, 'utf8'),
@@ -46,7 +58,52 @@ async function main() {
     )
   }
 
-  console.log(`SEO artifacts verified (${actualUrlCount} sitemap URLs).`)
+  const spaShell = await readFile(spaShellPath, 'utf8')
+  if (!spaShell.includes('noindex')) {
+    throw new Error('spa-shell.html is missing noindex robots meta')
+  }
+
+  for (const route of STATIC_INDEXABLE_ROUTES) {
+    const relativePath = staticRouteDistPath(route)
+    try {
+      await readFile(resolve(distDir, relativePath), 'utf8')
+    } catch {
+      throw new Error(`Missing prerendered file: dist/${relativePath}`)
+    }
+  }
+
+  const youtubeLinked = catalogEntriesWithYoutubeLink(episodes)
+  let watchPrerenderCount = 0
+  for (const episode of youtubeLinked) {
+    const watchPath = `watch/${episode.id}/index.html`
+    try {
+      await readFile(resolve(distDir, watchPath), 'utf8')
+      watchPrerenderCount += 1
+    } catch {
+      throw new Error(`Missing prerendered watch page: dist/${watchPath}`)
+    }
+  }
+
+  if (watchPrerenderCount !== youtubeLinked.length) {
+    throw new Error(
+      `Expected ${youtubeLinked.length} watch prerender files; found ${watchPrerenderCount}`,
+    )
+  }
+
+  await assertFileContains('index.html', '<title>RiffSync — watch parties</title>')
+  await assertFileContains('index.html', 'rel="canonical" href="https://riffsync.tv/"')
+  await assertFileContains(
+    `watch/${WATCH_FIXTURE_ID}/index.html`,
+    'The Crawling Eye — RiffSync',
+  )
+  await assertFileContains(
+    `watch/${WATCH_FIXTURE_ID}/index.html`,
+    `rel="canonical" href="https://riffsync.tv/watch/${WATCH_FIXTURE_ID}"`,
+  )
+
+  console.log(
+    `SEO artifacts verified (${actualUrlCount} sitemap URLs, ${watchPrerenderCount} watch prerenders).`,
+  )
 }
 
 main().catch((error) => {

--- a/apps/web/src/seo/buildPrerenderDocument.ts
+++ b/apps/web/src/seo/buildPrerenderDocument.ts
@@ -1,0 +1,98 @@
+import type { RouteHeadTags } from './routeHeadTags'
+
+function escapeHtmlText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+}
+
+function replaceTitle(html: string, title: string): string {
+  return html.replace(/<title>[^<]*<\/title>/, `<title>${escapeHtmlText(title)}</title>`)
+}
+
+function replaceMetaDescription(html: string, description: string): string {
+  const meta = `<meta\n      name="description"\n      content="${escapeHtmlAttribute(description)}"\n    />`
+  if (/<meta\s+name="description"[\s\S]*?\/>/.test(html)) {
+    return html.replace(/<meta\s+name="description"[\s\S]*?\/>/, meta)
+  }
+  return html.replace('</title>', `</title>\n    ${meta}`)
+}
+
+function replaceCanonicalLink(html: string, canonicalUrl: string | null): string {
+  if (canonicalUrl == null) {
+    return html.replace(/\s*<link rel="canonical"[^>]*>\s*/g, '\n')
+  }
+  const link = `<link rel="canonical" href="${escapeHtmlAttribute(canonicalUrl)}" />`
+  if (/<link rel="canonical"[^>]*>/.test(html)) {
+    return html.replace(/<link rel="canonical"[^>]*>/, link)
+  }
+  return html.replace(
+    /<meta\s+name="description"[\s\S]*?\/>/,
+    (match) => `${match}\n    ${link}`,
+  )
+}
+
+function replaceRobotsMeta(html: string, noindex: boolean): string {
+  const withoutRobots = html.replace(/\s*<meta name="robots" content="noindex"[^>]*>\s*/g, '\n')
+  if (!noindex) {
+    return withoutRobots
+  }
+  return withoutRobots.replace(
+    /<meta\s+name="description"[\s\S]*?\/>/,
+    (match) => `${match}\n    <meta name="robots" content="noindex" />`,
+  )
+}
+
+function replaceMetaProperty(html: string, property: string, content: string): string {
+  const escaped = escapeHtmlAttribute(content)
+  const pattern = new RegExp(
+    `<meta property="${property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" content="[^"]*" />`,
+  )
+  const replacement = `<meta property="${property}" content="${escaped}" />`
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement)
+  }
+  return html
+}
+
+function replaceMetaName(html: string, name: string, content: string): string {
+  const escaped = escapeHtmlAttribute(content)
+  const pattern = new RegExp(
+    `<meta name="${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" content="[^"]*" />`,
+  )
+  const replacement = `<meta name="${name}" content="${escaped}" />`
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement)
+  }
+  return html
+}
+
+/** Inject per-route head tags into the Vite HTML shell without changing body markup. */
+export function buildPrerenderDocument(templateHtml: string, head: RouteHeadTags): string {
+  let html = templateHtml
+  html = replaceTitle(html, head.documentTitle)
+  html = replaceMetaDescription(html, head.description)
+  html = replaceCanonicalLink(html, head.canonicalUrl)
+  html = replaceRobotsMeta(html, head.robotsNoindex)
+
+  const ogUrl = head.canonicalUrl ?? ''
+  html = replaceMetaProperty(html, 'og:title', head.ogTitle)
+  html = replaceMetaProperty(html, 'og:description', head.description)
+  if (ogUrl) {
+    html = replaceMetaProperty(html, 'og:url', ogUrl)
+  }
+  html = replaceMetaProperty(html, 'og:image', head.ogImageUrl)
+
+  html = replaceMetaName(html, 'twitter:title', head.ogTitle)
+  html = replaceMetaName(html, 'twitter:description', head.description)
+  html = replaceMetaName(html, 'twitter:image', head.ogImageUrl)
+
+  return html
+}

--- a/apps/web/src/seo/generateSeoArtifacts.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.ts
@@ -1,5 +1,6 @@
 import type { CatalogEpisode } from '../catalog/catalogTypes'
 import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
+import { STATIC_INDEXABLE_ROUTES } from './indexableRoutes'
 
 export const DEFAULT_PUBLIC_ORIGIN = 'https://riffsync.tv'
 
@@ -14,13 +15,8 @@ export const ROBOTS_DISALLOW_PATHS = [
   '/admin/auth/callback',
 ] as const
 
-export const STATIC_SITEMAP_PATHS = [
-  '/',
-  '/catalog',
-  '/how-to-host-a-watchparty',
-  '/terms',
-  '/privacy',
-] as const
+/** @deprecated Import `STATIC_INDEXABLE_ROUTES` from `indexableRoutes.ts` for new code. */
+export const STATIC_SITEMAP_PATHS = STATIC_INDEXABLE_ROUTES
 
 /** Canonical origin for absolute SEO URLs at build time. */
 export function resolveCanonicalOrigin(envOrigin: string | undefined): string {

--- a/apps/web/src/seo/indexableRoutes.ts
+++ b/apps/web/src/seo/indexableRoutes.ts
@@ -1,0 +1,18 @@
+/** Static indexable paths shared by sitemap, prerender, and tests. */
+export const STATIC_INDEXABLE_ROUTES = [
+  '/',
+  '/catalog',
+  '/how-to-host-a-watchparty',
+  '/terms',
+  '/privacy',
+] as const
+
+export type StaticIndexableRoute = (typeof STATIC_INDEXABLE_ROUTES)[number]
+
+/** Dist path relative to `apps/web/dist/` for a static indexable route. */
+export function staticRouteDistPath(route: StaticIndexableRoute): string {
+  if (route === '/') {
+    return 'index.html'
+  }
+  return `${route.slice(1)}/index.html`
+}

--- a/apps/web/src/seo/routeHeadTags.test.ts
+++ b/apps/web/src/seo/routeHeadTags.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { buildPrerenderDocument } from './buildPrerenderDocument'
+import { STATIC_INDEXABLE_ROUTES } from './indexableRoutes'
+import {
+  buildSpaShellHeadTags,
+  buildStaticRouteHeadTags,
+  buildWatchRouteHeadTags,
+} from './routeHeadTags'
+
+const TEMPLATE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RiffSync</title>
+    <meta
+      name="description"
+      content="Generic description"
+    />
+    <link rel="canonical" href="https://riffsync.tv/" />
+    <meta property="og:title" content="RiffSync — watch parties" />
+    <meta property="og:description" content="Generic OG description" />
+    <meta property="og:url" content="https://riffsync.tv/" />
+    <meta property="og:image" content="https://riffsync.tv/og-card.png" />
+    <meta name="twitter:title" content="RiffSync — watch parties" />
+    <meta name="twitter:description" content="Generic Twitter description" />
+    <meta name="twitter:image" content="https://riffsync.tv/og-card.png" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/assets/main.js"></script>
+  </body>
+</html>`
+
+function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>): CatalogEpisode {
+  return {
+    experimentNumber: 101,
+    title: 'The Crawling Eye',
+    era: 'joel',
+    youtubeVideoId: 'abc123',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc123',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    ...overrides,
+  }
+}
+
+describe('buildStaticRouteHeadTags', () => {
+  it('produces normative home copy', () => {
+    const head = buildStaticRouteHeadTags('/', 'https://riffsync.tv')
+    expect(head.documentTitle).toBe('RiffSync — watch parties')
+    expect(head.description).toContain('fan watch parties')
+    expect(head.canonicalUrl).toBe('https://riffsync.tv/')
+    expect(head.ogImageUrl).toBe('https://riffsync.tv/og-card.png')
+    expect(head.robotsNoindex).toBe(false)
+  })
+
+  it('covers every static indexable route', () => {
+    for (const route of STATIC_INDEXABLE_ROUTES) {
+      const head = buildStaticRouteHeadTags(route, 'https://riffsync.tv')
+      expect(head.documentTitle.length).toBeGreaterThan(0)
+      expect(head.description.length).toBeGreaterThan(0)
+      expect(head.canonicalUrl).toContain('https://riffsync.tv')
+      expect(head.robotsNoindex).toBe(false)
+    }
+  })
+
+  it('uses normative catalog title and description', () => {
+    const head = buildStaticRouteHeadTags('/catalog', 'https://riffsync.tv')
+    expect(head.documentTitle).toBe('RiffSync Catalog — browse the library')
+    expect(head.description).toContain('Browse the RiffSync catalog')
+    expect(head.canonicalUrl).toBe('https://riffsync.tv/catalog')
+  })
+})
+
+describe('buildWatchRouteHeadTags', () => {
+  it('uses catalog title without tagline and falls back to og-card image', () => {
+    const head = buildWatchRouteHeadTags(
+      episode({ id: '101-the-crawling-eye', title: 'The Crawling Eye' }),
+      'https://riffsync.tv',
+    )
+    expect(head.documentTitle).toBe('The Crawling Eye — RiffSync')
+    expect(head.ogTitle).toBe('The Crawling Eye — RiffSync')
+    expect(head.description).toBe(
+      'Watch The Crawling Eye on RiffSync — fan watch parties with lawful YouTube embeds. Unofficial fan project.',
+    )
+    expect(head.canonicalUrl).toBe('https://riffsync.tv/watch/101-the-crawling-eye')
+    expect(head.ogImageUrl).toBe('https://riffsync.tv/og-card.png')
+  })
+
+  it('includes tagline in description when present', () => {
+    const head = buildWatchRouteHeadTags(
+      episode({
+        id: 'fixture',
+        title: 'Pod People',
+        tagline: 'They tried to run',
+      }),
+      'https://riffsync.tv',
+    )
+    expect(head.description).toBe(
+      'They tried to run — watch Pod People on RiffSync. Unofficial fan project with lawful YouTube embeds.',
+    )
+  })
+
+  it('prefers poster art over backdrop for OG image', () => {
+    const head = buildWatchRouteHeadTags(
+      episode({
+        id: 'fixture',
+        posterImageUrl: '/posters/pod-people.jpg',
+        backdropImageUrl: '/backdrops/pod-people.jpg',
+      }),
+      'https://riffsync.tv',
+    )
+    expect(head.ogImageUrl).toBe('https://riffsync.tv/posters/pod-people.jpg')
+  })
+
+  it('uses backdrop when poster is absent', () => {
+    const head = buildWatchRouteHeadTags(
+      episode({
+        id: 'fixture',
+        posterImageUrl: null,
+        backdropImageUrl: 'https://images.example/backdrop.jpg',
+      }),
+      'https://riffsync.tv',
+    )
+    expect(head.ogImageUrl).toBe('https://images.example/backdrop.jpg')
+  })
+
+  it('trims HTML title only when composed title exceeds 70 characters', () => {
+    const longTitle =
+      'A Very Long Episode Title That Would Overflow Browser Tab Labels If Left Untrimmed'
+    const head = buildWatchRouteHeadTags(
+      episode({ id: 'fixture', title: longTitle }),
+      'https://riffsync.tv',
+    )
+    expect(head.documentTitle.length).toBeLessThanOrEqual(70)
+    expect(head.ogTitle).toBe(`${longTitle} — RiffSync`)
+    expect(head.documentTitle).not.toBe(head.ogTitle)
+  })
+})
+
+describe('buildSpaShellHeadTags', () => {
+  it('uses generic noindex shell without canonical', () => {
+    const head = buildSpaShellHeadTags()
+    expect(head.documentTitle).toBe('RiffSync')
+    expect(head.robotsNoindex).toBe(true)
+    expect(head.canonicalUrl).toBeNull()
+  })
+})
+
+describe('buildPrerenderDocument', () => {
+  it('injects home head tags without changing body markup', () => {
+    const head = buildStaticRouteHeadTags('/', 'https://riffsync.tv')
+    const html = buildPrerenderDocument(TEMPLATE_HTML, head)
+    expect(html).toContain('<title>RiffSync — watch parties</title>')
+    expect(html).toContain('rel="canonical" href="https://riffsync.tv/"')
+    expect(html).toContain('<div id="root"></div>')
+    expect(html).toContain('<script type="module" src="/assets/main.js"></script>')
+    expect(html).not.toContain('name="robots" content="noindex"')
+  })
+
+  it('emits noindex and removes canonical for spa shell', () => {
+    const html = buildPrerenderDocument(TEMPLATE_HTML, buildSpaShellHeadTags())
+    expect(html).toContain('<meta name="robots" content="noindex" />')
+    expect(html).not.toContain('rel="canonical"')
+    expect(html).toContain('<title>RiffSync</title>')
+  })
+})

--- a/apps/web/src/seo/routeHeadTags.ts
+++ b/apps/web/src/seo/routeHeadTags.ts
@@ -1,0 +1,117 @@
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { trimTabTitleSegment } from '../config/documentTitle'
+import { absoluteUrl, resolveCanonicalOrigin } from './generateSeoArtifacts'
+
+export const SITE_SUFFIX = 'RiffSync'
+
+export const GENERIC_FAN_DESCRIPTION =
+  'RiffSync — fan watch parties with a curated MST3K-friendly catalog, shared viewing, and room chat. Unofficial fan project.'
+
+const STATIC_ROUTE_COPY = {
+  '/': {
+    title: 'RiffSync — watch parties',
+    description: GENERIC_FAN_DESCRIPTION,
+  },
+  '/catalog': {
+    title: 'RiffSync Catalog — browse the library',
+    description:
+      'Browse the RiffSync catalog of riff-style episodes with lawful YouTube embeds. Filter by era, pick an experiment, and start a watch party. Unofficial fan project.',
+  },
+  '/how-to-host-a-watchparty': {
+    title: 'How to host a watch party — RiffSync',
+    description:
+      'Step-by-step help for hosting a RiffSync watch party: share your YouTube tab, keep guests in sync, and fix common screen-share issues.',
+  },
+  '/terms': {
+    title: 'Terms of Service — RiffSync',
+    description:
+      'RiffSync Terms of Service — rules for using the fan watch-party site, catalog, chat, and related features. Unofficial fan project; not affiliated with MST3K or RiffTrax.',
+  },
+  '/privacy': {
+    title: 'Privacy Policy — RiffSync',
+    description:
+      'RiffSync Privacy Policy — what we collect when you browse the catalog, join watch parties, or sign in, and how we use that information.',
+  },
+} as const
+
+export type StaticIndexableRoute = keyof typeof STATIC_ROUTE_COPY
+
+export interface RouteHeadTags {
+  documentTitle: string
+  ogTitle: string
+  description: string
+  canonicalUrl: string | null
+  ogImageUrl: string
+  robotsNoindex: boolean
+}
+
+export function resolveSeoOrigin(envOrigin: string | undefined): string {
+  return resolveCanonicalOrigin(envOrigin)
+}
+
+export function resolveAbsoluteAssetUrl(origin: string, assetUrl: string | null | undefined): string | null {
+  if (assetUrl == null) return null
+  const trimmed = assetUrl.trim()
+  if (trimmed.length === 0) return null
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
+    return trimmed
+  }
+  const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return absoluteUrl(origin, path)
+}
+
+export function defaultOgCardUrl(origin: string): string {
+  return absoluteUrl(origin, '/og-card.png')
+}
+
+export function buildStaticRouteHeadTags(
+  route: StaticIndexableRoute,
+  origin: string,
+): RouteHeadTags {
+  const copy = STATIC_ROUTE_COPY[route]
+  const canonicalUrl = absoluteUrl(origin, route)
+  return {
+    documentTitle: copy.title,
+    ogTitle: copy.title,
+    description: copy.description,
+    canonicalUrl,
+    ogImageUrl: defaultOgCardUrl(origin),
+    robotsNoindex: false,
+  }
+}
+
+export function buildWatchRouteHeadTags(episode: CatalogEpisode, origin: string): RouteHeadTags {
+  const untrimmedTitle = `${episode.title} — ${SITE_SUFFIX}`
+  const documentTitle =
+    untrimmedTitle.length > 70 ? trimTabTitleSegment(untrimmedTitle) : untrimmedTitle
+
+  const tagline = episode.tagline?.trim() ?? ''
+  const description =
+    tagline.length > 0
+      ? `${tagline} — watch ${episode.title} on RiffSync. Unofficial fan project with lawful YouTube embeds.`
+      : `Watch ${episode.title} on RiffSync — fan watch parties with lawful YouTube embeds. Unofficial fan project.`
+
+  const poster = resolveAbsoluteAssetUrl(origin, episode.posterImageUrl)
+  const backdrop = resolveAbsoluteAssetUrl(origin, episode.backdropImageUrl)
+  const ogImageUrl = poster ?? backdrop ?? defaultOgCardUrl(origin)
+
+  return {
+    documentTitle,
+    ogTitle: untrimmedTitle,
+    description,
+    canonicalUrl: absoluteUrl(origin, `/watch/${episode.id}`),
+    ogImageUrl,
+    robotsNoindex: false,
+  }
+}
+
+export function buildSpaShellHeadTags(): RouteHeadTags {
+  return {
+    documentTitle: SITE_SUFFIX,
+    ogTitle: SITE_SUFFIX,
+    description: GENERIC_FAN_DESCRIPTION,
+    canonicalUrl: null,
+    ogImageUrl: defaultOgCardUrl(resolveCanonicalOrigin(undefined)),
+    robotsNoindex: true,
+  }
+}

--- a/infra/cdk/lib/static-site-stack.test.ts
+++ b/infra/cdk/lib/static-site-stack.test.ts
@@ -71,6 +71,18 @@ describe('StaticSiteStack', () => {
             Ref: Match.stringLikeRegexp('WebResponseHeadersPolicy'),
           },
         },
+        CustomErrorResponses: Match.arrayWith([
+          Match.objectLike({
+            ErrorCode: 403,
+            ResponseCode: 200,
+            ResponsePagePath: '/spa-shell.html',
+          }),
+          Match.objectLike({
+            ErrorCode: 404,
+            ResponseCode: 200,
+            ResponsePagePath: '/spa-shell.html',
+          }),
+        ]),
       },
     });
 

--- a/infra/cdk/lib/static-site-stack.ts
+++ b/infra/cdk/lib/static-site-stack.ts
@@ -192,19 +192,20 @@ export class StaticSiteStack extends cdk.Stack {
       certificate,
       /**
        * SPA client routes: S3 has no object for `/lobby`, so CloudFront would otherwise
-       * surface 403/404; map those to `index.html` so refreshes and deep links work.
+       * surface 403/404; map those to `spa-shell.html` (generic noindex) so ephemeral
+       * deep links do not inherit home canonical metadata.
        */
       errorResponses: [
         {
           httpStatus: 403,
           responseHttpStatus: 200,
-          responsePagePath: '/index.html',
+          responsePagePath: '/spa-shell.html',
           ttl: cdk.Duration.minutes(0),
         },
         {
           httpStatus: 404,
           responseHttpStatus: 200,
-          responsePagePath: '/index.html',
+          responsePagePath: '/spa-shell.html',
           ttl: cdk.Duration.minutes(0),
         },
       ],


### PR DESCRIPTION
## Summary

- Adds shared SEO modules (`indexableRoutes`, `routeHeadTags`, `buildPrerenderDocument`) and a `prerender-indexable-routes.mjs` build step that writes static HTML for indexable routes plus `spa-shell.html`.
- Extends `verify:seo-artifacts` to assert prerender file counts and spot-check head tags on `/` and `/watch/101-the-crawling-eye`.
- Updates CloudFront 403/404 custom error responses to serve `/spa-shell.html` so ephemeral deep links do not inherit home canonical metadata.

Closes #326

## Test plan

- [x] `cd apps/web && npm ci && npm run build`
- [x] `npm run verify:seo-artifacts`
- [x] `npm test -- src/seo/routeHeadTags.test.ts`
- [x] `npm test` (full web suite)
- [x] `npm run lint`
- [x] `cd infra/cdk && npm test` (spa-shell error response assertion)
- [ ] CI `web-app` and `infra-cdk` jobs green on this PR