### PR TITLE
feat(dm): M35 thread ensure and durable history sync (#359)

### DIFF
--- a/infra/cdk/lambda/dm-messages-list.test.ts
+++ b/infra/cdk/lambda/dm-messages-list.test.ts
@@ -1,0 +1,260 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+import { handler } from './dm-messages-list';
+import {
+  directMessageSortKey,
+  dmReadRateLimitKey,
+  encodeHistoryCursor,
+  friendshipPairKey,
+} from './dm-shared';
+import { minuteBucketEpochMs } from './friends-shared';
+
+function historyEvent(
+  pairKey: string,
+  opts?: { claims?: Record<string, unknown>; query?: Record<string, string> },
+): APIGatewayProxyEventV2 {
+  const path = `/v1/dm/threads/${encodeURIComponent(pairKey)}/messages`;
+  const query = opts?.query ?? {};
+  const rawQueryString = Object.entries(query)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  return {
+    version: '2.0',
+    routeKey: `GET ${path}`,
+    rawPath: path,
+    rawQueryString,
+    headers: {},
+    pathParameters: { pairKey },
+    queryStringParameters: Object.keys(query).length > 0 ? query : undefined,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'GET',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-dm-history-1',
+      routeKey: `GET ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('dm-messages-list handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    process.env.DIRECT_MESSAGES_TABLE_NAME = 'DirectMessages';
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.DM_READ_LIMIT_PER_MINUTE = '60';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(historyEvent(pairKey), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(401);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('fan_auth_required');
+  });
+
+  it('returns 403 dm_not_member when caller is not in pairKey', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-c' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_not_member');
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 friendship_not_active when friendship edge missing', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_active');
+  });
+
+  it('returns 404 dm_thread_not_found when no thread row', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(404);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_not_found');
+  });
+
+  it('returns 403 dm_thread_closed after remove-friend', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+      });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+  });
+
+  it('returns empty messages for new thread', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 1 },
+      })
+      .mockResolvedValueOnce({ Items: [] });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.messages).toEqual([]);
+    expect(body.nextCursor).toBeNull();
+
+    const queryCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'Query');
+    expect(queryCall?.[0]?.input?.TableName).toBe('DirectMessages');
+    expect(queryCall?.[0]?.input?.ScanIndexForward).toBe(false);
+  });
+
+  it('returns seeded messages newest-first with pagination cursor', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const msgNew = {
+      pairKey: 'fan-a#fan-b',
+      sk: directMessageSortKey(2000, 'msg-new'),
+      messageId: 'msg-new',
+      senderSub: 'fan-a',
+      kind: 'text',
+      body: 'hello',
+      sentAt: 2000,
+    };
+    const msgOld = {
+      pairKey: 'fan-a#fan-b',
+      sk: directMessageSortKey(1000, 'msg-old'),
+      messageId: 'msg-old',
+      senderSub: 'fan-b',
+      kind: 'text',
+      body: 'hi',
+      sentAt: 1000,
+    };
+
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 1 },
+      })
+      .mockResolvedValueOnce({
+        Items: [msgNew, msgOld],
+        LastEvaluatedKey: { pairKey: 'fan-a#fan-b', sk: msgOld.sk },
+      });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' }, query: { limit: '2' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.messages).toEqual([
+      { messageId: 'msg-new', senderSub: 'fan-a', kind: 'text', body: 'hello', sentAt: 2000 },
+      { messageId: 'msg-old', senderSub: 'fan-b', kind: 'text', body: 'hi', sentAt: 1000 },
+    ]);
+    expect(body.nextCursor).toBe(encodeHistoryCursor({ sentAt: 1000, messageId: 'msg-old' }));
+  });
+
+  it('passes before cursor as ExclusiveStartKey', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const before = encodeHistoryCursor({ sentAt: 1000, messageId: 'msg-old' });
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 1 },
+      })
+      .mockResolvedValueOnce({ Items: [] });
+
+    await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' }, query: { before } }),
+      {} as never,
+      {} as never,
+    );
+
+    const queryCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'Query');
+    expect(queryCall?.[0]?.input?.ExclusiveStartKey).toEqual({
+      pairKey: 'fan-a#fan-b',
+      sk: directMessageSortKey(1000, 'msg-old'),
+    });
+  });
+
+  it('returns 429 rate_limited when read throttle exceeded', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend.mockRejectedValueOnce({ name: 'ConditionalCheckFailedException' });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+
+    const bucket = minuteBucketEpochMs();
+    expect(mocks.docSend.mock.calls[0]?.[0]?.input?.Key).toEqual(
+      dmReadRateLimitKey('fan-a', bucket),
+    );
+  });
+});

--- a/infra/cdk/lambda/dm-messages-list.ts
+++ b/infra/cdk/lambda/dm-messages-list.ts
@@ -1,0 +1,122 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  decodeHistoryCursor,
+  directMessageSortKey,
+  dmDeny,
+  encodeHistoryCursor,
+  enforceDmReadRateLimit,
+  friendshipActiveForCaller,
+  getDmThread,
+  isPairMember,
+  jsonResponse,
+  parseDirectMessageItem,
+  parseHistoryLimit,
+  requireFanSub,
+  toDirectMessageWire,
+  DM_READ_LIMIT_PER_MINUTE,
+} from './dm-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | { ok: true; dmThreads: string; directMessages: string; friendships: string; rateLimits: string }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const dmThreads = process.env.DM_THREADS_TABLE_NAME?.trim();
+  const directMessages = process.env.DIRECT_MESSAGES_TABLE_NAME?.trim();
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  if (!dmThreads || !directMessages || !friendships || !rateLimits) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, dmThreads, directMessages, friendships, rateLimits };
+}
+
+function readLimit(): number {
+  const raw = process.env.DM_READ_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : DM_READ_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : DM_READ_LIMIT_PER_MINUTE;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'GET' || !/^\/v1\/dm\/threads\/[^/]+\/messages$/.test(path)) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const pairKey = event.pathParameters?.pairKey?.trim() ?? '';
+  if (!pairKey || !isPairMember(pairKey, auth.fanSub)) {
+    return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
+  }
+
+  const allowed = await enforceDmReadRateLimit(doc, t.rateLimits, auth.fanSub, readLimit());
+  if (!allowed) {
+    return dmDeny(429, 'rate_limited', 'DM read rate limit exceeded');
+  }
+
+  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
+  if (!friendshipActive) {
+    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  }
+
+  const thread = await getDmThread(doc, t.dmThreads, pairKey);
+  if (!thread) {
+    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
+  }
+  if (thread.status === 'closed') {
+    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+  }
+
+  const limit = parseHistoryLimit(event.queryStringParameters?.limit);
+  const beforeRaw = event.queryStringParameters?.before?.trim();
+  let exclusiveStartKey: { pairKey: string; sk: string } | undefined;
+  if (beforeRaw) {
+    const cursor = decodeHistoryCursor(beforeRaw);
+    if (!cursor) {
+      return jsonResponse(400, { error: 'Invalid before cursor', code: 'invalid_request' });
+    }
+    exclusiveStartKey = {
+      pairKey,
+      sk: directMessageSortKey(cursor.sentAt, cursor.messageId),
+    };
+  }
+
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: t.directMessages,
+      KeyConditionExpression: 'pairKey = :pairKey',
+      ExpressionAttributeValues: { ':pairKey': pairKey },
+      ScanIndexForward: false,
+      Limit: limit,
+      ExclusiveStartKey: exclusiveStartKey,
+    }),
+  );
+
+  const messages = [];
+  for (const raw of out.Items ?? []) {
+    const parsed = parseDirectMessageItem(raw as Record<string, unknown>);
+    if (parsed) {
+      messages.push(toDirectMessageWire(parsed));
+    }
+  }
+
+  const lastRaw = out.Items?.[messages.length - 1] as Record<string, unknown> | undefined;
+  const lastParsed = parseDirectMessageItem(lastRaw);
+  const nextCursor =
+    out.LastEvaluatedKey && lastParsed
+      ? encodeHistoryCursor({ sentAt: lastParsed.sentAt, messageId: lastParsed.messageId })
+      : null;
+
+  return jsonResponse(200, { messages, nextCursor });
+};

--- a/infra/cdk/lambda/dm-shared.test.ts
+++ b/infra/cdk/lambda/dm-shared.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeHistoryCursor,
+  directMessageSortKey,
+  encodeHistoryCursor,
+  isPairMember,
+  parseHistoryLimit,
+} from './dm-shared';
+import { friendshipPairKey } from './friends-shared';
+
+describe('dm-shared helpers', () => {
+  it('builds zero-padded message sort keys', () => {
+    expect(directMessageSortKey(42, 'abc')).toBe('m#0000000000042#abc');
+  });
+
+  it('round-trips history cursors as base64url JSON', () => {
+    const cursor = { sentAt: 1700000000123, messageId: '550e8400-e29b-41d4-a716-446655440000' };
+    const encoded = encodeHistoryCursor(cursor);
+    expect(decodeHistoryCursor(encoded)).toEqual(cursor);
+  });
+
+  it('returns null for invalid cursors', () => {
+    expect(decodeHistoryCursor('not-valid')).toBeNull();
+    expect(decodeHistoryCursor('')).toBeNull();
+  });
+
+  it('detects pair membership', () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    expect(isPairMember(pairKey, 'fan-a')).toBe(true);
+    expect(isPairMember(pairKey, 'fan-c')).toBe(false);
+    expect(isPairMember('bad-key', 'fan-a')).toBe(false);
+  });
+
+  it('clamps history limit to max 100', () => {
+    expect(parseHistoryLimit(undefined)).toBe(50);
+    expect(parseHistoryLimit('10')).toBe(10);
+    expect(parseHistoryLimit('500')).toBe(100);
+  });
+});

--- a/infra/cdk/lambda/dm-shared.ts
+++ b/infra/cdk/lambda/dm-shared.ts
@@ -1,0 +1,221 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  friendshipPairKey,
+  jsonResponse,
+  minuteBucketEpochMs,
+  requireFanSub,
+  splitPairKey,
+} from './friends-shared';
+
+export const DM_READ_LIMIT_PER_MINUTE = 60;
+export const DM_HISTORY_DEFAULT_LIMIT = 50;
+export const DM_HISTORY_MAX_LIMIT = 100;
+export const DM_BODY_MAX_LEN = 2000;
+
+export type DmDenyCode =
+  | 'cannot_dm_self'
+  | 'fan_auth_required'
+  | 'friendship_not_active'
+  | 'dm_not_member'
+  | 'dm_thread_closed'
+  | 'dm_thread_not_found'
+  | 'rate_limited';
+
+export type DmThreadItem = {
+  pairKey: string;
+  subA: string;
+  subB: string;
+  status: 'open' | 'closed';
+  openedAt: number;
+  updatedAt: number;
+  closedAt?: number;
+  reopenedAt?: number;
+};
+
+export type DirectMessageItem = {
+  pairKey: string;
+  sk: string;
+  messageId: string;
+  senderSub: string;
+  kind: 'text';
+  body: string;
+  sentAt: number;
+};
+
+export type DirectMessageWire = {
+  messageId: string;
+  senderSub: string;
+  kind: 'text';
+  body: string;
+  sentAt: number;
+};
+
+export type DmHistoryCursor = {
+  sentAt: number;
+  messageId: string;
+};
+
+export function dmDeny(statusCode: number, code: DmDenyCode, error: string): APIGatewayProxyResultV2 {
+  return jsonResponse(statusCode, { error, code });
+}
+
+export { friendshipPairKey, jsonResponse, requireFanSub, splitPairKey };
+
+export function isPairMember(pairKey: string, fanSub: string): boolean {
+  const parts = splitPairKey(pairKey);
+  if (!parts) return false;
+  return fanSub === parts.fanSubA || fanSub === parts.fanSubB;
+}
+
+export function directMessageSortKey(sentAt: number, messageId: string): string {
+  return `m#${String(sentAt).padStart(13, '0')}#${messageId}`;
+}
+
+export function encodeHistoryCursor(cursor: DmHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export function decodeHistoryCursor(raw: string): DmHistoryCursor | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const padded = trimmed.replace(/-/g, '+').replace(/_/g, '/');
+    const padLen = (4 - (padded.length % 4)) % 4;
+    const json = Buffer.from(padded + '='.repeat(padLen), 'base64').toString('utf8');
+    const parsed = JSON.parse(json) as { sentAt?: unknown; messageId?: unknown };
+    const sentAt = typeof parsed.sentAt === 'number' && Number.isFinite(parsed.sentAt) ? parsed.sentAt : NaN;
+    const messageId = typeof parsed.messageId === 'string' ? parsed.messageId.trim() : '';
+    if (!Number.isFinite(sentAt) || !messageId) return null;
+    return { sentAt, messageId };
+  } catch {
+    return null;
+  }
+}
+
+export function parseDmThreadItem(raw: Record<string, unknown> | undefined): DmThreadItem | null {
+  if (!raw) return null;
+  const pairKey = typeof raw.pairKey === 'string' ? raw.pairKey : '';
+  const subA = typeof raw.subA === 'string' ? raw.subA : '';
+  const subB = typeof raw.subB === 'string' ? raw.subB : '';
+  const status = raw.status === 'open' || raw.status === 'closed' ? raw.status : null;
+  const openedAt = typeof raw.openedAt === 'number' && Number.isFinite(raw.openedAt) ? raw.openedAt : NaN;
+  const updatedAt = typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : NaN;
+  if (!pairKey || !subA || !subB || !status || !Number.isFinite(openedAt) || !Number.isFinite(updatedAt)) {
+    return null;
+  }
+  const closedAt =
+    typeof raw.closedAt === 'number' && Number.isFinite(raw.closedAt) ? raw.closedAt : undefined;
+  const reopenedAt =
+    typeof raw.reopenedAt === 'number' && Number.isFinite(raw.reopenedAt) ? raw.reopenedAt : undefined;
+  return { pairKey, subA, subB, status, openedAt, updatedAt, closedAt, reopenedAt };
+}
+
+export function parseDirectMessageItem(raw: Record<string, unknown> | undefined): DirectMessageItem | null {
+  if (!raw) return null;
+  const pairKey = typeof raw.pairKey === 'string' ? raw.pairKey : '';
+  const sk = typeof raw.sk === 'string' ? raw.sk : '';
+  const messageId = typeof raw.messageId === 'string' ? raw.messageId : '';
+  const senderSub = typeof raw.senderSub === 'string' ? raw.senderSub : '';
+  const kind = raw.kind === 'text' ? 'text' : null;
+  const body = typeof raw.body === 'string' ? raw.body : '';
+  const sentAt = typeof raw.sentAt === 'number' && Number.isFinite(raw.sentAt) ? raw.sentAt : NaN;
+  if (!pairKey || !sk || !messageId || !senderSub || !kind || !body || !Number.isFinite(sentAt)) {
+    return null;
+  }
+  return { pairKey, sk, messageId, senderSub, kind, body, sentAt };
+}
+
+export function toDirectMessageWire(item: DirectMessageItem): DirectMessageWire {
+  return {
+    messageId: item.messageId,
+    senderSub: item.senderSub,
+    kind: item.kind,
+    body: item.body,
+    sentAt: item.sentAt,
+  };
+}
+
+export function dmReadRateLimitKey(fanSub: string, bucketMs: number): { pk: string; sk: string } {
+  return { pk: `dm-read#${fanSub}`, sk: String(bucketMs) };
+}
+
+export async function enforceDmReadRateLimit(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+  limit: number,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  const { pk, sk } = dmReadRateLimitKey(fanSub, bucketMs);
+  const expiresAt = Math.floor(nowMs / 1000) + 120;
+
+  try {
+    await doc.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { pk, sk },
+        UpdateExpression: 'ADD requestCount :one SET expiresAt = :expiresAt',
+        ConditionExpression: 'attribute_not_exists(requestCount) OR requestCount < :limit',
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':limit': limit,
+          ':expiresAt': expiresAt,
+        },
+      }),
+    );
+    return true;
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name === 'ConditionalCheckFailedException') {
+      return false;
+    }
+    throw e;
+  }
+}
+
+export async function friendshipActiveForCaller(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  pairKey: string,
+  fanSub: string,
+): Promise<boolean> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { pairKey, fanSub },
+    }),
+  );
+  return Boolean(out.Item);
+}
+
+export async function getDmThread(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  pairKey: string,
+): Promise<DmThreadItem | null> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { pairKey },
+    }),
+  );
+  return parseDmThreadItem(out.Item as Record<string, unknown> | undefined);
+}
+
+export function parseHistoryLimit(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') {
+    return DM_HISTORY_DEFAULT_LIMIT;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    return DM_HISTORY_DEFAULT_LIMIT;
+  }
+  return Math.min(n, DM_HISTORY_MAX_LIMIT);
+}

