### PR TITLE
docs(ai): refine issue #356 contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -108,7 +108,7 @@ Signed-in fans maintain friendships and exchange private 1:1 messages as a socia
 | Phase | Outcome |
 | --- | --- |
 | **Invite** | Requester (signed-in fan) creates a **FriendshipRequest** toward a recipient fan **`sub`**. Edge does not exist yet. |
-| **Pending** | Recipient may **accept** or **decline**. Duplicate pending requests follow idempotent / conflict rules (see open implementation decisions). |
+| **Pending** | Recipient may **accept** or **decline**; requester may **cancel**. At most one open pending request per unordered fan pair (either direction). Same-direction re-invite while pending is idempotent (**200** with existing request). Opposite-direction invite while a pending exists returns **409** so the caller handles inbound first. **Accept** creates the edge and clears all pendings between the pair. |
 | **Accept** | Durable **Friendship** edge exists between the two **`sub`s**. DM open/send becomes eligible. |
 | **Decline** | Request ends without a **Friendship**. No DM eligibility from that request alone. |
 | **Remove friend** | Immediately mutual: edge gone for both. Existing **DmThread** closed/hidden for both (no compose, no history access). |
@@ -343,16 +343,32 @@ Friends online is room-presence-derived and aggregate across rooms. It is not a 
 | Separate block product? | **No** — teardown verb is **remove friend**. |
 | Friends vs room People? | Orthogonal durable social store; does not replace **People**. |
 
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| **FriendshipRequest status while row exists?** | **`pending`** only. Terminal transitions **hard-delete** the row (accept, decline, cancel). No tombstone attribute on requests for MVP. |
+| **Friendship edge "active"?** | Implied by durable **Friendship** row keyed by canonical unordered **`pairKey`**. **Remove friend** deletes the row (#358). No separate edge status enum. |
+| **Pair uniqueness (pending)?** | At most **one** open pending per unordered fan pair (either direction). Enforced via sparse **`pairKey`** on pending rows. |
+| **Same-direction duplicate invite?** | **Idempotent 200** returning the existing pending **`requestId`**. |
+| **Opposite-direction invite while pending?** | **409 `friend_request_inbound_exists`** — caller should accept/decline inbound instead of creating a reverse pending. |
+| **Accept authority?** | **Recipient only** on **`POST .../accept`**. Creates **Friendship** and deletes **all** pending requests between the pair (both directions). |
+| **Decline authority?** | **Recipient only**; hard-deletes that request. |
+| **Cancel authority?** | **Requester only** on **`DELETE .../requests/{requestId}`**; hard-deletes that request. |
+| **Already friends?** | **409 `already_friends`** on new invite. |
+| **Self-invite?** | **400 `cannot_friend_self`**. |
+| **Accept-after-remove / after decline?** | Allowed via a **new** invite/accept cycle. Prior DM history stays inaccessible (#358 default). |
+| **Instant mutual-add without accept?** | **Out of scope** — reciprocal pendings still require **accept** on an inbound request. |
+
 ## Open implementation decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### friends-and-direct-messaging
-- Exact friendship state labels and transition names (pending / active / declined / removed) and idempotent handling for duplicate invites, accept-after-remove, and concurrent mutual invites.
-- Cross-room aggregation rules for friends-list **online** from **RoomPresence** (multi-tab / multi-room fan, stale presence after disconnect, field names for the derived signal).
-- Explicit DM delete semantics and account-closure cascade relative to inaccessible-after-unfriend history (soft-hide vs hard delete; whether storage purge jobs are required).
+- Cross-room aggregation rules for friends-list **online** from **RoomPresence** (multi-tab / multi-room fan, stale presence after disconnect, field names for the derived signal) — **#357**.
+- Explicit DM delete semantics and account-closure cascade relative to inaccessible-after-unfriend history (soft-hide vs hard delete; whether storage purge jobs are required) — **#358 / M35**.
 - Whether re-friend ever restores prior **DmThread** history (default remains inaccessible).
-- Whether **DirectMessage** supports the same message kinds as room chat (text, emoji, Giphy GIF, reactions) or a reduced v1 set.
-- Friend row display label / avatar resolution source and ordering when profile data is missing.
+- Whether **DirectMessage** supports the same message kinds as room chat (text, emoji, Giphy GIF, reactions) or a reduced v1 set — **M35**.
+- Friend row display label / avatar resolution source and ordering when profile data is missing — **#357**.
 
 - Domain services colocated with Lambda packages when implemented.

--- a/.ai/business_logic/error_handling.md
+++ b/.ai/business_logic/error_handling.md
@@ -91,8 +91,8 @@ After durable **`avDisabled`** write on room document, room **`PATCH`** Lambda f
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
 
 ### friends-and-direct-messaging
-- Stable structured **`code`** names for auth miss, not-friends, request-already-pending, request-not-found, thread-closed-after-remove, and rate-limited friend/DM paths.
-- Whether DM send denials after remove use the same envelope family as room **`CHAT_SEND_DROPPED`** analogues or a friends/DM-specific code set.
+- Stable structured **`code`** names for not-friends, thread-closed-after-remove, and rate-limited DM paths — **M35** / **#358**.
+- Whether DM send denials after remove use the same envelope family as room **`CHAT_SEND_DROPPED`** analogues or a friends/DM-specific code set — **M35**.
 - Retry/backoff guidance copy for DM sync failure vs friend-list load failure.
 
 ## Primary code pointers (optional)

--- a/.ai/data/consistency.md
+++ b/.ai/data/consistency.md
@@ -61,7 +61,7 @@
 | Property | Level |
 | --- | --- |
 | **Friendship edge** | Durable in Dynamo before clients treat the pair as friends. Accept creates the edge (and retires the pending request) as one product outcome; exact transactional bundling is tier-TW. |
-| **FriendshipRequest** | Durable pending state; accept/decline/cancel are authoritative server writes. Duplicate open requests for the same pair are rejected or coalesced (policy tier-TW). |
+| **FriendshipRequest** | Durable pending state; accept/decline/cancel are authoritative server writes. Duplicate open requests for the same unordered pair are rejected (**409**) or coalesced idempotently (same direction **200**). |
 | **Remove-friend** | Mutual teardown is immediate for both parties' friendship view. DM compose/history access closes for **both** in the same outcome (hide/close). Soft vs hard delete of message bodies does not change the access rule. |
 | **DM delivery / history** | **Casual / last-write-wins** ordering acceptable for MVP (room-chat precedent). History is account-lifetime durable; reconnect and open-thread sync may replay from Dynamo (unlike drawer-only room chat client buffer language). |
 | **DmUnread** | Server-authoritative per recipient; clear-on-view is a durable write. Concurrent clears coalesce to the newest watermark (LWW acceptable). |
@@ -75,11 +75,19 @@
 | Remove-friend visibility? | Both parties lose friendship and DM access together; no one-sided lingering read/compose. |
 | Friends online vs RoomPresence? | Derived signal; may lag roster reality; no durable last-seen clock to reconcile. |
 
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| **Accept write shape?** | **TransactWrite** (preferred): delete all pending **FriendshipRequest** rows for the **`pairKey`**, **Put** **Friendship** item. Retry-safe: second accept on missing request returns **404 `friend_request_not_found`**. |
+| **Decline / cancel write shape?** | Single **DeleteItem** on **`requestId`**; conditional on **`status: pending`** and caller role (recipient vs requester). |
+| **Concurrent accept on reciprocal pendings?** | First successful accept wins; transaction clears **both** pendings and creates one **Friendship**. Second accept returns **404** after pendings cleared. |
+
 ## Open implementation decisions
 
 - Whether **`lastActiveAt`** updates use unconditional **`UpdateItem`** or conditional max-timestamp write to reduce clock-skew regressions.
 - Cross-tab **`fanSub`** badge consistency when one tab disconnects while another remains **active** — roster shows multiple **RoomPresence** rows per fan today; **active** is per-row unless product merges (tier TW).
-- Accept-friendship write shape: single **TransactWrite** (delete/update request + put edge [+ ensure thread]) vs ordered multi-step with idempotency keys.
+- Accept-friendship write shape: single **TransactWrite** (delete/update request + put edge [+ ensure thread]) vs ordered multi-step with idempotency keys — **#356**: **TransactWrite** for accept; decline/cancel single delete.
 - Remove-friend write shape: edge delete + thread access close (and optional message tombstone/purge) atomicity and retry semantics.
 - Unread watermark concurrency when both devices view the same thread (conditional update vs blind LWW).
 - Online derivation freshness: strongly consistent **RoomPresence** query vs eventual; stale-online window after disconnect before TTL/row delete.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -82,8 +82,10 @@ Durable **pending** social request between two signed-in fans. Exists **before**
 | Concept | Contract |
 | --- | --- |
 | **Participants** | Cognito fan **`sub`** pair: **`requesterSub`**, **`recipientSub`**. |
-| **Lifecycle** | Created on invite send; ends on **accept** (edge created, request removed or terminal), **decline**, or cancel by requester (exact terminal retention tier-TW). |
-| **Uniqueness** | At most one open pending request for an unordered fan pair (or directed pair policy — tier-TW). |
+| **Lifecycle** | Created on invite send with **`status: pending`**. Terminal on **accept** (edge created, request row **hard-deleted**), **decline** (hard-deleted), or **cancel** by requester (hard-deleted). No tombstone attribute on requests for MVP. |
+| **Uniqueness** | At most one open pending request per **unordered** fan pair (either direction), keyed by canonical **`pairKey`**. Same-direction re-invite while pending is idempotent (returns existing **`requestId`**). |
+| **`requestId`** | UUID primary identifier for accept/decline/cancel routes. |
+| **`createdAt`** | Epoch ms on create. |
 | **Not a friendship** | Pending requests do **not** authorize DM compose or friends-list membership. |
 
 ## Friendship (durable edge)
@@ -92,7 +94,9 @@ Mutual social relationship between two signed-in fans. Durable until **remove-fr
 
 | Concept | Contract |
 | --- | --- |
-| **Participants** | Unordered pair of Cognito fan **`sub`s** (canonical pair key — tier-TW). |
+| **Participants** | Unordered pair of Cognito fan **`sub`s**. |
+| **`pairKey`** | **`min(subA, subB) + '#' + max(subA, subB)`** (lexicographic on **`sub`** strings). Primary key for the **Friendships** item. |
+| **`createdAt`** | Epoch ms when the edge formed (accept time). |
 | **Created when** | Recipient **accepts** a **FriendshipRequest**. Instant mutual-add without accept is out of scope. |
 | **Remove-friend** | **Immediately mutual**: both parties lose the edge at once. No one-sided lingering friendship. |
 | **DM eligibility** | Active **Friendship** is required to open/send on the pair’s 1:1 DM. |
@@ -202,14 +206,24 @@ Server-authoritative unread state for DM activity. Survives refresh and device c
 | Identity keys? | Cognito fan **`sub`** only; no guest friends/DM rows. |
 | System of record? | Existing **DynamoDB** class; **no new RDBMS**. |
 
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| **FriendshipRequest terminal retention?** | **Hard-delete** on accept, decline, and cancel. |
+| **Pending pair uniqueness?** | **Unordered** — one open pending per **`pairKey`** (either direction). |
+| **Canonical pair key?** | **`min(subA, subB) + '#' + max(subA, subB)`** for **Friendship** PK and pending **`pairKey`** GSI. |
+| **Physical tables (this slice)?** | Dedicated **`FriendshipRequests`** and **`Friendships`** Dynamo tables. |
+| **FriendshipRequests access** | PK **`requestId`**; GSI **`recipientSub`** (inbound pending), GSI **`requesterSub`** (outbound pending), sparse GSI **`pairKey`** (pending uniqueness). |
+| **Friendships access** | PK **`pairKey`**; GSI **`fanSub`** + SK **`pairKey`** for list-my-friends (#357). |
+
 ## Open implementation decisions
 
 - SFU **`listProducerSummaries`** (or successor) payload fields for Theater strip / Video Chat grid (**`sessionId`**, **`fanSub`**, producer class) beyond today's **`{ producerId, kind }`** — **#102** / layout runtime (#104/#105).
 - Future scaling (out of scope for catalog subcategory browse IA): if the full catalog bundle grows large enough that client-side fetch + `filterCatalogEntries({ catalogs })` becomes a performance concern, consider a server-side **`catalog`** / **`catalogs`** query parameter on **`GET /v1/catalog`**. Current access pattern remains full-bundle fetch with client Set-membership filter; hub mixed grid uses no catalog constraint (`catalogs: []`).
-- Friends/DM physical Dynamo table split vs co-location (new tables vs patterns alongside **FanProfiles**): **FriendshipRequest**, **Friendship**, **DmThread**, **DirectMessage**, unread watermark items.
-- Partition/sort keys and GSI shapes for: list-my-friends, list-pending-requests (in/out), open-thread-by-peer, page DM history newest-first, unread badge aggregation.
-- Canonical unordered pair key encoding for friendship and **DmThread** (sort order of the two **`sub`s**, delimiter, collision rules).
-- **FriendshipRequest** terminal retention: hard-delete on accept/decline vs tombstone status attribute; directed vs undirected uniqueness constraint.
+- Friends/DM physical Dynamo table split for **DmThread**, **DirectMessage**, unread watermark items (friendship tables decided above).
+- Partition/sort keys and GSI shapes for: open-thread-by-peer, page DM history newest-first, unread badge aggregation.
+- Canonical **`pairKey`** reuse for **DmThread** partition (same encoding as **Friendship**).
 - **DirectMessage** row identity and ordering keys (e.g. thread partition + `m#<ts>#<messageId>` analogue) — no RoomChat-style TTL attribute on bodies.
 - Soft-delete / tombstone vs hard-delete of **DirectMessage** rows (and thread metadata) when remove-friend hides history for both, and on account closure / explicit delete.
 - Whether remove-friend deletes message bodies immediately, retains tombstoned rows inaccessible to both, or schedules deferred purge.

--- a/.ai/data/persistence_abstractions.md
+++ b/.ai/data/persistence_abstractions.md
@@ -15,8 +15,8 @@ Storage responsibilities; physical layout is IaC (**`architecture.server.md`**).
 | **RoomChat** | Bounded room chat retention keyed **`roomId`** + **`sk`**. Message rows use **`m#<ts>#<messageId>`**; active reaction rows use **`r#<messageId>#<emoji>#<sessionId>`**. **TTL** **`expiresAt`**. Queried on **`presence_request`** to post requester-only **`chat_history`**. |
 | **Lists** *(when shipped)* | Curated list meta + membership rows (**`docs/architecture.admin.md`**). |
 | **FanProfiles** | **`sub`** → **`displayName`**, optional **`avatarUrl`** / timestamps (signed-in fan continuity). |
-| **FriendshipRequests** *(logical)* | Durable pending invite rows (**`requesterSub`**, **`recipientSub`**) before a friendship edge. Physical table split vs co-location with friendships — tier-TW. |
-| **Friendships** *(logical)* | Durable mutual edges between fan **`sub`** pairs until remove-friend / account lifecycle. |
+| **FriendshipRequests** *(logical)* | Durable pending invite rows (**`requestId`**, **`requesterSub`**, **`recipientSub`**, **`status: pending`**, **`pairKey`**, **`createdAt`**) before a friendship edge. **Hard-deleted** on accept, decline, or cancel. |
+| **Friendships** *(logical)* | Durable mutual edges keyed **`pairKey`** until remove-friend / account lifecycle. GSI on **`fanSub`** for list-my-friends. |
 | **DmThreads** / **DirectMessages** *(logical)* | Account-lifetime 1:1 DM thread metadata and message bodies — **distinct** from **RoomChat**. **No** RoomChat-style TTL on DM bodies. |
 | **DmUnread** *(logical)* | Per-recipient unread watermarks / cursors for DM threads (may co-locate with thread or friendship items — tier-TW). |
 | **Events** *(optional)* | Append-only audit per admin docs—add when needed. |
@@ -76,8 +76,17 @@ Exact CloudFormation resource names are **IaC**; logical keys/GSIs follow **acce
 | Friends/DM SoR? | **DynamoDB** only — same class as **FanProfiles** / **RoomChat**; **no new RDBMS** or external social SaaS. |
 | DM vs RoomChat tables? | **Distinct logical persistence** — DM history is not stored as **RoomChat** room-partitioned rows. |
 | DM body TTL? | **None** for account-lifetime retention (RoomChat keeps **`expiresAt`** TTL). Purge on explicit delete / account closure only. |
-| Pending requests durable? | **Yes** — **FriendshipRequest** rows exist before the edge. |
+| Pending requests durable? | **Yes** — **FriendshipRequest** rows exist before the edge; **hard-deleted** on terminal transitions (#356). |
 | Friends online materialization? | **Ephemeral derivation** from **RoomPresence**; do not add durable last-seen attributes for this product meaning. |
+
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| **Physical tables** | Dedicated **`FriendshipRequests`** and **`Friendships`** Dynamo tables (env-suffixed names in IaC). |
+| **FriendshipRequests keys** | PK **`requestId`**; GSI **`recipientSub`** + **`createdAt`**; GSI **`requesterSub`** + **`createdAt`**; sparse GSI **`pairKey`** for pending uniqueness. |
+| **Friendships keys** | PK **`pairKey`**; GSI **`fanSub`** + SK **`pairKey`**. |
+| **Env vars** | Lambdas receive **`FRIENDSHIP_REQUESTS_TABLE_NAME`**, **`FRIENDSHIPS_TABLE_NAME`**. |
 
 ## Open implementation decisions
 
@@ -86,11 +95,11 @@ Exact CloudFormation resource names are **IaC**; logical keys/GSIs follow **acce
 - SFU multi-producer registry structure (map key, **`tearDownSession`** per-session vs room-wide wipe) and idle room close when only consumers remain.
 - Kill-switch enforcement storage touchpoints: read **`avDisabled`** on **`POST /v1/webrtc/sfu-token`**, SFU **`produce`**, and whether Lambda triggers SFU admin tear-down vs client-only close.
 - IaC env wiring already passes **`ROOM_PRESENCE_TABLE_NAME`** to WS and SFU-token Lambdas — document any additional consumers (e.g. layout fan-out Lambda).
-- Exact Dynamo table resource split for **FriendshipRequest**, **Friendship**, **DmThread**, **DirectMessage**, **DmUnread** (dedicated tables vs single social table with entity-prefixed keys).
-- Partition key / sort key / GSI attribute shapes and names for friends list, pending inbox/outbox, thread-by-peer, message paging, unread aggregation.
+- Exact Dynamo table resource split for **DmThread**, **DirectMessage**, **DmUnread** (friendship tables decided #356).
+- Partition key / sort key / GSI attribute shapes and names for thread-by-peer, message paging, unread aggregation.
 - Whether **RoomPresence** gains a **`fanSub`** GSI (or equivalent) for any-room online checks; projection and TTL interaction with existing **`expiresAt`**.
 - Soft-delete / tombstone attributes vs hard-delete for friendships, threads, and DM bodies on remove-friend and account closure; cascade order and idempotency.
-- Env/IaC table name wiring for friends/DM Lambdas (parallel to **`ROOM_PRESENCE_TABLE_NAME`** / **`ROOM_CHAT_TABLE_NAME`** patterns).
+- Env/IaC table name wiring for DM Lambdas ( **`FRIENDSHIP_*`** decided #356; parallel to **`ROOM_PRESENCE_TABLE_NAME`** / **`ROOM_CHAT_TABLE_NAME`** patterns).
 
 ## Primary code pointers (optional)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -22,7 +22,7 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 | **`GET /v1/fans/me`**, **`PATCH /v1/fans/me`** | **Fan Cognito JWT**. | Read/update **`displayName`** on **FanProfiles** row keyed by **`sub`**; **`GET`** also returns optional **`avatarUrl`** / **`avatarUpdatedAt`**. |
 | **`POST /v1/fans/me/avatar`** *(multipart body; presigned PUT deferred)* | **Fan Cognito JWT**. | Upload/replace **one** avatar image; persists **`avatarUrl`** + **`avatarUpdatedAt`** on FanProfiles; object in **S3** served via **public HTTPS** (see **`data_model.md`**). |
 | **`GET /v1/giphy/search`** | **Fan Cognito JWT**. | Server-side **Giphy** search proxy; returns normalized GIF candidates for compose UI; **API key never in browser**. |
-| **Friends lifecycle (invite / accept / decline / list / remove)** | **Fan Cognito JWT** only. | Signed-in fans create **pending** friendship requests, **accept** or **decline** inbound requests, list friends and pending, and **remove** an accepted friendship. Durable friendship exists only after accept. Exact path prefix and field names are open (see **Open implementation decisions**). Main-site friends affordance and watch-party Friends pane call the **same** fan-gated APIs. |
+| **Friends lifecycle (invite / accept / decline / list pending / remove)** | **Fan Cognito JWT** only. | Signed-in fans create **pending** friendship requests, **accept** or **decline** inbound requests, **cancel** outbound pending, and list pending inbound/outbound. **Remove** accepted friendship is **#358**. Durable friendship exists only after accept. Paths under **`/v1/friends/*`** (see **Friendship HTTP routes**). Main-site and room Friends surfaces call the **same** fan-gated APIs when UI ships (**M36**). |
 | **DM thread / history / send / unread clear** | **Fan Cognito JWT** only. | 1:1 DM between two fan **`sub`s** with an **active friendship**. History is **account-lifetime durable** (distinct from TTL-bounded **RoomChat**). Delivery: **history sync on open** plus **realtime push while connected** (write-then-fan-out class — **`messaging_async.md`**). After mutual remove-friend, **both** parties lose send and history access on that thread (**`authorization.md`**). Exact paths, envelopes, and error **`code`** strings are open. |
 | **`/v1/admin/*`** | **Staff-only** Cognito JWT (separate pool or app client). | Full route surface aligned with **`docs/architecture.admin.md`** (summary below). **CloudWatch** remains the primary ops chart layer. **No** staff route grants DM body read or friendship mutation for this product slice. |
 
@@ -81,13 +81,27 @@ Friends and 1:1 DMs are a **fan social plane** beside watch-party room chat. The
 
 | Step | Contract |
 | --- | --- |
-| **Invite** | Caller (**fan JWT `sub`**) sends a friendship request to another fan **`sub`**. Creates a **pending** request; no durable friendship edge yet. |
-| **Accept** | Recipient accepts an inbound pending request → durable mutual friendship. |
-| **Decline** | Recipient declines an inbound pending request → no friendship edge; pending cleared. |
-| **List** | Authenticated fan lists accepted friends (and pending inbound/outbound as product surfaces require). Friend display name / avatar resolve from **FanProfiles**. |
-| **Remove** | Either party removes an accepted friendship → **immediately mutual** edge teardown. Both lose DM send and history access for that pair (**`authorization.md`**). |
+| **Invite** | **`POST /v1/friends/requests`** with body **`{ "recipientSub": "<cognito-sub>" }`**. Caller **`sub`** is requester. Creates **`pending`** row; returns **`201`** with **`requestId`**, **`requesterSub`**, **`recipientSub`**, **`createdAt`**. Same-direction pending → idempotent **`200`** with existing request. |
+| **List pending** | **`GET /v1/friends/requests`** returns **`{ "inbound": [...], "outbound": [...] }`** of pending requests for caller (each entry: **`requestId`**, **`requesterSub`**, **`recipientSub`**, **`createdAt`**). Does **not** include accepted friends (**#357**). |
+| **Accept** | **`POST /v1/friends/requests/{requestId}/accept`**. **Recipient only**. Creates **Friendship** **`pairKey`** item; **hard-deletes** all pending requests for that unordered pair. **`200`** with **`pairKey`**, **`fanSubA`**, **`fanSubB`**, **`createdAt`**. |
+| **Decline** | **`POST /v1/friends/requests/{requestId}/decline`**. **Recipient only**. Hard-deletes request. **`204`**. |
+| **Cancel** | **`DELETE /v1/friends/requests/{requestId}`**. **Requester only**. Hard-deletes pending request. **`204`**. |
+| **Remove** | **`DELETE /v1/friends/{pairKey}`** or peer-scoped variant — **#358**. |
 
 Anonymous guests have **no** friends lifecycle routes. Staff JWT does **not** authorize friendship mutations.
+
+### Friendship HTTP deny codes (#356)
+
+| **`code`** | HTTP | When |
+| --- | --- | --- |
+| **`cannot_friend_self`** | **400** | **`recipientSub === caller sub`**. |
+| **`fan_auth_required`** | **401** | Missing/invalid fan JWT. |
+| **`friend_request_not_recipient`** | **403** | Accept/decline by non-recipient. |
+| **`friend_request_not_requester`** | **403** | Cancel by non-requester. |
+| **`friend_request_not_found`** | **404** | Unknown or non-pending **`requestId`**. |
+| **`already_friends`** | **409** | **`pairKey`** friendship exists. |
+| **`friend_request_inbound_exists`** | **409** | Opposite pending exists. |
+| **`rate_limited`** | **429** | Throttle exceeded. |
 
 ### Friends-list online (RoomPresence-derived)
 
@@ -127,6 +141,8 @@ Anonymous guests have **no** friends lifecycle routes. Staff JWT does **not** au
 | **Chat** | **20** chat actions per **minute** per **`sessionId`** (text, GIF post, and reaction add/remove each count; HTTP/WS enforced). Bodies persist in **RoomChat** with **bounded TTL** retention (not account-lifetime inbox); do not log raw bodies at INFO — see **`operations/security.md`** and **`data/persistence_abstractions.md`**. |
 | **Typing indicators** | **30** **`typing_start`** + **`typing_stop`** pairs per **minute** per **`sessionId`** (WS enforced; over-cap **`typing_start`** / **`typing_stop`** **drops silently** — no business **`error`** envelope to client). Counts toward the same abuse posture as chat compose; does **not** bypass chat send limits. |
 | **Giphy search** | **30** search requests per **minute** per **`sub`** (HTTP; tune in IaC). |
+| **Friend-request send** | **10** **`POST /v1/friends/requests`** per **minute** per **`fanSub`** (HTTP; API Gateway + Lambda guard). |
+| **Friend-request accept / decline / cancel** | **30** combined actions per **minute** per **`fanSub`**. |
 | **Participant A/V publishers** | **8** concurrent signed-in AV publishers per room (hard ceiling; tune in IaC / SFU env). **403** or visible client error when cap hit — no auto-degrade in MVP. |
 | **WebSocket** | Subject to **API Gateway** account/service quotas; design for **≤50 concurrent connections per room** under normal use (matches participant cap). |
 
@@ -164,6 +180,16 @@ Anonymous guests have **no** friends lifecycle routes. Staff JWT does **not** au
 | Remove-friend access? | **Mutual** teardown; **both** parties lose DM send and history access. Encode on DM list/send/history authz. |
 | Staff DM body access? | **None** for this slice — fan JWT only; no **`/v1/admin/*`** DM body read. |
 | Shared API surfaces? | Main site and room Friends pane use the **same** fan-gated friends/DM APIs. |
+
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| Friendship HTTP prefix? | **`/v1/friends/*`** on fan JWT authorizer (alongside **`/v1/fans/*`**). |
+| Pending list vs friends list? | **`GET /v1/friends/requests`** = pending only; accepted friends list is **`GET /v1/friends`** (**#357**). |
+| Invite idempotency? | Same-direction pending → **200** with existing request. |
+| Pair conflict? | Opposite pending → **409 `friend_request_inbound_exists`**. |
+| Request terminal storage? | **Hard-delete** on accept, decline, cancel. |
 
 ## Decisions (answered — #101 HTTP room AV)
 
@@ -389,14 +415,15 @@ Stable JSON field names for PR harness assertions and fan-visible status mapping
 
 ### friends-and-direct-messaging (paths, envelopes, codes)
 
-- Exact HTTP **path** and **method** set for friendship invite / accept / decline / list / remove and for DM thread open, history page, send, and unread clear (e.g. under **`/v1/fans/...`** vs **`/v1/friends`** / **`/v1/dms`**), plus request/response field names.
-- Stable business **`code`** strings for deny cases (not friends, pending already exists, cannot friend self, thread closed after remove, auth miss, rate limited) — analogous to **`CHAT_SEND_DROPPED`** / SFU denial codes.
+- DM thread open, history page, send, unread clear HTTP paths and envelopes — **M35**.
+- Remove-friend **`DELETE`** path shape — **#358**.
+- Stable business **`code`** strings for not-friends, thread-closed-after-remove, DM send when plane down — **M35** / **#358**.
 - DM realtime topology: new WebSocket application routes, fan-scoped connection (not **`roomId`**-keyed), HTTP sync-only with optional push, or hybrid; exact outbound/inbound **`type`** and **`schemaVersion`** discriminators. Prefer documenting any shared transport with room WS **explicitly** rather than silently reusing **`ChatSession`**.
-- Friends-list online payload keys (boolean field name, whether to include room id of presence, reuse of **`fanSub`** / **`displayName`** / **`avatarUrl`** shapes).
-- Unread wire: per-friend count vs boolean, aggregate badge field(s), clear-on-view acknowledgment body shape.
+- Friends-list online payload keys (boolean field name, whether to include room id of presence, reuse of **`fanSub`** / **`displayName`** / **`avatarUrl`** shapes) — **#357**.
+- Unread wire: per-friend count vs boolean, aggregate badge field(s), clear-on-view acknowledgment body shape — **M35**.
 - Client drop / unavailable codes for DM send when the chosen realtime plane is down (DM analogue of **`CHAT_SEND_DROPPED`**).
-- Rate-limit numeric thresholds for friend requests and DM send (operations may own abuse posture; numbers stay here or in ops refine).
-- IaC / env names for any new tables, WS APIs, or Lambda grants.
+- Rate-limit numeric thresholds for DM send (friend-request bands decided above).
+- IaC / env names for DM tables, WS APIs, or Lambda grants beyond **`FRIENDSHIP_REQUESTS_TABLE_NAME`** / **`FRIENDSHIPS_TABLE_NAME`**.
 
 ## Decisions (answered — M22 presence routes)
 

--- a/.ai/integration/authorization.md
+++ b/.ai/integration/authorization.md
@@ -28,7 +28,7 @@ Who may do what, and how identity is represented. Aligns with **`docs/architectu
 
 | Authorizer | Issuer / audience | Routes |
 | --- | --- | --- |
-| **Fan JWT** | Fan pool id + fan SPA client id | **`POST /v1/rooms`**, room-admin **`PATCH`/`PUT`**, **`/v1/fans/*`**, **`GET /v1/giphy/search`**, **friends lifecycle** and **DM** routes (same fan authorizer family; exact path prefix open), publisher WebSocket paths requiring **`sub === hostSub`**. |
+| **Fan JWT** | Fan pool id + fan SPA client id | **`POST /v1/rooms`**, room-admin **`PATCH`/`PUT`**, **`/v1/fans/*`**, **`/v1/friends/*`**, **`GET /v1/giphy/search`**, **DM** routes (fan authorizer family), publisher WebSocket paths requiring **`sub === hostSub`**. |
 | **Staff JWT** | Staff pool id + staff SPA client id | **`/v1/admin/*`** only. **Does not** bind to friends/DM body or friendship mutation routes. |
 
 - **Cross-pool rejection:** API Gateway validates **issuer** and **jwt audience** per route binding. A fan token on **`/v1/admin/*`** or a staff token on fan-gated routes **fails at the authorizer** (typically **401**) without Lambda involvement.
@@ -92,10 +92,33 @@ Who may do what, and how identity is represented. Aligns with **`docs/architectu
 | Remove-friend authz effect? | **Mutual** edge teardown; **both** lose DM send and history access — enforced on DM routes. |
 | Staff DM moderation? | **Out of scope** — no staff DM body read path. |
 
+## Decisions (answered — friendship invite/accept lifecycle #356)
+
+| Question | Decision |
+| --- | --- |
+| **Invite / accept / decline / cancel authz?** | **Fan JWT `sub` only**. Recipient-only accept/decline; requester-only cancel. Guests **401**; staff token on route **401** at authorizer. |
+| **Pending vs friendship for DM?** | Pending request grants **no** DM or accepted-friends list authority. |
+
+## Friendship lifecycle HTTP deny codes (#356)
+
+When status is **400**, **403**, **404**, or **409**, body includes stable **`code`** (optional **`message`**):
+
+| **`code`** | HTTP | Meaning |
+| --- | --- | --- |
+| **`cannot_friend_self`** | **400** | **`recipientSub`** equals caller **`sub`**. |
+| **`fan_auth_required`** | **401** | Missing or invalid fan JWT (authorizer or handler). |
+| **`friend_request_not_recipient`** | **403** | Accept/decline by non-recipient. |
+| **`friend_request_not_requester`** | **403** | Cancel by non-requester. |
+| **`friend_request_not_found`** | **404** | Unknown **`requestId`** or no longer pending. |
+| **`already_friends`** | **409** | Active **Friendship** **`pairKey`** exists. |
+| **`friend_request_pending`** | **409** | Same-direction pending already exists (non-idempotent clients; prefer idempotent **200**). |
+| **`friend_request_inbound_exists`** | **409** | Opposite-direction pending exists; accept/decline inbound instead. |
+| **`rate_limited`** | **429** | Per-**`fanSub`** throttle exceeded. |
+
 ## Open implementation decisions
 
 ### friends-and-dm-authz-codes
-- Exact HTTP / WS deny **`code`** strings for not-friends, pending-exists, cannot-friend-self, thread-closed-after-remove, guest-forbidden, rate-limited (refine with **`api_contracts.md`**).
+- Exact HTTP / WS deny **`code`** strings for not-friends, thread-closed-after-remove, and DM rate-limited paths (**M35** / **#358**).
 - Whether closed-thread state is an explicit durable flag vs inferred solely from missing friendship edge (data domain may own persistence; authz only requires a deniable check on every DM list/send/history call).
 
 ## SFU join token claims (`SfuJoinClaims`)

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -45,7 +45,7 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 | **Retention classes (normative)** | **RoomChat** = bounded TTL room retention + do not log bodies. **DM** = account-lifetime private retention + do not log bodies + no staff DM read path. Typing, join/leave **`chat_system`**, and similar control-plane lines remain ephemeral fan-out and are **not** RoomChat/DM body classes. |
 | **Private vs room** | UI may reuse room-chat interaction language; ops must **not** treat DM bodies as room-broadcast content. Private threads stay participant-scoped. |
 | **Moderation (this initiative)** | **No** staff moderation of DM bodies. No admin tooling that dumps DM history for operators. |
-| **Abuse controls** | Friend-request send, accept/decline, remove-friend, DM send, unread mark-read, and friends-online query/push inherit the existing **API Gateway / WAF / Lambda** per-identity / per-route throttle mindset used for chat, Giphy, and SFU token mint. Exact numeric bands are TW. |
+| **Abuse controls** | Friend-request send (**10**/min), accept/decline/cancel (**30**/min combined), remove-friend, DM send, unread mark-read, and friends-online query/push inherit the existing **API Gateway / WAF / Lambda** per-identity / per-route throttle mindset. DM and remove bands refined in peer issues. |
 | **Account closure** | DM history and friendship state follow normal account lifecycle deletion/closure obligations once those flows exist; no separate archive/export staff plane in this initiative. |
 
 ## Service expectations (OSS / cost)
@@ -93,9 +93,9 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 ## Open implementation decisions
 
 ### friends-and-direct-messaging
-- Exact **rate-limit bands** (per-`fanSub` / per-route / rolling window) for friend-request send, accept/decline, remove-friend, DM send, unread mark-read, and friends-online query or push.
-- WAF / API Gateway throttle key placement vs Lambda in-memory counters for new friends/DM HTTP (and any WS) routes.
-- Soft-delete / hide flag vs hard-delete purge job for mutual unfriend thread closure (privacy obligation is closed/hidden for both; mechanism is TW with data).
+- Exact **rate-limit bands** for remove-friend, DM send, unread mark-read, and friends-online query or push — **#358**, **M35**, **#357**.
+- WAF / API Gateway throttle key placement vs Lambda in-memory counters for DM HTTP (and any WS) routes.
+- Soft-delete / hide flag vs hard-delete purge job for mutual unfriend thread closure (privacy obligation is closed/hidden for both; mechanism is TW with data) — **#358**.
 - Account-closure cascade timing for durable DM rows (batch purge schedule, Dynamo TTL on tombstones, or synchronous delete) once account deletion flows are wired.
 - Whether any sampled DEBUG redaction helpers are shared between RoomChat and DM log paths (implementation detail; INFO remains body-free).
 

--- a/.ai/specs/friends-and-direct-messaging.spec.md
+++ b/.ai/specs/friends-and-direct-messaging.spec.md
@@ -22,7 +22,9 @@ Main-site chrome: authenticated person icon opens a friends dropdown (online ind
 
 **Identity and AuthZ:** Fan Cognito JWT on the shared HTTP API authorizer family. Guests (`sessionId`) remain out of scope for friends/DM mutations. No staff `/v1/admin/*` path reads DM bodies.
 
-**Data:** DynamoDB system of record (same class as **FanProfiles** / **RoomChat**). Logical entities: **FriendshipRequest**, **Friendship**, **DmThread**, **DirectMessage**, per-recipient unread. DM bodies are not **RoomChat** rows and do not use RoomChat-style TTL. Soft-hide vs hard-delete after mutual unfriend is an open implementation detail; product-visible access is closed for both.
+**Data:** DynamoDB system of record (same class as **FanProfiles** / **RoomChat**). Logical entities: **FriendshipRequest**, **Friendship**, **DmThread**, **DirectMessage**, per-recipient unread. **FriendshipRequest** rows use **`status: pending`** only and **hard-delete** on accept, decline, or cancel. **Friendship** items use canonical **`pairKey = min(subA,subB)#max(subA,subB)`**. Dedicated **`FriendshipRequests`** and **`Friendships`** tables (#356). DM bodies are not **RoomChat** rows and do not use RoomChat-style TTL. Soft-hide vs hard-delete after mutual unfriend is an open implementation detail; product-visible access is closed for both.
+
+**HTTP (invite/accept lifecycle #356):** Fan JWT routes under **`/v1/friends/*`**: **`POST /v1/friends/requests`** (invite), **`GET /v1/friends/requests`** (pending inbound/outbound), **`POST .../{requestId}/accept`**, **`POST .../{requestId}/decline`**, **`DELETE .../{requestId}`** (requester cancel). At most one open pending per unordered pair; same-direction re-invite idempotent **200**; opposite pending **409 `friend_request_inbound_exists`**. Accept uses **TransactWrite** to put **Friendship** and delete all pendings for the pair. Friend-request send throttle **10/min** per **`fanSub`**; accept/decline/cancel **30/min**.
 
 **Presence:** Friends online is derived from existing **RoomPresence** (friend has an open presence row in any room). No new platform-wide presence plane and no durable last-seen PII class. Does not use the SFU media plane.
 
@@ -36,7 +38,9 @@ Relevant web stack versions from `@riffsync/web` package metadata: React `^19.2.
 
 ## Testing Strategy
 
-Contract and unit coverage should prove invite/accept lifecycle (pending → accept creates edge; decline does not), mutual remove closes friendship and blocks DM compose/history for both, friends online true only when any-room **RoomPresence** exists for the peer, DM history survives reload (account-lifetime class), unread clears on view, and fan JWT gates all friends/DM mutations while guests and staff tokens cannot send or read DMs.
+Contract and unit coverage should prove invite/accept lifecycle (pending → accept creates edge; decline and cancel leave no edge; duplicate and reciprocal pending rules), mutual remove closes friendship and blocks DM compose/history for both, friends online true only when any-room **RoomPresence** exists for the peer, DM history survives reload (account-lifetime class), unread clears on view, and fan JWT gates all friends/DM mutations while guests and staff tokens cannot send or read DMs.
+
+**#356 testing focus:** Lambda unit tests for **`POST/GET /v1/friends/requests`**, accept, decline, cancel; assert **401** without fan JWT, **400 `cannot_friend_self`**, **409 `already_friends`**, idempotent same-direction invite, **409 `friend_request_inbound_exists`**, recipient-only accept/decline, requester-only cancel, **TransactWrite** accept clearing reciprocal pendings, and **429 `rate_limited`** at configured thresholds. CDK route wiring smoke optional in same PR.
 
 Integration tests should cover write-then-fan-out DM delivery to a connected peer, history sync on open, and isolation from room **ChatSession** teardown. UI smoke should cover main-site person-icon dropdown (hidden when signed out) and room Friends pane coexistence with Chat and People. Abuse/rate-limit posture for friend-request and DM send should be verified at the throttle class level (exact bands refined in issues).
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #356
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.