### PR TITLE
[M32] Catalog browse IA: hub, nav, and subcategory routes (#344, #345, #346)

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import { SiteLayout } from './layouts/SiteLayout'
 import { HomePage } from './pages/HomePage'
 import { CatalogPage } from './pages/CatalogPage'
+import { CatalogSubcategoryPage } from './pages/CatalogSubcategoryPage'
 import { LobbyPage } from './pages/LobbyPage'
 import { AccountPage } from './pages/AccountPage'
 import { RoomPage } from './pages/RoomPage'
@@ -41,6 +42,10 @@ export function AppRoutes() {
       <Route element={<SiteLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/catalog" element={<CatalogPage />} />
+        <Route path="/catalog/mst3k" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/community" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/riff-ready" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/movie-night" element={<CatalogSubcategoryPage />} />
         <Route path="/watch/:catalogEpisodeId" element={<SoloWatchPage />} />
         <Route path="/lobby" element={<LobbyPage />} />
         <Route path="/account" element={<AccountPage />} />

--- a/apps/web/src/catalog/catalogBrowseIa.ts
+++ b/apps/web/src/catalog/catalogBrowseIa.ts
@@ -1,7 +1,42 @@
-/** Public catalog hub entry links and subcategory routes (M32 browse IA). */
-export const CATALOG_HUB_ENTRY_LINKS = [
-  { label: 'MST3K', href: '/catalog/mst3k' },
-  { label: 'Community', href: '/catalog/community' },
-  { label: 'Riff-Ready', href: '/catalog/riff-ready' },
-  { label: 'Movie Night', href: '/catalog/movie-night' },
+import type { CatalogEra } from './catalogTypes'
+
+/** Route-fixed subcategory browse destinations (M32 browse IA). */
+export const CATALOG_SUBCATEGORIES = [
+  {
+    slug: 'mst3k',
+    path: '/catalog/mst3k',
+    label: 'MST3K',
+    eras: ['joel', 'mike', 'jonah', 'emily'] as const satisfies readonly CatalogEra[],
+  },
+  {
+    slug: 'community',
+    path: '/catalog/community',
+    label: 'Community',
+    eras: ['community'] as const satisfies readonly CatalogEra[],
+  },
+  {
+    slug: 'riff-ready',
+    path: '/catalog/riff-ready',
+    label: 'Riff-Ready',
+    eras: ['riffable'] as const satisfies readonly CatalogEra[],
+  },
+  {
+    slug: 'movie-night',
+    path: '/catalog/movie-night',
+    label: 'Movie Night',
+    eras: ['movie_night'] as const satisfies readonly CatalogEra[],
+  },
 ] as const
+
+export type CatalogSubcategory = (typeof CATALOG_SUBCATEGORIES)[number]
+export type CatalogSubcategorySlug = CatalogSubcategory['slug']
+
+/** Public catalog hub entry links (same order and labels as subcategory routes). */
+export const CATALOG_HUB_ENTRY_LINKS = CATALOG_SUBCATEGORIES.map(({ label, path }) => ({
+  label,
+  href: path,
+}))
+
+export function getCatalogSubcategoryByPath(pathname: string): CatalogSubcategory | undefined {
+  return CATALOG_SUBCATEGORIES.find((entry) => entry.path === pathname)
+}

--- a/apps/web/src/catalog/catalogBrowseIa.ts
+++ b/apps/web/src/catalog/catalogBrowseIa.ts
@@ -1,0 +1,7 @@
+/** Public catalog hub entry links and subcategory routes (M32 browse IA). */
+export const CATALOG_HUB_ENTRY_LINKS = [
+  { label: 'MST3K', href: '/catalog/mst3k' },
+  { label: 'Community', href: '/catalog/community' },
+  { label: 'Riff-Ready', href: '/catalog/riff-ready' },
+  { label: 'Movie Night', href: '/catalog/movie-night' },
+] as const

--- a/apps/web/src/catalog/filterCatalogEntries.test.ts
+++ b/apps/web/src/catalog/filterCatalogEntries.test.ts
@@ -75,6 +75,16 @@ describe('filterCatalogEntries', () => {
     expect(result.map((e) => e.experimentNumber)).toEqual([101, 200, 999])
   })
 
+  it('filters MST3K host eras and excludes community, riffable, movie_night, and other', () => {
+    const mst3kEras = ['joel', 'mike', 'jonah', 'emily'] as const
+    const result = filterCatalogEntries(sampleEntries, { titleQuery: '', eras: mst3kEras })
+    expect(result.map((e) => e.id)).toEqual(['ep-b', 'ep-a', 'ep-c', 'ep-d'])
+    expect(result.map((e) => e.era)).not.toContain('community')
+    expect(result.map((e) => e.era)).not.toContain('riffable')
+    expect(result.map((e) => e.era)).not.toContain('movie_night')
+    expect(result.map((e) => e.era)).not.toContain('other')
+  })
+
   it('filters by default catalog eras (Joel, Mike, Jonah, Emily, Community, Riffable)', () => {
     const result = filterCatalogEntries(sampleEntries, {
       titleQuery: '',

--- a/apps/web/src/components/catalog/CatalogBreadcrumbs.tsx
+++ b/apps/web/src/components/catalog/CatalogBreadcrumbs.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+
+export interface CatalogBreadcrumbsProps {
+  subcategoryLabel: string
+}
+
+export function CatalogBreadcrumbs({ subcategoryLabel }: CatalogBreadcrumbsProps) {
+  return (
+    <nav className="riffsync-catalog-breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        <li>
+          <Link to="/catalog">Catalog</Link>
+        </li>
+        <li aria-current="page">
+          {subcategoryLabel}
+        </li>
+      </ol>
+    </nav>
+  )
+}

--- a/apps/web/src/components/catalog/CatalogFilterBar.tsx
+++ b/apps/web/src/components/catalog/CatalogFilterBar.tsx
@@ -1,11 +1,13 @@
 import { PUBLIC_CATALOG_ERAS, formatCatalogEraLabel, type CatalogEra } from '../../catalog/catalogTypes'
 
 export interface CatalogFilterBarProps {
-  selectedEras: CatalogEra[]
-  onSelectedErasChange: (eras: CatalogEra[]) => void
+  selectedEras?: CatalogEra[]
+  onSelectedErasChange?: (eras: CatalogEra[]) => void
   titleQuery: string
   onTitleQueryChange: (query: string) => void
   disabled?: boolean
+  /** When false, era-chip toggles are hidden (catalog hub). Defaults to true. */
+  showEraChips?: boolean
 }
 
 function toggleEra(selectedEras: CatalogEra[], era: CatalogEra): CatalogEra[] {
@@ -16,35 +18,38 @@ function toggleEra(selectedEras: CatalogEra[], era: CatalogEra): CatalogEra[] {
 }
 
 export function CatalogFilterBar({
-  selectedEras,
+  selectedEras = [],
   onSelectedErasChange,
   titleQuery,
   onTitleQueryChange,
   disabled = false,
+  showEraChips = true,
 }: CatalogFilterBarProps) {
   return (
     <div className="riffsync-catalog-filter-bar">
-      <div className="riffsync-catalog-filter-bar__era-group" role="group" aria-label="Filter by era">
-        {PUBLIC_CATALOG_ERAS.map((era) => {
-          const selected = selectedEras.includes(era)
-          return (
-            <button
-              key={era}
-              type="button"
-              className={
-                selected
-                  ? 'riffsync-catalog-filter-bar__era riffsync-catalog-filter-bar__era--selected'
-                  : 'riffsync-catalog-filter-bar__era'
-              }
-              aria-pressed={selected}
-              disabled={disabled}
-              onClick={() => onSelectedErasChange(toggleEra(selectedEras, era))}
-            >
-              {formatCatalogEraLabel(era)}
-            </button>
-          )
-        })}
-      </div>
+      {showEraChips && onSelectedErasChange && (
+        <div className="riffsync-catalog-filter-bar__era-group" role="group" aria-label="Filter by era">
+          {PUBLIC_CATALOG_ERAS.map((era) => {
+            const selected = selectedEras.includes(era)
+            return (
+              <button
+                key={era}
+                type="button"
+                className={
+                  selected
+                    ? 'riffsync-catalog-filter-bar__era riffsync-catalog-filter-bar__era--selected'
+                    : 'riffsync-catalog-filter-bar__era'
+                }
+                aria-pressed={selected}
+                disabled={disabled}
+                onClick={() => onSelectedErasChange(toggleEra(selectedEras, era))}
+              >
+                {formatCatalogEraLabel(era)}
+              </button>
+            )
+          })}
+        </div>
+      )}
       <label className="riffsync-catalog-filter-bar__title">
         <span className="sr-only">Search by title</span>
         <input

--- a/apps/web/src/components/catalog/CatalogGridCard.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom'
+import { catalogCardImageUrl } from '../../catalog/mockCatalog'
+import { formatCatalogEraLabel, type CatalogEpisode } from '../../catalog/catalogTypes'
+import { PlaybackExpectationBadge } from '../watch/PlaybackExpectationBadge'
+import { EpisodeTileActions } from './EpisodeTileActions'
+
+export function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
+  const img = catalogCardImageUrl(episode)
+  return (
+    <article className="riffsync-catalog-card movie type-movie status-publish has-post-thumbnail hentry">
+      <div className="gen-carousel-movies-style-3 movie-grid style-3">
+        <div className="gen-movie-contain">
+          <div className="gen-movie-img">
+            <img src={img} alt={episode.title} loading="lazy" />
+          </div>
+          <EpisodeTileActions episode={episode} />
+          <div className="gen-info-contain">
+            <div className="gen-movie-info">
+              <h3>
+                <Link to={`/watch/${episode.id}`}>{episode.title}</Link>
+              </h3>
+            </div>
+            <div className="gen-movie-meta-holder">
+              <ul>
+                <li>#{episode.experimentNumber}</li>
+                <li>
+                  <span>{formatCatalogEraLabel(episode.era)}</span>
+                </li>
+              </ul>
+              <div className="riffsync-catalog-card__advisory">
+                <PlaybackExpectationBadge expectation={episode.playbackExpectation} />
+              </div>
+              {episode.embedAllows === false && (
+                <p className="riffsync-catalog-card__embed" role="status">
+                  Not embeddable in-app — use YouTube directly if available.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/components/catalog/CatalogHubEntryLinks.tsx
+++ b/apps/web/src/components/catalog/CatalogHubEntryLinks.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom'
+import { CATALOG_HUB_ENTRY_LINKS } from '../../catalog/catalogBrowseIa'
+
+export function CatalogHubEntryLinks() {
+  return (
+    <nav className="riffsync-catalog-hub-entry-links" aria-label="Catalog categories">
+      <ul className="riffsync-catalog-hub-entry-links__list">
+        {CATALOG_HUB_ENTRY_LINKS.map(({ label, href }) => (
+          <li key={href}>
+            <Link className="riffsync-catalog-hub-entry-links__link" to={href}>
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/web/src/components/site/CatalogNavItem.test.tsx
+++ b/apps/web/src/components/site/CatalogNavItem.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { CATALOG_HUB_ENTRY_LINKS } from '../../catalog/catalogBrowseIa'
+import { CatalogNavItem } from './CatalogNavItem'
+
+describe('CatalogNavItem', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderNav(path = '/catalog') {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={[path]}>
+          <ul>
+            <CatalogNavItem />
+          </ul>
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  function desktopRoot() {
+    return container.querySelector('.riffsync-catalog-nav__desktop')
+  }
+
+  function mobileRoot() {
+    return container.querySelector('.riffsync-catalog-nav__mobile')
+  }
+
+  function subcategoryHrefs(scope: ParentNode) {
+    return [...scope.querySelectorAll('a')]
+      .map((anchor) => anchor.getAttribute('href'))
+      .filter((href): href is string => href?.startsWith('/catalog/') ?? false)
+  }
+
+  function subcategoryLabels(scope: ParentNode) {
+    return [...scope.querySelectorAll('.riffsync-catalog-nav__dropdown a, .riffsync-catalog-nav__accordion-panel a')].map(
+      (anchor) => anchor.textContent?.trim(),
+    )
+  }
+
+  it('keeps Catalog parent links navigable to /catalog', () => {
+    renderNav('/')
+
+    const desktopParent = desktopRoot()?.querySelector('a[href="/catalog"]')
+    const mobileParent = mobileRoot()?.querySelector('a[href="/catalog"]')
+
+    expect(desktopParent?.textContent?.trim()).toBe('Catalog')
+    expect(mobileParent?.textContent?.trim()).toBe('Catalog')
+  })
+
+  it('lists the four public subcategory destinations in order on desktop and mobile', () => {
+    renderNav('/catalog')
+
+    const expectedHrefs = CATALOG_HUB_ENTRY_LINKS.map((entry) => entry.href)
+    const expectedLabels = CATALOG_HUB_ENTRY_LINKS.map((entry) => entry.label)
+
+    expect(subcategoryHrefs(desktopRoot()!)).toEqual(expectedHrefs)
+    expect(subcategoryHrefs(mobileRoot()!)).toEqual(expectedHrefs)
+    expect(subcategoryLabels(container)).toEqual([...expectedLabels, ...expectedLabels])
+    expect(container.textContent).not.toContain('other')
+  })
+
+  it('marks the catalog nav item active on subcategory routes', () => {
+    renderNav('/catalog/mst3k')
+
+    expect(container.querySelector('.riffsync-catalog-nav')?.classList.contains('active')).toBe(true)
+  })
+
+  it('exposes desktop disclosure semantics and keyboard toggling', () => {
+    renderNav('/catalog')
+
+    const trigger = desktopRoot()?.querySelector('.riffsync-catalog-nav__disclosure-trigger') as HTMLButtonElement
+    const panel = desktopRoot()?.querySelector('.riffsync-catalog-nav__dropdown') as HTMLUListElement
+
+    expect(trigger.getAttribute('aria-haspopup')).toBe('true')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(panel.hidden).toBe(true)
+
+    act(() => {
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(panel.hidden).toBe(false)
+
+    act(() => {
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(panel.hidden).toBe(true)
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('expands the mobile accordion inline inside the nav item', () => {
+    renderNav('/catalog')
+
+    const collapse = document.createElement('div')
+    collapse.className = 'navbar-collapse show'
+    const navItem = container.querySelector('.riffsync-catalog-nav')
+    collapse.appendChild(navItem!)
+    container.appendChild(collapse)
+
+    const trigger = mobileRoot()?.querySelector('.riffsync-catalog-nav__accordion-trigger') as HTMLButtonElement
+    const panel = mobileRoot()?.querySelector('.riffsync-catalog-nav__accordion-panel') as HTMLUListElement
+
+    expect(collapse.contains(panel)).toBe(true)
+    expect(panel.hidden).toBe(true)
+
+    act(() => {
+      trigger.click()
+    })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(panel.hidden).toBe(false)
+    expect(subcategoryHrefs(panel)).toEqual(CATALOG_HUB_ENTRY_LINKS.map((entry) => entry.href))
+
+    act(() => {
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(panel.hidden).toBe(true)
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/apps/web/src/components/site/CatalogNavItem.tsx
+++ b/apps/web/src/components/site/CatalogNavItem.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { NavLink, useMatch } from 'react-router-dom'
+import { CATALOG_HUB_ENTRY_LINKS } from '../../catalog/catalogBrowseIa'
+
+function CatalogSubcategoryLinks() {
+  return (
+    <>
+      {CATALOG_HUB_ENTRY_LINKS.map(({ label, href }) => (
+        <li key={href}>
+          <NavLink to={href} end>
+            {label}
+          </NavLink>
+        </li>
+      ))}
+    </>
+  )
+}
+
+export function CatalogNavItem() {
+  const catalogActive = !!useMatch({ path: '/catalog', end: false })
+  const [desktopOpen, setDesktopOpen] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const desktopTriggerRef = useRef<HTMLButtonElement>(null)
+  const mobileTriggerRef = useRef<HTMLButtonElement>(null)
+  const desktopPanelId = useId()
+  const mobilePanelId = useId()
+
+  const closeDesktop = useCallback(() => {
+    setDesktopOpen(false)
+  }, [])
+
+  const toggleDesktop = useCallback(() => {
+    setDesktopOpen((open) => !open)
+  }, [])
+
+  const toggleMobile = useCallback(() => {
+    setMobileOpen((open) => !open)
+  }, [])
+
+  const onDesktopTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      toggleDesktop()
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeDesktop()
+      desktopTriggerRef.current?.focus()
+    }
+  }
+
+  const onMobileTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      toggleMobile()
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      setMobileOpen(false)
+      mobileTriggerRef.current?.focus()
+    }
+  }
+
+  useEffect(() => {
+    if (!desktopOpen) {
+      return
+    }
+
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) {
+        return
+      }
+      const root = desktopTriggerRef.current?.closest('.riffsync-catalog-nav__desktop')
+      if (root && !root.contains(target)) {
+        closeDesktop()
+      }
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [closeDesktop, desktopOpen])
+
+  return (
+    <li className={`menu-item riffsync-catalog-nav${catalogActive ? ' active' : ''}`}>
+      <div
+        className="riffsync-catalog-nav__desktop"
+        onMouseEnter={() => setDesktopOpen(true)}
+        onMouseLeave={closeDesktop}
+      >
+        <NavLink to="/catalog" end={false}>
+          Catalog
+        </NavLink>
+        <button
+          ref={desktopTriggerRef}
+          type="button"
+          className="riffsync-catalog-nav__disclosure-trigger"
+          aria-label="Show catalog categories"
+          aria-haspopup="true"
+          aria-expanded={desktopOpen}
+          aria-controls={desktopPanelId}
+          onClick={toggleDesktop}
+          onKeyDown={onDesktopTriggerKeyDown}
+        >
+          <span aria-hidden="true">▾</span>
+        </button>
+        <ul
+          id={desktopPanelId}
+          className={`riffsync-catalog-nav__dropdown${desktopOpen ? ' is-open' : ''}`}
+          hidden={!desktopOpen}
+        >
+          <CatalogSubcategoryLinks />
+        </ul>
+      </div>
+
+      <div className="riffsync-catalog-nav__mobile">
+        <div className="riffsync-catalog-nav__mobile-row">
+          <NavLink to="/catalog" end={false}>
+            Catalog
+          </NavLink>
+          <button
+            ref={mobileTriggerRef}
+            type="button"
+            className="riffsync-catalog-nav__accordion-trigger"
+            aria-label="Expand catalog categories"
+            aria-expanded={mobileOpen}
+            aria-controls={mobilePanelId}
+            onClick={toggleMobile}
+            onKeyDown={onMobileTriggerKeyDown}
+          >
+            <span aria-hidden="true">{mobileOpen ? '▴' : '▾'}</span>
+          </button>
+        </div>
+        <ul
+          id={mobilePanelId}
+          className={`riffsync-catalog-nav__accordion-panel${mobileOpen ? ' is-open' : ''}`}
+          hidden={!mobileOpen}
+        >
+          <CatalogSubcategoryLinks />
+        </ul>
+      </div>
+    </li>
+  )
+}

--- a/apps/web/src/components/site/SiteHeader.test.tsx
+++ b/apps/web/src/components/site/SiteHeader.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CATALOG_HUB_ENTRY_LINKS } from '../../catalog/catalogBrowseIa'
 import { SiteHeader } from './SiteHeader'
 
 const startFanHostedUiSignIn = vi.fn<(returnPath: string) => Promise<void>>()
@@ -74,5 +75,17 @@ describe('SiteHeader fan session nav', () => {
 
     expect(container.querySelector('a[href="/account"]')?.textContent).toBe('Account')
     expect(container.querySelector('.riffsync-site-nav-sign-in')).toBeNull()
+  })
+
+  it('renders catalog nav chrome inside navbar-collapse', () => {
+    useFanSession.mockReturnValue({ fanToken: null })
+    renderHeader('/catalog')
+
+    const collapse = container.querySelector('#navbarSupportedContent')
+    const catalogNav = container.querySelector('.riffsync-catalog-nav')
+
+    expect(collapse?.contains(catalogNav)).toBe(true)
+    expect(container.querySelectorAll('a[href="/catalog"]').length).toBeGreaterThanOrEqual(2)
+    expect(CATALOG_HUB_ENTRY_LINKS.every(({ href }) => container.querySelector(`a[href="${href}"]`))).toBe(true)
   })
 })

--- a/apps/web/src/components/site/SiteHeader.tsx
+++ b/apps/web/src/components/site/SiteHeader.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../auth/fanHostedUiPkce'
 import { useFanSession } from '../../auth/useFanSession'
 import { useRoomChromeOptional } from '../../room/useRoomChrome'
+import { CatalogNavItem } from './CatalogNavItem'
 
 function PrimaryNavItem({
   to,
@@ -86,7 +87,7 @@ export function SiteHeader({ compact = false }: { compact?: boolean }) {
                       <PrimaryNavItem to="/" end>
                         Home
                       </PrimaryNavItem>
-                      <PrimaryNavItem to="/catalog">Catalog</PrimaryNavItem>
+                      <CatalogNavItem />
                       <PrimaryNavItem to="/lobby">Lobby</PrimaryNavItem>
                       {fanToken ? (
                         <PrimaryNavItem to="/account">Account</PrimaryNavItem>

--- a/apps/web/src/pages/CatalogPage.test.tsx
+++ b/apps/web/src/pages/CatalogPage.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CatalogPage } from './CatalogPage'
+import { CATALOG_HUB_ENTRY_LINKS } from '../catalog/catalogBrowseIa'
 import type { CatalogEpisode } from '../catalog/catalogTypes'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -82,5 +83,43 @@ describe('CatalogPage', () => {
     for (const img of posterImages) {
       expect(img.getAttribute('alt')).not.toBe('')
     }
+  })
+
+  it('renders four hub entry links above search and the mixed grid in fixed order', () => {
+    renderCatalogPage()
+
+    const hubNav = container.querySelector('.riffsync-catalog-hub-entry-links')
+    expect(hubNav).not.toBeNull()
+
+    const filterBar = container.querySelector('.riffsync-catalog-filter-bar')
+    const grid = container.querySelector('.riffsync-catalog-grid')
+    expect(hubNav!.compareDocumentPosition(filterBar!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(filterBar!.compareDocumentPosition(grid!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+
+    const hubLinks = Array.from(
+      container.querySelectorAll('.riffsync-catalog-hub-entry-links__link'),
+    ) as HTMLAnchorElement[]
+
+    expect(hubLinks).toHaveLength(4)
+    expect(hubLinks.map((link) => link.textContent?.trim())).toEqual(
+      CATALOG_HUB_ENTRY_LINKS.map((entry) => entry.label),
+    )
+    expect(hubLinks.map((link) => link.getAttribute('href'))).toEqual(
+      CATALOG_HUB_ENTRY_LINKS.map((entry) => entry.href),
+    )
+  })
+
+  it('does not render public era-chip toggles on the hub', () => {
+    renderCatalogPage()
+
+    expect(container.querySelector('.riffsync-catalog-filter-bar__era-group')).toBeNull()
+    expect(container.querySelector('.riffsync-catalog-filter-bar__era')).toBeNull()
+  })
+
+  it('keeps the mixed grid unfiltered by era on the hub', () => {
+    renderCatalogPage()
+
+    const cards = container.querySelectorAll('.riffsync-catalog-card')
+    expect(cards).toHaveLength(catalogFixtures.length)
   })
 })

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -3,12 +3,13 @@ import { useMemo, useState } from 'react'
 import { useCatalogListQuery } from '../catalog/catalogQueries'
 import { CatalogLoadErrorPanel } from '../components/catalog/CatalogLoadErrorPanel'
 import { CatalogFilterBar } from '../components/catalog/CatalogFilterBar'
+import { CatalogHubEntryLinks } from '../components/catalog/CatalogHubEntryLinks'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
 import { catalogCardImageUrl, catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
-import { filterCatalogEntries, DEFAULT_CATALOG_FILTER_ERAS } from '../catalog/filterCatalogEntries'
+import { filterCatalogEntries } from '../catalog/filterCatalogEntries'
 import { PlaybackExpectationBadge } from '../components/watch/PlaybackExpectationBadge'
 import { EpisodeTileActions } from '../components/catalog/EpisodeTileActions'
-import { formatCatalogEraLabel, type CatalogEra, type CatalogEpisode } from '../catalog/catalogTypes'
+import { formatCatalogEraLabel, type CatalogEpisode } from '../catalog/catalogTypes'
 
 function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
   const img = catalogCardImageUrl(episode)
@@ -52,7 +53,6 @@ function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
 export function CatalogPage() {
   const navigate = useNavigate()
   const { data, isPending, isError, error, refetch } = useCatalogListQuery()
-  const [selectedEras, setSelectedEras] = useState<CatalogEra[]>(() => [...DEFAULT_CATALOG_FILTER_ERAS])
   const [titleQuery, setTitleQuery] = useState('')
 
   useResumePendingPartyRoom(data, navigate)
@@ -63,8 +63,8 @@ export function CatalogPage() {
     [allEntries],
   )
   const filteredEntries = useMemo(
-    () => filterCatalogEntries(youtubeEntries, { titleQuery, eras: selectedEras }),
-    [youtubeEntries, titleQuery, selectedEras],
+    () => filterCatalogEntries(youtubeEntries, { titleQuery, eras: [] }),
+    [youtubeEntries, titleQuery],
   )
 
   const filterBarDisabled = isPending && !data
@@ -97,12 +97,12 @@ export function CatalogPage() {
     <div className="container riffsync-catalog-page">
       <h1>Catalog</h1>
       <p className="riffsync-catalog-page__lede">Push the button, Frank</p>
+      <CatalogHubEntryLinks />
       <CatalogFilterBar
-        selectedEras={selectedEras}
-        onSelectedErasChange={setSelectedEras}
         titleQuery={titleQuery}
         onTitleQueryChange={setTitleQuery}
         disabled={filterBarDisabled}
+        showEraChips={false}
       />
       <div className="riffsync-catalog-grid">
         {filteredEntries.map((ep) => (
@@ -119,9 +119,7 @@ export function CatalogPage() {
       {isFilterNoMatch && (
         <div className="riffsync-catalog-no-match">
           <p>No episodes match your filters.</p>
-          <p className="riffsync-catalog-no-match-hint">
-            Clear the search field or deselect era filters to see all episodes.
-          </p>
+          <p className="riffsync-catalog-no-match-hint">Clear the search field to see all episodes.</p>
         </div>
       )}
       <p>

--- a/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CATALOG_SUBCATEGORIES } from '../catalog/catalogBrowseIa'
+import { filterCatalogEntries } from '../catalog/filterCatalogEntries'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+import { CatalogSubcategoryPage } from './CatalogSubcategoryPage'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const useCatalogListQuery = vi.fn()
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogListQuery: () => useCatalogListQuery(),
+}))
+
+function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>): CatalogEpisode {
+  return {
+    experimentNumber: 100,
+    title: 'Default title',
+    era: 'joel',
+    youtubeVideoId: 'abc123',
+    youtubeWatchUrl: 'https://youtube.com/watch?v=abc123',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    ...overrides,
+  }
+}
+
+const catalogFixtures: CatalogEpisode[] = [
+  episode({ id: 'ep-joel', experimentNumber: 200, title: 'Pod People', era: 'joel' }),
+  episode({ id: 'ep-mike', experimentNumber: 101, title: 'Cave Dwellers', era: 'mike' }),
+  episode({ id: 'ep-jonah', experimentNumber: 310, title: 'Giant Spider', era: 'jonah' }),
+  episode({ id: 'ep-emily', experimentNumber: 1200, title: 'Emily Special', era: 'emily' }),
+  episode({ id: 'ep-community', experimentNumber: 500, title: 'Community Riff', era: 'community' }),
+  episode({ id: 'ep-riffable', experimentNumber: 1600, title: 'Riffable Classic', era: 'riffable' }),
+  episode({ id: 'ep-movie-night', experimentNumber: 1500, title: 'Movie Night Pick', era: 'movie_night' }),
+  episode({ id: 'ep-other', experimentNumber: 999, title: 'Other Experiment', era: 'other' }),
+]
+
+describe('CatalogSubcategoryPage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    useCatalogListQuery.mockReset()
+    useCatalogListQuery.mockReturnValue({
+      data: catalogFixtures,
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderSubcategoryPage(path: string) {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={[path]}>
+          <CatalogSubcategoryPage />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it.each(CATALOG_SUBCATEGORIES.map((entry) => [entry.path, entry.label] as const))(
+    'renders H1, breadcrumbs, search, and filtered grid for %s',
+    (path, label) => {
+      renderSubcategoryPage(path)
+
+      const h1 = container.querySelector('h1')
+      expect(h1?.textContent).toBe(label)
+
+      const breadcrumbNav = container.querySelector('.riffsync-catalog-breadcrumb')
+      expect(breadcrumbNav).not.toBeNull()
+
+      const breadcrumbLinks = Array.from(
+        breadcrumbNav!.querySelectorAll('a'),
+      ) as HTMLAnchorElement[]
+      expect(breadcrumbLinks.map((link) => link.textContent?.trim())).toEqual(['Home', 'Catalog'])
+      expect(breadcrumbLinks.map((link) => link.getAttribute('href'))).toEqual(['/', '/catalog'])
+
+      const currentCrumb = breadcrumbNav!.querySelector('[aria-current="page"]')
+      expect(currentCrumb?.textContent?.trim()).toBe(label)
+
+      expect(container.querySelector('.riffsync-catalog-filter-bar')).not.toBeNull()
+      expect(container.querySelector('.riffsync-catalog-filter-bar__era-group')).toBeNull()
+      expect(container.querySelector('input[type="search"]')).not.toBeNull()
+
+      const subcategory = CATALOG_SUBCATEGORIES.find((entry) => entry.path === path)!
+      const expectedIds = filterCatalogEntries(catalogFixtures, {
+        titleQuery: '',
+        eras: subcategory.eras,
+      }).map((entry) => entry.id)
+
+      const cards = container.querySelectorAll('.riffsync-catalog-card')
+      expect(cards).toHaveLength(expectedIds.length)
+    },
+  )
+
+  it('MST3K includes host eras and excludes community, riffable, movie_night, and other', () => {
+    renderSubcategoryPage('/catalog/mst3k')
+
+    const titles = Array.from(container.querySelectorAll('.riffsync-catalog-card h3 a')).map(
+      (link) => link.textContent?.trim(),
+    )
+
+    expect(titles).toEqual(['Cave Dwellers', 'Pod People', 'Giant Spider', 'Emily Special'])
+    expect(titles).not.toContain('Community Riff')
+    expect(titles).not.toContain('Riffable Classic')
+    expect(titles).not.toContain('Movie Night Pick')
+    expect(titles).not.toContain('Other Experiment')
+  })
+
+  it('Riff-Ready shows public label in chrome while filtering riffable rows', () => {
+    renderSubcategoryPage('/catalog/riff-ready')
+
+    expect(container.querySelector('h1')?.textContent).toBe('Riff-Ready')
+    expect(container.querySelector('[aria-current="page"]')?.textContent?.trim()).toBe('Riff-Ready')
+
+    const cards = container.querySelectorAll('.riffsync-catalog-card')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.querySelector('h3 a')?.textContent?.trim()).toBe('Riffable Classic')
+  })
+
+  it('sets poster img alt text to each episode title', () => {
+    renderSubcategoryPage('/catalog/community')
+
+    const posterImages = Array.from(
+      container.querySelectorAll('.riffsync-catalog-card img'),
+    ) as HTMLImageElement[]
+
+    expect(posterImages).toHaveLength(1)
+    expect(posterImages[0]?.getAttribute('alt')).toBe('Community Riff')
+  })
+
+  it('shows empty-catalog presentation when the subcategory filter matches no rows', () => {
+    useCatalogListQuery.mockReturnValue({
+      data: [episode({ id: 'ep-joel-only', experimentNumber: 200, title: 'Pod People', era: 'joel' })],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderSubcategoryPage('/catalog/community')
+
+    expect(container.querySelector('.riffsync-catalog-grid')?.children.length).toBe(0)
+    expect(container.querySelector('.riffsync-catalog-no-match')).not.toBeNull()
+    expect(container.textContent).toContain('No episodes match your filters')
+  })
+})

--- a/apps/web/src/pages/CatalogSubcategoryPage.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.tsx
@@ -1,16 +1,19 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useMemo, useState } from 'react'
 import { useCatalogListQuery } from '../catalog/catalogQueries'
+import { getCatalogSubcategoryByPath } from '../catalog/catalogBrowseIa'
 import { CatalogLoadErrorPanel } from '../components/catalog/CatalogLoadErrorPanel'
 import { CatalogFilterBar } from '../components/catalog/CatalogFilterBar'
-import { CatalogHubEntryLinks } from '../components/catalog/CatalogHubEntryLinks'
+import { CatalogBreadcrumbs } from '../components/catalog/CatalogBreadcrumbs'
 import { CatalogGridCard } from '../components/catalog/CatalogGridCard'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
 import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
 import { filterCatalogEntries } from '../catalog/filterCatalogEntries'
 
-export function CatalogPage() {
+export function CatalogSubcategoryPage() {
+  const { pathname } = useLocation()
   const navigate = useNavigate()
+  const subcategory = getCatalogSubcategoryByPath(pathname)
   const { data, isPending, isError, error, refetch } = useCatalogListQuery()
   const [titleQuery, setTitleQuery] = useState('')
 
@@ -22,17 +25,32 @@ export function CatalogPage() {
     [allEntries],
   )
   const filteredEntries = useMemo(
-    () => filterCatalogEntries(youtubeEntries, { titleQuery, eras: [] }),
-    [youtubeEntries, titleQuery],
+    () =>
+      subcategory
+        ? filterCatalogEntries(youtubeEntries, { titleQuery, eras: subcategory.eras })
+        : [],
+    [youtubeEntries, titleQuery, subcategory],
   )
 
   const filterBarDisabled = isPending && !data
   const isFilterNoMatch = youtubeEntries.length > 0 && filteredEntries.length === 0
 
-  if (isPending && !data) {
+  if (!subcategory) {
     return (
       <div className="container">
         <h1>Catalog</h1>
+        <p>That catalog category was not found.</p>
+        <p>
+          <Link to="/catalog">← Catalog</Link>
+        </p>
+      </div>
+    )
+  }
+
+  if (isPending && !data) {
+    return (
+      <div className="container">
+        <h1>{subcategory.label}</h1>
         <p>Loading…</p>
       </div>
     )
@@ -53,10 +71,9 @@ export function CatalogPage() {
   }
 
   return (
-    <div className="container riffsync-catalog-page">
-      <h1>Catalog</h1>
-      <p className="riffsync-catalog-page__lede">Push the button, Frank</p>
-      <CatalogHubEntryLinks />
+    <div className="container riffsync-catalog-page riffsync-catalog-subcategory-page">
+      <CatalogBreadcrumbs subcategoryLabel={subcategory.label} />
+      <h1>{subcategory.label}</h1>
       <CatalogFilterBar
         titleQuery={titleQuery}
         onTitleQueryChange={setTitleQuery}
@@ -81,9 +98,6 @@ export function CatalogPage() {
           <p className="riffsync-catalog-no-match-hint">Clear the search field to see all episodes.</p>
         </div>
       )}
-      <p>
-        <Link to="/">← Home</Link>
-      </p>
     </div>
   )
 }

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -363,6 +363,33 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   max-width: 48rem;
 }
 
+.riffsync-catalog-hub-entry-links {
+  margin-bottom: 1.25rem;
+}
+
+.riffsync-catalog-hub-entry-links__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.riffsync-catalog-hub-entry-links__link {
+  color: var(--white-color);
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.riffsync-catalog-hub-entry-links__link:hover,
+.riffsync-catalog-hub-entry-links__link:focus-visible {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+
 .riffsync-catalog-filter-bar {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -390,6 +390,38 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   text-decoration: underline;
 }
 
+.riffsync-catalog-breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  font-size: 0.875rem;
+  color: var(--secondary-color);
+}
+
+.riffsync-catalog-breadcrumb a {
+  color: var(--secondary-color);
+  text-decoration: none;
+}
+
+.riffsync-catalog-breadcrumb a:hover,
+.riffsync-catalog-breadcrumb a:focus {
+  color: var(--primary-color);
+}
+
+.riffsync-catalog-breadcrumb li:not(:last-child)::after {
+  content: '>';
+  margin-left: 0.5rem;
+  color: rgb(255 255 255 / 0.35);
+}
+
+.riffsync-catalog-breadcrumb li[aria-current='page'] {
+  color: var(--white-color);
+}
+
 .riffsync-catalog-filter-bar {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -545,6 +545,96 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   }
 }
 
+/* Catalog nav — desktop dropdown + mobile accordion (M32 #345) */
+.riffsync-catalog-nav__desktop {
+  display: none;
+}
+
+.riffsync-catalog-nav__mobile {
+  display: block;
+}
+
+.riffsync-catalog-nav__mobile-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.riffsync-catalog-nav__accordion-panel {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 1rem;
+}
+
+.riffsync-catalog-nav__accordion-panel li {
+  line-height: 2.5rem;
+}
+
+.riffsync-catalog-nav__disclosure-trigger,
+.riffsync-catalog-nav__accordion-trigger {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0 0.25rem;
+  margin: 0;
+  font: inherit;
+  color: var(--white-color);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.riffsync-catalog-nav__disclosure-trigger:hover,
+.riffsync-catalog-nav__disclosure-trigger:focus,
+.riffsync-catalog-nav__accordion-trigger:hover,
+.riffsync-catalog-nav__accordion-trigger:focus {
+  color: var(--primary-color);
+}
+
+@media (min-width: 992px) {
+  .riffsync-catalog-nav__desktop {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.15rem;
+  }
+
+  .riffsync-catalog-nav__mobile {
+    display: none;
+  }
+
+  .riffsync-catalog-nav__dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 20;
+    list-style: none;
+    margin: 0.35rem 0 0;
+    padding: 0.35rem 0;
+    min-width: 11rem;
+    background: var(--black-color);
+    border: 1px solid rgb(255 255 255 / 12%);
+    border-radius: 4px;
+    box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  }
+
+  .riffsync-catalog-nav__dropdown li {
+    line-height: 2.25rem;
+  }
+
+  .riffsync-catalog-nav__dropdown a {
+    display: block;
+    padding: 0 1rem;
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 991px) {
+  .riffsync-catalog-nav {
+    width: 100%;
+  }
+}
+
 /* Room shell: cinematic backdrop matching solo watch home-style treatment */
 .riffsync-site--room {
   height: 100dvh;


### PR DESCRIPTION
## Summary

- Removes public era-chip toggles from `/catalog` and keeps the mixed/all-titles grid unfiltered (`eras: []`) (#344).
- Adds four large text hub entry links above title search in fixed order: MST3K, Community, Riff-Ready, Movie Night (#344).
- Adds `CatalogNavItem` in `SiteHeader`: Catalog remains a link to `/catalog`, with a desktop disclosure dropdown and a mobile inline accordion listing the same four subcategory destinations (#345).
- Adds four public subcategory routes with a shared shell: H1, breadcrumbs (`Home > Catalog > {Subcategory}`), title search scoped to route-fixed `eras`, and `CatalogGridCard` grid (#346).
- Extracts shared `CatalogGridCard`, `CatalogBreadcrumbs`, and `CATALOG_SUBCATEGORIES` constants for hub/nav/subcategory alignment.

Part of epic #340 (M32 catalog subcategory browse IA). SEO sitemap/prerender packaging for subcategory paths remains #341 (M33).

Closes #344, #345, and #346 when merged.

## Test plan

- [x] `npm test` in `apps/web` (863 tests)
- [x] `npm run lint` in `apps/web`
- [x] `npm run build` in `apps/web`
- [ ] Manual hub (#344): `/catalog` shows four large text links above search + mixed grid; no public era chips
- [ ] Manual nav (#345): desktop Catalog parent navigates to `/catalog`; dropdown lists four destinations in order
- [ ] Manual nav (#345): narrow viewport hamburger expands Catalog inline to the same four links
- [ ] Manual subcategories (#346): each `/catalog/{mst3k,community,riff-ready,movie-night}` shows H1, breadcrumbs, search/sort, and correctly filtered cards; Riff-Ready chrome label vs `riffable` filter key