--- a/infra/cdk/lambda/dm-thread-ensure.test.ts
+++ b/infra/cdk/lambda/dm-thread-ensure.test.ts
@@ -1,0 +1,162 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+import { handler } from './dm-thread-ensure';
+import { dmReadRateLimitKey, friendshipPairKey } from './dm-shared';
+import { minuteBucketEpochMs } from './friends-shared';
+
+function ensureEvent(
+  peerSub: string,
+  opts?: { claims?: Record<string, unknown> },
+): APIGatewayProxyEventV2 {
+  const path = `/v1/dm/threads/${encodeURIComponent(peerSub)}`;
+  return {
+    version: '2.0',
+    routeKey: `PUT ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: {},
+    pathParameters: { peerSub },
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'PUT',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-dm-ensure-1',
+      routeKey: `PUT ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('dm-thread-ensure handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.DM_READ_LIMIT_PER_MINUTE = '60';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const res = await handler(ensureEvent('fan-b'), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(401);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('fan_auth_required');
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 cannot_dm_self when peerSub equals caller sub', async () => {
+    const res = await handler(ensureEvent('fan-a', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(400);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('cannot_dm_self');
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 friendship_not_active when no friendship edge', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: undefined }); // friendship get
+
+    const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_active');
+  });
+
+  it('returns 403 dm_thread_closed when thread is closed', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+      });
+
+    const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+  });
+
+  it('returns 200 idempotently when thread already open', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1000, updatedAt: 1000 },
+      });
+
+    const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body).toEqual({
+      pairKey: 'fan-a#fan-b',
+      peerSub: 'fan-b',
+      status: 'open',
+      openedAt: 1000,
+    });
+    expect(mocks.docSend.mock.calls.some((c) => c[0]?.kind === 'Put')).toBe(false);
+  });
+
+  it('creates DmThread row when missing', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.pairKey).toBe('fan-a#fan-b');
+    expect(body.peerSub).toBe('fan-b');
+    expect(body.status).toBe('open');
+    expect(typeof body.openedAt).toBe('number');
+
+    const putCall = mocks.docSend.mock.calls.find((c) => c[0]?.kind === 'Put');
+    expect(putCall?.[0]?.input?.TableName).toBe('DmThreads');
+    expect(putCall?.[0]?.input?.Item?.pairKey).toBe('fan-a#fan-b');
+    expect(putCall?.[0]?.input?.Item?.status).toBe('open');
+  });
+
+  it('returns 429 rate_limited when read throttle exceeded', async () => {
+    mocks.docSend.mockRejectedValueOnce({ name: 'ConditionalCheckFailedException' });
+
+    const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+
+    const bucket = minuteBucketEpochMs();
+    expect(mocks.docSend.mock.calls[0]?.[0]?.input?.Key).toEqual(
+      dmReadRateLimitKey('fan-a', bucket),
+    );
+  });
+});

