### PR TITLE
[M35] Unread DM badges on friends list (#361)

### DIFF
--- a/infra/cdk/lambda/dm-messages-send.test.ts
+++ b/infra/cdk/lambda/dm-messages-send.test.ts
@@ -75,6 +75,7 @@ describe('dm-messages-send handler', () => {
     process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
     process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
     process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    process.env.DM_UNREAD_TABLE_NAME = 'DmUnread';
     process.env.DM_SEND_LIMIT_PER_MINUTE = '20';
   });
 
@@ -202,6 +203,7 @@ describe('dm-messages-send handler', () => {
       .mockResolvedValueOnce({
         Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
       })
+      .mockResolvedValueOnce({})
       .mockResolvedValueOnce({});
 
     const res = await handler(
@@ -238,5 +240,11 @@ describe('dm-messages-send handler', () => {
         body: 'hello',
       }),
     );
+
+    const unreadUpdate = mocks.docSend.mock.calls.find(
+      (call) => call[0].kind === 'Update' && call[0].input.TableName === 'DmUnread',
+    );
+    expect(unreadUpdate).toBeTruthy();
+    expect(unreadUpdate![0].input.Key).toEqual({ recipientSub: 'fan-b', pairKey });
   });
 });

--- a/infra/cdk/lambda/dm-messages-send.ts
+++ b/infra/cdk/lambda/dm-messages-send.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import {
   directMessageSortKey,
   dmDeny,
@@ -27,6 +27,7 @@ function tables():
       rateLimits: string;
       fanConnections: string;
       fanProfiles: string;
+      dmUnread: string;
     }
   | { ok: false; response: APIGatewayProxyResultV2 } {
   const dmThreads = process.env.DM_THREADS_TABLE_NAME?.trim();
@@ -35,13 +36,23 @@ function tables():
   const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
   const fanConnections = process.env.FAN_CONNECTIONS_TABLE_NAME?.trim();
   const fanProfiles = process.env.FAN_PROFILES_TABLE_NAME?.trim();
-  if (!dmThreads || !directMessages || !friendships || !rateLimits || !fanConnections || !fanProfiles) {
+  const dmUnread = process.env.DM_UNREAD_TABLE_NAME?.trim();
+  if (!dmThreads || !directMessages || !friendships || !rateLimits || !fanConnections || !fanProfiles || !dmUnread) {
     return {
       ok: false,
       response: jsonResponse(500, { error: 'Server misconfigured' }),
     };
   }
-  return { ok: true, dmThreads, directMessages, friendships, rateLimits, fanConnections, fanProfiles };
+  return {
+    ok: true,
+    dmThreads,
+    directMessages,
+    friendships,
+    rateLimits,
+    fanConnections,
+    fanProfiles,
+    dmUnread,
+  };
 }
 
 function sendLimit(): number {
@@ -110,6 +121,21 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         kind: parsedBody.kind,
         body: parsedBody.body,
         sentAt,
+      },
+    }),
+  );
+
+  await doc.send(
+    new UpdateCommand({
+      TableName: t.dmUnread,
+      Key: { recipientSub: recipientFanSub, pairKey },
+      UpdateExpression:
+        'SET hasUnread = :true, updatedAt = :now, lastReadSentAt = if_not_exists(lastReadSentAt, :zero), lastReadMessageId = if_not_exists(lastReadMessageId, :empty)',
+      ExpressionAttributeValues: {
+        ':true': true,
+        ':now': sentAt,
+        ':zero': 0,
+        ':empty': '',
       },
     }),
   );

--- a/infra/cdk/lambda/dm-shared.test.ts
+++ b/infra/cdk/lambda/dm-shared.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  compareReadCursors,
   decodeHistoryCursor,
   directMessageSortKey,
   encodeHistoryCursor,
+  isDirectMessageUnread,
   isPairMember,
+  isReadCursorNewer,
   parseHistoryLimit,
 } from './dm-shared';
 import { friendshipPairKey } from './friends-shared';
@@ -35,5 +38,26 @@ describe('dm-shared helpers', () => {
     expect(parseHistoryLimit(undefined)).toBe(50);
     expect(parseHistoryLimit('10')).toBe(10);
     expect(parseHistoryLimit('500')).toBe(100);
+  });
+
+  it('compares read cursors with sentAt then messageId tie-break', () => {
+    expect(compareReadCursors({ lastReadSentAt: 1, lastReadMessageId: 'a' }, { lastReadSentAt: 2, lastReadMessageId: 'a' })).toBeLessThan(0);
+    expect(isReadCursorNewer({ lastReadSentAt: 2, lastReadMessageId: 'a' }, { lastReadSentAt: 1, lastReadMessageId: 'z' })).toBe(true);
+    expect(isReadCursorNewer({ lastReadSentAt: 1, lastReadMessageId: 'b' }, { lastReadSentAt: 1, lastReadMessageId: 'a' })).toBe(true);
+  });
+
+  it('detects unread messages against cursor', () => {
+    const message = {
+      pairKey: 'a#b',
+      sk: 'm#1#id',
+      messageId: 'msg-b',
+      senderSub: 'fan-b',
+      kind: 'text' as const,
+      body: 'hi',
+      sentAt: 100,
+    };
+    expect(isDirectMessageUnread(message, { lastReadSentAt: 99, lastReadMessageId: 'msg-a' })).toBe(true);
+    expect(isDirectMessageUnread(message, { lastReadSentAt: 100, lastReadMessageId: 'msg-a' })).toBe(true);
+    expect(isDirectMessageUnread(message, { lastReadSentAt: 100, lastReadMessageId: 'msg-b' })).toBe(false);
   });
 });

