### PR TITLE
feat(dm): M35 realtime 1:1 DM send and receive (#360)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -9,6 +9,9 @@
 # WebSocket API (`wss://…` CDK output `WebSocketUrl`). Required for `/room` realtime (chat / signaling).
 # VITE_PUBLIC_WS_URL=
 
+# Fan DM push WebSocket (`wss://…` CDK output `FanDmWebSocketUrl`). Separate from room chat WS.
+# VITE_PUBLIC_FAN_DM_WS_URL=
+
 # Fan Hosted UI PKCE (`/auth/callback` must be allowed in the Cognito app client redirect URLs).
 # VITE_COGNITO_HOSTED_UI_DOMAIN=
 # VITE_COGNITO_CLIENT_ID=

--- a/apps/web/src/config/fanDmWsUrl.ts
+++ b/apps/web/src/config/fanDmWsUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * Fan DM push WebSocket URL (`wss://…`) from **`RiffSyncApi-prod`** **`FanDmWebSocketUrl`** output.
+ * Separate from room **`WebSocketUrl`** / **`VITE_PUBLIC_WS_URL`**.
+ */
+export function getPublicFanDmWsUrl(): string | undefined {
+  const raw = import.meta.env.VITE_PUBLIC_FAN_DM_WS_URL?.trim()
+  return raw && raw.length > 0 ? raw.replace(/\/$/, '') : undefined
+}
+
+export function getFanDmWsUrlOrThrow(): string {
+  const u = getPublicFanDmWsUrl()
+  if (!u) {
+    throw new Error(
+      'Set VITE_PUBLIC_FAN_DM_WS_URL to the deployed Fan DM WebSocket URL (see infra/cdk/README — FanDmWebSocketUrl output).',
+    )
+  }
+  return u
+}

--- a/apps/web/src/friends/FanDmSession.test.ts
+++ b/apps/web/src/friends/FanDmSession.test.ts
@@ -7,6 +7,7 @@ class MockWebSocket {
   static OPEN = 1
   static CLOSED = 3
 
+  url: string
   readyState = MockWebSocket.CONNECTING
   onopen: (() => void) | null = null
   onmessage: ((event: { data: string }) => void) | null = null
@@ -14,7 +15,8 @@ class MockWebSocket {
   onclose: (() => void) | null = null
   sent: string[] = []
 
-  constructor(readonly url: string) {
+  constructor(url: string) {
+    this.url = url
     MockWebSocket.instances.push(this)
     queueMicrotask(() => {
       this.readyState = MockWebSocket.OPEN

--- a/apps/web/src/friends/FanDmSession.test.ts
+++ b/apps/web/src/friends/FanDmSession.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FanDmSession } from './FanDmSession'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  sent: string[] = []
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN
+      this.onopen?.()
+    })
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+}
+
+describe('FanDmSession', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubEnv('VITE_PUBLIC_FAN_DM_WS_URL', 'wss://fan-dm.test.example/prod')
+    vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('connects with accessToken and sessionId query params', async () => {
+    const session = new FanDmSession({}, 'tab-1')
+    session.connect('fan-jwt-token')
+    await Promise.resolve()
+    expect(MockWebSocket.instances).toHaveLength(1)
+    const url = MockWebSocket.instances[0].url
+    expect(url).toContain('wss://fan-dm.test.example/prod')
+    expect(url).toContain('accessToken=fan-jwt-token')
+    expect(url).toContain('sessionId=tab-1')
+    expect(session.getStatus()).toBe('open')
+  })
+
+  it('parses inbound dm_message frames', async () => {
+    const inbound: unknown[] = []
+    const session = new FanDmSession({
+      onInboundMessage: (msg) => inbound.push(msg),
+    })
+    session.connect('fan-jwt-token')
+    await Promise.resolve()
+    const ws = MockWebSocket.instances[0]
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'dm_message',
+        schemaVersion: 1,
+        pairKey: 'a#b',
+        messageId: 'm1',
+        senderSub: 'b',
+        kind: 'text',
+        body: 'hello',
+        sentAt: 123,
+      }),
+    })
+    expect(inbound).toHaveLength(1)
+  })
+
+  it('emits DM_PUSH_UNAVAILABLE when open socket closes', async () => {
+    const errors: string[] = []
+    const session = new FanDmSession({
+      onDrawerError: (err) => errors.push(err.code),
+    })
+    session.connect('fan-jwt-token')
+    await Promise.resolve()
+    MockWebSocket.instances[0].close()
+    expect(errors).toContain('DM_PUSH_UNAVAILABLE')
+  })
+})