--- a/infra/cdk/lambda/dm-thread-ensure.ts
+++ b/infra/cdk/lambda/dm-thread-ensure.ts
@@ -1,0 +1,132 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  dmDeny,
+  enforceDmReadRateLimit,
+  friendshipActiveForCaller,
+  friendshipPairKey,
+  getDmThread,
+  jsonResponse,
+  requireFanSub,
+  splitPairKey,
+  DM_READ_LIMIT_PER_MINUTE,
+} from './dm-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | { ok: true; dmThreads: string; friendships: string; rateLimits: string }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const dmThreads = process.env.DM_THREADS_TABLE_NAME?.trim();
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  if (!dmThreads || !friendships || !rateLimits) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, dmThreads, friendships, rateLimits };
+}
+
+function readLimit(): number {
+  const raw = process.env.DM_READ_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : DM_READ_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : DM_READ_LIMIT_PER_MINUTE;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'PUT' || !/^\/v1\/dm\/threads\/[^/]+$/.test(path)) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const peerSub = event.pathParameters?.peerSub?.trim() ?? '';
+  if (!peerSub) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  if (peerSub === auth.fanSub) {
+    return dmDeny(400, 'cannot_dm_self', 'Cannot open a DM thread with yourself');
+  }
+
+  const allowed = await enforceDmReadRateLimit(doc, t.rateLimits, auth.fanSub, readLimit());
+  if (!allowed) {
+    return dmDeny(429, 'rate_limited', 'DM read rate limit exceeded');
+  }
+
+  const pairKey = friendshipPairKey(auth.fanSub, peerSub);
+  const parts = splitPairKey(pairKey);
+  if (!parts) {
+    return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
+  }
+
+  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
+  if (!friendshipActive) {
+    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  }
+
+  const existing = await getDmThread(doc, t.dmThreads, pairKey);
+  if (existing) {
+    if (existing.status === 'closed') {
+      return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+    }
+    return jsonResponse(200, {
+      pairKey,
+      peerSub,
+      status: existing.status,
+      openedAt: existing.openedAt,
+    });
+  }
+
+  const now = Date.now();
+  try {
+    await doc.send(
+      new PutCommand({
+        TableName: t.dmThreads,
+        Item: {
+          pairKey,
+          subA: parts.fanSubA,
+          subB: parts.fanSubB,
+          status: 'open',
+          openedAt: now,
+          updatedAt: now,
+        },
+        ConditionExpression: 'attribute_not_exists(pairKey)',
+      }),
+    );
+  } catch (e) {
+    const name = e && typeof e === 'object' && 'name' in e ? String((e as { name: string }).name) : '';
+    if (name !== 'ConditionalCheckFailedException') {
+      throw e;
+    }
+    const raced = await getDmThread(doc, t.dmThreads, pairKey);
+    if (!raced) {
+      throw e;
+    }
+    if (raced.status === 'closed') {
+      return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+    }
+    return jsonResponse(200, {
+      pairKey,
+      peerSub,
+      status: raced.status,
+      openedAt: raced.openedAt,
+    });
+  }
+
+  return jsonResponse(200, {
+    pairKey,
+    peerSub,
+    status: 'open',
+    openedAt: now,
+  });
+};

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -189,6 +189,8 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly fanProfilesTable: dynamodb.Table;
   public readonly friendshipRequestsTable: dynamodb.Table;
   public readonly friendshipsTable: dynamodb.Table;
