### PR TITLE
feat(dm): enforce post-remove access and re-friend reopen (#362)

### DIFF
--- a/infra/cdk/lambda/dm-messages-list.test.ts
+++ b/infra/cdk/lambda/dm-messages-list.test.ts
@@ -240,6 +240,56 @@ describe('dm-messages-list handler', () => {
     });
   });
 
+  it('excludes pre-closedAt messages after re-friend reopen', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const msgNew = {
+      pairKey: 'fan-a#fan-b',
+      sk: directMessageSortKey(2000, 'msg-new'),
+      messageId: 'msg-new',
+      senderSub: 'fan-a',
+      kind: 'text',
+      body: 'after reopen',
+      sentAt: 2000,
+    };
+    const msgOld = {
+      pairKey: 'fan-a#fan-b',
+      sk: directMessageSortKey(1000, 'msg-old'),
+      messageId: 'msg-old',
+      senderSub: 'fan-b',
+      kind: 'text',
+      body: 'before unfriend',
+      sentAt: 1000,
+    };
+
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: {
+          pairKey,
+          subA: 'fan-a',
+          subB: 'fan-b',
+          status: 'open',
+          openedAt: 1,
+          updatedAt: 1500,
+          closedAt: 1500,
+          reopenedAt: 1800,
+        },
+      })
+      .mockResolvedValueOnce({ Items: [msgNew, msgOld] });
+
+    const res = await handler(
+      historyEvent(pairKey, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body.messages).toEqual([
+      { messageId: 'msg-new', senderSub: 'fan-a', kind: 'text', body: 'after reopen', sentAt: 2000 },
+    ]);
+  });
+
   it('returns 429 rate_limited when read throttle exceeded', async () => {
     const pairKey = friendshipPairKey('fan-a', 'fan-b');
     mocks.docSend.mockRejectedValueOnce({ name: 'ConditionalCheckFailedException' });

--- a/infra/cdk/lambda/dm-messages-list.ts
+++ b/infra/cdk/lambda/dm-messages-list.ts
@@ -2,13 +2,13 @@ import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lamb
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import {
+  assertDmThreadAccess,
   decodeHistoryCursor,
+  directMessagePassesHistoryCutoff,
   directMessageSortKey,
   dmDeny,
   encodeHistoryCursor,
   enforceDmReadRateLimit,
-  friendshipActiveForCaller,
-  getDmThread,
   isPairMember,
   jsonResponse,
   parseDirectMessageItem,
@@ -65,18 +65,17 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     return dmDeny(429, 'rate_limited', 'DM read rate limit exceeded');
   }
 
-  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
-  if (!friendshipActive) {
-    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  const access = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'history',
+  });
+  if (!access.ok) {
+    return dmDeny(access.statusCode, access.code, 'DM thread access denied');
   }
-
-  const thread = await getDmThread(doc, t.dmThreads, pairKey);
-  if (!thread) {
-    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
-  }
-  if (thread.status === 'closed') {
-    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
-  }
+  const thread = access.thread!;
 
   const limit = parseHistoryLimit(event.queryStringParameters?.limit);
   const beforeRaw = event.queryStringParameters?.before?.trim();
@@ -106,16 +105,15 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const messages = [];
   for (const raw of out.Items ?? []) {
     const parsed = parseDirectMessageItem(raw as Record<string, unknown>);
-    if (parsed) {
+    if (parsed && directMessagePassesHistoryCutoff(parsed, thread)) {
       messages.push(toDirectMessageWire(parsed));
     }
   }
 
-  const lastRaw = out.Items?.[messages.length - 1] as Record<string, unknown> | undefined;
-  const lastParsed = parseDirectMessageItem(lastRaw);
+  const lastIncluded = messages[messages.length - 1];
   const nextCursor =
-    out.LastEvaluatedKey && lastParsed
-      ? encodeHistoryCursor({ sentAt: lastParsed.sentAt, messageId: lastParsed.messageId })
+    out.LastEvaluatedKey && lastIncluded
+      ? encodeHistoryCursor({ sentAt: lastIncluded.sentAt, messageId: lastIncluded.messageId })
       : null;
 
   return jsonResponse(200, { messages, nextCursor });

--- a/infra/cdk/lambda/dm-messages-send.test.ts
+++ b/infra/cdk/lambda/dm-messages-send.test.ts
@@ -195,14 +195,42 @@ describe('dm-messages-send handler', () => {
     expect(mocks.docSend.mock.calls[0][0].input.Key).toEqual({ pk, sk });
   });
 
+  it('returns 403 on pre-write re-check when remove wins concurrent race', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const openThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+    };
+    const closedThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+    };
+    mocks.docSend
+      .mockResolvedValueOnce({}) // rate limit
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } }) // friendship (first access)
+      .mockResolvedValueOnce(openThread) // thread (first access)
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } }) // friendship (pre-write)
+      .mockResolvedValueOnce(closedThread); // thread closed on pre-write
+
+    const res = await handler(
+      sendEvent(pairKey, { messageId: 'msg-1', kind: 'text', body: 'hello' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+    expect(mocks.docSend.mock.calls.filter((c) => c[0]?.kind === 'Put')).toHaveLength(0);
+  });
+
   it('returns 201, persists DirectMessage, and pushes to recipient fanSub only', async () => {
     const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const openThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+    };
     mocks.docSend
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
-      .mockResolvedValueOnce({
-        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
-      })
+      .mockResolvedValueOnce(openThread)
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce(openThread)
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({});
 

--- a/infra/cdk/lambda/dm-messages-send.ts
+++ b/infra/cdk/lambda/dm-messages-send.ts
@@ -2,11 +2,10 @@ import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lamb
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import {
+  assertDmThreadAccess,
   directMessageSortKey,
   dmDeny,
   enforceDmSendRateLimit,
-  friendshipActiveForCaller,
-  getDmThread,
   isPairMember,
   jsonResponse,
   parseDmSendBody,
@@ -89,17 +88,15 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     return dmDeny(429, 'rate_limited', 'DM send rate limit exceeded');
   }
 
-  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
-  if (!friendshipActive) {
-    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
-  }
-
-  const thread = await getDmThread(doc, t.dmThreads, pairKey);
-  if (!thread) {
-    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
-  }
-  if (thread.status === 'closed') {
-    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+  const access = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'send',
+  });
+  if (!access.ok) {
+    return dmDeny(access.statusCode, access.code, 'DM thread access denied');
   }
 
   const recipientFanSub = peerSubForCaller(pairKey, auth.fanSub);
@@ -109,6 +106,17 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
   const sentAt = Date.now();
   const sk = directMessageSortKey(sentAt, parsedBody.messageId);
+
+  const preWriteAccess = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'send',
+  });
+  if (!preWriteAccess.ok) {
+    return dmDeny(preWriteAccess.statusCode, preWriteAccess.code, 'DM thread access denied');
+  }
 
   await doc.send(
     new PutCommand({

--- a/infra/cdk/lambda/dm-shared.test.ts
+++ b/infra/cdk/lambda/dm-shared.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   compareReadCursors,
   decodeHistoryCursor,
+  directMessagePassesHistoryCutoff,
   directMessageSortKey,
   encodeHistoryCursor,
   isDirectMessageUnread,
@@ -59,5 +60,40 @@ describe('dm-shared helpers', () => {
     expect(isDirectMessageUnread(message, { lastReadSentAt: 99, lastReadMessageId: 'msg-a' })).toBe(true);
     expect(isDirectMessageUnread(message, { lastReadSentAt: 100, lastReadMessageId: 'msg-a' })).toBe(true);
     expect(isDirectMessageUnread(message, { lastReadSentAt: 100, lastReadMessageId: 'msg-b' })).toBe(false);
+  });
+
+  it('filters history by closedAt cutoff after re-friend reopen', () => {
+    const thread = {
+      pairKey: 'a#b',
+      subA: 'a',
+      subB: 'b',
+      status: 'open' as const,
+      openedAt: 1,
+      updatedAt: 2,
+      closedAt: 500,
+      reopenedAt: 1000,
+    };
+    const oldMessage = {
+      pairKey: 'a#b',
+      sk: 'm#1#old',
+      messageId: 'old',
+      senderSub: 'a',
+      kind: 'text' as const,
+      body: 'before',
+      sentAt: 400,
+    };
+    const cutoffMessage = {
+      ...oldMessage,
+      messageId: 'at-cutoff',
+      sentAt: 500,
+    };
+    const newMessage = {
+      ...oldMessage,
+      messageId: 'new',
+      sentAt: 600,
+    };
+    expect(directMessagePassesHistoryCutoff(oldMessage, thread)).toBe(false);
+    expect(directMessagePassesHistoryCutoff(cutoffMessage, thread)).toBe(false);
+    expect(directMessagePassesHistoryCutoff(newMessage, thread)).toBe(true);
   });
 });

--- a/infra/cdk/lambda/dm-shared.ts
+++ b/infra/cdk/lambda/dm-shared.ts
@@ -275,6 +275,69 @@ export async function friendshipActiveForCaller(
   return Boolean(out.Item);
 }
 
+export type DmAccessMode = 'ensure' | 'history' | 'send' | 'read';
+
+export type AssertDmThreadAccessOk = {
+  ok: true;
+  thread: DmThreadItem | null;
+  friendshipActive: boolean;
+};
+
+export type AssertDmThreadAccessDeny = {
+  ok: false;
+  statusCode: number;
+  code: DmDenyCode;
+};
+
+export type AssertDmThreadAccessResult = AssertDmThreadAccessOk | AssertDmThreadAccessDeny;
+
+export async function assertDmThreadAccess(
+  doc: DynamoDBDocumentClient,
+  params: {
+    pairKey: string;
+    fanSub: string;
+    friendshipsTable: string;
+    dmThreadsTable: string;
+    mode: DmAccessMode;
+  },
+): Promise<AssertDmThreadAccessResult> {
+  const { pairKey, fanSub, friendshipsTable, dmThreadsTable, mode } = params;
+
+  if (!isPairMember(pairKey, fanSub)) {
+    return { ok: false, statusCode: 403, code: 'dm_not_member' };
+  }
+
+  const friendshipActive = await friendshipActiveForCaller(doc, friendshipsTable, pairKey, fanSub);
+  if (!friendshipActive) {
+    return { ok: false, statusCode: 403, code: 'friendship_not_active' };
+  }
+
+  const thread = await getDmThread(doc, dmThreadsTable, pairKey);
+
+  if (mode === 'ensure') {
+    return { ok: true, thread, friendshipActive };
+  }
+
+  if (!thread) {
+    return { ok: false, statusCode: 404, code: 'dm_thread_not_found' };
+  }
+  if (thread.status === 'closed') {
+    return { ok: false, statusCode: 403, code: 'dm_thread_closed' };
+  }
+
+  return { ok: true, thread, friendshipActive };
+}
+
+export function directMessagePassesHistoryCutoff(
+  message: DirectMessageItem,
+  thread: DmThreadItem,
+): boolean {
+  if (thread.closedAt === undefined) {
+    return true;
+  }
+  return message.sentAt > thread.closedAt;
+}
+
 export async function getDmThread(
   doc: DynamoDBDocumentClient,
   tableName: string,

--- a/infra/cdk/lambda/dm-thread-ensure.test.ts
+++ b/infra/cdk/lambda/dm-thread-ensure.test.ts
@@ -90,18 +90,40 @@ describe('dm-thread-ensure handler', () => {
     expect(JSON.parse((res as { body: string }).body).code).toBe('friendship_not_active');
   });
 
-  it('returns 403 dm_thread_closed when thread is closed', async () => {
+  it('reopens closed thread when friendship is active (re-friend)', async () => {
     const pairKey = friendshipPairKey('fan-a', 'fan-b');
     mocks.docSend
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
       .mockResolvedValueOnce({
-        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
-      });
+        Item: {
+          pairKey,
+          subA: 'fan-a',
+          subB: 'fan-b',
+          status: 'closed',
+          openedAt: 1000,
+          updatedAt: 2000,
+          closedAt: 2000,
+        },
+      })
+      .mockResolvedValueOnce({});
 
     const res = await handler(ensureEvent('fan-b', { claims: { sub: 'fan-a' } }), {} as never, {} as never);
-    expect((res as { statusCode: number }).statusCode).toBe(403);
-    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    const body = JSON.parse((res as { body: string }).body);
+    expect(body).toMatchObject({
+      pairKey: 'fan-a#fan-b',
+      peerSub: 'fan-b',
+      status: 'open',
+      openedAt: 1000,
+    });
+    expect(typeof body.reopenedAt).toBe('number');
+
+    const updateCall = mocks.docSend.mock.calls.find(
+      (c) => c[0]?.kind === 'Update' && c[0]?.input?.TableName === 'DmThreads',
+    );
+    expect(updateCall?.[0]?.input?.TableName).toBe('DmThreads');
+    expect(updateCall?.[0]?.input?.Key).toEqual({ pairKey: 'fan-a#fan-b' });
   });
 
   it('returns 200 idempotently when thread already open', async () => {

--- a/infra/cdk/lambda/dm-thread-ensure.ts
+++ b/infra/cdk/lambda/dm-thread-ensure.ts
@@ -1,10 +1,10 @@
 import type { APIGatewayProxyHandlerV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import {
+  assertDmThreadAccess,
   dmDeny,
   enforceDmReadRateLimit,
-  friendshipActiveForCaller,
   friendshipPairKey,
   getDmThread,
   jsonResponse,
@@ -69,15 +69,44 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     return dmDeny(403, 'dm_not_member', 'Not a member of this DM pair');
   }
 
-  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
-  if (!friendshipActive) {
-    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
+  const access = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'ensure',
+  });
+  if (!access.ok) {
+    return dmDeny(access.statusCode, access.code, 'DM thread access denied');
   }
 
-  const existing = await getDmThread(doc, t.dmThreads, pairKey);
+  const existing = access.thread;
   if (existing) {
     if (existing.status === 'closed') {
-      return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+      const now = Date.now();
+      await doc.send(
+        new UpdateCommand({
+          TableName: t.dmThreads,
+          Key: { pairKey },
+          UpdateExpression:
+            'SET #status = :open, reopenedAt = :reopenedAt, updatedAt = :updatedAt',
+          ExpressionAttributeNames: { '#status': 'status' },
+          ExpressionAttributeValues: {
+            ':open': 'open',
+            ':reopenedAt': now,
+            ':updatedAt': now,
+            ':closed': 'closed',
+          },
+          ConditionExpression: '#status = :closed',
+        }),
+      );
+      return jsonResponse(200, {
+        pairKey,
+        peerSub,
+        status: 'open',
+        openedAt: existing.openedAt,
+        reopenedAt: now,
+      });
     }
     return jsonResponse(200, {
       pairKey,
@@ -113,7 +142,30 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       throw e;
     }
     if (raced.status === 'closed') {
-      return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+      const now = Date.now();
+      await doc.send(
+        new UpdateCommand({
+          TableName: t.dmThreads,
+          Key: { pairKey },
+          UpdateExpression:
+            'SET #status = :open, reopenedAt = :reopenedAt, updatedAt = :updatedAt',
+          ExpressionAttributeNames: { '#status': 'status' },
+          ExpressionAttributeValues: {
+            ':open': 'open',
+            ':reopenedAt': now,
+            ':updatedAt': now,
+            ':closed': 'closed',
+          },
+          ConditionExpression: '#status = :closed',
+        }),
+      );
+      return jsonResponse(200, {
+        pairKey,
+        peerSub,
+        status: 'open',
+        openedAt: raced.openedAt,
+        reopenedAt: now,
+      });
     }
     return jsonResponse(200, {
       pairKey,

--- a/infra/cdk/lambda/dm-thread-read.test.ts
+++ b/infra/cdk/lambda/dm-thread-read.test.ts
@@ -178,12 +178,13 @@ describe('dm-thread-read handler', () => {
 
   it('returns 200, updates cursor, recomputes hasUnread, and pushes dm_unread', async () => {
     const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const openThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+    };
     mocks.docSend
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
-      .mockResolvedValueOnce({
-        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
-      })
+      .mockResolvedValueOnce(openThread)
       .mockResolvedValueOnce({ Item: undefined })
       .mockResolvedValueOnce({
         Items: [
@@ -198,6 +199,8 @@ describe('dm-thread-read handler', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce(openThread)
       .mockResolvedValueOnce({});
 
     const res = await handler(
@@ -228,6 +231,63 @@ describe('dm-thread-read handler', () => {
         lastReadMessageId: 'msg-tip',
       }),
     );
+  });
+
+  it('returns 403 dm_thread_closed after remove-friend', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce({
+        Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+      });
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 100, lastReadMessageId: 'msg-1' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+  });
+
+  it('returns 403 on pre-write re-check when remove wins concurrent race', async () => {
+    const pairKey = friendshipPairKey('fan-a', 'fan-b');
+    const openThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'open', openedAt: 1, updatedAt: 2 },
+    };
+    const closedThread = {
+      Item: { pairKey, subA: 'fan-a', subB: 'fan-b', status: 'closed', openedAt: 1, updatedAt: 2, closedAt: 3 },
+    };
+    mocks.docSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce(openThread)
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            pairKey,
+            sk: 'm#0000000000500#msg-tip',
+            messageId: 'msg-tip',
+            senderSub: 'fan-b',
+            kind: 'text',
+            body: 'latest',
+            sentAt: 500,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: { pairKey, fanSub: 'fan-a' } })
+      .mockResolvedValueOnce(closedThread);
+
+    const res = await handler(
+      readEvent(pairKey, { lastReadSentAt: 500, lastReadMessageId: 'msg-tip' }, { claims: { sub: 'fan-a' } }),
+      {} as never,
+      {} as never,
+    );
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect(JSON.parse((res as { body: string }).body).code).toBe('dm_thread_closed');
+    expect(mocks.docSend.mock.calls.filter((c) => c[0]?.kind === 'Update' && c[0]?.input?.TableName === 'DmUnread')).toHaveLength(0);
   });
 
   it('returns 429 rate_limited at combined DM read throttle', async () => {

--- a/infra/cdk/lambda/dm-thread-read.ts
+++ b/infra/cdk/lambda/dm-thread-read.ts
@@ -3,11 +3,10 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { pushDmUnreadToRecipient } from './fan-dm-shared';
 import {
+  assertDmThreadAccess,
   dmDeny,
   dmUnreadCursorFromItem,
   enforceDmReadRateLimit,
-  friendshipActiveForCaller,
-  getDmThread,
   getDmUnread,
   getLatestDirectMessage,
   isDirectMessageUnread,
@@ -81,17 +80,15 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     return dmDeny(429, 'rate_limited', 'DM read rate limit exceeded');
   }
 
-  const friendshipActive = await friendshipActiveForCaller(doc, t.friendships, pairKey, auth.fanSub);
-  if (!friendshipActive) {
-    return dmDeny(403, 'friendship_not_active', 'Active friendship required');
-  }
-
-  const thread = await getDmThread(doc, t.dmThreads, pairKey);
-  if (!thread) {
-    return dmDeny(404, 'dm_thread_not_found', 'DM thread not found');
-  }
-  if (thread.status === 'closed') {
-    return dmDeny(403, 'dm_thread_closed', 'DM thread is closed');
+  const access = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'read',
+  });
+  if (!access.ok) {
+    return dmDeny(access.statusCode, access.code, 'DM thread access denied');
   }
 
   const existing = await getDmUnread(doc, t.dmUnread, auth.fanSub, pairKey);
@@ -113,6 +110,17 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const tip = await getLatestDirectMessage(doc, t.directMessages, pairKey);
   const hasUnread = tip ? isDirectMessageUnread(tip, proposedCursor) : false;
   const now = Date.now();
+
+  const preWriteAccess = await assertDmThreadAccess(doc, {
+    pairKey,
+    fanSub: auth.fanSub,
+    friendshipsTable: t.friendships,
+    dmThreadsTable: t.dmThreads,
+    mode: 'read',
+  });
+  if (!preWriteAccess.ok) {
+    return dmDeny(preWriteAccess.statusCode, preWriteAccess.code, 'DM thread access denied');
+  }
 
   await doc.send(
     new UpdateCommand({


### PR DESCRIPTION
## Summary

- Add shared `assertDmThreadAccess` helper used by ensure, history, send, and mark-read DM Lambdas
- Deny DM access after mutual remove-friend with stable `friendship_not_active` / `dm_thread_closed` codes
- Reopen closed threads on re-friend via `PUT` ensure (`reopenedAt`, preserve `closedAt` cutoff)
- Filter history to exclude pre-unfriend messages; re-check access immediately before send/read writes

Closes #362

## Test plan

- [x] `npm run test --prefix infra/cdk` (388 tests pass)
- [x] `npm run synth --prefix infra/cdk`
- [x] Unit tests cover post-remove denies, re-friend reopen, history cutoff, and concurrent remove vs send/read race