### PR TITLE
Catalog cards: dynamic tags replace ad advisory (#349)

### DIFF
--- a/.ai/business_logic/user_stories.md
+++ b/.ai/business_logic/user_stories.md
@@ -128,4 +128,4 @@ Implementation-level items not yet fully specified. `/refine-issue` resolves the
 ## Primary code pointers (optional)
 
 - Link GitHub issues when filed.
-- **US-P0-01 (browse):** `apps/web` home + `/catalog` hub and `/catalog/*` subcategory routes load from **`GET /v1/catalog`** when **`VITE_PUBLIC_API_BASE_URL`** is set (**M4 / issue #13**); **US-P0-07 (advisory):** `PlaybackExpectationBadge` + optional `playbackExpectation` on catalog rows (honor-system; see **`README`**).
+- **US-P0-01 (browse):** `apps/web` home + `/catalog` hub and `/catalog/*` subcategory routes load from **`GET /v1/catalog`** when **`VITE_PUBLIC_API_BASE_URL`** is set (**M4 / issue #13**); **US-P0-07 (advisory):** honor-system **`playbackExpectation`** on room/share surfaces (see **`README`**); **`CatalogGridCard`** shows **`episode.tags`** in source order with no playback-advisory fallback when tags are empty (**#349**).

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -58,6 +58,10 @@ Meta titles/descriptions/OG for **`/watch/:id`** always use the catalog **`title
 
 **`CatalogGridCard`** poster **`<img>`** elements use **`alt={episode.title}`** (catalog **`title`** field only — Invariant 9) instead of today's empty **`alt=""`**. Do **not** append **`poster`**, catalog labels, or experiment numbers to alt text; the adjacent visible **`h3`** link already carries the title for sighted users. Applies on **`/catalog`** and all four subcategory routes. Additive accessibility/SEO fix — no new interaction pattern, no visible layout change. **`HomeMovieCard`** on home rows is unchanged in this slice.
 
+### Catalog card browse metadata
+
+**`CatalogGridCard`** renders **`episode.tags`** in the card metadata area in the exact order received from the API. Tag strings are displayed as provided (namespace-agnostic; no hard-coded **`Season`**, **`Era`**, or **`Genre`** rendering rules). When **`episode.tags`** is empty, the card shows no fallback playback-advisory copy (**`Ads may appear`**, **`Premium-friendly`**, **`Likely ad-supported`**, or equivalent). Catalog cards do **not** show a visible not-embeddable message; **`embedAllows === false`** continues to gate in-app embed affordances through **`EpisodeTileActions`** / watch routing only.
+
 ### `/watch/:catalogEpisodeId` heading
 
 The existing **`sr-only`** **`<h1>{episode.title}</h1>`** on **`SoloWatchPage`** already satisfies the document-outline contract; this initiative adds only head-tag metadata (title/description/canonical/OG/Twitter per the table above) — no markup change to the existing heading.

--- a/apps/web/src/components/catalog/CatalogGridCard.test.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CatalogEpisode } from '../../catalog/catalogTypes'
+import { CatalogGridCard } from './CatalogGridCard'
+
+vi.mock('../../auth/fanTokens', () => ({
+  getFanAccessToken: () => null,
+}))
+
+vi.mock('../../auth/fanHostedUiPkce', () => ({
+  startFanHostedUiSignIn: vi.fn(),
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
+  return {
+    id: '032-mitchell',
+    experimentNumber: 32,
+    title: 'Mitchell',
+    catalog: 'mst3k',
+    tags: [],
+    labels: [],
+    youtubeVideoId: 'NXGXtm6gcxk',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    ...overrides,
+  }
+}
+
+describe('CatalogGridCard', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.restoreAllMocks()
+  })
+
+  function renderCard(ep: CatalogEpisode) {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <CatalogGridCard episode={ep} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('renders all episode tags in source order', () => {
+    renderCard(
+      episode({
+        tags: ['Era: Joel', 'Season: 1', 'Genre: Comedy'],
+      }),
+    )
+
+    const tagEls = Array.from(container.querySelectorAll('.riffsync-catalog-card__tag'))
+    expect(tagEls.map((el) => el.textContent)).toEqual(['Era: Joel', 'Season: 1', 'Genre: Comedy'])
+  })
+
+  it('renders arbitrary tag namespaces without special casing', () => {
+    renderCard(
+      episode({
+        tags: ['CustomNamespace: FutureValue', 'Another: Shape'],
+      }),
+    )
+
+    expect(container.textContent).toContain('CustomNamespace: FutureValue')
+    expect(container.textContent).toContain('Another: Shape')
+  })
+
+  it('renders no advisory slot when tags are empty', () => {
+    renderCard(episode({ tags: [], playbackExpectation: 'ad_supported' }))
+
+    expect(container.querySelector('.riffsync-catalog-card__advisory')).toBeNull()
+    expect(container.textContent).not.toContain('Ads may appear')
+    expect(container.textContent).not.toContain('Premium-friendly')
+    expect(container.textContent).not.toContain('Likely ad-supported')
+  })
+
+  it('does not render playback advisory or not-embeddable copy', () => {
+    renderCard(
+      episode({
+        tags: ['Era: Mike'],
+        playbackExpectation: 'premium',
+        embedAllows: false,
+      }),
+    )
+
+    expect(container.textContent).not.toContain('Ads may appear')
+    expect(container.textContent).not.toContain('Premium-friendly')
+    expect(container.textContent).not.toContain('Likely ad-supported')
+    expect(container.textContent).not.toContain('Not embeddable')
+  })
+
+  it('still gates in-app embed actions when embedAllows is false', () => {
+    renderCard(episode({ embedAllows: false }))
+
+    const watchSolo = container.querySelector('button.gen-button--ghost') as HTMLButtonElement | null
+    expect(watchSolo).not.toBeNull()
+    expect(container.querySelector('a.gen-button--ghost[href="/watch/032-mitchell"]')).toBeNull()
+  })
+
+  it('keeps the internal watch link for embeddable episodes', () => {
+    renderCard(episode({ embedAllows: true }))
+
+    const watchSolo = container.querySelector('a.gen-button--ghost') as HTMLAnchorElement | null
+    expect(watchSolo?.getAttribute('href')).toBe('/watch/032-mitchell')
+    expect(container.querySelector('button.gen-button--ghost')).toBeNull()
+  })
+})

--- a/apps/web/src/components/catalog/CatalogGridCard.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom'
 import { catalogCardImageUrl } from '../../catalog/mockCatalog'
 import { formatCatalogLabel, type CatalogEpisode } from '../../catalog/catalogTypes'
-import { PlaybackExpectationBadge } from '../watch/PlaybackExpectationBadge'
 import { EpisodeTileActions } from './EpisodeTileActions'
 
 export function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
@@ -30,13 +29,14 @@ export function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
                   </li>
                 ))}
               </ul>
-              <div className="riffsync-catalog-card__advisory">
-                <PlaybackExpectationBadge expectation={episode.playbackExpectation} />
-              </div>
-              {episode.embedAllows === false && (
-                <p className="riffsync-catalog-card__embed" role="status">
-                  Not embeddable in-app — use YouTube directly if available.
-                </p>
+              {episode.tags.length > 0 && (
+                <div className="riffsync-catalog-card__advisory">
+                  {episode.tags.map((tag) => (
+                    <span key={tag} className="riffsync-catalog-card__tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -553,11 +553,13 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
 }
 
 .riffsync-catalog-card__advisory {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
   margin-top: 0.35rem;
 }
 
-.riffsync-catalog-card__embed {
-  margin-top: 0.35rem;
+.riffsync-catalog-card__tag {
   font-size: 0.85rem;
   opacity: 0.9;
 }


### PR DESCRIPTION
## Summary

- Replace `PlaybackExpectationBadge` and the visible not-embeddable message on `CatalogGridCard` with dynamic `episode.tags` rendered in API order.
- Leave in-app embed gating unchanged via `EpisodeTileActions` / `episodeAllowsInAppEmbed`.
- Add focused `CatalogGridCard` tests and update `.ai` catalog card presentation contracts.

Closes #349

## Test plan

- [x] `cd apps/web && npm test`
- [x] `cd apps/web && npm run lint`
- [x] `cd apps/web && npm run build`
- [ ] Manual check on `/catalog` or `/catalog/mst3k`: cards show tags in order; no ad advisory or not-embeddable copy