### PR TITLE
feat(friends): mutual remove-friend DELETE /v1/friends/{pairKey} (#358)

### DIFF
--- a/infra/cdk/lambda/friends-remove.test.ts
+++ b/infra/cdk/lambda/friends-remove.test.ts
@@ -1,0 +1,213 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  TransactWriteCommand: vi.fn((input: unknown) => ({ input, kind: 'TransactWrite' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+import { handler } from './friends-remove';
+import { friendshipPairKey, friendshipRateLimitKey, minuteBucketEpochMs } from './friends-shared';
+
+function fanEvent(
+  pairKey: string,
+  opts?: { claims?: Record<string, unknown> },
+): APIGatewayProxyEventV2 {
+  const path = `/v1/friends/${encodeURIComponent(pairKey)}`;
+  return {
+    version: '2.0',
+    routeKey: `DELETE ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    pathParameters: { pairKey },
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'DELETE',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-friends-remove-1',
+      routeKey: `DELETE ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('friends-remove handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.FRIEND_ACTION_LIMIT_PER_MINUTE = '30';
+    delete process.env.DM_THREADS_TABLE_NAME;
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(fanEvent(pairKey), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(401);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      error: 'Fan authentication required',
+      code: 'fan_auth_required',
+    });
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 friendship_not_member when caller is not in pairKey', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-c' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_member');
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 friendship_not_member for malformed pairKey', async () => {
+    const res = await handler(fanEvent('not-a-valid-pair', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_member');
+  });
+
+  it('returns 404 friendship_not_found when edge is absent', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: undefined }); // friendship get
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(404);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_found');
+  });
+
+  it('returns 429 rate_limited when action throttle exceeded', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const bucket = minuteBucketEpochMs();
+    mocks.docSend.mockRejectedValueOnce({
+      name: 'ConditionalCheckFailedException',
+    });
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+
+    const rateCall = mocks.docSend.mock.calls[0]?.[0];
+    expect(rateCall?.kind).toBe('Update');
+    expect(rateCall?.input?.Key).toEqual(friendshipRateLimitKey('action', 'fan-a', bucket).pk
+      ? friendshipRateLimitKey('action', 'fan-a', bucket)
+      : expect.anything());
+  });
+
+  it('returns 200 and hard-deletes both friendship rows', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } }) // friendship get
+      .mockResolvedValueOnce({}); // transact
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.pairKey).toBe('fan-a#fan-b');
+    expect(typeof body.removedAt).toBe('number');
+
+    const transactCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'TransactWrite');
+    expect(transactCall?.[0]?.input?.TransactItems).toEqual([
+      {
+        Delete: {
+          TableName: 'Friendships',
+          Key: { pairKey: 'fan-a#fan-b', fanSub: 'fan-a' },
+          ConditionExpression: 'attribute_exists(pairKey)',
+        },
+      },
+      {
+        Delete: {
+          TableName: 'Friendships',
+          Key: { pairKey: 'fan-a#fan-b', fanSub: 'fan-b' },
+          ConditionExpression: 'attribute_exists(pairKey)',
+        },
+      },
+    ]);
+  });
+
+  it('allows either party to remove the friendship', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-b' } })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-b' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+  });
+
+  it('soft-closes DmThread in the same TransactWrite when table is wired', async () => {
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } }) // friendship get
+      .mockResolvedValueOnce({ Item: { pairKey, status: 'open' } }) // dm thread get
+      .mockResolvedValueOnce({}); // transact
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+
+    const transactCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'TransactWrite');
+    const items = transactCall?.[0]?.input?.TransactItems ?? [];
+    expect(items).toHaveLength(3);
+    expect(items[2]?.Update?.TableName).toBe('DmThreads');
+    expect(items[2]?.Update?.ExpressionAttributeValues?.[':closed']).toBe('closed');
+    expect(items[2]?.Update?.ExpressionAttributeValues?.[':closedAt']).toBe(body.removedAt);
+  });
+
+  it('skips DmThread update when no thread row exists', async () => {
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const transactCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'TransactWrite');
+    expect(transactCall?.[0]?.input?.TransactItems).toHaveLength(2);
+  });
+
+  it('returns 404 on idempotent second remove after transact race', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockRejectedValueOnce({ name: 'TransactionCanceledException' })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(fanEvent(pairKey, { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(404);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_found');
+  });
+});