--- a/infra/cdk/lambda/dm-shared.ts
+++ b/infra/cdk/lambda/dm-shared.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import {
   friendshipPairKey,
   jsonResponse,
@@ -24,6 +24,7 @@ export type DmDenyCode =
   | 'dm_thread_closed'
   | 'dm_thread_not_found'
   | 'invalid_dm_body'
+  | 'invalid_read_cursor'
   | 'rate_limited';
 
 export type DmThreadItem = {
@@ -58,6 +59,25 @@ export type DirectMessageWire = {
 export type DmHistoryCursor = {
   sentAt: number;
   messageId: string;
+};
+
+export type DmReadCursor = {
+  lastReadSentAt: number;
+  lastReadMessageId: string;
+};
+
+export type DmUnreadItem = {
+  recipientSub: string;
+  pairKey: string;
+  lastReadSentAt: number;
+  lastReadMessageId: string;
+  hasUnread: boolean;
+  updatedAt: number;
+};
+
+export const DM_UNREAD_DEFAULT_CURSOR: DmReadCursor = {
+  lastReadSentAt: 0,
+  lastReadMessageId: '',
 };
 
 export function dmDeny(statusCode: number, code: DmDenyCode, error: string): APIGatewayProxyResultV2 {
@@ -267,6 +287,123 @@ export async function getDmThread(
     }),
   );
   return parseDmThreadItem(out.Item as Record<string, unknown> | undefined);
+}
+
+export function compareReadCursors(a: DmReadCursor, b: DmReadCursor): number {
+  if (a.lastReadSentAt !== b.lastReadSentAt) {
+    return a.lastReadSentAt < b.lastReadSentAt ? -1 : 1;
+  }
+  if (a.lastReadMessageId === b.lastReadMessageId) {
+    return 0;
+  }
+  return a.lastReadMessageId < b.lastReadMessageId ? -1 : 1;
+}
+
+export function isReadCursorNewer(proposed: DmReadCursor, current: DmReadCursor): boolean {
+  return compareReadCursors(proposed, current) > 0;
+}
+
+export function isDirectMessageUnread(message: DirectMessageItem, cursor: DmReadCursor): boolean {
+  if (message.sentAt > cursor.lastReadSentAt) {
+    return true;
+  }
+  if (message.sentAt < cursor.lastReadSentAt) {
+    return false;
+  }
+  return message.messageId > cursor.lastReadMessageId;
+}
+
+export function parseDmUnreadItem(raw: Record<string, unknown> | undefined): DmUnreadItem | null {
+  if (!raw) return null;
+  const recipientSub = typeof raw.recipientSub === 'string' ? raw.recipientSub : '';
+  const pairKey = typeof raw.pairKey === 'string' ? raw.pairKey : '';
+  const lastReadSentAt =
+    typeof raw.lastReadSentAt === 'number' && Number.isFinite(raw.lastReadSentAt) ? raw.lastReadSentAt : NaN;
+  const lastReadMessageId = typeof raw.lastReadMessageId === 'string' ? raw.lastReadMessageId : '';
+  const hasUnread = raw.hasUnread === true;
+  const updatedAt = typeof raw.updatedAt === 'number' && Number.isFinite(raw.updatedAt) ? raw.updatedAt : NaN;
+  if (!recipientSub || !pairKey || !Number.isFinite(lastReadSentAt) || !Number.isFinite(updatedAt)) {
+    return null;
+  }
+  return {
+    recipientSub,
+    pairKey,
+    lastReadSentAt,
+    lastReadMessageId,
+    hasUnread,
+    updatedAt,
+  };
+}
+
+export function dmUnreadCursorFromItem(item: DmUnreadItem | null | undefined): DmReadCursor {
+  if (!item) {
+    return { ...DM_UNREAD_DEFAULT_CURSOR };
+  }
+  return {
+    lastReadSentAt: item.lastReadSentAt,
+    lastReadMessageId: item.lastReadMessageId,
+  };
+}
+
+export function parseDmReadBody(raw: string | undefined):
+  | { ok: true; lastReadSentAt: number; lastReadMessageId: string }
+  | { ok: false; code: 'invalid_read_cursor' } {
+  if (!raw || raw.trim() === '') {
+    return { ok: false, code: 'invalid_read_cursor' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, code: 'invalid_read_cursor' };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, code: 'invalid_read_cursor' };
+  }
+  const record = parsed as Record<string, unknown>;
+  const lastReadSentAt =
+    typeof record.lastReadSentAt === 'number' && Number.isFinite(record.lastReadSentAt)
+      ? record.lastReadSentAt
+      : NaN;
+  const lastReadMessageId =
+    typeof record.lastReadMessageId === 'string' ? record.lastReadMessageId.trim() : '';
+  if (!Number.isFinite(lastReadSentAt) || !lastReadMessageId) {
+    return { ok: false, code: 'invalid_read_cursor' };
+  }
+  return { ok: true, lastReadSentAt, lastReadMessageId };
+}
+
+export async function getLatestDirectMessage(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  pairKey: string,
+): Promise<DirectMessageItem | null> {
+  const out = await doc.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: 'pairKey = :pairKey',
+      ExpressionAttributeValues: { ':pairKey': pairKey },
+      ScanIndexForward: false,
+      Limit: 1,
+    }),
+  );
+  const raw = out.Items?.[0] as Record<string, unknown> | undefined;
+  return parseDirectMessageItem(raw);
+}
+
+export async function getDmUnread(
+  doc: DynamoDBDocumentClient,
+  tableName: string,
+  recipientSub: string,
+  pairKey: string,
+): Promise<DmUnreadItem | null> {
+  const out = await doc.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { recipientSub, pairKey },
+    }),
+  );
+  return parseDmUnreadItem(out.Item as Record<string, unknown> | undefined);
 }
 
 export function parseHistoryLimit(raw: string | undefined): number {

--- a/infra/cdk/lambda/dm-thread-read.test.ts
+++ b/infra/cdk/lambda/dm-thread-read.test.ts
@@ -1,0 +1,250 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  pushDmUnreadToRecipient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+}));
+
+vi.mock('./fan-dm-shared', () => ({
+  pushDmUnreadToRecipient: mocks.pushDmUnreadToRecipient,
+}));
+
+import { handler } from './dm-thread-read';
+import { dmReadRateLimitKey, friendshipPairKey } from './dm-shared';
+import { minuteBucketEpochMs } from './friends-shared';
+
+function readEvent(
+  pairKey: string,
+  body: Record<string, unknown>,
+  opts?: { claims?: Record<string, unknown> },
+): APIGatewayProxyEventV2 {
+  const path = `/v1/dm/threads/${encodeURIComponent(pairKey)}/read`;
+  return {
+    version: '2.0',
+    routeKey: `POST ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: { 'content-type': 'application/json' },
+    pathParameters: { pairKey },
+    body: JSON.stringify(body),
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method: 'POST',
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-dm-read-1',
+      routeKey: `POST ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+      authorizer: opts?.claims ? { jwt: { claims: opts.claims } } : undefined,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+describe('dm-thread-read handler', () => {
+  beforeEach(() => {
+    mocks.docSend.mockReset();
+    mocks.pushDmUnreadToRecipient.mockReset();
+    mocks.pushDmUnreadToRecipient.mockResolvedValue(undefined);
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    process.env.DIRECT_MESSAGES_TABLE_NAME = 'DirectMessages';
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.DM_UNREAD_TABLE_NAME = 'DmUnread';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
+    process.env.DM_READ_LIMIT_PER_MINUTE = '60';
+  });
+
+  it('returns 401 fan_auth_required without fan JWT', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(401);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('fan_auth_required');
+  });
+
+  it('returns 400 invalid_read_cursor for malformed body', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 'bad', lastReadMessageId: '' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(400);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('invalid_read_cursor');
+  });
+
+  it('returns 403 dm_not_member when caller is not in pairKey', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }, { claims: { sub: 'fan-c' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_not_member');
+  });
+
+  it('returns 403 friendship_not_active when friendship edge missing', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend.mockResolvedValueOnce({}).mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_active');
+  });
+
+  it('returns 404 dm_thread_not_found when no thread row', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(404);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_not_found');
+  });
+
+  it('ignores stale read cursor and returns current state', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+      })
+      .mockResolvedValueOnce({
+        Item: {
+          recipientSub: 'fan-a',
+          pairKey,
+          lastReadSentAt: 500,
+          lastReadMessageId: 'msg-newer',
+          hasUnread: false,
+          updatedAt: 600,
+        },
+      });
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-old' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      pairKey,
+      lastReadSentAt: 500,
+      lastReadMessageId: 'msg-newer',
+      hasUnread: false,
+    });
+    expect(mocks.docSend.mock.calls.filter((call) => call[0].kind === 'Update' && call[0].input?.TableName === 'DmUnread')).toHaveLength(0);
+    expect(mocks.pushDmUnreadToRecipient).not.toHaveBeenCalled();
+  });
+
+  it('returns 200, updates cursor, recomputes hasUnread, and pushes dm_unread', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+      })
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            pairKey,
+            sk: 'm#0000000000500#msg-tip',
+            messageId: 'msg-tip',
+            senderSub: 'fan-b',
+            kind: 'text',
+            body: 'latest',
+            sentAt: 500,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 500, lastReadMessageId: 'msg-tip' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(JSON.parse((res as { body: string }).body)).toEqual({
+      pairKey,
+      lastReadSentAt: 500,
+      lastReadMessageId: 'msg-tip',
+      hasUnread: false,
+    });
+
+    const updateCall = mocks.docSend.mock.calls.find(
+      (call) => call[0].kind === 'Update' && call[0].input?.TableName === 'DmUnread',
+    );
+    expect(updateCall).toBeTruthy();
+    expect((updateCall![0].input as { TableName: string }).TableName).toBe('DmUnread');
+
+    expect(mocks.pushDmUnreadToRecipient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientFanSub: 'fan-a',
+        pairKey,
+        hasUnread: false,
+        lastReadSentAt: 500,
+        lastReadMessageId: 'msg-tip',
+      }),
+    );
+  });
+
+  it('returns 429 rate_limited at combined DM read throttle', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const bucketMs = minuteBucketEpochMs();
+    const { pk, sk } = dmReadRateLimitKey('fan-a', bucketMs);
+    const err = new Error('ConditionalCheckFailedException');
+    err.name = 'ConditionalCheckFailedException';
+    mocks.docSend.mockRejectedValueOnce(err);
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(429);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('rate_limited');
+    expect(mocks.docSend.mock.calls[0][0].input.Key).toEqual({ pk, sk });
+  });
+});

