### PR TITLE
[M34] Friends list with room-derived online indicators (#357)

### DIFF
--- a/infra/cdk/lambda/friends-list.test.ts
+++ b/infra/cdk/lambda/friends-list.test.ts
@@ -1,0 +1,292 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  BatchGetCommand: vi.fn((input: unknown) => ({ input, kind: 'BatchGet' })),
+}));
+
+import { buildFriendListEntries, handler, sortFriendListEntries } from './friends-list';
+import { friendshipPairKey, friendshipRateLimitKey, minuteBucketEpochMs } from './friends-shared';
+import { ROOM_PRESENCE_FAN_SUB_INDEX } from './room-presence-shared';
+
+function fanEvent(
+  method: string,
+  path: string,
+  opts?: { claims?: Record<string, unknown> },
+): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: `${method} ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method,
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-friends-list-1',
+      routeKey: `${method} ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+function friendshipEdge(callerSub: string, peerSub: string, createdAt: number) {
+  const pairKey = friendshipPairKey(callerSub, peerSub);
+  const [fanSubA, fanSubB] = callerSub < peerSub ? [callerSub, peerSub] : [peerSub, callerSub];
+  return {
+    pairKey,
+    fanSub: callerSub,
+    peerSub,
+    fanSubA,
+    fanSubB,
+    createdAt,
+  };
+}
+
+describe('friends-list handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'RoomPresence';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.FRIEND_LIST_LIMIT_PER_MINUTE = '60';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const res = await handler(fanEvent('GET', '/v1/friends'), {} as never, {} as never);
+    expect(res && typeof res === 'object' && 'statusCode' in res ? res.statusCode : 0).toBe(401);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      error: 'Fan authentication required',
+      code: 'fan_auth_required',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns empty friends list when caller has no edges', async () => {
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: { UpdateExpression?: string } }) => {
+      if (cmd.kind === 'Update') return {};
+      if (cmd.kind === 'Query') return { Items: [] };
+      throw new Error(`unexpected ${cmd.kind}`);
+    });
+
+    const res = await handler(
+      fanEvent('GET', '/v1/friends', { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({ friends: [] });
+  });
+
+  it('returns friends with online true/false, profile fields, and sort order', async () => {
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: Record<string, unknown> }) => {
+      if (cmd.kind === 'Update') return {};
+      if (cmd.kind === 'Query') {
+        const input = cmd.input as {
+          TableName?: string;
+          IndexName?: string;
+          ExpressionAttributeValues?: { ':fanSub'?: string };
+        };
+        if (input.TableName === 'Friendships') {
+          return {
+            Items: [
+              friendshipEdge('fan-a', 'fan-z', 100),
+              friendshipEdge('fan-a', 'fan-b', 200),
+            ],
+          };
+        }
+        if (input.IndexName === ROOM_PRESENCE_FAN_SUB_INDEX) {
+          const peer = input.ExpressionAttributeValues?.[':fanSub'];
+          return { Items: peer === 'fan-b' ? [{ fanSub: 'fan-b' }] : [] };
+        }
+        throw new Error('unexpected Query');
+      }
+      if (cmd.kind === 'BatchGet') {
+        const input = cmd.input as {
+          RequestItems?: { FanProfiles?: { Keys?: { sub: string }[] } };
+        };
+        const keys = input.RequestItems?.FanProfiles?.Keys ?? [];
+        const items = keys.map((k) => {
+          if (k.sub === 'fan-b') {
+            return { sub: 'fan-b', displayName: 'Beta Fan', avatarUrl: 'https://cdn.example/b.png' };
+          }
+          if (k.sub === 'fan-z') {
+            return { sub: 'fan-z', displayName: 'alpha peer' };
+          }
+          return { sub: k.sub };
+        });
+        return { Responses: { FanProfiles: items } };
+      }
+      throw new Error(`unexpected ${cmd.kind}`);
+    });
+
+    const res = await handler(
+      fanEvent('GET', '/v1/friends', { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.friends).toEqual([
+      {
+        fanSub: 'fan-z',
+        pairKey: friendshipPairKey('fan-a', 'fan-z'),
+        displayName: 'alpha peer',
+        online: false,
+        createdAt: 100,
+      },
+      {
+        fanSub: 'fan-b',
+        pairKey: friendshipPairKey('fan-a', 'fan-b'),
+        displayName: 'Beta Fan',
+        avatarUrl: 'https://cdn.example/b.png',
+        online: true,
+        createdAt: 200,
+      },
+    ]);
+  });
+
+  it('uses displayName Friend when profile missing or empty', async () => {
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: Record<string, unknown> }) => {
+      if (cmd.kind === 'Update') return {};
+      if (cmd.kind === 'Query') {
+        const input = cmd.input as { TableName?: string };
+        if (input.TableName === 'Friendships') {
+          return { Items: [friendshipEdge('fan-a', 'fan-b', 1)] };
+        }
+        return { Items: [] };
+      }
+      if (cmd.kind === 'BatchGet') {
+        return { Responses: { FanProfiles: [{ sub: 'fan-b', displayName: '   ' }] } };
+      }
+      throw new Error(`unexpected ${cmd.kind}`);
+    });
+
+    const res = await handler(
+      fanEvent('GET', '/v1/friends', { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.friends[0].displayName).toBe('Friend');
+    expect(body.friends[0].avatarUrl).toBeUndefined();
+  });
+
+  it('returns 429 rate_limited when list quota exceeded', async () => {
+    const now = Date.now();
+    const bucket = minuteBucketEpochMs(now);
+    const { pk, sk } = friendshipRateLimitKey('list', 'fan-a', bucket);
+
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: Record<string, unknown> }) => {
+      if (cmd.kind === 'Update') {
+        const input = cmd.input as { Key?: { pk?: string; sk?: string } };
+        if (input.Key?.pk === pk && input.Key?.sk === sk) {
+          const err = new Error('ConditionalCheckFailedException');
+          (err as { name: string }).name = 'ConditionalCheckFailedException';
+          throw err;
+        }
+        return {};
+      }
+      throw new Error('should not query after rate limit');
+    });
+
+    const res = await handler(
+      fanEvent('GET', '/v1/friends', { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+  });
+});
+
+describe('sortFriendListEntries', () => {
+  it('sorts case-insensitively by displayName then pairKey', () => {
+    const sorted = sortFriendListEntries([
+      {
+        fanSub: 'z',
+        pairKey: 'a#z',
+        displayName: 'Beta',
+        online: false,
+        createdAt: 1,
+      },
+      {
+        fanSub: 'b',
+        pairKey: 'a#b',
+        displayName: 'alpha',
+        online: false,
+        createdAt: 2,
+      },
+      {
+        fanSub: 'c',
+        pairKey: 'a#c',
+        displayName: 'Alpha',
+        online: false,
+        createdAt: 3,
+      },
+    ]);
+    expect(sorted.map((e) => e.displayName)).toEqual(['alpha', 'Alpha', 'Beta']);
+  });
+});
+
+describe('buildFriendListEntries', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'RoomPresence';
+  });
+
+  it('treats any RoomPresence row as online (multi-tab OR)', async () => {
+    mocks.docSend.mockImplementation(async (cmd: { kind?: string; input?: Record<string, unknown> }) => {
+      if (cmd.kind === 'Query') {
+        const input = cmd.input as { TableName?: string; IndexName?: string };
+        if (input.TableName === 'Friendships') {
+          return { Items: [friendshipEdge('fan-a', 'fan-b', 1)] };
+        }
+        if (input.IndexName === ROOM_PRESENCE_FAN_SUB_INDEX) {
+          return { Items: [{ fanSub: 'fan-b' }] };
+        }
+      }
+      if (cmd.kind === 'BatchGet') {
+        return { Responses: { FanProfiles: [] } };
+      }
+      throw new Error(`unexpected ${cmd.kind}`);
+    });
+
+    const entries = await buildFriendListEntries('fan-a', {
+      friendships: 'Friendships',
+      fanProfiles: 'FanProfiles',
+      roomPresence: 'RoomPresence',
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.online).toBe(true);
+  });
+});