--- a/apps/web/src/friends/FanDmSession.ts
+++ b/apps/web/src/friends/FanDmSession.ts
@@ -1,0 +1,234 @@
+import { getPublicFanDmWsUrl } from '../config/fanDmWsUrl'
+import { FAN_AUTH_CHANGED_EVENT, getFanAccessToken } from '../auth/fanTokens'
+import { dmPushUnavailableError, dmSendDroppedError, type DmDrawerError } from './dmDrawerCodes'
+import { postDmMessage, type DmSendRequest, type DmSendResponse } from './dmApi'
+
+const PING_MS = 25_000
+const SEND_RETRY_ATTEMPTS = 3
+const SEND_RETRY_BASE_MS = 400
+
+export type InboundDmMessage = {
+  type: 'dm_message'
+  schemaVersion: 1
+  pairKey: string
+  messageId: string
+  senderSub: string
+  kind: 'text'
+  body: string
+  sentAt: number
+  displayName?: string
+  avatarUrl?: string
+}
+
+export type FanDmSessionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
+
+export type FanDmSessionHandlers = {
+  onInboundMessage?: (message: InboundDmMessage) => void
+  onStatusChange?: (status: FanDmSessionStatus) => void
+  onDrawerError?: (error: DmDrawerError) => void
+}
+
+function buildFanDmWsUrl(wsBase: string, accessToken: string, sessionId: string): string {
+  const url = new URL(wsBase)
+  url.searchParams.set('accessToken', accessToken)
+  url.searchParams.set('sessionId', sessionId)
+  return url.toString()
+}
+
+function parseInboundDmMessage(raw: unknown): InboundDmMessage | null {
+  if (!raw || typeof raw !== 'object') return null
+  const record = raw as Record<string, unknown>
+  if (record.type !== 'dm_message' || record.schemaVersion !== 1) return null
+  const pairKey = typeof record.pairKey === 'string' ? record.pairKey : ''
+  const messageId = typeof record.messageId === 'string' ? record.messageId : ''
+  const senderSub = typeof record.senderSub === 'string' ? record.senderSub : ''
+  const kind = record.kind === 'text' ? 'text' : null
+  const body = typeof record.body === 'string' ? record.body : ''
+  const sentAt = typeof record.sentAt === 'number' && Number.isFinite(record.sentAt) ? record.sentAt : NaN
+  if (!pairKey || !messageId || !senderSub || !kind || !body || !Number.isFinite(sentAt)) {
+    return null
+  }
+  const displayName = typeof record.displayName === 'string' ? record.displayName : undefined
+  const avatarUrl = typeof record.avatarUrl === 'string' ? record.avatarUrl : undefined
+  return {
+    type: 'dm_message',
+    schemaVersion: 1,
+    pairKey,
+    messageId,
+    senderSub,
+    kind,
+    body,
+    sentAt,
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
+}
+
+/**
+ * Fan DM push session — independent of room ChatSession / RoomRealtimeSdk lifecycle.
+ */
+export class FanDmSession {
+  private ws: WebSocket | null = null
+  private pingTimer: number | null = null
+  private status: FanDmSessionStatus = 'idle'
+  private readonly sessionId: string
+  private readonly handlers: FanDmSessionHandlers
+
+  constructor(handlers: FanDmSessionHandlers = {}, sessionId?: string) {
+    this.handlers = handlers
+    this.sessionId =
+      sessionId ??
+      (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `fan-dm-${Date.now()}`)
+  }
+
+  getStatus(): FanDmSessionStatus {
+    return this.status
+  }
+
+  isPushAvailable(): boolean {
+    return this.status === 'open'
+  }
+
+  private setStatus(next: FanDmSessionStatus): void {
+    if (this.status === next) return
+    const wasOpen = this.status === 'open'
+    this.status = next
+    this.handlers.onStatusChange?.(next)
+    if (wasOpen && next !== 'open') {
+      this.handlers.onDrawerError?.(dmPushUnavailableError())
+    }
+  }
+
+  connect(accessToken: string): void {
+    const wsBase = getPublicFanDmWsUrl()
+    if (!wsBase) {
+      this.setStatus('error')
+      this.handlers.onDrawerError?.(dmPushUnavailableError(new Error('Fan DM WebSocket URL not configured')))
+      return
+    }
+
+    this.disconnect()
+    this.setStatus('connecting')
+
+    const ws = new WebSocket(buildFanDmWsUrl(wsBase, accessToken, this.sessionId))
+    this.ws = ws
+
+    ws.onopen = () => {
+      if (this.ws !== ws) return
+      this.setStatus('open')
+      this.startPing()
+    }
+
+    ws.onmessage = (event) => {
+      if (this.ws !== ws) return
+      try {
+        const parsed = parseInboundDmMessage(JSON.parse(String(event.data)))
+        if (parsed) {
+          this.handlers.onInboundMessage?.(parsed)
+        }
+      } catch {
+        // ignore malformed push frames
+      }
+    }
+
+    ws.onerror = () => {
+      if (this.ws !== ws) return
+      this.setStatus('error')
+    }
+
+    ws.onclose = () => {
+      if (this.ws !== ws) return
+      this.stopPing()
+      this.setStatus('closed')
+    }
+  }
+
+  disconnect(): void {
+    this.stopPing()
+    if (this.ws) {
+      const socket = this.ws
+      this.ws = null
+      socket.close()
+    }
+    this.setStatus('idle')
+  }
+
+  async sendMessage(accessToken: string, pairKey: string, payload: DmSendRequest): Promise<DmSendResponse | null> {
+    if (!this.isPushAvailable()) {
+      this.handlers.onDrawerError?.(dmPushUnavailableError())
+    }
+
+    let lastFailure: unknown
+    for (let attempt = 0; attempt < SEND_RETRY_ATTEMPTS; attempt += 1) {
+      try {
+        const result = await postDmMessage(accessToken, pairKey, payload)
+        if (result.ok) {
+          return result.message
+        }
+        if (result.status >= 400 && result.status < 500 && result.status !== 429) {
+          this.handlers.onDrawerError?.(dmSendDroppedError(result))
+          return null
+        }
+        lastFailure = result
+      } catch (err) {
+        lastFailure = err
+      }
+      if (attempt < SEND_RETRY_ATTEMPTS - 1) {
+        await sleep(SEND_RETRY_BASE_MS * 2 ** attempt)
+      }
+    }
+
+    this.handlers.onDrawerError?.(dmSendDroppedError(lastFailure))
+    return null
+  }
+
+  private startPing(): void {
+    this.stopPing()
+    this.pingTimer = globalThis.setInterval(() => {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+      this.ws.send(JSON.stringify({ action: 'ping' }))
+    }, PING_MS) as unknown as number
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer !== null) {
+      globalThis.clearInterval(this.pingTimer)
+      this.pingTimer = null
+    }
+  }
+}
+
+let sharedSession: FanDmSession | null = null
+
+export function getSharedFanDmSession(handlers?: FanDmSessionHandlers): FanDmSession {
+  if (!sharedSession) {
+    sharedSession = new FanDmSession(handlers)
+  }
+  return sharedSession
+}
+
+export function syncSharedFanDmSessionWithAuth(): void {
+  const token = getFanAccessToken()
+  const session = getSharedFanDmSession()
+  if (!token) {
+    session.disconnect()
+    return
+  }
+  if (session.getStatus() === 'open' || session.getStatus() === 'connecting') {
+    return
+  }
+  session.connect(token)
+}
+
+export function installFanDmSessionAuthListener(): () => void {
+  const onAuthChanged = () => syncSharedFanDmSessionWithAuth()
+  window.addEventListener(FAN_AUTH_CHANGED_EVENT, onAuthChanged)
+  syncSharedFanDmSessionWithAuth()
+  return () => window.removeEventListener(FAN_AUTH_CHANGED_EVENT, onAuthChanged)
+}

--- a/apps/web/src/friends/FanDmSessionKeepAlive.tsx
+++ b/apps/web/src/friends/FanDmSessionKeepAlive.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+import { installFanDmSessionAuthListener } from './FanDmSession'
+
+/**
+ * Opens the Fan DM push WebSocket when a signed-in fan session is present.
+ * Independent of room ChatSession / SFU lifecycle.
+ */
+export function FanDmSessionKeepAlive() {
+  useEffect(() => installFanDmSessionAuthListener(), [])
+  return null
+}