--- a/infra/cdk/lambda/dm-thread-read.ts
+++ b/infra/cdk/lambda/dm-thread-read.ts
@@ -1,0 +1,156 @@
+import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { pushDmUnreadToRecipient } from './fan-dm-shared';
+import {
+  dmDeny,
+  dmUnreadCursorFromItem,
+  enforceDmReadRateLimit,
+  friendshipActiveForCaller,
+  getDmThread,
+  getDmUnread,
+  getLatestDirectMessage,
+  isDirectMessageUnread,
+  isPairMember,
+  isReadCursorNewer,
+  jsonResponse,
+  parseDmReadBody,
+  requireFanSub,
+  DM_READ_LIMIT_PER_MINUTE,
+} from './dm-shared';
+
+const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+function tables():
+  | {
+      ok: true;
+      dmThreads: string;
+      directMessages: string;
+      friendships: string;
+      dmUnread: string;
+      rateLimits: string;
+      fanConnections: string;
+    }
+  | { ok: false; response: APIGatewayProxyResultV2 } {
+  const dmThreads = process.env.DM_THREADS_TABLE_NAME?.trim();
+  const directMessages = process.env.DIRECT_MESSAGES_TABLE_NAME?.trim();
+  const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
+  const dmUnread = process.env.DM_UNREAD_TABLE_NAME?.trim();
+  const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
+  const fanConnections = process.env.FAN_CONNECTIONS_TABLE_NAME?.trim();
+  if (!dmThreads || !directMessages || !friendships || !dmUnread || !rateLimits || !fanConnections) {
+    return {
+      ok: false,
+      response: jsonResponse(500, { error: 'Server misconfigured' }),
+    };
+  }
+  return { ok: true, dmThreads, directMessages, friendships, dmUnread, rateLimits, fanConnections };
+}
+
+function readLimit(): number {
+  const raw = process.env.DM_READ_LIMIT_PER_MINUTE;
+  const n = raw !== undefined ? Number.parseInt(raw, 10) : DM_READ_LIMIT_PER_MINUTE;
+  return Number.isFinite(n) && n > 0 ? n : DM_READ_LIMIT_PER_MINUTE;
+}
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const t = tables();
+  if (!t.ok) return t.response;
+
+  const auth = requireFanSub(event);
+  if (!auth.ok) return auth.response;
+
+  const method = event.requestContext.http.method.toUpperCase();
+  const path = event.rawPath.replace(/\/+$/, '') || '/';
+  if (method !== 'POST' || !/^\/v1\/dm\/threads\/[^/]+\/read$/.test(path)) {
+    return jsonResponse(404, { error: 'Not found' });
+  }
+
+  const pairKey = event.pathParameters?.pairKey?.trim() ?? '';
+  if (!pairKey || !isPairMember(pairKey, auth.fanSub)) {
+    return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
+  }
+
+  const parsedBody = parseDmReadBody(event.body);
+  if (!parsedBody.ok) {
+    return dmDeny(400, parsedBody.code, 'Invalid read cursor');
+  }
+
+  const allowed = await enforceDmReadRateLimit(doc, t.rateLimits, auth.fanSub, readLimit());
+  if (!allowed) {
+    return dmDeny(429, 'rate_limited', 'DM read rate limit exceeded');
+  }
+
+  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
+  if (!friendshipActive) {
+    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  }
+
+  const thread = await getDmThread(doc, t.dmThreads, pairKey);
+  if (!thread) {
+    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
+  }
+  if (thread.status === 'closed') {
+    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+  }
+
+  const existing = await getDmUnread(doc, t.dmUnread, auth.fanSub, pairKey);
+  const currentCursor = dmUnreadCursorFromItem(existing);
+  const proposedCursor = {
+    lastReadSentAt: parsedBody.lastReadSentAt,
+    lastReadMessageId: parsedBody.lastReadMessageId,
+  };
+
+  if (!isReadCursorNewer(proposedCursor, currentCursor)) {
+    return jsonResponse(200, {
+      pairKey,
+      lastReadSentAt: currentCursor.lastReadSentAt,
+      lastReadMessageId: currentCursor.lastReadMessageId,
+      hasUnread: existing?.hasUnread ?? false,
+    });
+  }
+
+  const tip = await getLatestDirectMessage(doc, t.directMessages, pairKey);
+  const hasUnread = tip ? isDirectMessageUnread(tip, proposedCursor) : false;
+  const now = Date.now();
+
+  await doc.send(
+    new UpdateCommand({
+      TableName: t.dmUnread,
+      Key: { recipientSub: auth.fanSub, pairKey },
+      UpdateExpression:
+        'SET lastReadSentAt = :lastReadSentAt, lastReadMessageId = :lastReadMessageId, hasUnread = :hasUnread, updatedAt = :updatedAt',
+      ExpressionAttributeValues: {
+        ':lastReadSentAt': proposedCursor.lastReadSentAt,
+        ':lastReadMessageId': proposedCursor.lastReadMessageId,
+        ':hasUnread': hasUnread,
+        ':updatedAt': now,
+      },
+    }),
+  );
+
+  await pushDmUnreadToRecipient({
+    doc,
+    fanConnectionsTable: t.fanConnections,
+    recipientFanSub: auth.fanSub,
+    pairKey,
+    hasUnread,
+    lastReadSentAt: proposedCursor.lastReadSentAt,
+    lastReadMessageId: proposedCursor.lastReadMessageId,
+  }).catch((err: unknown) => {
+    console.warn(
+      JSON.stringify({
+        riffsyncDiag: 'fan_dm_unread_push_after_read_failed',
+        pairKeyHead: pairKey.slice(0, 12),
+        errorName: err && typeof err === 'object' && 'name' in err ? String((err as { name: string }).name) : 'unknown',
+      }),
+    );
+  });
+
+  return jsonResponse(200, {
+    pairKey,
+    lastReadSentAt: proposedCursor.lastReadSentAt,
+    lastReadMessageId: proposedCursor.lastReadMessageId,
+    hasUnread,
+  });
+};