--- a/infra/cdk/lambda/friends-list.ts
+++ b/infra/cdk/lambda/friends-list.ts
@@ -1,0 +1,147 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { batchAvatarUrlsByFanSub, batchDisplayNamesByFanSub } from './fan-profile-shared';
+import {
+  deny,
+  enforceFriendshipRateLimit,
+  FRIENDSHIPS_FAN_SUB_INDEX,
+  jsonResponse,
+  parseFriendshipMemberItem,
+  requireFanSub,
+  type FriendshipMemberItem,
+} from './friends-shared';
+import { isFanOnlineInAnyRoom } from './room-presence-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const FRIEND_LIST_LIMIT_PER_MINUTE = 60;
+
+export type FriendListEntryWire = {
+  fanSub: string;
+  pairKey: string;
+  displayName: string;
+  avatarUrl?: string;
+  online: boolean;
+  createdAt: number;
+};
+
+function tables():
+  | {
+      ok: true;
+      friendships: string;
+      fanProfiles: string;
+      roomPresence: string;
+      rateLimits: string;
+    }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const fanProfiles = process.env.FAN_PROFILES_TABLE_NAME?.trim();
+  const roomPresence = process.env.ROOM_PRESENCE_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  if (!friendships || !fanProfiles || !roomPresence || !rateLimits) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, friendships, fanProfiles, roomPresence, rateLimits };
+}
+
+function listLimit(): number {
+  const raw = process.env.FRIEND_LIST_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : FRIEND_LIST_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : FRIEND_LIST_LIMIT_PER_MINUTE;
+}
+
+async function queryFriendshipsByFanSub(
+  tableName: string,
+  fanSub: string,
+): Promise<FriendshipMemberItem[]> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: FRIENDSHIPS_FAN_SUB_INDEX,
+      KeyConditionExpression: 'fanSub = :fanSub',
+      ExpressionAttributeValues: { ':fanSub': fanSub },
+    }),
+  );
+  const items: FriendshipMemberItem[] = [];
+  for (const raw of out.Items ?? []) {
+    const parsed = parseFriendshipMemberItem(raw as Record<string, unknown>);
+    if (parsed) items.push(parsed);
+  }
+  return items;
+}
+
+export function sortFriendListEntries(entries: FriendListEntryWire[]): FriendListEntryWire[] {
+  return [...entries].sort((a, b) => {
+    const nameCmp = a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' });
+    if (nameCmp !== 0) return nameCmp;
+    return a.pairKey.localeCompare(b.pairKey);
+  });
+}
+
+export async function buildFriendListEntries(
+  callerFanSub: string,
+  t: { friendships: string; fanProfiles: string; roomPresence: string },
+): Promise<FriendListEntryWire[]> {
+  const edges = await queryFriendshipsByFanSub(t.friendships, callerFanSub);
+  if (edges.length === 0) {
+    return [];
+  }
+
+  const peerSubs = edges.map((e) => e.peerSub);
+  const [displayNames, avatarUrls] = await Promise.all([
+    batchDisplayNamesByFanSub(doc, t.fanProfiles, peerSubs),
+    batchAvatarUrlsByFanSub(doc, t.fanProfiles, peerSubs),
+  ]);
+
+  const onlineByPeer = new Map<string, boolean>();
+  await Promise.all(
+    peerSubs.map(async (peerSub) => {
+      const online = await isFanOnlineInAnyRoom(doc, t.roomPresence, peerSub);
+      onlineByPeer.set(peerSub, online);
+    }),
+  );
+
+  const entries: FriendListEntryWire[] = edges.map((edge) => {
+    const displayName = displayNames.get(edge.peerSub) ?? 'Friend';
+    const avatarUrl = avatarUrls.get(edge.peerSub);
+    const entry: FriendListEntryWire = {
+      fanSub: edge.peerSub,
+      pairKey: edge.pairKey,
+      displayName,
+      online: onlineByPeer.get(edge.peerSub) ?? false,
+      createdAt: edge.createdAt,
+    };
+    if (avatarUrl) {
+      entry.avatarUrl = avatarUrl;
+    }
+    return entry;
+  });
+
+  return sortFriendListEntries(entries);
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'GET' || path !== '/v1/friends') {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'list', auth.fanSub, listLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friends list rate limit exceeded');
+  }
+
+  const friends = await buildFriendListEntries(auth.fanSub, t);
+  return jsonResponse(200, { friends });
+};