--- a/apps/web/src/friends/dmApi.test.ts
+++ b/apps/web/src/friends/dmApi.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { postDmMessage } from './dmApi'
+
+describe('postDmMessage', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('returns persisted message on 201', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        pairKey: 'a#b',
+        messageId: 'm1',
+        senderSub: 'a',
+        kind: 'text',
+        body: 'hello',
+        sentAt: 100,
+      }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await postDmMessage('token', 'a#b', {
+      messageId: 'm1',
+      kind: 'text',
+      body: 'hello',
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.message.body).toBe('hello')
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test.example/v1/dm/threads/a%23b/messages',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('returns structured failure on 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        json: async () => ({ code: 'friendship_not_active', error: 'Active friendship required' }),
+      })),
+    )
+
+    const result = await postDmMessage('token', 'a#b', {
+      messageId: 'm1',
+      kind: 'text',
+      body: 'hello',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('friendship_not_active')
+    }
+  })
+})

--- a/apps/web/src/friends/dmApi.ts
+++ b/apps/web/src/friends/dmApi.ts
@@ -1,0 +1,64 @@
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+
+export type DmSendRequest = {
+  messageId: string
+  kind: 'text'
+  body: string
+}
+
+export type DmSendResponse = {
+  pairKey: string
+  messageId: string
+  senderSub: string
+  kind: 'text'
+  body: string
+  sentAt: number
+}
+
+export type DmSendFailure = {
+  ok: false
+  status: number
+  code?: string
+  error?: string
+}
+
+export type DmSendResult = { ok: true; message: DmSendResponse } | DmSendFailure
+
+export async function postDmMessage(
+  accessToken: string,
+  pairKey: string,
+  payload: DmSendRequest,
+  signal?: AbortSignal,
+): Promise<DmSendResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const path = `/v1/dm/threads/${encodeURIComponent(pairKey)}/messages`
+  const res = await fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+    signal,
+  })
+
+  if (!res.ok) {
+    let code: string | undefined
+    let error: string | undefined
+    try {
+      const json = (await res.json()) as { code?: unknown; error?: unknown }
+      code = typeof json.code === 'string' ? json.code : undefined
+      error = typeof json.error === 'string' ? json.error : undefined
+    } catch {
+      // ignore parse errors
+    }
+    return { ok: false, status: res.status, code, error }
+  }
+
+  const message = (await res.json()) as DmSendResponse
+  return { ok: true, message }
+}

--- a/apps/web/src/friends/dmDrawerCodes.ts
+++ b/apps/web/src/friends/dmDrawerCodes.ts
@@ -1,0 +1,20 @@
+export const DM_DRAWER_ERROR_CODES = ['DM_SEND_DROPPED', 'DM_PUSH_UNAVAILABLE'] as const
+
+export type DmDrawerErrorCode = (typeof DM_DRAWER_ERROR_CODES)[number]
+
+export type DmDrawerError = {
+  code: DmDrawerErrorCode
+  cause?: unknown
+}
+
+export function dmSendDroppedError(cause?: unknown): DmDrawerError {
+  return { code: 'DM_SEND_DROPPED', cause }
+}
+
+export function dmPushUnavailableError(cause?: unknown): DmDrawerError {
+  return { code: 'DM_PUSH_UNAVAILABLE', cause }
+}
+
+export function isDmDrawerErrorCode(value: string): value is DmDrawerErrorCode {
+  return (DM_DRAWER_ERROR_CODES as readonly string[]).includes(value)
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import './styles/riffsync-app.css'
 import { FanSessionKeepAlive } from './auth/FanSessionKeepAlive'
+import { FanDmSessionKeepAlive } from './friends/FanDmSessionKeepAlive'
 import { GoogleAnalytics } from './components/GoogleAnalytics'
 import { ScrollToTop } from './components/ScrollToTop'
 import { AppRoutes } from './AppRoutes.tsx'
@@ -31,6 +32,7 @@ createRoot(document.getElementById('root')!).render(
         <ScrollToTop />
         <GoogleAnalytics />
         <FanSessionKeepAlive />
+        <FanDmSessionKeepAlive />
         <AppRoutes />
       </BrowserRouter>
     </QueryClientProvider>

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,8 @@ interface ImportMetaEnv {
   readonly VITE_PUBLIC_API_BASE_URL?: string
   /** API Gateway WebSocket **`wss://…`** (`WebSocketUrl` CDK output; include stage path if present). */
   readonly VITE_PUBLIC_WS_URL?: string
+  /** Fan DM push WebSocket (`FanDmWebSocketUrl` CDK output). Separate from room chat WS. */
+  readonly VITE_PUBLIC_FAN_DM_WS_URL?: string
   /** Cognito Hosted UI domain only (no `https://`; e.g. `your-domain.auth.region.amazoncognito.com`). */
   readonly VITE_COGNITO_HOSTED_UI_DOMAIN?: string
   /** Fan app client id (SPA / public client) for Hosted UI PKCE + token exchange. */

--- a/infra/cdk/lambda/dm-messages-send.test.ts
+++ b/infra/cdk/lambda/dm-messages-send.test.ts
@@ -1,0 +1,242 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  pushDmMessageToRecipient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+vi.mock('./fan-dm-shared', () => ({
+  pushDmMessageToRecipient: mocks.pushDmMessageToRecipient,
+}));
+
+import { handler } from './dm-messages-send';
+import { directMessageSortKey, dmSendRateLimitKey, friendshipPairKey } from './dm-shared';
+import { minuteBucketEpochMs } from './friends-shared';
+
+function sendEvent(
+  pairKey: string,
+  body: Record<string, unknown>,
+  opts?: { claims?: Record<string, unknown> },
+): APIGatewayProxyEventV2 {
+  const path = `/v1/dm/threads/${encodeURIComponent(pairKey)}/messages`;
+  return {
+    version: '2.0',
+    routeKey: `POST ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: { 'content-type': 'application/json' },
+    pathParameters: { pairKey },
+    body: JSON.stringify(body),
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'POST',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-dm-send-1',
+      routeKey: `POST ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('dm-messages-send handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    mocks.pushDmMessageToRecipient.mockReset();
+    mocks.pushDmMessageToRecipient.mockResolvedValue(undefined);
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    process.env.DIRECT_MESSAGES_TABLE_NAME = 'DirectMessages';
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    process.env.DM_SEND_LIMIT_PER_MINUTE = '20';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(401);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('fan_auth_required');
+  });
+
+  it('returns 400 invalid_dm_body for empty body', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: '   ' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(400);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('invalid_dm_body');
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 invalid_dm_body for overlong body', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      sendEvent(
+        pairKey,
+        { messageId: 'msg-1', kind: 'text', body: 'x'.repeat(2001) },
+        { claims: { sub: 'fan-a' } },
+      ),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(400);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('invalid_dm_body');
+  });
+
+  it('returns 403 dm_not_member when caller is not in pairKey', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-c' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_not_member');
+  });
+
+  it('returns 403 friendship_not_active when friendship edge missing', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_active');
+  });
+
+  it('returns 404 dm_thread_not_found when no thread row', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(404);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_not_found');
+  });
+
+  it('returns 403 dm_thread_closed after remove-friend', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+      });
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+  });
+
+  it('returns 429 rate_limited at send throttle', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const bucketMs = minuteBucketEpochMs();
+    const { pk, sk } = dmSendRateLimitKey('fan-a', bucketMs);
+    const err = new Error('ConditionalCheckFailedException');
+    err.name = 'ConditionalCheckFailedException';
+    mocks.docSend.mockRejectedValueOnce(err);
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+    expect(mocks.docSend.mock.calls[0][0].input.Key).toEqual({ pk, sk });
+  });
+
+  it('returns 201, persists DirectMessage, and pushes to recipient fanSub only', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+      })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-uuid-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(201);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body).toMatchObject({
+      pairKey,
+      messageId: 'msg-uuid-1',
+      senderSub: 'fan-a',
+      kind: 'text',
+      body: 'hello',
+    });
+    expect(typeof body.sentAt).toBe('number');
+
+    const putCall = mocks.docSend.mock.calls.find((call) => call[0].kind === 'Put');
+    expect(putCall).toBeTruthy();
+    const put = putCall![0].input as { TableName: string; Item: Record<string, unknown> };
+    expect(put.TableName).toBe('DirectMessages');
+    expect(put.Item.pairKey).toBe(pairKey);
+    expect(put.Item.messageId).toBe('msg-uuid-1');
+    expect(put.Item.senderSub).toBe('fan-a');
+    expect(put.Item.sk).toBe(directMessageSortKey(body.sentAt, 'msg-uuid-1'));
+
+    expect(mocks.pushDmMessageToRecipient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientFanSub: 'fan-b',
+        senderSub: 'fan-a',
+        pairKey,
+        messageId: 'msg-uuid-1',
+        body: 'hello',
+      }),
+    );
+  });
+});