--- a/infra/cdk/lambda/fan-dm-shared.ts
+++ b/infra/cdk/lambda/fan-dm-shared.ts
@@ -23,6 +23,15 @@ export type DmMessagePushEnvelope = {
   avatarUrl?: string;
 };
 
+export type DmUnreadPushEnvelope = {
+  type: 'dm_unread';
+  schemaVersion: 1;
+  pairKey: string;
+  hasUnread: boolean;
+  lastReadSentAt: number;
+  lastReadMessageId: string;
+};
+
 export function fanDmWsManagementClient(): ApiGatewayManagementApiClient {
   const endpoint = process.env.FAN_DM_WS_MANAGEMENT_API_ENDPOINT;
   if (!endpoint) {
@@ -164,6 +173,51 @@ export async function pushDmMessageToRecipient(input: {
     body: input.body,
     sentAt: input.sentAt,
     senderProfile,
+  });
+  const payload = encoder.encode(JSON.stringify(envelope));
+  const client = fanDmWsManagementClient();
+  await postToFanConnections(client, input.doc, input.fanConnectionsTable, connectionIds, payload);
+}
+
+export function buildDmUnreadPushEnvelope(input: {
+  pairKey: string;
+  hasUnread: boolean;
+  lastReadSentAt: number;
+  lastReadMessageId: string;
+}): DmUnreadPushEnvelope {
+  return {
+    type: 'dm_unread',
+    schemaVersion: 1,
+    pairKey: input.pairKey,
+    hasUnread: input.hasUnread,
+    lastReadSentAt: input.lastReadSentAt,
+    lastReadMessageId: input.lastReadMessageId,
+  };
+}
+
+export async function pushDmUnreadToRecipient(input: {
+  doc: DynamoDBDocumentClient;
+  fanConnectionsTable: string;
+  recipientFanSub: string;
+  pairKey: string;
+  hasUnread: boolean;
+  lastReadSentAt: number;
+  lastReadMessageId: string;
+}): Promise<void> {
+  const connectionIds = await queryFanConnectionIdsForFanSub(
+    input.doc,
+    input.fanConnectionsTable,
+    input.recipientFanSub,
+  );
+  if (connectionIds.length === 0) {
+    return;
+  }
+
+  const envelope = buildDmUnreadPushEnvelope({
+    pairKey: input.pairKey,
+    hasUnread: input.hasUnread,
+    lastReadSentAt: input.lastReadSentAt,
+    lastReadMessageId: input.lastReadMessageId,
   });
   const payload = encoder.encode(JSON.stringify(envelope));
   const client = fanDmWsManagementClient();

--- a/infra/cdk/lambda/friends-list.test.ts
+++ b/infra/cdk/lambda/friends-list.test.ts
@@ -76,6 +76,7 @@ describe('friends-list handler', () => {
     process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
     process.env.ROOM_PRESENCE_TABLE_NAME = 'RoomPresence';
     process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.DM_UNREAD_TABLE_NAME = 'DmUnread';
     process.env.FRIEND_LIST_LIMIT_PER_MINUTE = '60';
   });
 
@@ -102,7 +103,7 @@ describe('friends-list handler', () => {
       {} as never,
     );
     expect((res as { statusCode: number }).statusCode).toBe(200);
-    expect(JSON.parse((res as { body: string }).body)).toEqual({ friends: [] });
+    expect(JSON.parse((res as { body: string }).body)).toEqual({ friends: [], anyUnread: false });
   });
 
   it('returns friends with online true/false, profile fields, and sort order', async () => {
@@ -130,19 +131,40 @@ describe('friends-list handler', () => {
       }
       if (cmd.kind === 'BatchGet') {
         const input = cmd.input as {
-          RequestItems?: { FanProfiles?: { Keys?: { sub: string }[] } };
+          RequestItems?: Record<string, { Keys?: { sub?: string; recipientSub?: string; pairKey?: string }[] }>;
         };
-        const keys = input.RequestItems?.FanProfiles?.Keys ?? [];
-        const items = keys.map((k) => {
-          if (k.sub === 'fan-b') {
-            return { sub: 'fan-b', displayName: 'Beta Fan', avatarUrl: 'https://cdn.example/b.png' };
-          }
-          if (k.sub === 'fan-z') {
-            return { sub: 'fan-z', displayName: 'alpha peer' };
-          }
-          return { sub: k.sub };
-        });
-        return { Responses: { FanProfiles: items } };
+        const fanProfileKeys = input.RequestItems?.FanProfiles?.Keys ?? [];
+        if (fanProfileKeys.length > 0) {
+          const keys = fanProfileKeys;
+          const items = keys.map((k) => {
+            if (k.sub === 'fan-b') {
+              return { sub: 'fan-b', displayName: 'Beta Fan', avatarUrl: 'https://cdn.example/b.png' };
+            }
+            if (k.sub === 'fan-z') {
+              return { sub: 'fan-z', displayName: 'alpha peer' };
+            }
+            return { sub: k.sub };
+          });
+          return { Responses: { FanProfiles: items } };
+        }
+        const dmUnreadKeys = input.RequestItems?.DmUnread?.Keys ?? [];
+        if (dmUnreadKeys.length > 0) {
+          return {
+            Responses: {
+              DmUnread: [
+                {
+                  recipientSub: 'fan-a',
+                  pairKey: friendshipPairKey('fan-a', 'fan-b'),
+                  lastReadSentAt: 0,
+                  lastReadMessageId: '',
+                  hasUnread: true,
+                  updatedAt: 1,
+                },
+              ],
+            },
+          };
+        }
+        throw new Error('unexpected BatchGet');
       }
       throw new Error(`unexpected ${cmd.kind}`);
     });
@@ -154,12 +176,14 @@ describe('friends-list handler', () => {
     );
     expect((res as { statusCode: number }).statusCode).toBe(200);
     const body = JSON.parse((res as { body: string }).body);
+    expect(body.anyUnread).toBe(true);
     expect(body.friends).toEqual([
       {
         fanSub: 'fan-z',
         pairKey: friendshipPairKey('fan-a', 'fan-z'),
         displayName: 'alpha peer',
         online: false,
+        hasUnread: false,
         createdAt: 100,
       },
       {
@@ -168,6 +192,7 @@ describe('friends-list handler', () => {
         displayName: 'Beta Fan',
         avatarUrl: 'https://cdn.example/b.png',
         online: true,
+        hasUnread: true,
         createdAt: 200,
       },
     ]);
@@ -235,6 +260,7 @@ describe('sortFriendListEntries', () => {
         pairKey: 'a#z',
         displayName: 'Beta',
         online: false,
+        hasUnread: false,
         createdAt: 1,
       },
       {
@@ -242,6 +268,7 @@ describe('sortFriendListEntries', () => {
         pairKey: 'a#b',
         displayName: 'alpha',
         online: false,
+        hasUnread: false,
         createdAt: 2,
       },
       {
@@ -249,6 +276,7 @@ describe('sortFriendListEntries', () => {
         pairKey: 'a#c',
         displayName: 'Alpha',
         online: false,
+        hasUnread: false,
         createdAt: 3,
       },
     ]);
@@ -276,7 +304,7 @@ describe('buildFriendListEntries', () => {
         }
       }
       if (cmd.kind === 'BatchGet') {
-        return { Responses: { FanProfiles: [] } };
+        return { Responses: { FanProfiles: [], DmUnread: [] } };
       }
       throw new Error(`unexpected ${cmd.kind}`);
     });
@@ -285,6 +313,7 @@ describe('buildFriendListEntries', () => {
       friendships: 'Friendships',
       fanProfiles: 'FanProfiles',
       roomPresence: 'RoomPresence',
+      dmUnread: 'DmUnread',
     });
     expect(entries).toHaveLength(1);
     expect(entries[0]?.online).toBe(true);

--- a/infra/cdk/lambda/friends-list.ts
+++ b/infra/cdk/lambda/friends-list.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb';
 import { batchAvatarUrlsByFanSub, batchDisplayNamesByFanSub } from './fan-profile-shared';
 import {
   deny,
@@ -12,6 +12,7 @@ import {
   type FriendshipMemberItem,
 } from './friends-shared';
 import { isFanOnlineInAnyRoom } from './room-presence-shared';
+import { parseDmUnreadItem } from './dm-shared';
 
 const doc = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -23,6 +24,7 @@ export type FriendListEntryWire = {
   displayName: string;
   avatarUrl?: string;
   online: boolean;
+  hasUnread: boolean;
   createdAt: number;
 };
 
@@ -33,19 +35,21 @@ function tables():
       fanProfiles: string;
       roomPresence: string;
       rateLimits: string;
+      dmUnread: string;
     }
   | { ok: false; response: APIGatewayProxyResultV2 } {
   const friendships = process.env.FRIENDSHIPS_TABLE_NAME?.trim();
   const fanProfiles = process.env.FAN_PROFILES_TABLE_NAME?.trim();
   const roomPresence = process.env.ROOM_PRESENCE_TABLE_NAME?.trim();
   const rateLimits = process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME?.trim();
-  if (!friendships || !fanProfiles || !roomPresence || !rateLimits) {
+  const dmUnread = process.env.DM_UNREAD_TABLE_NAME?.trim();
+  if (!friendships || !fanProfiles || !roomPresence || !rateLimits || !dmUnread) {
     return {
       ok: false,
       response: jsonResponse(500, { error: 'Server misconfigured' }),
     };
   }
-  return { ok: true, friendships, fanProfiles, roomPresence, rateLimits };
+  return { ok: true, friendships, fanProfiles, roomPresence, rateLimits, dmUnread };
 }
 
 function listLimit(): number {
@@ -84,7 +88,7 @@ export function sortFriendListEntries(entries: FriendListEntryWire[]): FriendLis
 
 export async function buildFriendListEntries(
   callerFanSub: string,
-  t: { friendships: string; fanProfiles: string; roomPresence: string },
+  t: { friendships: string; fanProfiles: string; roomPresence: string; dmUnread: string },
 ): Promise<FriendListEntryWire[]> {
   const edges = await queryFriendshipsByFanSub(t.friendships, callerFanSub);
   if (edges.length === 0) {
@@ -92,9 +96,10 @@ export async function buildFriendListEntries(
   }
 
   const peerSubs = edges.map((e) => e.peerSub);
-  const [displayNames, avatarUrls] = await Promise.all([
+  const [displayNames, avatarUrls, unreadByPairKey] = await Promise.all([
     batchDisplayNamesByFanSub(doc, t.fanProfiles, peerSubs),
     batchAvatarUrlsByFanSub(doc, t.fanProfiles, peerSubs),
+    batchHasUnreadByPairKey(doc, t.dmUnread, callerFanSub, edges.map((e) => e.pairKey)),
   ]);
 
   const onlineByPeer = new Map<string, boolean>();
@@ -113,6 +118,7 @@ export async function buildFriendListEntries(
       pairKey: edge.pairKey,
       displayName,
       online: onlineByPeer.get(edge.peerSub) ?? false,
+      hasUnread: unreadByPairKey.get(edge.pairKey) ?? false,
       createdAt: edge.createdAt,
     };
     if (avatarUrl) {
@@ -122,6 +128,40 @@ export async function buildFriendListEntries(
   });
 
   return sortFriendListEntries(entries);
+}
+
+async function batchHasUnreadByPairKey(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+  recipientSub: string,
+  pairKeys: string[],
+): Promise<Map<string, boolean>> {
+  const result = new Map<string, boolean>();
+  if (pairKeys.length === 0) {
+    return result;
+  }
+
+  const chunkSize = 100;
+  for (let i = 0; i < pairKeys.length; i += chunkSize) {
+    const chunk = pairKeys.slice(i, i + chunkSize);
+    const out = await docClient.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [tableName]: {
+            Keys: chunk.map((pairKey) => ({ recipientSub, pairKey })),
+          },
+        },
+      }),
+    );
+    for (const raw of out.Responses?.[tableName] ?? []) {
+      const parsed = parseDmUnreadItem(raw as Record<string, unknown>);
+      if (parsed) {
+        result.set(parsed.pairKey, parsed.hasUnread);
+      }
+    }
+  }
+
+  return result;
 }
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
@@ -143,5 +183,6 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   }
 
   const friends = await buildFriendListEntries(auth.fanSub, t);
-  return jsonResponse(200, { friends });
+  const anyUnread = friends.some((friend) => friend.hasUnread);
+  return jsonResponse(200, { friends, anyUnread });
 };

--- a/infra/cdk/lib/api-catalog-stack.ts
+++ b/infra/cdk/lib/api-catalog-stack.ts
@@ -191,6 +191,7 @@ export class ApiCatalogStack extends cdk.Stack {
   public readonly friendshipsTable: dynamodb.Table;
   public readonly dmThreadsTable: dynamodb.Table;
   public readonly directMessagesTable: dynamodb.Table;
+  public readonly dmUnreadTable: dynamodb.Table;
   public readonly fanConnectionsTable: dynamodb.Table;
   public readonly fanAvatarsBucket: s3.Bucket;
   public readonly fanAvatarsDistribution: cloudfront.Distribution;
@@ -333,6 +334,14 @@ export class ApiCatalogStack extends cdk.Stack {
     this.directMessagesTable = new dynamodb.Table(this, 'DirectMessagesTable', {
       partitionKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'sk', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+
+    this.dmUnreadTable = new dynamodb.Table(this, 'DmUnreadTable', {
+      partitionKey: { name: 'recipientSub', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'pairKey', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
@@ -984,6 +993,7 @@ export class ApiCatalogStack extends cdk.Stack {
         FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
         ROOM_PRESENCE_TABLE_NAME: this.roomPresenceTable.tableName,
         FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        DM_UNREAD_TABLE_NAME: this.dmUnreadTable.tableName,
         FRIEND_LIST_LIMIT_PER_MINUTE: '60',
         RIFFSYNC_ENVIRONMENT: environment,
         NODE_OPTIONS: '--enable-source-maps',
@@ -992,6 +1002,7 @@ export class ApiCatalogStack extends cdk.Stack {
     this.friendshipsTable.grantReadData(friendsListFn);
     this.fanProfilesTable.grantReadData(friendsListFn);
     this.roomPresenceTable.grantReadData(friendsListFn);
+    this.dmUnreadTable.grantReadData(friendsListFn);
     friendshipRateLimitTable.grantReadWriteData(friendsListFn);
 
     const friendsRemoveFn = new lambdaNodejs.NodejsFunction(this, 'FriendsRemoveFn', {
@@ -1070,6 +1081,7 @@ export class ApiCatalogStack extends cdk.Stack {
         FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
         FAN_CONNECTIONS_TABLE_NAME: this.fanConnectionsTable.tableName,
         FAN_PROFILES_TABLE_NAME: this.fanProfilesTable.tableName,
+        DM_UNREAD_TABLE_NAME: this.dmUnreadTable.tableName,
         DM_SEND_LIMIT_PER_MINUTE: '20',
         RIFFSYNC_ENVIRONMENT: environment,
         NODE_OPTIONS: '--enable-source-maps',
@@ -1080,7 +1092,34 @@ export class ApiCatalogStack extends cdk.Stack {
     this.friendshipsTable.grantReadData(dmMessagesSendFn);
     this.fanConnectionsTable.grantReadWriteData(dmMessagesSendFn);
     this.fanProfilesTable.grantReadData(dmMessagesSendFn);
+    this.dmUnreadTable.grantReadWriteData(dmMessagesSendFn);
     friendshipRateLimitTable.grantReadWriteData(dmMessagesSendFn);
+
+    const dmThreadReadFn = new lambdaNodejs.NodejsFunction(this, 'DmThreadReadFn', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      timeout: cdk.Duration.seconds(10),
+      memorySize: 256,
+      bundling: sharedLambdaBundle,
+      entry: path.join(__dirname, '../lambda/dm-thread-read.ts'),
+      handler: 'handler',
+      environment: {
+        DM_THREADS_TABLE_NAME: this.dmThreadsTable.tableName,
+        DIRECT_MESSAGES_TABLE_NAME: this.directMessagesTable.tableName,
+        FRIENDSHIPS_TABLE_NAME: this.friendshipsTable.tableName,
+        FRIENDSHIP_RATE_LIMIT_TABLE_NAME: friendshipRateLimitTable.tableName,
+        DM_UNREAD_TABLE_NAME: this.dmUnreadTable.tableName,
+        FAN_CONNECTIONS_TABLE_NAME: this.fanConnectionsTable.tableName,
+        DM_READ_LIMIT_PER_MINUTE: '60',
+        RIFFSYNC_ENVIRONMENT: environment,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+    });
+    this.dmThreadsTable.grantReadData(dmThreadReadFn);
+    this.directMessagesTable.grantReadData(dmThreadReadFn);
+    this.friendshipsTable.grantReadData(dmThreadReadFn);
+    this.dmUnreadTable.grantReadWriteData(dmThreadReadFn);
+    this.fanConnectionsTable.grantReadWriteData(dmThreadReadFn);
+    friendshipRateLimitTable.grantReadWriteData(dmThreadReadFn);
 
     /** WebSocket management URL (HTTPS) for `PostToConnection`. */
     this.webSocketApi = new apigwv2.WebSocketApi(this, 'WebSocketApi', {
@@ -1260,6 +1299,8 @@ export class ApiCatalogStack extends cdk.Stack {
 
     dmMessagesSendFn.addEnvironment('FAN_DM_WS_MANAGEMENT_API_ENDPOINT', fanDmWsMgmtEndpoint);
     this.fanDmWebSocketApi.grantManageConnections(dmMessagesSendFn);
+    dmThreadReadFn.addEnvironment('FAN_DM_WS_MANAGEMENT_API_ENDPOINT', fanDmWsMgmtEndpoint);
+    this.fanDmWebSocketApi.grantManageConnections(dmThreadReadFn);
 
     fanDmWsPingFn.addPermission('FanDmWsPingFnAllowExecuteApiWebSocket', {
       principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
@@ -1342,6 +1383,7 @@ export class ApiCatalogStack extends cdk.Stack {
     const dmThreadEnsureIntegration = new integrations.HttpLambdaIntegration('DmThreadEnsureInt', dmThreadEnsureFn);
     const dmMessagesListIntegration = new integrations.HttpLambdaIntegration('DmMessagesListInt', dmMessagesListFn);
     const dmMessagesSendIntegration = new integrations.HttpLambdaIntegration('DmMessagesSendInt', dmMessagesSendFn);
+    const dmThreadReadIntegration = new integrations.HttpLambdaIntegration('DmThreadReadInt', dmThreadReadFn);
     const adminSessionGetIntegration = new integrations.HttpLambdaIntegration(
       'AdminSessionGetInt',
       adminSessionGetFn,
@@ -1527,6 +1569,13 @@ export class ApiCatalogStack extends cdk.Stack {
     });
 
     this.httpApi.addRoutes({
+      path: '/v1/dm/threads/{pairKey}/read',
+      methods: [apigwv2.HttpMethod.POST],
+      integration: dmThreadReadIntegration,
+      authorizer: fanJwtAuthorizer,
+    });
+
+    this.httpApi.addRoutes({
       path: '/v1/admin/session',
       methods: [apigwv2.HttpMethod.GET],
       integration: adminSessionGetIntegration,
@@ -1648,6 +1697,11 @@ export class ApiCatalogStack extends cdk.Stack {
       description: 'DynamoDB DirectMessages — PK `pairKey`, SK `m#<sentAtMs>#<messageId>`.',
     });
 
+    new cdk.CfnOutput(this, 'DmUnreadTableName', {
+      value: this.dmUnreadTable.tableName,
+      description: 'DynamoDB DmUnread — PK `recipientSub`, SK `pairKey`; read cursors and hasUnread denorm.',
+    });
+
     new cdk.CfnOutput(this, 'FanConnectionsTableName', {
       value: this.fanConnectionsTable.tableName,
       description:
@@ -1684,7 +1738,7 @@ export class ApiCatalogStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'HttpApiUrl', {
       value: this.httpApi.apiEndpoint,
       description:
-        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/dm/threads/{peerSub}` (PUT), `/v1/dm/threads/{pairKey}/messages` (GET/POST), `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
+        'HTTP API base URL (HTTPS). Append `/v1/catalog`, `/v1/rooms`, `/v1/lobby`, `/v1/webrtc/ice`, `/v1/fans/me`, `/v1/giphy/search`, `/v1/friends`, `/v1/friends/{pairKey}` (DELETE), `/v1/friends/requests`, `/v1/dm/threads/{peerSub}` (PUT), `/v1/dm/threads/{pairKey}/messages` (GET/POST), `/v1/dm/threads/{pairKey}/read` (POST), `/v1/admin/session`, `/v1/admin/catalog`, `/v1/admin/catalog/episodes/{id}` (GET/POST/PATCH/DELETE), `/v1/admin/email/audience`, `/v1/admin/email/test`, `/v1/admin/email/send`.',
     });
 
     new cdk.CfnOutput(this, 'HttpApiId', {


### PR DESCRIPTION
## Summary

- Add **DmUnread** Dynamo table and **`POST /v1/dm/threads/{pairKey}/read`** with monotonic read cursors and **`invalid_read_cursor`** validation.
- Extend **`GET /v1/friends`** with per-friend **`hasUnread`** and response **`anyUnread`** via BatchGet on DmUnread.
- Set recipient **`hasUnread: true`** on send persist and push **`dm_unread`** to recipient Fan DM WS connections after read writes.

Closes #361

## Test plan

- [x] `npm run test --prefix infra/cdk` (383 tests pass)
- [x] `npm run synth --prefix infra/cdk`
- [ ] Manual: peer sends message, recipient sees `hasUnread: true` on friends list
- [ ] Manual: `POST .../read` clears unread; refresh preserves server state
- [ ] Manual: second WS tab receives `dm_unread` push after read in first tab