--- a/infra/cdk/lambda/friends-shared.ts
+++ b/infra/cdk/lambda/friends-shared.ts
@@ -10,6 +10,7 @@ export const FRIENDSHIPS_FAN_SUB_INDEX = 'FanSubIndex';
 
 export const FRIEND_INVITE_LIMIT_PER_MINUTE = 10;
 export const FRIEND_ACTION_LIMIT_PER_MINUTE = 30;
+export const FRIEND_LIST_LIMIT_PER_MINUTE = 60;
 
 export type FriendshipDenyCode =
   | 'cannot_friend_self'
@@ -124,7 +125,7 @@ export function minuteBucketEpochMs(nowMs: number = Date.now()): number {
 }
 
 export function friendshipRateLimitKey(
-  kind: 'invite' | 'action',
+  kind: 'invite' | 'action' | 'list',
   fanSub: string,
   bucketMs: number,
 ): { pk: string; sk: string } {
@@ -134,7 +135,7 @@ export function friendshipRateLimitKey(
 export async function enforceFriendshipRateLimit(
   doc: DynamoDBDocumentClient,
   tableName: string,
-  kind: 'invite' | 'action',
+  kind: 'invite' | 'action' | 'list',
   fanSub: string,
   limit: number,
   nowMs: number = Date.now(),
@@ -227,6 +228,20 @@ export async function friendshipExists(
     }),
   );
   return (out.Items?.length ?? 0) > 0;
+}
+
+export function parseFriendshipMemberItem(raw: Record<string, unknown> | undefined): FriendshipMemberItem | null {
+  if (!raw) return null;
+  const pairKey = typeof raw.pairKey === 'string' ? raw.pairKey : '';
+  const fanSub = typeof raw.fanSub === 'string' ? raw.fanSub : '';
+  const peerSub = typeof raw.peerSub === 'string' ? raw.peerSub : '';
+  const fanSubA = typeof raw.fanSubA === 'string' ? raw.fanSubA : '';
+  const fanSubB = typeof raw.fanSubB === 'string' ? raw.fanSubB : '';
+  const createdAt = typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) ? raw.createdAt : NaN;
+  if (!pairKey || !fanSub || !peerSub || !fanSubA || !fanSubB || !Number.isFinite(createdAt)) {
+    return null;
+  }
+  return { pairKey, fanSub, peerSub, fanSubA, fanSubB, createdAt };
 }
 
 export function friendshipMemberItems(

--- a/infra/cdk/lambda/room-presence-shared.test.ts
+++ b/infra/cdk/lambda/room-presence-shared.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { fanSubRoomPresenceSk, ROOM_PRESENCE_FAN_SUB_INDEX } from './room-presence-shared';
+
+describe('room-presence-shared', () => {
+  it('defines FanSubPresenceIndex GSI name', () => {
+    expect(ROOM_PRESENCE_FAN_SUB_INDEX).toBe('FanSubPresenceIndex');
+  });
+
+  it('builds fanSubRoomSk as roomId#presenceKey', () => {
+    expect(fanSubRoomPresenceSk('room-1', 'sess#conn')).toBe('room-1#sess#conn');
+  });
+});

--- a/infra/cdk/lambda/room-presence-shared.ts
+++ b/infra/cdk/lambda/room-presence-shared.ts
@@ -1,0 +1,28 @@
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+/** Sparse GSI on RoomPresence — PK `fanSub`, SK `fanSubRoomSk` (`roomId#presenceKey`). */
+export const ROOM_PRESENCE_FAN_SUB_INDEX = 'FanSubPresenceIndex';
+
+export function fanSubRoomPresenceSk(roomId: string, presenceKey: string): string {
+  return `${roomId}#${presenceKey}`;
+}
+
+/** True when the fan has at least one live RoomPresence row in any room (multi-tab OR). */
+export async function isFanOnlineInAnyRoom(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+): Promise<boolean> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: ROOM_PRESENCE_FAN_SUB_INDEX,
+      KeyConditionExpression: 'fanSub = :fanSub',
+      ExpressionAttributeValues: { ':fanSub': fanSub },
+      Limit: 1,
+      ProjectionExpression: 'fanSub',
+    }),
+  );
+  return (out.Items?.length ?? 0) > 0;
+}

