### PR TITLE
feat(friends): friendship invite/accept/decline lifecycle (#356)

### DIFF
--- a/infra/cdk/lambda/friends-requests.test.ts
+++ b/infra/cdk/lambda/friends-requests.test.ts
@@ -1,0 +1,400 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+  QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  TransactWriteCommand: vi.fn((input: unknown) => ({ input, kind: 'TransactWrite' })),
+}));
+
+import { handler } from './friends-requests';
+import {
+  friendshipPairKey,
+  friendshipRateLimitKey,
+  minuteBucketEpochMs,
+} from './friends-shared';
+
+function fanEvent(
+  method: string,
+  path: string,
+  opts?: {
+    claims?: Record<string, unknown>;
+    body?: Record<string, unknown>;
+    pathParameters?: Record<string, string>;
+  },
+): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: `${method} ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    body: opts?.body ? JSON.stringify(opts.body) : undefined,
+    pathParameters: opts?.pathParameters,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method,
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-friends-1',
+      routeKey: `${method} ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+function pendingItem(overrides: Partial<{
+  requestId: string;
+  requesterSub: string;
+  recipientSub: string;
+  createdAt: number;
+}> = {}) {
+  const requesterSub = overrides.requesterSub ?? 'fan-a';
+  const recipientSub = overrides.recipientSub ?? 'fan-b';
+  return {
+    requestId: overrides.requestId ?? 'req-1',
+    requesterSub,
+    recipientSub,
+    status: 'pending' as const,
+    pairKey: friendshipPairKey(requesterSub, recipientSub),
+    createdAt: overrides.createdAt ?? 1_700_000_000_000,
+  };
+}
+
+describe('friends-requests handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.FRIENDSHIP_REQUESTS_TABLE_NAME = 'FriendshipRequests';
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.FRIEND_INVITE_LIMIT_PER_MINUTE = '10';
+    process.env.FRIEND_ACTION_LIMIT_PER_MINUTE = '30';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const res = await handler(fanEvent('POST', '/v1/friends/requests', { body: { recipientSub: 'fan-b' } }), {} as never, {} as never);
+    expect(res && typeof res === 'object' && 'statusCode' in res ? res.statusCode : 0).toBe(401);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      error: 'Fan authentication required',
+      code: 'fan_auth_required',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 cannot_friend_self', async () => {
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-a' },
+      }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(400);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('cannot_friend_self');
+  });
+
+  it('creates a pending invite with 201', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Items: [] }) // friendship exists
+      .mockResolvedValueOnce({ Items: [] }) // pending by pair
+      .mockResolvedValueOnce({}); // put
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-b' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(201);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.requesterSub).toBe('fan-a');
+    expect(body.recipientSub).toBe('fan-b');
+    expect(typeof body.requestId).toBe('string');
+    expect(body.requestId.length).toBeGreaterThan(0);
+
+    const putCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'Put');
+    expect(putCall?.[0]?.input?.Item?.pairKey).toBe('fan-a#fan-b');
+    expect(putCall?.[0]?.input?.Item?.status).toBe('pending');
+  });
+
+  it('returns 200 with existing request for same-direction re-invite', async () => {
+    const existing = pendingItem();
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Items: [] }) // friendship
+      .mockResolvedValueOnce({ Items: [existing] }); // pending
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-b' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      requestId: 'req-1',
+      requesterSub: 'fan-a',
+      recipientSub: 'fan-b',
+      createdAt: existing.createdAt,
+    });
+  });
+
+  it('returns 409 friend_request_inbound_exists for opposite pending', async () => {
+    const inbound = pendingItem({ requesterSub: 'fan-b', recipientSub: 'fan-a' });
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [inbound] });
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-b' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(409);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friend_request_inbound_exists');
+  });
+
+  it('returns 409 already_friends when friendship edge exists', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Items: [{ pairKey: 'fan-a#fan-b' }] });
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-b' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(409);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('already_friends');
+  });
+
+  it('lists inbound and outbound pending for caller only', async () => {
+    const inbound = pendingItem({ requestId: 'in-1', requesterSub: 'fan-b', recipientSub: 'fan-a' });
+    const outbound = pendingItem({ requestId: 'out-1', requesterSub: 'fan-a', recipientSub: 'fan-c' });
+    mocks.docSend
+      .mockResolvedValueOnce({ Items: [inbound] })
+      .mockResolvedValueOnce({ Items: [outbound] });
+
+    const res = await handler(
+      fanEvent('GET', '/v1/friends/requests', { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      inbound: [
+        {
+          requestId: 'in-1',
+          requesterSub: 'fan-b',
+          recipientSub: 'fan-a',
+          createdAt: inbound.createdAt,
+        },
+      ],
+      outbound: [
+        {
+          requestId: 'out-1',
+          requesterSub: 'fan-a',
+          recipientSub: 'fan-c',
+          createdAt: outbound.createdAt,
+        },
+      ],
+    });
+  });
+
+  it('accept creates friendship and clears all pendings for the pair', async () => {
+    const primary = pendingItem({ requestId: 'req-1', requesterSub: 'fan-a', recipientSub: 'fan-b' });
+    const reciprocal = pendingItem({ requestId: 'req-2', requesterSub: 'fan-b', recipientSub: 'fan-a' });
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: primary }) // get
+      .mockResolvedValueOnce({ Items: [primary, reciprocal] }) // query pair
+      .mockResolvedValueOnce({}); // transact
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests/req-1/accept', {
+        claims: { sub: 'fan-b' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.pairKey).toBe('fan-a#fan-b');
+    expect(body.fanSubA).toBe('fan-a');
+    expect(body.fanSubB).toBe('fan-b');
+    expect(typeof body.createdAt).toBe('number');
+
+    const tx = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'TransactWrite');
+    const items = tx?.[0]?.input?.TransactItems ?? [];
+    expect(items.filter((i: { Delete?: unknown }) => i.Delete)).toHaveLength(2);
+    expect(items.filter((i: { Put?: unknown }) => i.Put)).toHaveLength(2);
+  });
+
+  it('accept returns 403 friend_request_not_recipient for requester', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: pendingItem() });
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests/req-1/accept', {
+        claims: { sub: 'fan-a' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friend_request_not_recipient');
+  });
+
+  it('decline hard-deletes and returns 204 for recipient', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: pendingItem() })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests/req-1/decline', {
+        claims: { sub: 'fan-b' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(204);
+    expect(mocks.docSend.mock.calls.some((c) => c[0]?.kind === 'Delete')).toBe(true);
+  });
+
+  it('cancel returns 403 friend_request_not_requester for recipient', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: pendingItem() });
+
+    const res = await handler(
+      fanEvent('DELETE', '/v1/friends/requests/req-1', {
+        claims: { sub: 'fan-b' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friend_request_not_requester');
+  });
+
+  it('cancel hard-deletes and returns 204 for requester', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: pendingItem() })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      fanEvent('DELETE', '/v1/friends/requests/req-1', {
+        claims: { sub: 'fan-a' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(204);
+  });
+
+  it('returns 429 rate_limited when invite throttle is exceeded', async () => {
+    mocks.docSend.mockRejectedValueOnce(
+      Object.assign(new Error('limit'), { name: 'ConditionalCheckFailedException' }),
+    );
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests', {
+        claims: { sub: 'fan-a' },
+        body: { recipientSub: 'fan-b' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+
+    const update = mocks.docSend.mock.calls[0]?.[0];
+    expect(update?.kind).toBe('Update');
+    const bucket = minuteBucketEpochMs();
+    expect(update?.input?.Key).toEqual(friendshipRateLimitKey('invite', 'fan-a', bucket));
+  });
+
+  it('returns 429 rate_limited when accept/decline/cancel throttle is exceeded', async () => {
+    mocks.docSend.mockRejectedValueOnce(
+      Object.assign(new Error('limit'), { name: 'ConditionalCheckFailedException' }),
+    );
+
+    const res = await handler(
+      fanEvent('POST', '/v1/friends/requests/req-1/accept', {
+        claims: { sub: 'fan-b' },
+        pathParameters: { requestId: 'req-1' },
+      }),
+      {} as never,
+      {} as never,
+    );
+
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+    const update = mocks.docSend.mock.calls[0]?.[0];
+    expect(update?.input?.Key?.pk).toContain('friend-action#fan-b');
+  });
+});
+
+describe('friendshipPairKey', () => {
+  it('orders subs lexicographically', () => {
+    expect(friendshipPairKey('b', 'a')).toBe('a#b');
+    expect(friendshipPairKey('a', 'b')).toBe('a#b');
+  });
+});

--- a/infra/cdk/lambda/friends-requests.ts
+++ b/infra/cdk/lambda/friends-requests.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from 'node:crypto';
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  TransactWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  deny,
+  emptyResponse,
+  enforceFriendshipRateLimit,
+  FRIEND_ACTION_LIMIT_PER_MINUTE,
+  FRIEND_INVITE_LIMIT_PER_MINUTE,
+  friendshipExists,
+  friendshipMemberItems,
+  friendshipPairKey,
+  FRIENDSHIP_REQUESTS_RECIPIENT_INDEX,
+  FRIENDSHIP_REQUESTS_REQUESTER_INDEX,
+  jsonResponse,
+  parseFriendshipRequestItem,
+  queryPendingByPairKey,
+  queryPendingByRole,
+  requireFanSub,
+  toPendingWire,
+  type FriendshipRequestItem,
+} from './friends-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | { ok: true; requests: string; friendships: string; rateLimits: string }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const requests = process.env.FRIENDSHIP_REQUESTS_TABLE_NAME?.trim();
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  if (!requests || !friendships || !rateLimits) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, requests, friendships, rateLimits };
+}
+
+function inviteLimit(): number {
+  const raw = process.env.FRIEND_INVITE_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : FRIEND_INVITE_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : FRIEND_INVITE_LIMIT_PER_MINUTE;
+}
+
+function actionLimit(): number {
+  const raw = process.env.FRIEND_ACTION_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : FRIEND_ACTION_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : FRIEND_ACTION_LIMIT_PER_MINUTE;
+}
+
+function parseRecipientSub(body: string | undefined): string | null {
+  if (!body) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body) as unknown;
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const recipientSub = (parsed as { recipientSub?: unknown }).recipientSub;
+  if (typeof recipientSub !== 'string') return null;
+  const trimmed = recipientSub.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function routeKind(
+  method: string,
+  rawPath: string,
+): 'invite' | 'list' | 'accept' | 'decline' | 'cancel' | 'unknown' {
+  const path = rawPath.replace(/\/+$/, '') || '/';
+  if (method === 'POST' && path.endsWith('/v1/friends/requests')) return 'invite';
+  if (method === 'GET' && path.endsWith('/v1/friends/requests')) return 'list';
+  if (method === 'POST' && /\/v1\/friends\/requests\/[^/]+\/accept$/.test(path)) return 'accept';
+  if (method === 'POST' && /\/v1\/friends\/requests\/[^/]+\/decline$/.test(path)) return 'decline';
+  if (method === 'DELETE' && /\/v1\/friends\/requests\/[^/]+$/.test(path)) return 'cancel';
+  return 'unknown';
+}
+
+async function handleInvite(
+  fanSub: string,
+  body: string | undefined,
+  t: { requests: string; friendships: string; rateLimits: string },
+): Promise<APIGatewayProxyResultV2> {
+  const recipientSub = parseRecipientSub(body);
+  if (!recipientSub) {
+    return deny(400, 'invalid_request', 'recipientSub is required');
+  }
+  if (recipientSub === fanSub) {
+    return deny(400, 'cannot_friend_self', 'Cannot send a friend request to yourself');
+  }
+
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'invite', fanSub, inviteLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friend request rate limit exceeded');
+  }
+
+  const pairKey = friendshipPairKey(fanSub, recipientSub);
+  if (await friendshipExists(doc, t.friendships, pairKey)) {
+    return deny(409, 'already_friends', 'Already friends');
+  }
+
+  const pending = await queryPendingByPairKey(doc, t.requests, pairKey);
+  const sameDirection = pending.find((p) => p.requesterSub === fanSub && p.recipientSub === recipientSub);
+  if (sameDirection) {
+    return jsonResponse(200, toPendingWire(sameDirection));
+  }
+  const opposite = pending.find((p) => p.requesterSub === recipientSub && p.recipientSub === fanSub);
+  if (opposite) {
+    return deny(409, 'friend_request_inbound_exists', 'Accept or decline the inbound friend request');
+  }
+
+  const createdAt = Date.now();
+  const item: FriendshipRequestItem = {
+    requestId: randomUUID(),
+    requesterSub: fanSub,
+    recipientSub,
+    status: 'pending',
+    pairKey,
+    createdAt,
+  };
+
+  try {
+    await doc.send(
+      new PutCommand({
+        TableName: t.requests,
+        Item: item,
+        ConditionExpression: 'attribute_not_exists(requestId)',
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      const again = await queryPendingByPairKey(doc, t.requests, pairKey);
+      const existing = again.find((p) => p.requesterSub === fanSub && p.recipientSub === recipientSub);
+      if (existing) return jsonResponse(200, toPendingWire(existing));
+    }
+    throw e;
+  }
+
+  return jsonResponse(201, toPendingWire(item));
+}
+
+async function handleList(
+  fanSub: string,
+  t: { requests: string },
+): Promise<APIGatewayProxyResultV2> {
+  const [inboundRaw, outboundRaw] = await Promise.all([
+    queryPendingByRole(doc, t.requests, FRIENDSHIP_REQUESTS_RECIPIENT_INDEX, 'recipientSub', fanSub),
+    queryPendingByRole(doc, t.requests, FRIENDSHIP_REQUESTS_REQUESTER_INDEX, 'requesterSub', fanSub),
+  ]);
+
+  return jsonResponse(200, {
+    inbound: inboundRaw.map(toPendingWire),
+    outbound: outboundRaw.map(toPendingWire),
+  });
+}
+
+async function loadRequest(
+  tableName: string,
+  requestId: string,
+): Promise<FriendshipRequestItem | null> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { requestId },
+    }),
+  );
+  return parseFriendshipRequestItem(out.Item as Record<string, unknown> | undefined);
+}
+
+async function handleAccept(
+  fanSub: string,
+  requestId: string,
+  t: { requests: string; friendships: string; rateLimits: string },
+): Promise<APIGatewayProxyResultV2> {
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'action', fanSub, actionLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friend request rate limit exceeded');
+  }
+
+  const request = await loadRequest(t.requests, requestId);
+  if (!request) {
+    return deny(404, 'friend_request_not_found', 'Friend request not found');
+  }
+  if (request.recipientSub !== fanSub) {
+    return deny(403, 'friend_request_not_recipient', 'Only the recipient may accept');
+  }
+
+  const createdAt = Date.now();
+  const [memberA, memberB] = friendshipMemberItems(request.pairKey, createdAt);
+  const pendings = await queryPendingByPairKey(doc, t.requests, request.pairKey);
+  const toDelete = pendings.length > 0 ? pendings : [request];
+
+  const transactItems = [
+    ...toDelete.map((p) => ({
+      Delete: {
+        TableName: t.requests,
+        Key: { requestId: p.requestId },
+      },
+    })),
+    {
+      Put: {
+        TableName: t.friendships,
+        Item: memberA,
+        ConditionExpression: 'attribute_not_exists(pairKey) AND attribute_not_exists(fanSub)',
+      },
+    },
+    {
+      Put: {
+        TableName: t.friendships,
+        Item: memberB,
+        ConditionExpression: 'attribute_not_exists(pairKey) AND attribute_not_exists(fanSub)',
+      },
+    },
+  ];
+
+  try {
+    await doc.send(
+      new TransactWriteCommand({
+        TransactItems: transactItems,
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'TransactionCanceledException' || name === 'ConditionalCheckFailedException') {
+      if (await friendshipExists(doc, t.friendships, request.pairKey)) {
+        return deny(409, 'already_friends', 'Already friends');
+      }
+      const still = await loadRequest(t.requests, requestId);
+      if (!still) {
+        return deny(404, 'friend_request_not_found', 'Friend request not found');
+      }
+    }
+    throw e;
+  }
+
+  return jsonResponse(200, {
+    pairKey: request.pairKey,
+    fanSubA: memberA.fanSubA,
+    fanSubB: memberA.fanSubB,
+    createdAt,
+  });
+}
+
+async function handleDecline(
+  fanSub: string,
+  requestId: string,
+  t: { requests: string; rateLimits: string },
+): Promise<APIGatewayProxyResultV2> {
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'action', fanSub, actionLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friend request rate limit exceeded');
+  }
+
+  const request = await loadRequest(t.requests, requestId);
+  if (!request) {
+    return deny(404, 'friend_request_not_found', 'Friend request not found');
+  }
+  if (request.recipientSub !== fanSub) {
+    return deny(403, 'friend_request_not_recipient', 'Only the recipient may decline');
+  }
+
+  try {
+    await doc.send(
+      new DeleteCommand({
+        TableName: t.requests,
+        Key: { requestId },
+        ConditionExpression: 'recipientSub = :fanSub AND #status = :pending',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':fanSub': fanSub, ':pending': 'pending' },
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return deny(404, 'friend_request_not_found', 'Friend request not found');
+    }
+    throw e;
+  }
+
+  return emptyResponse(204);
+}
+
+async function handleCancel(
+  fanSub: string,
+  requestId: string,
+  t: { requests: string; rateLimits: string },
+): Promise<APIGatewayProxyResultV2> {
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'action', fanSub, actionLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friend request rate limit exceeded');
+  }
+
+  const request = await loadRequest(t.requests, requestId);
+  if (!request) {
+    return deny(404, 'friend_request_not_found', 'Friend request not found');
+  }
+  if (request.requesterSub !== fanSub) {
+    return deny(403, 'friend_request_not_requester', 'Only the requester may cancel');
+  }
+
+  try {
+    await doc.send(
+      new DeleteCommand({
+        TableName: t.requests,
+        Key: { requestId },
+        ConditionExpression: 'requesterSub = :fanSub AND #status = :pending',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':fanSub': fanSub, ':pending': 'pending' },
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return deny(404, 'friend_request_not_found', 'Friend request not found');
+    }
+    throw e;
+  }
+
+  return emptyResponse(204);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const kind = routeKind(method, event.rawPath);
+  const requestId = event.pathParameters?.requestId?.trim() ?? '';
+
+  switch (kind) {
+    case 'invite':
+      return handleInvite(auth.fanSub, event.body, t);
+    case 'list':
+      return handleList(auth.fanSub, t);
+    case 'accept':
+      if (!requestId) return deny(404, 'friend_request_not_found', 'Friend request not found');
+      return handleAccept(auth.fanSub, requestId, t);
+    case 'decline':
+      if (!requestId) return deny(404, 'friend_request_not_found', 'Friend request not found');
+      return handleDecline(auth.fanSub, requestId, t);
+    case 'cancel':
+      if (!requestId) return deny(404, 'friend_request_not_found', 'Friend request not found');
+      return handleCancel(auth.fanSub, requestId, t);
+    default:
+      return deny(404, 'friend_request_not_found', 'Not found');
+  }
+};

--- a/infra/cdk/lambda/friends-shared.ts
+++ b/infra/cdk/lambda/friends-shared.ts
@@ -1,0 +1,259 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { getJwtSub } from './fan-profile-shared';
+
+export const FRIENDSHIP_REQUESTS_RECIPIENT_INDEX = 'RecipientSubIndex';
+export const FRIENDSHIP_REQUESTS_REQUESTER_INDEX = 'RequesterSubIndex';
+export const FRIENDSHIP_REQUESTS_PAIR_INDEX = 'PairKeyIndex';
+export const FRIENDSHIPS_FAN_SUB_INDEX = 'FanSubIndex';
+
+export const FRIEND_INVITE_LIMIT_PER_MINUTE = 10;
+export const FRIEND_ACTION_LIMIT_PER_MINUTE = 30;
+
+export type FriendshipDenyCode =
+  | 'cannot_friend_self'
+  | 'fan_auth_required'
+  | 'friend_request_not_recipient'
+  | 'friend_request_not_requester'
+  | 'friend_request_not_found'
+  | 'already_friends'
+  | 'friend_request_inbound_exists'
+  | 'rate_limited'
+  | 'invalid_request';
+
+export type FriendshipRequestItem = {
+  requestId: string;
+  requesterSub: string;
+  recipientSub: string;
+  status: 'pending';
+  pairKey: string;
+  createdAt: number;
+};
+
+export type FriendshipMemberItem = {
+  pairKey: string;
+  fanSub: string;
+  peerSub: string;
+  fanSubA: string;
+  fanSubB: string;
+  createdAt: number;
+};
+
+export type PendingRequestWire = {
+  requestId: string;
+  requesterSub: string;
+  recipientSub: string;
+  createdAt: number;
+};
+
+type JsonRecord = { [key: string]: unknown };
+
+export function jsonResponse(statusCode: number, body: JsonRecord): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify(body),
+  };
+}
+
+export function emptyResponse(statusCode: number): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: '',
+  };
+}
+
+export function deny(statusCode: number, code: FriendshipDenyCode, error: string): APIGatewayProxyResultV2 {
+  return jsonResponse(statusCode, { error, code });
+}
+
+export function requireFanSub(
+  event: Parameters<APIGatewayProxyHandlerV2>[0],
+): { ok: true; fanSub: string } | { ok: false; response: APIGatewayProxyResultV2 } {
+  const fanSub = getJwtSub(event);
+  if (!fanSub) {
+    return {
+      ok: false,
+      response: deny(401, 'fan_auth_required', 'Fan authentication required'),
+    };
+  }
+  return { ok: true, fanSub };
+}
+
+/** Canonical unordered pair key: min(subA,subB)#max(subA,subB). */
+export function friendshipPairKey(subA: string, subB: string): string {
+  return subA < subB ? `${subA}#${subB}` : `${subB}#${subA}`;
+}
+
+export function splitPairKey(pairKey: string): { fanSubA: string; fanSubB: string } | null {
+  const i = pairKey.indexOf('#');
+  if (i <= 0 || i === pairKey.length - 1) return null;
+  const fanSubA = pairKey.slice(0, i);
+  const fanSubB = pairKey.slice(i + 1);
+  if (!fanSubA || !fanSubB || fanSubA.includes('#') || fanSubA >= fanSubB) return null;
+  return { fanSubA, fanSubB };
+}
+
+export function toPendingWire(item: FriendshipRequestItem): PendingRequestWire {
+  return {
+    requestId: item.requestId,
+    requesterSub: item.requesterSub,
+    recipientSub: item.recipientSub,
+    createdAt: item.createdAt,
+  };
+}
+
+export function parseFriendshipRequestItem(raw: Record<string, unknown> | undefined): FriendshipRequestItem | null {
+  if (!raw) return null;
+  const requestId = typeof raw.requestId === 'string' ? raw.requestId : '';
+  const requesterSub = typeof raw.requesterSub === 'string' ? raw.requesterSub : '';
+  const recipientSub = typeof raw.recipientSub === 'string' ? raw.recipientSub : '';
+  const pairKey = typeof raw.pairKey === 'string' ? raw.pairKey : '';
+  const status = raw.status === 'pending' ? 'pending' : null;
+  const createdAt = typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) ? raw.createdAt : NaN;
+  if (!requestId || !requesterSub || !recipientSub || !pairKey || !status || !Number.isFinite(createdAt)) {
+    return null;
+  }
+  return { requestId, requesterSub, recipientSub, status, pairKey, createdAt };
+}
+
+export function minuteBucketEpochMs(nowMs: number = Date.now()): number {
+  return Math.floor(nowMs / 60_000) * 60_000;
+}
+
+export function friendshipRateLimitKey(
+  kind: 'invite' | 'action',
+  fanSub: string,
+  bucketMs: number,
+): { pk: string; sk: string } {
+  return { pk: `friend-${kind}#${fanSub}`, sk: String(bucketMs) };
+}
+
+export async function enforceFriendshipRateLimit(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  kind: 'invite' | 'action',
+  fanSub: string,
+  limit: number,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  const { pk, sk } = friendshipRateLimitKey(kind, fanSub, bucketMs);
+  const expiresAt = Math.floor(nowMs / 1000) + 120;
+
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { pk, sk },
+        UpdateExpression: 'ADD requestCount :one SET expiresAt = :expiresAt',
+        ConditionExpression: 'attribute_not_exists(requestCount) OR requestCount < :limit',
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':limit': limit,
+          ':expiresAt': expiresAt,
+        },
+      }),
+    );
+    return true;
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return false;
+    }
+    throw e;
+  }
+}
+
+export async function queryPendingByPairKey(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  pairKey: string,
+): Promise<FriendshipRequestItem[]> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: FRIENDSHIP_REQUESTS_PAIR_INDEX,
+      KeyConditionExpression: 'pairKey = :pairKey',
+      ExpressionAttributeValues: { ':pairKey': pairKey },
+    }),
+  );
+  const items: FriendshipRequestItem[] = [];
+  for (const raw of out.Items ?? []) {
+    const parsed = parseFriendshipRequestItem(raw as Record<string, unknown>);
+    if (parsed) items.push(parsed);
+  }
+  return items;
+}
+
+export async function queryPendingByRole(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  indexName: string,
+  keyName: 'recipientSub' | 'requesterSub',
+  fanSub: string,
+): Promise<FriendshipRequestItem[]> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: indexName,
+      KeyConditionExpression: `${keyName} = :fanSub`,
+      ExpressionAttributeValues: { ':fanSub': fanSub },
+      ScanIndexForward: false,
+    }),
+  );
+  const items: FriendshipRequestItem[] = [];
+  for (const raw of out.Items ?? []) {
+    const parsed = parseFriendshipRequestItem(raw as Record<string, unknown>);
+    if (parsed) items.push(parsed);
+  }
+  return items;
+}
+
+export async function friendshipExists(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  pairKey: string,
+): Promise<boolean> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: 'pairKey = :pairKey',
+      ExpressionAttributeValues: { ':pairKey': pairKey },
+      Limit: 1,
+      ProjectionExpression: 'pairKey',
+    }),
+  );
+  return (out.Items?.length ?? 0) > 0;
+}
+
+export function friendshipMemberItems(
+  pairKey: string,
+  createdAt: number,
+): [FriendshipMemberItem, FriendshipMemberItem] {
+  const parts = splitPairKey(pairKey);
+  if (!parts) {
+    throw new Error(`Invalid pairKey: ${pairKey}`);
+  }
+  const { fanSubA, fanSubB } = parts;
+  return [
+    {
+      pairKey,
+      fanSub: fanSubA,
+      peerSub: fanSubB,
+      fanSubA,
+      fanSubB,
+      createdAt,
+    },
+    {
+      pairKey,
+      fanSub: fanSubB,
+      peerSub: fanSubA,
+      fanSubA,
+      fanSubB,
+      createdAt,
+    },
+  ];
+}

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -187,6 +187,8 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly roomPresenceTable: dynamodb.Table;
   public readonly roomChatTable: dynamodb.Table;
   public readonly fanProfilesTable: dynamodb.Table;
