### PR TITLE
feat(a11y): home sr-only H1 and catalog card alt text (M30)

### DIFF
--- a/apps/web/src/pages/CatalogPage.test.tsx
+++ b/apps/web/src/pages/CatalogPage.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CatalogPage } from './CatalogPage'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const useCatalogListQuery = vi.fn()
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogListQuery: () => useCatalogListQuery(),
+}))
+
+function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>): CatalogEpisode {
+  return {
+    experimentNumber: 100,
+    title: 'Default title',
+    era: 'joel',
+    youtubeVideoId: 'abc123',
+    youtubeWatchUrl: 'https://youtube.com/watch?v=abc123',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    ...overrides,
+  }
+}
+
+const catalogFixtures: CatalogEpisode[] = [
+  episode({ id: 'ep-a', experimentNumber: 200, title: 'Pod People', era: 'joel' }),
+  episode({ id: 'ep-b', experimentNumber: 101, title: 'Cave Dwellers', era: 'mike' }),
+]
+
+describe('CatalogPage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    useCatalogListQuery.mockReset()
+    useCatalogListQuery.mockReturnValue({
+      data: catalogFixtures,
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderCatalogPage() {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <CatalogPage />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('sets poster img alt text to each episode title', () => {
+    renderCatalogPage()
+
+    const posterImages = Array.from(
+      container.querySelectorAll('.riffsync-catalog-card img'),
+    ) as HTMLImageElement[]
+
+    expect(posterImages).toHaveLength(catalogFixtures.length)
+    expect(posterImages.map((img) => img.getAttribute('alt')).sort()).toEqual(['Cave Dwellers', 'Pod People'])
+    for (const img of posterImages) {
+      expect(img.getAttribute('alt')).not.toBe('')
+    }
+  })
+})

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -17,7 +17,7 @@ function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
       <div className="gen-carousel-movies-style-3 movie-grid style-3">
         <div className="gen-movie-contain">
           <div className="gen-movie-img">
-            <img src={img} alt="" loading="lazy" />
+            <img src={img} alt={episode.title} loading="lazy" />
           </div>
           <EpisodeTileActions episode={episode} />
           <div className="gen-info-contain">

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HomePage } from './HomePage'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const useCatalogListQuery = vi.fn()
+const useCatalogCarouselQuery = vi.fn()
+const useCatalogSpotlightQuery = vi.fn()
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogListQuery: () => useCatalogListQuery(),
+  useCatalogCarouselQuery: () => useCatalogCarouselQuery(),
+  useCatalogSpotlightQuery: () => useCatalogSpotlightQuery(),
+}))
+
+function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>): CatalogEpisode {
+  return {
+    experimentNumber: 100,
+    title: 'Pod People',
+    era: 'joel',
+    youtubeVideoId: 'abc123',
+    youtubeWatchUrl: 'https://youtube.com/watch?v=abc123',
+    tagline: 'Push the button, Frank.',
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: true,
+    spotlight: true,
+    ...overrides,
+  }
+}
+
+const playableEpisode = episode({ id: 'ep-1', title: 'Pod People' })
+
+function mockCatalogQueries(options: {
+  list?: ReturnType<typeof useCatalogListQuery>
+  carousel?: ReturnType<typeof useCatalogCarouselQuery>
+  spotlight?: ReturnType<typeof useCatalogSpotlightQuery>
+}) {
+  useCatalogListQuery.mockReturnValue(
+    options.list ?? {
+      data: [playableEpisode],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    },
+  )
+  useCatalogCarouselQuery.mockReturnValue(
+    options.carousel ?? {
+      data: [playableEpisode],
+    },
+  )
+  useCatalogSpotlightQuery.mockReturnValue(
+    options.spotlight ?? {
+      data: [playableEpisode],
+    },
+  )
+}
+
+describe('HomePage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    useCatalogListQuery.mockReset()
+    useCatalogCarouselQuery.mockReset()
+    useCatalogSpotlightQuery.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderHomePage() {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  function srOnlyHeadings(): HTMLHeadingElement[] {
+    return Array.from(container.querySelectorAll('h1.sr-only'))
+  }
+
+  it('renders exactly one sr-only H1 with text RiffSync on the happy path', () => {
+    mockCatalogQueries({})
+    renderHomePage()
+
+    const headings = srOnlyHeadings()
+    expect(headings).toHaveLength(1)
+    expect(headings[0]?.textContent).toBe('RiffSync')
+  })
+
+  it('renders exactly one sr-only H1 while loading', () => {
+    mockCatalogQueries({
+      list: {
+        data: undefined,
+        isPending: true,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    })
+    renderHomePage()
+
+    const headings = srOnlyHeadings()
+    expect(headings).toHaveLength(1)
+    expect(headings[0]?.textContent).toBe('RiffSync')
+  })
+
+  it('renders exactly one sr-only H1 on catalog load error', () => {
+    mockCatalogQueries({
+      list: {
+        data: undefined,
+        isPending: false,
+        isError: true,
+        error: new Error('Catalog unavailable'),
+        refetch: vi.fn(),
+      },
+    })
+    renderHomePage()
+
+    const headings = srOnlyHeadings()
+    expect(headings).toHaveLength(1)
+    expect(headings[0]?.textContent).toBe('RiffSync')
+  })
+
+  it('renders exactly one sr-only H1 when the catalog is empty', () => {
+    mockCatalogQueries({
+      list: {
+        data: [],
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    })
+    renderHomePage()
+
+    const headings = srOnlyHeadings()
+    expect(headings).toHaveLength(1)
+    expect(headings[0]?.textContent).toBe('RiffSync')
+  })
+
+  it('renders exactly one sr-only H1 when no episodes have a YouTube link', () => {
+    mockCatalogQueries({
+      list: {
+        data: [episode({ id: 'ep-no-yt', youtubeVideoId: null, youtubeWatchUrl: null })],
+        isPending: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    })
+    renderHomePage()
+
+    const headings = srOnlyHeadings()
+    expect(headings).toHaveLength(1)
+    expect(headings[0]?.textContent).toBe('RiffSync')
+  })
+})

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -16,6 +16,10 @@ import { HomeHeroBanner } from './home/HomeHeroBanner'
 import { HomeMovieRowSection } from './home/HomeMovieRowSection'
 import { HomeSpotlightBanner } from './home/HomeSpotlightBanner'
 
+function HomePageDocumentHeading() {
+  return <h1 className="sr-only">RiffSync</h1>
+}
+
 /**
  * Catalog landing (/) — full list from **`GET /v1/catalog`**; hero from
  * **`GET /v1/catalog?carousel=true`**; spotlight from **`GET /v1/catalog?spotlight=true`**
@@ -36,6 +40,7 @@ export function HomePage() {
   if (isPending && !data) {
     return (
       <div className="riffsync-home">
+        <HomePageDocumentHeading />
         <p className="container">Loading catalog…</p>
       </div>
     )
@@ -44,6 +49,7 @@ export function HomePage() {
   if (isError && !data) {
     return (
       <div className="riffsync-home">
+        <HomePageDocumentHeading />
         <div className="container">
           <CatalogLoadErrorPanel
             error={error}
@@ -67,6 +73,7 @@ export function HomePage() {
   if (entries.length === 0) {
     return (
       <div className="riffsync-home">
+        <HomePageDocumentHeading />
         <p className="container">The catalog is empty.</p>
       </div>
     )
@@ -75,6 +82,7 @@ export function HomePage() {
   if (playableEntries.length === 0) {
     return (
       <div className="riffsync-home">
+        <HomePageDocumentHeading />
         <p className="container">No episodes with a YouTube link are available yet.</p>
       </div>
     )
@@ -88,6 +96,7 @@ export function HomePage() {
 
   return (
     <div className="riffsync-home">
+      <HomePageDocumentHeading />
       {heroSlides.length > 0 ? <HomeHeroBanner slides={heroSlides} /> : null}
       <HomeMovieRowSection
         sectionId="home-most-popular"


### PR DESCRIPTION
## Summary

- Adds a single static `sr-only` `<h1>RiffSync</h1>` to every `HomePage` render branch so `/` has a stable document heading without changing visible hero, carousel, or spotlight markup.
- Sets `CatalogGridCard` poster `alt` to `episode.title` instead of an empty string.
- Adds `HomePage.test.tsx` and `CatalogPage.test.tsx` coverage for the new accessibility behavior.

Closes #327

## Test plan

- [x] `npm test -- src/pages/HomePage.test.tsx src/pages/CatalogPage.test.tsx`
- [x] `npm run lint` (apps/web)
- [x] `npm run verify:push:web`
- [ ] Manual spot-check: `/` shows one sr-only H1 in DevTools; `/catalog` poster images have non-empty alt matching episode titles