--- a/infra/cdk/lambda/dm-messages-send.ts
+++ b/infra/cdk/lambda/dm-messages-send.ts
@@ -1,0 +1,145 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  directMessageSortKey,
+  dmDeny,
+  enforceDmSendRateLimit,
+  friendshipActiveForCaller,
+  getDmThread,
+  isPairMember,
+  jsonResponse,
+  parseDmSendBody,
+  peerSubForCaller,
+  requireFanSub,
+  DM_SEND_LIMIT_PER_MINUTE,
+} from './dm-shared';
+import { pushDmMessageToRecipient } from './fan-dm-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | {
+      ok: true;
+      dmThreads: string;
+      directMessages: string;
+      friendships: string;
+      rateLimits: string;
+      fanConnections: string;
+      fanProfiles: string;
+    }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const dmThreads = process.env.DM_THREADS_TABLE_NAME?.trim();
+  const directMessages = process.env.DIRECT_MESSAGES_TABLE_NAME?.trim();
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  const fanConnections = process.env.FAN_CONNECTIONS_TABLE_NAME?.trim();
+  const fanProfiles = process.env.FAN_PROFILES_TABLE_NAME?.trim();
+  if (!dmThreads || !directMessages || !friendships || !rateLimits || !fanConnections || !fanProfiles) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, dmThreads, directMessages, friendships, rateLimits, fanConnections, fanProfiles };
+}
+
+function sendLimit(): number {
+  const raw = process.env.DM_SEND_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : DM_SEND_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : DM_SEND_LIMIT_PER_MINUTE;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'POST' || !/^\/v1\/dm\/threads\/[^/]+\/messages$/.test(path)) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const pairKey = event.pathParameters?.pairKey?.trim() ?? '';
+  if (!pairKey || !isPairMember(pairKey, auth.fanSub)) {
+    return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
+  }
+
+  const parsedBody = parseDmSendBody(event.body);
+  if (!parsedBody.ok) {
+    return dmDeny(400, parsedBody.code, 'Invalid DM message body');
+  }
+
+  const allowed = await enforceDmSendRateLimit(doc, t.rateLimits, auth.fanSub, sendLimit());
+  if (!allowed) {
+    return dmDeny(429, 'rate_limited', 'DM send rate limit exceeded');
+  }
+
+  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
+  if (!friendshipActive) {
+    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  }
+
+  const thread = await getDmThread(doc, t.dmThreads, pairKey);
+  if (!thread) {
+    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
+  }
+  if (thread.status === 'closed') {
+    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+  }
+
+  const recipientFanSub = peerSubForCaller(pairKey, auth.fanSub);
+  if (!recipientFanSub) {
+    return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
+  }
+
+  const sentAt = Date.now();
+  const sk = directMessageSortKey(sentAt, parsedBody.messageId);
+
+  await doc.send(
+    new PutCommand({
+      TableName: t.directMessages,
+      Item: {
+        pairKey,
+        sk,
+        messageId: parsedBody.messageId,
+        senderSub: auth.fanSub,
+        kind: parsedBody.kind,
+        body: parsedBody.body,
+        sentAt,
+      },
+    }),
+  );
+
+  await pushDmMessageToRecipient({
+    doc,
+    fanConnectionsTable: t.fanConnections,
+    fanProfilesTable: t.fanProfiles,
+    recipientFanSub,
+    senderSub: auth.fanSub,
+    pairKey,
+    messageId: parsedBody.messageId,
+    body: parsedBody.body,
+    sentAt,
+  }).catch((err: unknown) => {
+    console.warn(
+      JSON.stringify({
+        riffsyncDiag: 'fan_dm_push_after_send_failed',
+        pairKeyHead: pairKey.slice(0, 12),
+        errorName: err && typeof err === 'object' && 'name' in err ? String((err as { name: string }).name) : 'unknown',
+      }),
+    );
+  });
+
+  return jsonResponse(201, {
+    pairKey,
+    messageId: parsedBody.messageId,
+    senderSub: auth.fanSub,
+    kind: parsedBody.kind,
+    body: parsedBody.body,
+    sentAt,
+  });
+};

--- a/infra/cdk/lambda/dm-shared.ts
+++ b/infra/cdk/lambda/dm-shared.ts
@@ -10,9 +10,11 @@ import {
 } from './friends-shared';
 
 export const DM_READ_LIMIT_PER_MINUTE = 60;