+  public readonly friendshipRequestsTable: dynamodb.Table;
+  public readonly friendshipsTable: dynamodb.Table;
   public readonly fanAvatarsBucket: s3.Bucket;
   public readonly fanAvatarsDistribution: cloudfront.Distribution;
   /** HTTPS origin for avatar object keys (no trailing slash). */
@@ -273,6 +275,44 @@ export class ApiCatalogStack extends cdk.Stack {
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
 
+    this.friendshipRequestsTable = new dynamodb.Table(this, 'FriendshipRequestsTable', {
+      partitionKey: { name: 'requestId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+    this.friendshipRequestsTable.addGlobalSecondaryIndex({
+      indexName: 'RecipientSubIndex',
+      partitionKey: { name: 'recipientSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    this.friendshipRequestsTable.addGlobalSecondaryIndex({
+      indexName: 'RequesterSubIndex',
+      partitionKey: { name: 'requesterSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    this.friendshipRequestsTable.addGlobalSecondaryIndex({
+      indexName: 'PairKeyIndex',
+      partitionKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    this.friendshipsTable = new dynamodb.Table(this, 'FriendshipsTable', {
+      partitionKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'fanSub', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+    this.friendshipsTable.addGlobalSecondaryIndex({
+      indexName: 'FanSubIndex',
+      partitionKey: { name: 'fanSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     this.fanAvatarsBucket = new s3.Bucket(this, 'FanAvatarsBucket', {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
@@ -319,6 +359,14 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     const giphyRateLimitTable = new dynamodb.Table(this, 'GiphyRateLimitTable', {
+      partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      timeToLiveAttribute: 'expiresAt',
+    });
+
+    const friendshipRateLimitTable = new dynamodb.Table(this, 'FriendshipRateLimitTable', {
       partitionKey: { name: 'pk', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
@@ -865,6 +913,27 @@ export class ApiCatalogStack extends cdk.Stack {
     this.fanAvatarsBucket.grantDelete(fanAvatarPostFn, `${FAN_AVATAR_S3_KEY_PREFIX}*`);
     this.fanProfilesTable.grantReadWriteData(fanAvatarPostFn);
 
+    const friendsRequestsFn = new lambdaNodejs.NodejsFunction(this, 'FriendsRequestsFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/friends-requests.ts'),
+      handler: 'handler',
+      environment: {
+        FRIENDSHIP_REQUESTS_TABLE_NAME: this.friendshipRequestsTable.tableName,
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        FRIEND_INVITE_LIMIT_PER_MINUTE: '10',
+        FRIEND_ACTION_LIMIT_PER_MINUTE: '30',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.friendshipRequestsTable.grantReadWriteData(friendsRequestsFn);
+    this.friendshipsTable.grantReadWriteData(friendsRequestsFn);
+    friendshipRateLimitTable.grantReadWriteData(friendsRequestsFn);
+
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
@@ -1042,6 +1111,10 @@ export class ApiCatalogStack extends cdk.Stack {
       'GiphySearchInt',
       giphySearchFn,
     );
+    const friendsRequestsIntegration = new integrations.HttpLambdaIntegration(
+      'FriendsRequestsInt',
+      friendsRequestsFn,
+    );
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1164,6 +1237,34 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     this.httpApi.addRoutes({
+      path: '/v1/friends/requests',
+      methods: [apigwv2.HttpMethod.POST, apigwv2.HttpMethod.GET],
+      integration: friendsRequestsIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/friends/requests/{requestId}/accept',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: friendsRequestsIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/friends/requests/{requestId}/decline',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: friendsRequestsIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/friends/requests/{requestId}',
+      methods: [apigwv2.HttpMethod.DELETE],
+      integration: friendsRequestsIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: '/v1/admin/session',
       methods: [apigwv2.HttpMethod.GET],
       integration: adminSessionGetIntegration,
@@ -1263,6 +1364,22 @@ export class ApiCatalogStack extends cdk.Stack {
       description: 'DynamoDB FanProfiles — partition key `sub` (Cognito subject).',
     });
 
+    new cdk.CfnOutput(this, 'FriendshipRequestsTableName', {
+      value: this.friendshipRequestsTable.tableName,
+      description:
+        'DynamoDB FriendshipRequests — PK `requestId`; GSIs RecipientSubIndex, RequesterSubIndex, PairKeyIndex.',
+    });
+
+    new cdk.CfnOutput(this, 'FriendshipsTableName', {
+      value: this.friendshipsTable.tableName,
+      description: 'DynamoDB Friendships — PK `pairKey`, SK `fanSub`; GSI FanSubIndex.',
+    });
+
+    new cdk.CfnOutput(this, 'FriendshipRateLimitTableName', {
+      value: friendshipRateLimitTable.tableName,
+      description: 'DynamoDB friendship invite/action rate limits — PK `pk`, SK `sk`, TTL `expiresAt`.',
+    });
+
     new cdk.CfnOutput(this, 'FanAvatarsBucketName', {
       value: this.fanAvatarsBucket.bucketName,
       description: `Private S3 bucket for fan avatars (keys under \`${FAN_AVATAR_S3_KEY_PREFIX}{sub}/\`).`,
@@ -1288,7 +1405,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary
- Add fan JWT routes for `POST/GET /v1/friends/requests`, accept, decline, and cancel with stable deny `code`s from the #356 contracts.
- Provision `FriendshipRequests` / `Friendships` Dynamo tables (GSIs + rate-limit table) and wire `FriendsRequestsFn` with invite (10/min) and accept/decline/cancel (30/min) throttles.
- Cover authz, idempotent re-invite, opposite-pending conflict, accept TransactWrite clearing reciprocal pendings, and rate-limit denials in CDK Lambda unit tests.

Closes #356

## Test plan
- [x] `npm run test --prefix infra/cdk` (321 passed)
- [x] `npm run synth --prefix infra/cdk`
- [ ] Manual API checks with two fan JWTs (invite → accept / decline / cancel paths) after deploy