--- a/infra/cdk/lambda/ws-connect.test.ts
+++ b/infra/cdk/lambda/ws-connect.test.ts
@@ -92,6 +92,7 @@ describe('ws-connect handler', () => {
     expect(presencePut?.hostSub).toBe('host-sub-1');
     expect(presencePut?.lastActiveAt).toEqual(expect.any(Number));
     expect(presencePut?.fanSub).toBe('host-sub-1');
+    expect(presencePut?.fanSubRoomSk).toBe('room-1#sess-host#conn-1');
   });
 
   it('does not maintain lobby cleanup for guest connections', async () => {

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -4,6 +4,7 @@ import { DynamoDBDocumentClient, GetCommand, TransactWriteCommand } from '@aws-s
 import { verifyAccessToken } from './cognito-jwt';
 import { maintainPublicLobbyOnHostConnect } from './room-lobby-cleanup';
 import { fanOutChatSystem, isWithinJoinReconnectCooldown } from './ws-chat-system-shared';
+import { fanSubRoomPresenceSk } from './room-presence-shared';
 import { broadcastRoomPresenceNow, presenceDisplayNameForSession } from './ws-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -86,7 +87,9 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
     presenceKey,
     sessionId,
     ...(displayName ? { displayName } : {}),
-    ...(fanSub ? { fanSub, lastActiveAt: nowSec } : {}),
+    ...(fanSub
+      ? { fanSub, fanSubRoomSk: fanSubRoomPresenceSk(roomId, presenceKey), lastActiveAt: nowSec }
+      : {}),
     ...(hostSub ? { hostSub } : {}),
     connectedAt: nowSec,
     lastSeenAt: nowSec,

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -259,6 +259,12 @@ export class ApiCatalogStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       timeToLiveAttribute: 'expiresAt',
     });