+export const DM_SEND_LIMIT_PER_MINUTE = 20;
 export const DM_HISTORY_DEFAULT_LIMIT = 50;
 export const DM_HISTORY_MAX_LIMIT = 100;
 export const DM_BODY_MAX_LEN = 2000;
+export const FAN_CONNECTIONS_FAN_SUB_INDEX = 'FanSubIndex';
 
 export type DmDenyCode =
   | 'cannot_dm_self'
@@ -21,6 +23,7 @@ export type DmDenyCode =
   | 'dm_not_member'
   | 'dm_thread_closed'
   | 'dm_thread_not_found'
+  | 'invalid_dm_body'
   | 'rate_limited';
 
 export type DmThreadItem = {
@@ -67,6 +70,14 @@ export function isPairMember(pairKey: string, fanSub: string): boolean {
   const parts = splitPairKey(pairKey);
   if (!parts) return false;
   return fanSub === parts.fanSubA || fanSub === parts.fanSubB;
+}
+
+export function peerSubForCaller(pairKey: string, fanSub: string): string | null {
+  const parts = splitPairKey(pairKey);
+  if (!parts) return null;
+  if (fanSub === parts.fanSubA) return parts.fanSubB;
+  if (fanSub === parts.fanSubB) return parts.fanSubA;
+  return null;
 }
 
 export function directMessageSortKey(sentAt: number, messageId: string): string {
@@ -145,22 +156,24 @@ export function dmReadRateLimitKey(fanSub: string, bucketMs: number): { pk: stri
   return { pk: `dm-read#${fanSub}`, sk: String(bucketMs) };
 }
 
-export async function enforceDmReadRateLimit(
+export function dmSendRateLimitKey(fanSub: string, bucketMs: number): { pk: string; sk: string } {
+  return { pk: `dm-send#${fanSub}`, sk: String(bucketMs) };
+}
+
+async function enforceDmRateLimit(
   doc: DynamoDBDocumentClient,
   tableName: string,
-  fanSub: string,
+  key: { pk: string; sk: string },
   limit: number,
-  nowMs: number = Date.now(),
+  nowMs: number,
 ): Promise<boolean> {
-  const bucketMs = minuteBucketEpochMs(nowMs);
-  const { pk, sk } = dmReadRateLimitKey(fanSub, bucketMs);
   const expiresAt = Math.floor(nowMs / 1000) + 120;
 
   try {
     await doc.send(
       new UpdateCommand({
         TableName: tableName,
-        Key: { pk, sk },
+        Key: key,
         UpdateExpression: 'ADD requestCount :one SET expiresAt = :expiresAt',
         ConditionExpression: 'attribute_not_exists(requestCount) OR requestCount < :limit',
         ExpressionAttributeValues: {
@@ -178,6 +191,53 @@ export async function enforceDmReadRateLimit(
     }
     throw e;
   }
+}
+
+export async function enforceDmReadRateLimit(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+  limit: number,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  return enforceDmRateLimit(doc, tableName, dmReadRateLimitKey(fanSub, bucketMs), limit, nowMs);
+}
+
+export async function enforceDmSendRateLimit(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+  limit: number,
+  nowMs: number = Date.now(),
+): Promise<boolean> {
+  const bucketMs = minuteBucketEpochMs(nowMs);
+  return enforceDmRateLimit(doc, tableName, dmSendRateLimitKey(fanSub, bucketMs), limit, nowMs);
+}
+
+export function parseDmSendBody(raw: string | undefined):
+  | { ok: true; messageId: string; kind: 'text'; body: string }
+  | { ok: false; code: 'invalid_dm_body' } {
+  if (!raw || raw.trim() === '') {
+    return { ok: false, code: 'invalid_dm_body' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, code: 'invalid_dm_body' };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, code: 'invalid_dm_body' };
+  }
+  const record = parsed as Record<string, unknown>;
+  const messageId = typeof record.messageId === 'string' ? record.messageId.trim() : '';
+  const kind = record.kind === 'text' ? 'text' : null;
+  const body = typeof record.body === 'string' ? record.body.trim() : '';
+  if (!messageId || !kind || !body || body.length > DM_BODY_MAX_LEN) {
+    return { ok: false, code: 'invalid_dm_body' };
+  }
+  return { ok: true, messageId, kind, body };
 }
 
 export async function friendshipActiveForCaller(

--- a/infra/cdk/lambda/fan-dm-shared.ts
+++ b/infra/cdk/lambda/fan-dm-shared.ts
@@ -1,0 +1,171 @@
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DeleteCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { TextEncoder } from 'node:util';
+import {
+  avatarUrlFromStoredProfile,
+  displayNameFromStoredProfile,
+} from './fan-profile-shared';
+import { FAN_CONNECTIONS_FAN_SUB_INDEX } from './dm-shared';
+
+const encoder = new TextEncoder();
+
+export type DmMessagePushEnvelope = {
+  type: 'dm_message';
+  schemaVersion: 1;
+  pairKey: string;
+  messageId: string;
+  senderSub: string;
+  kind: 'text';
+  body: string;
+  sentAt: number;
+  displayName?: string;
+  avatarUrl?: string;
+};
+
+export function fanDmWsManagementClient(): ApiGatewayManagementApiClient {
+  const endpoint = process.env.FAN_DM_WS_MANAGEMENT_API_ENDPOINT;
+  if (!endpoint) {
+    throw new Error('Missing FAN_DM_WS_MANAGEMENT_API_ENDPOINT');
+  }
+  return new ApiGatewayManagementApiClient({ endpoint });
+}
+
+export async function queryFanConnectionIdsForFanSub(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+): Promise<string[]> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: FAN_CONNECTIONS_FAN_SUB_INDEX,
+      KeyConditionExpression: 'fanSub = :fanSub',
+      ExpressionAttributeValues: { ':fanSub': fanSub },
+    }),
+  );
+  const ids: string[] = [];
+  for (const item of out.Items ?? []) {
+    const connectionId = item.connectionId;
+    if (typeof connectionId === 'string' && connectionId.length > 0) {
+      ids.push(connectionId);
+    }
+  }
+  return ids;
+}
+
+function isPostToConnectionGone(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'GoneException';
+}
+
+export async function postToFanConnections(
+  client: ApiGatewayManagementApiClient,
+  doc: DynamoDBDocumentClient,
+  connectionsTable: string,
+  connectionIds: readonly string[],
+  payload: Uint8Array,
+): Promise<void> {
+  for (const connectionId of connectionIds) {
+    try {
+      await client.send(
+        new PostToConnectionCommand({
+          ConnectionId: connectionId,
+          Data: payload,
+        }),
+      );
+    } catch (err: unknown) {
+      if (isPostToConnectionGone(err)) {
+        await doc
+          .send(
+            new DeleteCommand({
+              TableName: connectionsTable,
+              Key: { connectionId },
+            }),
+          )
+          .catch(() => undefined);
+      } else {
+        console.warn(
+          JSON.stringify({
+            riffsyncDiag: 'fan_dm_post_to_connection_failed',
+            connectionIdTail: connectionId.slice(-12),
+            errorName: err && typeof err === 'object' && 'name' in err ? String((err as { name: string }).name) : 'unknown',
+          }),
+        );
+      }
+    }
+  }
+}
+
+export function buildDmMessagePushEnvelope(input: {
+  pairKey: string;
+  messageId: string;
+  senderSub: string;
+  body: string;
+  sentAt: number;
+  senderProfile?: Record<string, unknown>;
+}): DmMessagePushEnvelope {
+  const displayName = displayNameFromStoredProfile(input.senderProfile);
+  const avatarUrl = avatarUrlFromStoredProfile(input.senderProfile);
+  return {
+    type: 'dm_message',
+    schemaVersion: 1,
+    pairKey: input.pairKey,
+    messageId: input.messageId,
+    senderSub: input.senderSub,
+    kind: 'text',
+    body: input.body,
+    sentAt: input.sentAt,
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
+export async function loadFanProfile(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  fanSub: string,
+): Promise<Record<string, unknown> | undefined> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { sub: fanSub },
+    }),
+  );
+  return out.Item as Record<string, unknown> | undefined;
+}
+
+export async function pushDmMessageToRecipient(input: {
+  doc: DynamoDBDocumentClient;
+  fanConnectionsTable: string;
+  fanProfilesTable: string;
+  recipientFanSub: string;
+  senderSub: string;
+  pairKey: string;
+  messageId: string;
+  body: string;
+  sentAt: number;
+}): Promise<void> {
+  const connectionIds = await queryFanConnectionIdsForFanSub(
+    input.doc,
+    input.fanConnectionsTable,
+    input.recipientFanSub,
+  );
+  if (connectionIds.length === 0) {
+    return;
+  }
+
+  const senderProfile = await loadFanProfile(input.doc, input.fanProfilesTable, input.senderSub).catch(
+    () => undefined,
+  );
+  const envelope = buildDmMessagePushEnvelope({
+    pairKey: input.pairKey,
+    messageId: input.messageId,
+    senderSub: input.senderSub,
+    body: input.body,
+    sentAt: input.sentAt,
+    senderProfile,
+  });
+  const payload = encoder.encode(JSON.stringify(envelope));
+  const client = fanDmWsManagementClient();
+  await postToFanConnections(client, input.doc, input.fanConnectionsTable, connectionIds, payload);
+}

--- a/infra/cdk/lambda/fan-dm-ws-connect.test.ts
+++ b/infra/cdk/lambda/fan-dm-ws-connect.test.ts
@@ -1,0 +1,77 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  verifyAccessToken: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+}));
+
+vi.mock('./cognito-jwt', () => ({
+  verifyAccessToken: mocks.verifyAccessToken,
+}));
+
+import { handler } from './fan-dm-ws-connect';
+
+describe('fan-dm-ws-connect handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
+    mocks.docSend.mockResolvedValue({});
+  });
+
+  it('returns 401 without fan JWT', async () => {
+    mocks.verifyAccessToken.mockResolvedValue(null);
+
+    const res = await handler(
+      {
+        requestContext: { connectionId: 'conn-1' },
+        queryStringParameters: {},
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+
+  it('writes FanConnections row with fanSub when JWT verifies', async () => {
+    mocks.verifyAccessToken.mockResolvedValue({ sub: 'fan-a' });
+
+    const res = await handler(
+      {
+        requestContext: { connectionId: 'conn-abc' },
+        queryStringParameters: {
+          accessToken: 'jwt-token',
+          sessionId: 'browser-tab-1',
+        },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+    const put = mocks.docSend.mock.calls[0][0].input as {
+      TableName: string;
+      Item: Record<string, unknown>;
+    };
+    expect(put.TableName).toBe('FanConnections');
+    expect(put.Item.connectionId).toBe('conn-abc');
+    expect(put.Item.fanSub).toBe('fan-a');
+    expect(put.Item.sessionId).toBe('browser-tab-1');
+    expect(typeof put.Item.connectedAt).toBe('number');
+    expect(typeof put.Item.expiresAt).toBe('number');
+  });
+});

--- a/infra/cdk/lambda/fan-dm-ws-connect.ts
+++ b/infra/cdk/lambda/fan-dm-ws-connect.ts
@@ -1,0 +1,65 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { verifyAccessToken } from './cognito-jwt';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
+  const fanConnectionsTable = process.env.FAN_CONNECTIONS_TABLE_NAME;
+  if (!fanConnectionsTable) {
+    return { statusCode: 500, body: 'Missing table env' };
+  }
+
+  const connectionId = event.requestContext.connectionId;
+  const qpToken = event.queryStringParameters?.accessToken;
+  const headerAuth = event.headers?.Authorization ?? event.headers?.authorization;
+  const authHdr =
+    typeof qpToken === 'string' && qpToken.trim().length > 0
+      ? qpToken.startsWith('Bearer ')
+        ? qpToken
+        : `Bearer ${qpToken.trim()}`
+      : headerAuth;
+
+  const jwtUser = await verifyAccessToken(authHdr);
+  if (!jwtUser) {
+    console.warn(
+      JSON.stringify({
+        riffsyncDiag: 'fan_dm_ws_connect',
+        outcome: 'fan_auth_required',
+        connectionIdTail: connectionId.slice(-12),
+      }),
+    );
+    return { statusCode: 401, body: 'Fan authentication required' };
+  }
+
+  const sessionIdRaw = event.queryStringParameters?.sessionId;
+  const sessionId =
+    typeof sessionIdRaw === 'string' && sessionIdRaw.trim() !== '' ? sessionIdRaw.trim().slice(0, 64) : undefined;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const ttl = nowSec + 90 * 60;
+
+  await doc.send(
+    new PutCommand({
+      TableName: fanConnectionsTable,
+      Item: {
+        connectionId,
+        fanSub: jwtUser.sub,
+        connectedAt: nowSec,
+        expiresAt: ttl,
+        ...(sessionId ? { sessionId } : {}),
+      },
+    }),
+  );
+
+  console.info(
+    JSON.stringify({
+      riffsyncDiag: 'fan_dm_ws_connect',
+      outcome: 'ok',
+      connectionIdTail: connectionId.slice(-12),
+      fanSubHead: jwtUser.sub.slice(0, 8),
+    }),
+  );
+
+  return { statusCode: 200, body: 'Connected' };
+};

--- a/infra/cdk/lambda/fan-dm-ws-disconnect.test.ts
+++ b/infra/cdk/lambda/fan-dm-ws-disconnect.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+}));
+
+import { handler } from './fan-dm-ws-disconnect';
+
+describe('fan-dm-ws-disconnect handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
+    mocks.docSend.mockResolvedValue({});
+  });
+
+  it('deletes FanConnections row by connectionId', async () => {
+    const res = await handler(
+      {
+        requestContext: { connectionId: 'conn-xyz' },
+      } as Parameters<typeof handler>[0],
+      {} as Parameters<typeof handler>[1],
+      () => undefined,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+    const del = mocks.docSend.mock.calls[0][0].input as {
+      TableName: string;
+      Key: { connectionId: string };
+    };
+    expect(del.TableName).toBe('FanConnections');
+    expect(del.Key.connectionId).toBe('conn-xyz');
+  });
+});