--- a/infra/cdk/lambda/friends-remove.ts
+++ b/infra/cdk/lambda/friends-remove.ts
@@ -1,0 +1,147 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  TransactWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  deny,
+  enforceFriendshipRateLimit,
+  FRIEND_ACTION_LIMIT_PER_MINUTE,
+  jsonResponse,
+  requireFanSub,
+  splitPairKey,
+} from './friends-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | { ok: true; friendships: string; rateLimits: string; dmThreads?: string }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  if (!friendships || !rateLimits) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  const dmThreadsRaw = process.env.DM_THREADS_TABLE_NAME?.trim();
+  return {
+    ok: true,
+    friendships,
+    rateLimits,
+    dmThreads: dmThreadsRaw || undefined,
+  };
+}
+
+function actionLimit(): number {
+  const raw = process.env.FRIEND_ACTION_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : FRIEND_ACTION_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : FRIEND_ACTION_LIMIT_PER_MINUTE;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'DELETE' || !/^\/v1\/friends\/[^/]+$/.test(path) || path === '/v1/friends/requests') {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const pairKey = event.pathParameters?.pairKey?.trim() ?? '';
+  if (!pairKey) {
+    return deny(404, 'friendship_not_found', 'Friendship not found');
+  }
+
+  const parts = splitPairKey(pairKey);
+  if (!parts || (auth.fanSub !== parts.fanSubA && auth.fanSub !== parts.fanSubB)) {
+    return deny(403, 'friendship_not_member', 'Not a member of this friendship pair');
+  }
+
+  const allowed = await enforceFriendshipRateLimit(doc, t.rateLimits, 'action', auth.fanSub, actionLimit());
+  if (!allowed) {
+    return deny(429, 'rate_limited', 'Friend request rate limit exceeded');
+  }
+
+  const edge = await doc.send(
+    new GetCommand({
+      TableName: t.friendships,
+      Key: { pairKey, fanSub: auth.fanSub },
+    }),
+  );
+  if (!edge.Item) {
+    return deny(404, 'friendship_not_found', 'Friendship not found');
+  }
+
+  const removedAt = Date.now();
+  const { fanSubA, fanSubB } = parts;
+
+  const transactItems: NonNullable<Parameters<typeof TransactWriteCommand>[0]>['TransactItems'] = [
+    {
+      Delete: {
+        TableName: t.friendships,
+        Key: { pairKey, fanSub: fanSubA },
+        ConditionExpression: 'attribute_exists(pairKey)',
+      },
+    },
+    {
+      Delete: {
+        TableName: t.friendships,
+        Key: { pairKey, fanSub: fanSubB },
+        ConditionExpression: 'attribute_exists(pairKey)',
+      },
+    },
+  ];
+
+  if (t.dmThreads) {
+    const thread = await doc.send(
+      new GetCommand({
+        TableName: t.dmThreads,
+        Key: { pairKey },
+      }),
+    );
+    if (thread.Item) {
+      transactItems.push({
+        Update: {
+          TableName: t.dmThreads,
+          Key: { pairKey },
+          UpdateExpression: 'SET #status = :closed, closedAt = :closedAt',
+          ExpressionAttributeNames: { '#status': 'status' },
+          ExpressionAttributeValues: { ':closed': 'closed', ':closedAt': removedAt },
+          ConditionExpression: 'attribute_exists(pairKey)',
+        },
+      });
+    }
+  }
+
+  try {
+    await doc.send(
+      new TransactWriteCommand({
+        TransactItems: transactItems,
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'TransactionCanceledException' || name === 'ConditionalCheckFailedException') {
+      const again = await doc.send(
+        new GetCommand({
+          TableName: t.friendships,
+          Key: { pairKey, fanSub: auth.fanSub },
+        }),
+      );
+      if (!again.Item) {
+        return deny(404, 'friendship_not_found', 'Friendship not found');
+      }
+    }
+    throw e;
+  }
+
+  return jsonResponse(200, { pairKey, removedAt });
+};

--- a/infra/cdk/lambda/friends-shared.ts
+++ b/infra/cdk/lambda/friends-shared.ts
@@ -18,6 +18,8 @@ export type FriendshipDenyCode =
   | 'friend_request_not_recipient'
   | 'friend_request_not_requester'
   | 'friend_request_not_found'
+  | 'friendship_not_found'
+  | 'friendship_not_member'
   | 'already_friends'
   | 'friend_request_inbound_exists'
   | 'rate_limited'

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -962,6 +962,24 @@ export class ApiCatalogStack extends cdk.Stack {
     this.roomPresenceTable.grantReadData(friendsListFn);
     friendshipRateLimitTable.grantReadWriteData(friendsListFn);
 
+    const friendsRemoveFn = new lambdaNodejs.NodejsFunction(this, 'FriendsRemoveFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/friends-remove.ts'),
+      handler: 'handler',
+      environment: {
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        FRIEND_ACTION_LIMIT_PER_MINUTE: '30',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.friendshipsTable.grantReadWriteData(friendsRemoveFn);
+    friendshipRateLimitTable.grantReadWriteData(friendsRemoveFn);
+
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
@@ -1144,6 +1162,7 @@ export class ApiCatalogStack extends cdk.Stack {
       friendsRequestsFn,
     );
     const friendsListIntegration = new integrations.HttpLambdaIntegration('FriendsListInt', friendsListFn);
+    const friendsRemoveIntegration = new integrations.HttpLambdaIntegration('FriendsRemoveInt', friendsRemoveFn);
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1269,6 +1288,13 @@ export class ApiCatalogStack extends cdk.Stack {
       path: '/v1/friends',
       methods: [apigwv2.HttpMethod.GET],
       integration: friendsListIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/friends/{pairKey}',
+      methods: [apigwv2.HttpMethod.DELETE],
+      integration: friendsRemoveIntegration,
       authorizer: fanJwtAuthorizer,
     });
 
@@ -1442,7 +1468,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/friends/{pairKey}` under fan JWT so either party can end a friendship immediately for both users.
- Hard-deletes both **Friendship** member rows in a single **TransactWrite**; when `DM_THREADS_TABLE_NAME` is set and a thread exists, soft-closes it (`status: closed`, `closedAt`) in the same transaction.
- Returns **200** `{ pairKey, removedAt }`, **404** `friendship_not_found`, **403** `friendship_not_member`, **401** `fan_auth_required`, **429** `rate_limited` (30/min action bucket).

Closes #358

## Test plan

- [x] `npm run test --prefix infra/cdk` (340 tests, including new `friends-remove.test.ts`)
- [x] `npm run synth --prefix infra/cdk`
- [ ] Manual: `DELETE /v1/friends/{pairKey}` with accepted friendship → **200**, both lists drop peer
- [ ] Manual: repeat delete → **404** `friendship_not_found`
- [ ] Manual: pairKey without caller sub → **403** `friendship_not_member`