+    this.roomPresenceTable.addGlobalSecondaryIndex({
+      indexName: 'FanSubPresenceIndex',
+      partitionKey: { name: 'fanSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'fanSubRoomSk', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    });
 
     this.roomChatTable = new dynamodb.Table(this, 'RoomChatTable', {
       partitionKey: { name: 'roomId', type: dynamodb.AttributeType.STRING },
@@ -934,6 +940,28 @@ export class ApiCatalogStack extends cdk.Stack {
     this.friendshipsTable.grantReadWriteData(friendsRequestsFn);
     friendshipRateLimitTable.grantReadWriteData(friendsRequestsFn);
 
+    const friendsListFn = new lambdaNodejs.NodejsFunction(this, 'FriendsListFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/friends-list.ts'),
+      handler: 'handler',
+      environment: {
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
+        ROOM_PRESENCE_TABLE_NAME: this.roomPresenceTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        FRIEND_LIST_LIMIT_PER_MINUTE: '60',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.friendshipsTable.grantReadData(friendsListFn);
+    this.fanProfilesTable.grantReadData(friendsListFn);
+    this.roomPresenceTable.grantReadData(friendsListFn);
+    friendshipRateLimitTable.grantReadWriteData(friendsListFn);
+
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
@@ -1115,6 +1143,7 @@ export class ApiCatalogStack extends cdk.Stack {
       'FriendsRequestsInt',
       friendsRequestsFn,
     );
+    const friendsListIntegration = new integrations.HttpLambdaIntegration('FriendsListInt', friendsListFn);
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1237,6 +1266,13 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     this.httpApi.addRoutes({
+      path: '/v1/friends',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: friendsListIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: '/v1/friends/requests',
       methods: [apigwv2.HttpMethod.POST, apigwv2.HttpMethod.GET],
       integration: friendsRequestsIntegration,
@@ -1350,7 +1386,8 @@ export class ApiCatalogStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'RoomPresenceTableName', {
       value: this.roomPresenceTable.tableName,
-      description: 'DynamoDB room presence table - partition key `roomId`, sort key `presenceKey`.',
+      description:
+        'DynamoDB room presence table - PK `roomId`, SK `presenceKey`; sparse GSI FanSubPresenceIndex (`fanSub`, `fanSubRoomSk`).',
     });
 
     new cdk.CfnOutput(this, 'RoomChatTableName', {
@@ -1405,7 +1442,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Adds `GET /v1/friends` for fan JWT callers returning accepted friendship edges with `displayName`, optional `avatarUrl`, and room-derived `online` status.
- Introduces sparse `FanSubPresenceIndex` GSI on **RoomPresence** (`fanSub` + `fanSubRoomSk`) and writes `fanSubRoomSk` from `ws-connect` for signed-in fans.
- Includes Lambda unit tests for auth, empty list, online true/false, profile fallback, sort order, and rate limiting (60/min).

Closes #357

## Test plan

- [x] `npm run test --prefix infra/cdk` (330 tests pass)
- [x] `npm run synth --prefix infra/cdk`
- [ ] Manual: fan JWT `GET /v1/friends` returns `{ friends: [...] }` with correct online/profile fields
- [ ] Manual: peer in any room shows `online: true`; peer absent shows `online: false`
- [ ] Manual: missing JWT returns `401 fan_auth_required`