--- a/infra/cdk/lambda/fan-dm-ws-disconnect.ts
+++ b/infra/cdk/lambda/fan-dm-ws-disconnect.ts
@@ -1,0 +1,30 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
+  const fanConnectionsTable = process.env.FAN_CONNECTIONS_TABLE_NAME;
+  if (!fanConnectionsTable) {
+    return { statusCode: 500, body: 'Missing table env' };
+  }
+
+  const connectionId = event.requestContext.connectionId;
+  await doc.send(
+    new DeleteCommand({
+      TableName: fanConnectionsTable,
+      Key: { connectionId },
+    }),
+  );
+
+  console.info(
+    JSON.stringify({
+      riffsyncDiag: 'fan_dm_ws_disconnect',
+      outcome: 'ok',
+      connectionIdTail: connectionId.slice(-12),
+    }),
+  );
+
+  return { statusCode: 200, body: 'Disconnected' };
+};

--- a/infra/cdk/lambda/fan-dm-ws-ping.ts
+++ b/infra/cdk/lambda/fan-dm-ws-ping.ts
@@ -1,0 +1,5 @@
+import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
+
+export const handler: APIGatewayProxyWebsocketHandlerV2 = async () => {
+  return { statusCode: 200, body: 'pong' };
+};

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -191,12 +191,14 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly friendshipsTable: dynamodb.Table;
   public readonly dmThreadsTable: dynamodb.Table;
   public readonly directMessagesTable: dynamodb.Table;