+  public readonly dmThreadsTable: dynamodb.Table;
+  public readonly directMessagesTable: dynamodb.Table;
   public readonly fanAvatarsBucket: s3.Bucket;
   public readonly fanAvatarsDistribution: cloudfront.Distribution;
   /** HTTPS origin for avatar object keys (no trailing slash). */
@@ -317,6 +319,21 @@ export class ApiCatalogStack extends cdk.Stack {
       partitionKey: { name: 'fanSub', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    this.dmThreadsTable = new dynamodb.Table(this, 'DmThreadsTable', {
+      partitionKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+
+    this.directMessagesTable = new dynamodb.Table(this, 'DirectMessagesTable', {
+      partitionKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
 
     this.fanAvatarsBucket = new s3.Bucket(this, 'FanAvatarsBucket', {
@@ -972,13 +989,57 @@ export class ApiCatalogStack extends cdk.Stack {
       environment: {
         FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
         FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        DM_THREADS_TABLE_NAME: this.dmThreadsTable.tableName,
         FRIEND_ACTION_LIMIT_PER_MINUTE: '30',
         RIFFSYNC_ENVIRONMENT: environment,
         NODE_OPTIONS: '--enable-source-maps',
       },
     });
     this.friendshipsTable.grantReadWriteData(friendsRemoveFn);
+    this.dmThreadsTable.grantReadWriteData(friendsRemoveFn);
     friendshipRateLimitTable.grantReadWriteData(friendsRemoveFn);
+
+    const dmThreadEnsureFn = new lambdaNodejs.NodejsFunction(this, 'DmThreadEnsureFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/dm-thread-ensure.ts'),
+      handler: 'handler',
+      environment: {
+        DM_THREADS_TABLE_NAME: this.dmThreadsTable.tableName,
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        DM_READ_LIMIT_PER_MINUTE: '60',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.dmThreadsTable.grantReadWriteData(dmThreadEnsureFn);
+    this.friendshipsTable.grantReadData(dmThreadEnsureFn);
+    friendshipRateLimitTable.grantReadWriteData(dmThreadEnsureFn);
+
+    const dmMessagesListFn = new lambdaNodejs.NodejsFunction(this, 'DmMessagesListFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/dm-messages-list.ts'),
+      handler: 'handler',
+      environment: {
+        DM_THREADS_TABLE_NAME: this.dmThreadsTable.tableName,
+        DIRECT_MESSAGES_TABLE_NAME: this.directMessagesTable.tableName,
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        DM_READ_LIMIT_PER_MINUTE: '60',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.dmThreadsTable.grantReadData(dmMessagesListFn);
+    this.directMessagesTable.grantReadData(dmMessagesListFn);
+    this.friendshipsTable.grantReadData(dmMessagesListFn);
+    friendshipRateLimitTable.grantReadWriteData(dmMessagesListFn);
 
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
@@ -1163,6 +1224,8 @@ export class ApiCatalogStack extends cdk.Stack {
     );
     const friendsListIntegration = new integrations.HttpLambdaIntegration('FriendsListInt', friendsListFn);
     const friendsRemoveIntegration = new integrations.HttpLambdaIntegration('FriendsRemoveInt', friendsRemoveFn);
+    const dmThreadEnsureIntegration = new integrations.HttpLambdaIntegration('DmThreadEnsureInt', dmThreadEnsureFn);
+    const dmMessagesListIntegration = new integrations.HttpLambdaIntegration('DmMessagesListInt', dmMessagesListFn);
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1327,6 +1390,20 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     this.httpApi.addRoutes({
+      path: '/v1/dm/threads/{peerSub}',
+      methods: [apigwv2.HttpMethod.PUT],
+      integration: dmThreadEnsureIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
+      path: '/v1/dm/threads/{pairKey}/messages',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: dmMessagesListIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: '/v1/admin/session',
       methods: [apigwv2.HttpMethod.GET],
       integration: adminSessionGetIntegration,
@@ -1438,6 +1515,16 @@ export class ApiCatalogStack extends cdk.Stack {
       description: 'DynamoDB Friendships — PK `pairKey`, SK `fanSub`; GSI FanSubIndex.',
     });
 
+    new cdk.CfnOutput(this, 'DmThreadsTableName', {
+      value: this.dmThreadsTable.tableName,
+      description: 'DynamoDB DmThreads — PK `pairKey`; thread metadata for 1:1 DM pairs.',
+    });
+
+    new cdk.CfnOutput(this, 'DirectMessagesTableName', {
+      value: this.directMessagesTable.tableName,
+      description: 'DynamoDB DirectMessages — PK `pairKey`, SK `m#<sentAtMs>#<messageId>`.',
+    });
+
     new cdk.CfnOutput(this, 'FriendshipRateLimitTableName', {
       value: friendshipRateLimitTable.tableName,
       description: 'DynamoDB friendship invite/action rate limits — PK `pk`, SK `sk`, TTL `expiresAt`.',
@@ -1468,7 +1555,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/dm/threads/{peerSub}` (PUT), `/v1/dm/threads/{pairKey}/messages` (GET), `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Adds **DmThreads** and **DirectMessages** DynamoDB tables in CDK with fan JWT routes `PUT /v1/dm/threads/{peerSub}` and `GET /v1/dm/threads/{pairKey}/messages`.
- Implements ensure-on-open thread creation (idempotent when already open), newest-first history pagination with base64url cursors, friendship/closed-thread/membership gates, and combined 60/min read rate limiting.
- Wires `DM_THREADS_TABLE_NAME` on the remove-friend handler so unfriend soft-closes existing threads in the same transaction.

Closes #359

## Test plan

- [x] `npm run test --prefix infra/cdk` (361 tests)
- [x] `npm run synth --prefix infra/cdk`
- [ ] Manual: fan JWT `PUT /v1/dm/threads/{peerSub}` with active friendship returns 200 `{ pairKey, peerSub, status, openedAt }`
- [ ] Manual: repeat ensure is idempotent; self-DM returns 400 `cannot_dm_self`
- [ ] Manual: `GET /v1/dm/threads/{pairKey}/messages` returns newest-first pages with `nextCursor`; empty thread returns `{ messages: [], nextCursor: null }`
- [ ] Manual: no friendship / closed thread / non-member return 403; missing thread on history returns 404 `dm_thread_not_found`