### PR TITLE
[M33] Catalog subcategory SEO packaging (sitemap, prerender, head tags)

### DIFF
--- a/apps/web/src/seo/indexableRoutes.ts
+++ b/apps/web/src/seo/indexableRoutes.ts
@@ -2,6 +2,10 @@
 export const STATIC_INDEXABLE_ROUTES = [
   '/',
   '/catalog',
+  '/catalog/mst3k',
+  '/catalog/community',
+  '/catalog/riff-ready',
+  '/catalog/movie-night',
   '/how-to-host-a-watchparty',
   '/terms',
   '/privacy',

--- a/apps/web/src/seo/routeHeadTags.test.ts
+++ b/apps/web/src/seo/routeHeadTags.test.ts
@@ -73,8 +73,55 @@ describe('buildStaticRouteHeadTags', () => {
   it('uses normative catalog title and description', () => {
     const head = buildStaticRouteHeadTags('/catalog', 'https://riffsync.tv')
     expect(head.documentTitle).toBe('RiffSync Catalog — browse the library')
-    expect(head.description).toContain('Browse the RiffSync catalog')
+    expect(head.description).toBe(
+      'Browse the RiffSync catalog of riff-style episodes with lawful YouTube embeds. Explore MST3K, Community, Riff-Ready, and Movie Night, pick an experiment, and start a watch party. Unofficial fan project.',
+    )
     expect(head.canonicalUrl).toBe('https://riffsync.tv/catalog')
+  })
+
+  it('uses normative subcategory copy for catalog subcategory routes', () => {
+    const subcategories = [
+      {
+        route: '/catalog/mst3k' as const,
+        title: 'MST3K — RiffSync Catalog',
+        description:
+          'Browse Mystery Science Theater 3000 episodes on RiffSync — Joel, Mike, Jonah, and Emily eras with lawful YouTube embeds. Unofficial fan project.',
+        canonical: 'https://riffsync.tv/catalog/mst3k',
+      },
+      {
+        route: '/catalog/community' as const,
+        title: 'Community — RiffSync Catalog',
+        description:
+          'Browse Community catalog titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
+        canonical: 'https://riffsync.tv/catalog/community',
+      },
+      {
+        route: '/catalog/riff-ready' as const,
+        title: 'Riff-Ready — RiffSync Catalog',
+        description:
+          'Browse Riff-Ready titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
+        canonical: 'https://riffsync.tv/catalog/riff-ready',
+      },
+      {
+        route: '/catalog/movie-night' as const,
+        title: 'Movie Night — RiffSync Catalog',
+        description:
+          'Browse Movie Night titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
+        canonical: 'https://riffsync.tv/catalog/movie-night',
+      },
+    ] as const
+
+    for (const { route, title, description, canonical } of subcategories) {
+      const head = buildStaticRouteHeadTags(route, 'https://riffsync.tv')
+      expect(head.documentTitle).toBe(title)
+      expect(head.description).toBe(description)
+      expect(head.canonicalUrl).toBe(canonical)
+      expect(head.ogImageUrl).toBe('https://riffsync.tv/og-card.png')
+    }
+  })
+
+  it('indexes nine static routes', () => {
+    expect(STATIC_INDEXABLE_ROUTES).toHaveLength(9)
   })
 })
 

--- a/apps/web/src/seo/routeHeadTags.ts
+++ b/apps/web/src/seo/routeHeadTags.ts
@@ -15,7 +15,27 @@ const STATIC_ROUTE_COPY = {
   '/catalog': {
     title: 'RiffSync Catalog — browse the library',
     description:
-      'Browse the RiffSync catalog of riff-style episodes with lawful YouTube embeds. Filter by era, pick an experiment, and start a watch party. Unofficial fan project.',
+      'Browse the RiffSync catalog of riff-style episodes with lawful YouTube embeds. Explore MST3K, Community, Riff-Ready, and Movie Night, pick an experiment, and start a watch party. Unofficial fan project.',
+  },
+  '/catalog/mst3k': {
+    title: 'MST3K — RiffSync Catalog',
+    description:
+      'Browse Mystery Science Theater 3000 episodes on RiffSync — Joel, Mike, Jonah, and Emily eras with lawful YouTube embeds. Unofficial fan project.',
+  },
+  '/catalog/community': {
+    title: 'Community — RiffSync Catalog',
+    description:
+      'Browse Community catalog titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
+  },
+  '/catalog/riff-ready': {
+    title: 'Riff-Ready — RiffSync Catalog',
+    description:
+      'Browse Riff-Ready titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
+  },
+  '/catalog/movie-night': {
+    title: 'Movie Night — RiffSync Catalog',
+    description:
+      'Browse Movie Night titles on RiffSync with lawful YouTube embeds. Pick an experiment and start a watch party. Unofficial fan project.',
   },
   '/how-to-host-a-watchparty': {
     title: 'How to host a watch party — RiffSync',

--- a/scripts/launch-readiness/smoke-production.mjs
+++ b/scripts/launch-readiness/smoke-production.mjs
@@ -47,6 +47,12 @@ const CHECKS = [
     expectStatus: 200,
     expectBodyExcludes: 'www.riffsync.tv',
   },
+  {
+    label: 'MST3K subcategory canonical link',
+    url: `${CANONICAL}/catalog/mst3k`,
+    expectStatus: 200,
+    expectBodyIncludes: '<link rel="canonical" href="https://riffsync.tv/catalog/mst3k">',
+  },
 ];
 
 async function runCheck(check) {


### PR DESCRIPTION
## Summary

- Extend `STATIC_INDEXABLE_ROUTES` from five to nine paths by adding `/catalog/mst3k`, `/catalog/community`, `/catalog/riff-ready`, and `/catalog/movie-night`.
- Add presentation-table head-tag copy for each subcategory route and refresh the hub `/catalog` description.
- Update `routeHeadTags` tests and add a post-deploy smoke check for `/catalog/mst3k` apex canonical.

Closes #341

## Test plan

- [x] `cd apps/web && npm ci && npm run build`
- [x] `npm run verify:seo-artifacts` (9 static routes + YouTube-linked watch pages)
- [x] `npm test`
- [x] `npm run lint`
- [ ] Manual post-deploy: `npm run smoke:production` after prod SPA publish