+  public readonly fanConnectionsTable: dynamodb.Table;
   public readonly fanAvatarsBucket: s3.Bucket;
   public readonly fanAvatarsDistribution: cloudfront.Distribution;
   /** HTTPS origin for avatar object keys (no trailing slash). */
   public readonly fanAvatarsPublicBaseUrl: string;
   public readonly httpApi: apigwv2.HttpApi;
   public readonly webSocketApi: apigwv2.WebSocketApi;
+  public readonly fanDmWebSocketApi: apigwv2.WebSocketApi;
   /** WebSocket stage name (same as prod environment label). */
   public readonly webSocketStageName: string;
   /** Launch-critical Lambdas wired to the operations dashboard. */
@@ -334,6 +336,19 @@ export class ApiCatalogStack extends cdk.Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+
+    this.fanConnectionsTable = new dynamodb.Table(this, 'FanConnectionsTable', {
+      partitionKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'expiresAt',
+    });
+    this.fanConnectionsTable.addGlobalSecondaryIndex({
+      indexName: 'FanSubIndex',
+      partitionKey: { name: 'fanSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
     });
 
     this.fanAvatarsBucket = new s3.Bucket(this, 'FanAvatarsBucket', {
@@ -1041,6 +1056,32 @@ export class ApiCatalogStack extends cdk.Stack {
     this.friendshipsTable.grantReadData(dmMessagesListFn);
     friendshipRateLimitTable.grantReadWriteData(dmMessagesListFn);
 
+    const dmMessagesSendFn = new lambdaNodejs.NodejsFunction(this, 'DmMessagesSendFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/dm-messages-send.ts'),
+      handler: 'handler',
+      environment: {
+        DM_THREADS_TABLE_NAME: this.dmThreadsTable.tableName,
+        DIRECT_MESSAGES_TABLE_NAME: this.directMessagesTable.tableName,
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        FAN_CONNECTIONS_TABLE_NAME: this.fanConnectionsTable.tableName,
+        FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
+        DM_SEND_LIMIT_PER_MINUTE: '20',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.dmThreadsTable.grantReadData(dmMessagesSendFn);
+    this.directMessagesTable.grantWriteData(dmMessagesSendFn);
+    this.friendshipsTable.grantReadData(dmMessagesSendFn);
+    this.fanConnectionsTable.grantReadWriteData(dmMessagesSendFn);
+    this.fanProfilesTable.grantReadData(dmMessagesSendFn);
+    friendshipRateLimitTable.grantReadWriteData(dmMessagesSendFn);
+
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
       apiName: `riffsync-${environment}-ws`,
@@ -1163,6 +1204,80 @@ export class ApiCatalogStack extends cdk.Stack {
     }
     this.webSocketApi.addRoute('$default', { integration: wsRouteInt });
 
+    this.fanDmWebSocketApi = new apigwv2.WebSocketApi(this, 'FanDmWebSocketApi', {
+      apiName: `riffsync-${environment}-fan-dm-ws`,
+      description:
+        'Fan DM push WebSocket (separate from room ChatSession) — $connect/$disconnect/ping only; send via HTTP POST',
+      routeSelectionExpression: '$request.body.action',
+    });
+
+    const fanDmWsStage = new apigwv2.WebSocketStage(this, 'FanDmWebSocketStage', {
+      webSocketApi: this.fanDmWebSocketApi,
+      stageName: environment,
+      autoDeploy: true,
+    });
+
+    const fanDmWsMgmtEndpoint = `https://${this.fanDmWebSocketApi.apiId}.execute-api.${this.region}.amazonaws.com/${fanDmWsStage.stageName}`;
+
+    const fanDmWsSharedEnv = {
+      FAN_CONNECTIONS_TABLE_NAME: this.fanConnectionsTable.tableName,
+      COGNITO_USER_POOL_ID: fanUserPool.userPoolId,
+      COGNITO_CLIENT_ID: fanUserPoolClient.userPoolClientId,
+      RIFFSYNC_ENVIRONMENT: environment,
+      NODE_OPTIONS: '--enable-source-maps',
+    };
+
+    const fanDmWsConnectFn = new lambdaNodejs.NodejsFunction(this, 'FanDmWsConnectFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/fan-dm-ws-connect.ts'),
+      handler: 'handler',
+      environment: fanDmWsSharedEnv,
+    });
+    const fanDmWsDisconnectFn = new lambdaNodejs.NodejsFunction(this, 'FanDmWsDisconnectFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/fan-dm-ws-disconnect.ts'),
+      handler: 'handler',
+      environment: fanDmWsSharedEnv,
+    });
+    const fanDmWsPingFn = new lambdaNodejs.NodejsFunction(this, 'FanDmWsPingFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/fan-dm-ws-ping.ts'),
+      handler: 'handler',
+      environment: fanDmWsSharedEnv,
+    });
+
+    this.fanConnectionsTable.grantReadWriteData(fanDmWsConnectFn);
+    this.fanConnectionsTable.grantReadWriteData(fanDmWsDisconnectFn);
+
+    dmMessagesSendFn.addEnvironment('FAN_DM_WS_MANAGEMENT_API_ENDPOINT', fanDmWsMgmtEndpoint);
+    this.fanDmWebSocketApi.grantManageConnections(dmMessagesSendFn);
+
+    fanDmWsPingFn.addPermission('FanDmWsPingFnAllowExecuteApiWebSocket', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      action: 'lambda:InvokeFunction',
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:${this.fanDmWebSocketApi.apiId}/*`,
+    });
+
+    const fanDmWsConnectInt = new integrations.WebSocketLambdaIntegration('FanDmWsConnectInt', fanDmWsConnectFn);
+    const fanDmWsDisconnectInt = new integrations.WebSocketLambdaIntegration(
+      'FanDmWsDisconnectInt',
+      fanDmWsDisconnectFn,
+    );
+    const fanDmWsPingInt = new integrations.WebSocketLambdaIntegration('FanDmWsPingInt', fanDmWsPingFn);
+
+    this.fanDmWebSocketApi.addRoute('$connect', { integration: fanDmWsConnectInt });
+    this.fanDmWebSocketApi.addRoute('$disconnect', { integration: fanDmWsDisconnectInt });
+    this.fanDmWebSocketApi.addRoute('ping', { integration: fanDmWsPingInt });
+
     this.httpApi = new apigwv2.HttpApi(this, 'HttpApi', {
       apiName: `riffsync-${environment}-http`,
       description: `RiffSync public HTTP API (${environment})`,
@@ -1226,6 +1341,7 @@ export class ApiCatalogStack extends cdk.Stack {
     const friendsRemoveIntegration = new integrations.HttpLambdaIntegration('FriendsRemoveInt', friendsRemoveFn);
     const dmThreadEnsureIntegration = new integrations.HttpLambdaIntegration('DmThreadEnsureInt', dmThreadEnsureFn);
     const dmMessagesListIntegration = new integrations.HttpLambdaIntegration('DmMessagesListInt', dmMessagesListFn);
+    const dmMessagesSendIntegration = new integrations.HttpLambdaIntegration('DmMessagesSendInt', dmMessagesSendFn);
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1404,6 +1520,13 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     this.httpApi.addRoutes({
+      path: '/v1/dm/threads/{pairKey}/messages',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: dmMessagesSendIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: '/v1/admin/session',
       methods: [apigwv2.HttpMethod.GET],
       integration: adminSessionGetIntegration,
@@ -1525,6 +1648,12 @@ export class ApiCatalogStack extends cdk.Stack {
       description: 'DynamoDB DirectMessages — PK `pairKey`, SK `m#<sentAtMs>#<messageId>`.',
     });
 
+    new cdk.CfnOutput(this, 'FanConnectionsTableName', {
+      value: this.fanConnectionsTable.tableName,
+      description:
+        'DynamoDB FanConnections — PK `connectionId`; GSI FanSubIndex for Fan DM WebSocket PostToConnection fan-out.',
+    });
+
     new cdk.CfnOutput(this, 'FriendshipRateLimitTableName', {
       value: friendshipRateLimitTable.tableName,
       description: 'DynamoDB friendship invite/action rate limits — PK `pk`, SK `sk`, TTL `expiresAt`.',
@@ -1555,7 +1684,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/dm/threads/{peerSub}` (PUT), `/v1/dm/threads/{pairKey}/messages` (GET), `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/dm/threads/{peerSub}` (PUT), `/v1/dm/threads/{pairKey}/messages` (GET/POST), `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {
@@ -1569,6 +1698,16 @@ export class ApiCatalogStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'WebSocketApiId', {
       value: this.webSocketApi.apiId,
+    });
+
+    new cdk.CfnOutput(this, 'FanDmWebSocketUrl', {
+      value: fanDmWsStage.url,
+      description:
+        'Fan DM push WebSocket `wss://` URL (separate from room ChatSession WebSocketUrl). JWT on $connect only.',
+    });
+
+    new cdk.CfnOutput(this, 'FanDmWebSocketApiId', {
+      value: this.fanDmWebSocketApi.apiId,
     });
 
     new cdk.CfnOutput(this, 'TmdbApiTokenSecretArn', {


### PR DESCRIPTION
## Summary

- Adds **FanConnections** Dynamo table and a **separate Fan DM WebSocket API** (`$connect` / `$disconnect` / `ping`) for push delivery, distinct from room ChatSession.
- Implements **`POST /v1/dm/threads/{pairKey}/messages`**: persists **DirectMessage**, then best-effort **`PostToConnection`** `dm_message` fan-out to the recipient's open Fan DM connections (20/min send throttle).
- Adds minimal client **`FanDmSession`** (HTTP send + inbound push handling, `DM_SEND_DROPPED` / `DM_PUSH_UNAVAILABLE` drawer codes) bootstrapped from fan auth, independent of **`RoomRealtimeSdk`**.

Closes #360

## Test plan

- [x] `npm run test --prefix infra/cdk` (373 tests, including `dm-messages-send`, `fan-dm-ws-connect`, `fan-dm-ws-disconnect`)
- [x] `npm run synth --prefix infra/cdk`
- [x] `npm test -- --run src/friends/` (FanDmSession + dmApi)
- [ ] Manual: fan JWT Fan DM WS connect writes **FanConnections** row; connected peer receives `dm_message` push after HTTP send; disconnected peer syncs on next history GET