### PR TITLE
[M31] Search Console/Bing verification and SEO release smoke check

### DIFF
--- a/docs/operations/public-site-seo.md
+++ b/docs/operations/public-site-seo.md
@@ -1,0 +1,97 @@
+# Public site SEO operator runbook
+
+Deployer-facing guide for **Search Console / Bing Webmaster verification** and the **post-deploy SEO smoke check** on production **`riffsync.tv`**. Normative capability contracts live in **`.ai/specs/public-site-seo.spec.md`**, **`.ai/operations/build_packaging.md`**, and **`.ai/operations/deployment_environments.md`**. This document covers DNS TXT verification, secret handling, the operator checklist, and smoke invocation.
+
+**Prerequisites:** M27 (apex canonical redirect), M28 (`robots.txt` / `sitemap.xml`), and M29 (per-route head tags + prerender) are deployed to production via **`deploy-prod.yml`** phase 5 before running the smoke script or announcing SEO-ready behavior.
+
+## 1. Hosted zone context
+
+| Item | Value |
+| --- | --- |
+| **Public hostname** | **`riffsync.tv`** (apex canonical) |
+| **Alternate hostname** | **`www.riffsync.tv`** (301 to apex at CloudFront) |
+| **Route 53 zone** | **`fanWebZoneName`** — typically **`riffsync.tv`** when **`RIFFSYNC_ROUTE53_ZONE_NAME`** is set in GitHub Actions / CDK context |
+| **CDK stack** | **`RiffSyncStatic-prod`** — creates alias **A** records for CloudFront; **does not** manage Search Console / Bing TXT records |
+
+TXT records for search-engine verification are **manual operator steps** in the Route 53 console. They are **not** CDK-managed, not HTML file uploads, and not meta-tag verification.
+
+## 2. Verification token storage
+
+| Rule | Detail |
+| --- | --- |
+| **Never commit tokens** | Do not put TXT values in git, CDK context, GitHub Variables, or CloudFormation templates. |
+| **Secret store** | Record actual TXT **values** in the team ops secret store (e.g. 1Password **RiffSync Ops**). This runbook documents **procedure and record names** only. |
+| **Rotation** | When a vendor re-issues a token, update Route 53 and the secret store; no stack redeploy is required for TXT-only changes. |
+
+## 3. Google Search Console
+
+1. Open [Google Search Console](https://search.google.com/search-console) and add a property for **`riffsync.tv`** (domain or URL-prefix property per your org preference; DNS TXT verification works for the apex zone).
+2. Choose **DNS** verification. Copy the **TXT record name** and **TXT value** from the console.
+3. In **AWS Console** → **Route 53** → hosted zone **`riffsync.tv`** (or the zone matching **`fanWebZoneName`**):
+   - Create a **TXT** record with the name and value Search Console provides.
+   - Use a short TTL (e.g. **300** seconds) during initial verification if you want faster propagation feedback.
+4. Wait for DNS propagation (minutes to hours). In Search Console, click **Verify**.
+5. Record the verified property and token metadata in **RiffSync Ops** (not in git).
+
+**Expected:** Search Console shows **Verified** for **`riffsync.tv`** after propagation.
+
+## 4. Bing Webmaster Tools
+
+1. Open [Bing Webmaster Tools](https://www.bing.com/webmasters) and add **`riffsync.tv`**.
+2. Choose **DNS** / **CNAME or TXT** verification per Bing's wizard. Copy the **TXT record name** and **value**.
+3. In the same Route 53 hosted zone, add a **TXT** record for Bing. If Google and Bing issue different tokens, create **one TXT record per vendor** (or combine per vendor instructions when multiple strings are allowed on one name).
+4. Wait for propagation and confirm **Verified** in Bing Webmaster.
+5. Store token values in **RiffSync Ops** only.
+
+**Expected:** Bing Webmaster shows **Verified** for **`riffsync.tv`**.
+
+## 5. Verification checklist (operator)
+
+Complete after M27-M29 are live on production:
+
+| Step | Done when |
+| --- | --- |
+| Search Console property added for **`riffsync.tv`** | Property exists in console |
+| Search Console DNS TXT in Route 53 | Record visible in zone |
+| Search Console **Verified** | Console status shows verified |
+| Bing Webmaster property added | Property exists in console |
+| Bing DNS TXT in Route 53 | Record visible in zone |
+| Bing **Verified** | Console status shows verified |
+| TXT values stored in ops secret store | 1Password (or equivalent) updated |
+| Production smoke script passes | **`npm run smoke:production`** exits **0** (section 6) |
+
+The smoke script does **not** assert Search Console or Bing verification status. Those rows are manual checklist items only.
+
+## 6. Post-deploy smoke check
+
+From the **repository root** (Node 22+ per CI):
+
+```bash
+cd /path/to/riffsync
+node --check scripts/launch-readiness/smoke-production.mjs   # syntax only
+npm run smoke:production                                      # live production URLs
+```
+
+**When to run:** after **`deploy-prod.yml`** completes phase 5 (S3 sync + CloudFront invalidation) and DNS points at the current distribution.
+
+**What the script asserts:**
+
+| # | Check |
+| --- | --- |
+| 1 | **`https://riffsync.tv/`** returns **200** |
+| 2 | **`https://www.riffsync.tv/lobby`** returns **301** with **`Location: https://riffsync.tv/lobby`** |
+| 3 | **`https://riffsync.tv/robots.txt`** and **`https://riffsync.tv/sitemap.xml`** return **200** |
+| 4 | **`/`** HTML contains **`<link rel="canonical" href="https://riffsync.tv/">`** |
+| 5 | **`/watch/101-the-crawling-eye`** HTML contains canonical **`https://riffsync.tv/watch/101-the-crawling-eye`** |
+| 6 | Fetched home **`index.html`** body contains no **`www.riffsync.tv`** host strings |
+
+**Expected output:** one **`OK:`** line per check, then **`Production smoke check passed.`** and exit code **0**.
+
+**Not CI-wired:** PR CI does not call this script. Run it manually before launch review or when validating a production deploy.
+
+## 7. Related docs
+
+- **`infra/cdk/README.md`** — *Production smoke checks*, Route 53 / CloudFront hostname variables
+- **`infra/cdk/lib/static-site-stack.ts`** — **`fanWebZoneName`**, canonical redirect context
+- **`.ai/operations/deployment_environments.md`** — *Public site SEO deployment readiness*
+- **`.ai/operations/build_packaging.md`** — *Decisions (M31 — Search Console verification and release smoke — #328)*

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -444,7 +444,15 @@ Prefer scoping to those ARNs instead of `*` once ARNs are known from a first dep
 
 ### Production smoke checks (operators)
 
-After **Deploy CDK (production)** completes:
+**Public site SEO (M31):** after M27–M29 are deployed, run the full SEO smoke band and complete Search Console / Bing DNS verification per **[`docs/operations/public-site-seo.md`](../../docs/operations/public-site-seo.md)**. From the repo root:
+
+```bash
+npm run smoke:production
+```
+
+The script asserts apex reachability, **`www`** → apex **301**, **`robots.txt`** / **`sitemap.xml`** **200**, apex canonical **`<link>`** on **`/`** and fixture **`/watch/101-the-crawling-eye`**, and no **`www.riffsync.tv`** absolute URLs in shipped home HTML. Search Console / Bing **Verified** status is a separate operator checklist row in that runbook (not asserted by the script).
+
+**SPA shell (baseline):** after **Deploy CDK (production)** completes:
 
 1. Resolve the URL: **`https://<DistributionDomainName>/`** (stack output, or **AWS Console** → **CloudFormation** → **Outputs**).
 2. **`curl -I`** — expect **`200`** for **`/`** and for **`/lobby`** (SPA fallback must return **`index.html`**, not S3 **`403`**).
@@ -454,6 +462,7 @@ After **Deploy CDK (production)** completes:
 
 ```bash
 cd apps/web && npm ci && npm run build && ls -la dist
+node --check ../../scripts/launch-readiness/smoke-production.mjs
 ```
 
 ### Repository configuration (preferred: OIDC → IAM role)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "verify:push": "npm run verify:push:cdk && npm run verify:push:web && npm run verify:push:sfu",
     "verify:push:cdk": "npm ci --prefix infra/cdk && npm run test --prefix infra/cdk && npm run synth --prefix infra/cdk",
     "verify:push:web": "npm ci --prefix apps/web && npm test --prefix apps/web",
-    "verify:push:sfu": "npm ci --prefix services/riffsync-sfu && npm run build --prefix services/riffsync-sfu"
+    "verify:push:sfu": "npm ci --prefix services/riffsync-sfu && npm run build --prefix services/riffsync-sfu",
+    "smoke:production": "node scripts/launch-readiness/smoke-production.mjs"
   },
   "devDependencies": {
     "husky": "^9.1.7"

--- a/scripts/launch-readiness/smoke-production.mjs
+++ b/scripts/launch-readiness/smoke-production.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy smoke checks for riffsync.tv public site SEO (M31).
+ * Run manually after M27-M29 are deployed to production.
+ */
+const CANONICAL = 'https://riffsync.tv';
+const WWW = 'https://www.riffsync.tv';
+const WATCH_FIXTURE_ID = '101-the-crawling-eye';
+
+const CHECKS = [
+  {
+    label: 'Apex home returns 200',
+    url: `${CANONICAL}/`,
+    expectStatus: 200,
+  },
+  {
+    label: 'www lobby redirects to apex',
+    url: `${WWW}/lobby`,
+    expectStatus: 301,
+    expectRedirectLocation: `${CANONICAL}/lobby`,
+  },
+  {
+    label: 'robots.txt returns 200',
+    url: `${CANONICAL}/robots.txt`,
+    expectStatus: 200,
+  },
+  {
+    label: 'sitemap.xml returns 200',
+    url: `${CANONICAL}/sitemap.xml`,
+    expectStatus: 200,
+  },
+  {
+    label: 'Home canonical link tag',
+    url: `${CANONICAL}/`,
+    expectStatus: 200,
+    expectBodyIncludes: '<link rel="canonical" href="https://riffsync.tv/">',
+  },
+  {
+    label: 'Watch fixture canonical link',
+    url: `${CANONICAL}/watch/${WATCH_FIXTURE_ID}`,
+    expectStatus: 200,
+    expectBodyIncludes: `https://riffsync.tv/watch/${WATCH_FIXTURE_ID}`,
+  },
+  {
+    label: 'index.html has no www.riffsync.tv hosts',
+    url: `${CANONICAL}/`,
+    expectStatus: 200,
+    expectBodyExcludes: 'www.riffsync.tv',
+  },
+];
+
+async function runCheck(check) {
+  const response = await fetch(check.url, { redirect: 'manual' });
+  const statuses = Array.isArray(check.expectStatus) ? check.expectStatus : [check.expectStatus];
+
+  if (!statuses.includes(response.status)) {
+    return `${check.label}: expected status ${statuses.join('|')}, got ${response.status} for ${check.url}`;
+  }
+
+  if (check.expectRedirectLocation) {
+    const location = response.headers.get('location') ?? '';
+    if (location !== check.expectRedirectLocation) {
+      return `${check.label}: redirect location "${location}" did not equal ${check.expectRedirectLocation}`;
+    }
+  }
+
+  if (check.expectBodyIncludes || check.expectBodyExcludes) {
+    const body = await response.text();
+    if (check.expectBodyIncludes && !body.includes(check.expectBodyIncludes)) {
+      return `${check.label}: response body did not include "${check.expectBodyIncludes}"`;
+    }
+    if (check.expectBodyExcludes && body.includes(check.expectBodyExcludes)) {
+      return `${check.label}: response body contained forbidden string "${check.expectBodyExcludes}"`;
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  const failures = [];
+
+  for (const check of CHECKS) {
+    try {
+      const failure = await runCheck(check);
+      if (failure) {
+        failures.push(failure);
+      } else {
+        console.log(`OK: ${check.label}`);
+      }
+    } catch (error) {
+      failures.push(`${check.label}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (failures.length) {
+    console.error('\nProduction smoke check failed:');
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('\nProduction smoke check passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `docs/operations/public-site-seo.md` operator runbook for Search Console and Bing Webmaster DNS TXT verification on the existing Route 53 zone (`riffsync.tv`), with secret-store handling and a verification checklist.
- Add `scripts/launch-readiness/smoke-production.mjs` implementing all six normative post-deploy SEO smoke checks (apex 200, www→apex 301, robots/sitemap 200, canonical links on `/` and `/watch/101-the-crawling-eye`, no `www.riffsync.tv` in home HTML).
- Wire `npm run smoke:production` at repo root and link the runbook from `infra/cdk/README.md` → Production smoke checks.

Closes #328

## Test plan

- [x] `node --check scripts/launch-readiness/smoke-production.mjs`
- [x] `npm run verify:push:web`
- [ ] `npm run smoke:production` against production after merge (operator; requires live M27–M29 deploy)
- [ ] Operator: add Search Console and Bing DNS TXT records per runbook; confirm both show Verified