### PR TITLE
[M36] People roster friend invite (#377) on #363 branch

### DIFF
--- a/apps/web/src/friends/friendsApi.test.ts
+++ b/apps/web/src/friends/friendsApi.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelFriendRequest, fetchFriendRosterSnapshot, sendFriendRequest } from './friendsApi'
+
+describe('friendsApi', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('sendFriendRequest posts recipientSub', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        requestId: 'req-1',
+        requesterSub: 'fan-a',
+        recipientSub: 'fan-b',
+        createdAt: 100,
+      }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await sendFriendRequest('token', 'fan-b')
+
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test.example/v1/friends/requests',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ recipientSub: 'fan-b' }),
+      }),
+    )
+  })
+
+  it('cancelFriendRequest deletes by request id', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await cancelFriendRequest('token', 'req-9')
+
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test.example/v1/friends/requests/req-9',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+
+  it('fetchFriendRosterSnapshot loads friends and pending requests', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('/v1/friends')) {
+          return {
+            ok: true,
+            json: async () => ({
+              friends: [{ fanSub: 'fan-b', pairKey: 'a#b', displayName: 'B', online: true, hasUnread: false, createdAt: 1 }],
+            }),
+          }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            inbound: [],
+            outbound: [{ requestId: 'req-2', requesterSub: 'fan-a', recipientSub: 'fan-c', createdAt: 2 }],
+          }),
+        }
+      }),
+    )
+
+    const snapshot = await fetchFriendRosterSnapshot('token')
+
+    expect(snapshot?.friends).toHaveLength(1)
+    expect(snapshot?.outbound).toHaveLength(1)
+  })
+})

--- a/apps/web/src/friends/friendsApi.ts
+++ b/apps/web/src/friends/friendsApi.ts
@@ -1,0 +1,176 @@
+import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+
+export type FriendRequestEntry = {
+  requestId: string
+  requesterSub: string
+  recipientSub: string
+  createdAt: number
+}
+
+export type FriendEntry = {
+  fanSub: string
+  pairKey: string
+  displayName: string
+  avatarUrl?: string
+  online: boolean
+  hasUnread: boolean
+  createdAt: number
+}
+
+export type FriendRosterSnapshot = {
+  friends: FriendEntry[]
+  inbound: FriendRequestEntry[]
+  outbound: FriendRequestEntry[]
+}
+
+export type FriendApiFailure = {
+  ok: false
+  status: number
+  code?: string
+  error?: string
+}
+
+export type SendFriendRequestResult =
+  | { ok: true; requestId: string; createdAt: number }
+  | FriendApiFailure
+
+export type CancelFriendRequestResult = { ok: true } | FriendApiFailure
+
+async function parseFailure(res: Response): Promise<FriendApiFailure> {
+  let code: string | undefined
+  let error: string | undefined
+  try {
+    const json = (await res.json()) as { code?: unknown; error?: unknown }
+    code = typeof json.code === 'string' ? json.code : undefined
+    error = typeof json.error === 'string' ? json.error : undefined
+  } catch {
+    // ignore parse errors
+  }
+  return { ok: false, status: res.status, code, error }
+}
+
+export function mapFriendRequestError(code?: string, fallback?: string): string {
+  switch (code) {
+    case 'already_friends':
+      return 'You are already friends.'
+    case 'friend_request_inbound_exists':
+      return 'They already sent you a request. Accept it from your friends list.'
+    case 'rate_limited':
+      return 'Too many requests. Try again in a minute.'
+    case 'cannot_friend_self':
+      return 'You cannot send a friend request to yourself.'
+    default:
+      return fallback ?? 'Could not send friend request. Try again.'
+  }
+}
+
+export async function fetchFriendRosterSnapshot(
+  accessToken: string,
+  signal?: AbortSignal,
+): Promise<FriendRosterSnapshot | null> {
+  const base = getPublicApiBaseUrl()
+  if (!base) return null
+
+  try {
+    const headers = { Authorization: `Bearer ${accessToken}` }
+    const [friendsRes, requestsRes] = await Promise.all([
+      fetch(`${base}/v1/friends`, { headers, signal }),
+      fetch(`${base}/v1/friends/requests`, { headers, signal }),
+    ])
+
+    if (!friendsRes.ok || !requestsRes.ok) {
+      return null
+    }
+
+    const friendsJson = (await friendsRes.json()) as { friends?: unknown }
+    const requestsJson = (await requestsRes.json()) as { inbound?: unknown; outbound?: unknown }
+
+    const friends = Array.isArray(friendsJson.friends)
+      ? friendsJson.friends.filter(
+          (entry): entry is FriendEntry =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            typeof (entry as FriendEntry).fanSub === 'string' &&
+            typeof (entry as FriendEntry).pairKey === 'string',
+        )
+      : []
+
+    const parseRequests = (raw: unknown): FriendRequestEntry[] =>
+      Array.isArray(raw)
+        ? raw.filter(
+            (entry): entry is FriendRequestEntry =>
+              typeof entry === 'object' &&
+              entry !== null &&
+              typeof (entry as FriendRequestEntry).requestId === 'string' &&
+              typeof (entry as FriendRequestEntry).requesterSub === 'string' &&
+              typeof (entry as FriendRequestEntry).recipientSub === 'string',
+          )
+        : []
+
+    return {
+      friends,
+      inbound: parseRequests(requestsJson.inbound),
+      outbound: parseRequests(requestsJson.outbound),
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function sendFriendRequest(
+  accessToken: string,
+  recipientSub: string,
+  signal?: AbortSignal,
+): Promise<SendFriendRequestResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/friends/requests`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ recipientSub }),
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseFailure(res)
+  }
+
+  const json = (await res.json()) as {
+    requestId?: unknown
+    createdAt?: unknown
+  }
+  const requestId = typeof json.requestId === 'string' ? json.requestId : ''
+  const createdAt = typeof json.createdAt === 'number' ? json.createdAt : Date.now()
+  if (!requestId) {
+    return { ok: false, status: res.status, error: 'Unexpected response from server' }
+  }
+  return { ok: true, requestId, createdAt }
+}
+
+export async function cancelFriendRequest(
+  accessToken: string,
+  requestId: string,
+  signal?: AbortSignal,
+): Promise<CancelFriendRequestResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/friends/requests/${encodeURIComponent(requestId)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseFailure(res)
+  }
+  return { ok: true }
+}

--- a/apps/web/src/room/PeopleRosterRow.tsx
+++ b/apps/web/src/room/PeopleRosterRow.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
+import { FanAvatarThumb } from '../components/FanAvatarThumb'
+import { PeopleRowAvIndicators } from './PeopleRowAvIndicators'
+import {
+  peopleFriendMenuPrimaryDisabled,
+  peopleFriendMenuPrimaryLabel,
+  resolvePeopleFriendMenuState,
+  type PeopleFriendMenuState,
+} from './peopleRosterFriendState'
+import type { FriendRosterSnapshot } from '../friends/friendsApi'
+import type { PresenceMember } from './roomPageTypes'
+import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
+
+type PeopleRosterRowProps = {
+  member: PresenceMember
+  sessionId: string
+  peopleAvatarUrl: string | undefined
+  producerSnapshot: ParticipantProducerSnapshot
+  speaking: boolean
+  showAvIndicators: boolean
+  rowClassName: string
+  myFanSub: string | undefined
+  snapshot: FriendRosterSnapshot | null
+  statusMessage: string | null
+  onInvitePeer: (peerFanSub: string) => void
+  onCancelPeerRequest: (peerFanSub: string, requestId: string) => void
+}
+
+export function PeopleRosterRow({
+  member,
+  sessionId,
+  peopleAvatarUrl,
+  producerSnapshot,
+  speaking,
+  showAvIndicators,
+  rowClassName,
+  myFanSub,
+  snapshot,
+  statusMessage,
+  onInvitePeer,
+  onCancelPeerRequest,
+}: PeopleRosterRowProps) {
+  const menuId = useId()
+  const rowRef = useRef<HTMLLIElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const peerFanSub = member.fanSub
+  const inviteEligible =
+    Boolean(myFanSub) &&
+    Boolean(peerFanSub) &&
+    peerFanSub !== myFanSub &&
+    Boolean(snapshot)
+
+  const menuState: PeopleFriendMenuState | null =
+    inviteEligible && snapshot && peerFanSub
+      ? resolvePeopleFriendMenuState(peerFanSub, snapshot)
+      : null
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false)
+  }, [])
+
+  const openMenu = useCallback(() => {
+    if (!menuState) return
+    setMenuOpen(true)
+  }, [menuState])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onPointerDown = (event: MouseEvent | globalThis.MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (rowRef.current?.contains(target)) return
+      closeMenu()
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [closeMenu, menuOpen])
+
+  const onRowContextMenu = (event: MouseEvent<HTMLLIElement>) => {
+    if (!menuState) return
+    event.preventDefault()
+    openMenu()
+  }
+
+  const onRowKeyDown = (event: KeyboardEvent<HTMLLIElement>) => {
+    if (!menuState) return
+    if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+      event.preventDefault()
+      openMenu()
+      return
+    }
+    if (event.key === 'Escape' && menuOpen) {
+      event.preventDefault()
+      closeMenu()
+    }
+  }
+
+  const onPrimaryMenuAction = () => {
+    if (!menuState || !peerFanSub) return
+    if (menuState.kind === 'add_friend') {
+      onInvitePeer(peerFanSub)
+    } else if (menuState.kind === 'cancel_request') {
+      onCancelPeerRequest(peerFanSub, menuState.requestId)
+    }
+    closeMenu()
+  }
+
+  const primaryDisabled = menuState ? peopleFriendMenuPrimaryDisabled(menuState) : true
+
+  return (
+    <li
+      ref={rowRef}
+      className={rowClassName}
+      onContextMenu={onRowContextMenu}
+      onKeyDown={onRowKeyDown}
+      tabIndex={menuState ? 0 : undefined}
+    >
+      <div className="riffsync-room-page__people-row-inner">
+        <span className="riffsync-room-page__person-label">
+          <FanAvatarThumb displayName={member.displayName} avatarUrl={peopleAvatarUrl} />
+          <span className="riffsync-room-page__person-name">
+            {member.isHost ? (
+              <>
+                <strong>{member.displayName}</strong>
+                <span className="riffsync-room-page__host-badge" aria-label="Host">
+                  Host
+                </span>
+              </>
+            ) : (
+              member.displayName
+            )}
+            {member.sessionId === sessionId ? <span className="riffsync-muted"> · you</span> : null}
+            {member.active ? (
+              <span className="riffsync-room-page__active-badge" aria-label="Active">
+                <span className="riffsync-room-page__active-dot" aria-hidden="true" />
+                Active
+              </span>
+            ) : null}
+            {speaking ? (
+              <span className="riffsync-room-page__speaking-badge" aria-hidden="true">
+                Speaking
+              </span>
+            ) : null}
+          </span>
+          {showAvIndicators ? (
+            <PeopleRowAvIndicators snapshot={producerSnapshot} speaking={speaking} />
+          ) : null}
+        </span>
+        {menuState ? (
+          <div className="riffsync-room-page__people-row-actions">
+            <button
+              type="button"
+              className="riffsync-room-page__people-row-overflow"
+              aria-label={`More actions for ${member.displayName}`}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              aria-controls={menuId}
+              onClick={() => (menuOpen ? closeMenu() : openMenu())}
+            >
+              <span aria-hidden="true">⋯</span>
+            </button>
+            {menuOpen ? (
+              <div
+                ref={menuRef}
+                id={menuId}
+                className="riffsync-room-page__people-row-menu"
+                role="menu"
+                aria-label={`Actions for ${member.displayName}`}
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="riffsync-room-page__people-row-menu-item"
+                  disabled={primaryDisabled}
+                  onClick={onPrimaryMenuAction}
+                >
+                  {peopleFriendMenuPrimaryLabel(menuState)}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {statusMessage ? (
+        <p className="riffsync-room-page__people-row-status riffsync-muted" role="status" aria-live="polite">
+          {statusMessage}
+        </p>
+      ) : null}
+    </li>
+  )
+}

--- a/apps/web/src/room/RoomPageSidebar.peopleFriendMenu.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.peopleFriendMenu.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { RoomPageSidebar } from './RoomPageSidebar'
+import type { ParticipantAvController } from './sfu/participantAvSession'
+import type { PresenceMember } from './roomPageTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const invitePeer = vi.fn()
+const cancelPeerRequest = vi.fn()
+
+vi.mock('../auth/jwtDecode', () => ({
+  cognitoSub: () => 'fan-a',
+}))
+
+vi.mock('./usePeopleRosterFriends', () => ({
+  usePeopleRosterFriends: () => ({
+    snapshot: {
+      friends: [],
+      inbound: [],
+      outbound: [],
+    },
+    myFanSub: 'fan-a',
+    loading: false,
+    statusByFanSub: {},
+    invitePeer,
+    cancelPeerRequest,
+    refreshSnapshot: vi.fn(),
+  }),
+}))
+
+function createParticipantAvControllerStub(): ParticipantAvController {
+  const state = {
+    cameraEnabled: false,
+    micEnabled: false,
+    micMuted: false,
+    canPublish: true,
+    needsProducerToken: false,
+    error: null,
+    busy: false,
+  }
+  return {
+    getState: () => state,
+    getLocalPreviewStream: () => null,
+    subscribe: () => () => undefined,
+    refreshPublishGate: vi.fn(),
+    attachSession: vi.fn(),
+    resetOnReconnect: vi.fn(),
+    teardownPublishing: vi.fn(),
+    enableCamera: vi.fn().mockResolvedValue(undefined),
+    disableCamera: vi.fn(),
+    enableMic: vi.fn().mockResolvedValue(undefined),
+    disableMic: vi.fn(),
+    toggleMicMute: vi.fn(),
+    failPublish: vi.fn(),
+    clearError: vi.fn(),
+  }
+}
+
+const peerWithFanSub: PresenceMember = {
+  sessionId: 'sess-peer',
+  displayName: 'Peer Fan',
+  isHost: false,
+  fanSub: 'fan-b',
+}
+
+const guestPeer: PresenceMember = {
+  sessionId: 'sess-guest',
+  displayName: 'Guest',
+  isHost: false,
+}
+
+const selfRow: PresenceMember = {
+  sessionId: 'sess-self',
+  displayName: 'You',
+  isHost: false,
+  fanSub: 'fan-a',
+}
+
+function buildSidebarProps(peopleShown: PresenceMember[]) {
+  return {
+    wsBase: 'wss://ws.test.example',
+    fanToken: 'fan-jwt',
+    roomId: 'room-test-1',
+    sessionId: 'sess-self',
+    myAvatarUrl: null,
+    activeSidebarTab: 'people' as const,
+    setRoomSidebarTab: vi.fn(),
+    viewerCount: peopleShown.length,
+    chat: [],
+    chatReactions: {},
+    remoteTyping: [],
+    chatMemberLabels: new Map<string, string>(),
+    chatDraft: '',
+    setChatDraft: vi.fn(),
+    notifyComposeBlur: vi.fn(),
+    chatLogRef: { current: null },
+    chatInputRef: { current: null },
+    showJumpToLatest: false,
+    jumpToLatestLabel: '',
+    jumpToLatest: vi.fn(),
+    chatDrawerBanner: null,
+    chatComposeStatus: { message: null, disableSubmit: false },
+    sendChat: vi.fn(),
+    sendChatGif: vi.fn(),
+    toggleChatReaction: vi.fn(),
+    peopleShown,
+    participantProducerBySessionId: new Map(),
+    speakingBySessionId: new Map(),
+    isPublisher: false,
+    experimentalFeatures: false,
+    shareHint: null,
+    onCopyShare: vi.fn(),
+    onOpenRenameModal: vi.fn(),
+    roomVisibility: 'public' as const,
+    visibilityBusy: false,
+    visibilityErr: null,
+    onSelectRoomVisibility: vi.fn(),
+    avDisabled: false,
+    participantAvController: createParticipantAvControllerStub(),
+    announceRoomA11y: vi.fn(),
+    profileDraft: '',
+    setProfileDraft: vi.fn(),
+    profileSaveErr: null,
+    profileSaving: false,
+    profileAvatarUrl: null,
+    profileAvatarLoading: false,
+    profileAvatarUploading: false,
+    profileAvatarErr: null,
+    profileAvatarInputRef: { current: null },
+    saveProfileDisplayName: vi.fn(),
+    onProfileAvatarSelected: vi.fn(),
+    castAvailability: 'unavailable' as const,
+    castStartLifecycle: 'idle' as const,
+    onCastToTvClick: vi.fn(),
+    castToTvButtonRef: { current: null },
+  }
+}
+
+describe('RoomPageSidebar People roster friend menu (#377)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    invitePeer.mockReset()
+    cancelPeerRequest.mockReset()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderPeople(peopleShown: PresenceMember[]) {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPageSidebar {...buildSidebarProps(peopleShown)} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('shows More actions only for eligible peer rows with fanSub', () => {
+    renderPeople([peerWithFanSub, guestPeer, selfRow])
+
+    const overflowButtons = container.querySelectorAll('.riffsync-room-page__people-row-overflow')
+    expect(overflowButtons).toHaveLength(1)
+    expect(overflowButtons[0]?.getAttribute('aria-label')).toBe('More actions for Peer Fan')
+  })
+
+  it('Add friend posts invite for peer fanSub from overflow menu', () => {
+    renderPeople([peerWithFanSub])
+
+    const overflow = container.querySelector('.riffsync-room-page__people-row-overflow') as HTMLButtonElement
+    act(() => {
+      overflow.click()
+    })
+
+    const addFriend = container.querySelector('.riffsync-room-page__people-row-menu-item') as HTMLButtonElement
+    expect(addFriend.textContent).toBe('Add friend')
+    act(() => {
+      addFriend.click()
+    })
+
+    expect(invitePeer).toHaveBeenCalledWith('fan-b')
+  })
+
+  it('opens the same menu from keyboard overflow control', () => {
+    renderPeople([peerWithFanSub])
+
+    const overflow = container.querySelector('.riffsync-room-page__people-row-overflow') as HTMLButtonElement
+    act(() => {
+      overflow.focus()
+      overflow.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      overflow.click()
+    })
+
+    expect(container.querySelector('.riffsync-room-page__people-row-menu')).not.toBeNull()
+  })
+})

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -15,8 +15,9 @@ import { formatChatSystemText } from './chatSystemLine'
 import { resolveMemberAvatarUrl } from './roomPageTypes'
 import type { ParticipantProducerSnapshot } from './participantProducerRegistry'
 import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from './participantProducerRegistry'
-import { PeopleRowAvIndicators } from './PeopleRowAvIndicators'
+import { PeopleRosterRow } from './PeopleRosterRow'
 import { peopleRowSpeakingClass, shouldShowPeopleAvIndicators } from './peoplePresentation'
+import { usePeopleRosterFriends } from './usePeopleRosterFriends'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
@@ -145,6 +146,8 @@ export function RoomPageSidebar({
   onCastToTvClick,
   castToTvButtonRef,
 }: RoomPageSidebarProps) {
+  const peopleFriends = usePeopleRosterFriends(fanToken, activeSidebarTab)
+
   const chatPlane = (
     <section
       className={`riffsync-room-page__chat${presentation === 'overlay' ? ' riffsync-room-page__chat--overlay' : ''}`}
@@ -322,42 +325,25 @@ export function RoomPageSidebar({
                   sessionId,
                   fanToken,
                 )
+                const rowClassName = `riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}${peopleRowSpeakingClass(speaking)}`
                 return (
-                  <li
+                  <PeopleRosterRow
                     key={p.sessionId}
-                    className={`riffsync-room-page__people-row${p.isHost ? ' riffsync-room-page__people-row--host' : ''}${peopleRowSpeakingClass(speaking)}`}
-                  >
-                    <span className="riffsync-room-page__person-label">
-                      <FanAvatarThumb displayName={p.displayName} avatarUrl={peopleAvatarUrl} />
-                      <span className="riffsync-room-page__person-name">
-                        {p.isHost ? (
-                          <>
-                            <strong>{p.displayName}</strong>
-                            <span className="riffsync-room-page__host-badge" aria-label="Host">
-                              Host
-                            </span>
-                          </>
-                        ) : (
-                          p.displayName
-                        )}
-                        {p.sessionId === sessionId ? <span className="riffsync-muted"> · you</span> : null}
-                        {p.active ? (
-                          <span className="riffsync-room-page__active-badge" aria-label="Active">
-                            <span className="riffsync-room-page__active-dot" aria-hidden="true" />
-                            Active
-                          </span>
-                        ) : null}
-                        {speaking ? (
-                          <span className="riffsync-room-page__speaking-badge" aria-hidden="true">
-                            Speaking
-                          </span>
-                        ) : null}
-                      </span>
-                      {showAvIndicators ? (
-                        <PeopleRowAvIndicators snapshot={producerSnapshot} speaking={speaking} />
-                      ) : null}
-                    </span>
-                  </li>
+                    member={p}
+                    sessionId={sessionId}
+                    peopleAvatarUrl={peopleAvatarUrl}
+                    producerSnapshot={producerSnapshot}
+                    speaking={speaking}
+                    showAvIndicators={showAvIndicators}
+                    rowClassName={rowClassName}
+                    myFanSub={peopleFriends.myFanSub}
+                    snapshot={peopleFriends.snapshot}
+                    statusMessage={
+                      p.fanSub ? (peopleFriends.statusByFanSub[p.fanSub] ?? null) : null
+                    }
+                    onInvitePeer={peopleFriends.invitePeer}
+                    onCancelPeerRequest={peopleFriends.cancelPeerRequest}
+                  />
                 )
               })}
             </ul>

--- a/apps/web/src/room/peopleRosterFriendState.ts
+++ b/apps/web/src/room/peopleRosterFriendState.ts
@@ -1,0 +1,45 @@
+import type { FriendRosterSnapshot } from '../friends/friendsApi'
+
+export type PeopleFriendMenuState =
+  | { kind: 'add_friend' }
+  | { kind: 'cancel_request'; requestId: string }
+  | { kind: 'request_pending' }
+  | { kind: 'friends' }
+
+export function resolvePeopleFriendMenuState(
+  peerFanSub: string,
+  snapshot: FriendRosterSnapshot,
+): PeopleFriendMenuState {
+  if (snapshot.friends.some((friend) => friend.fanSub === peerFanSub)) {
+    return { kind: 'friends' }
+  }
+
+  const outbound = snapshot.outbound.find((request) => request.recipientSub === peerFanSub)
+  if (outbound) {
+    return { kind: 'cancel_request', requestId: outbound.requestId }
+  }
+
+  const inbound = snapshot.inbound.find((request) => request.requesterSub === peerFanSub)
+  if (inbound) {
+    return { kind: 'request_pending' }
+  }
+
+  return { kind: 'add_friend' }
+}
+
+export function peopleFriendMenuPrimaryLabel(state: PeopleFriendMenuState): string {
+  switch (state.kind) {
+    case 'add_friend':
+      return 'Add friend'
+    case 'cancel_request':
+      return 'Cancel request'
+    case 'request_pending':
+      return 'Request pending'
+    case 'friends':
+      return 'Friends'
+  }
+}
+
+export function peopleFriendMenuPrimaryDisabled(state: PeopleFriendMenuState): boolean {
+  return state.kind === 'request_pending' || state.kind === 'friends'
+}

--- a/apps/web/src/room/roomPageTypes.ts
+++ b/apps/web/src/room/roomPageTypes.ts
@@ -10,6 +10,8 @@ export type PresenceMember = {
   isHost: boolean
   active?: boolean
   lastActiveAt?: number
+  /** Present for signed-in fan connections only; omitted for anonymous guests. */
+  fanSub?: string
   avatarUrl?: string
 }
 

--- a/apps/web/src/room/sessions/ChatSession.presence.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.presence.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { routeInboundChatMessage } from './ChatSession'
+
+describe('routeInboundChatMessage presence fanSub (#377)', () => {
+  it('parses optional fanSub on presence members', () => {
+    const routed = routeInboundChatMessage(
+      {
+        type: 'presence',
+        roomId: 'room-1',
+        members: [
+          {
+            sessionId: 'sess-fan',
+            displayName: 'Fan',
+            isHost: false,
+            fanSub: 'fan-sub-b',
+          },
+          {
+            sessionId: 'sess-guest',
+            displayName: 'Guest',
+            isHost: false,
+          },
+        ],
+      },
+      'room-1',
+    )
+
+    expect(routed?.type).toBe('presence')
+    if (routed?.type !== 'presence') return
+    expect(routed.event.members[0]?.fanSub).toBe('fan-sub-b')
+    expect(routed.event.members[1]?.fanSub).toBeUndefined()
+  })
+})

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -63,6 +63,7 @@ export type ChatPresenceMember = {
   isHost: boolean
   active?: boolean
   lastActiveAt?: number
+  fanSub?: string
   avatarUrl?: string
 }
 
@@ -137,6 +138,12 @@ function parseInboundAvatarUrl(raw: unknown): string | undefined {
 function parseInboundLastActiveAt(raw: unknown): number | undefined {
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return undefined
   return Math.floor(raw)
+}
+
+function parseInboundFanSub(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  return trimmed !== '' ? trimmed : undefined
 }
 
 function parseHistoryTextLine(raw: Record<string, unknown>): ChatTextLine | null {
@@ -253,12 +260,14 @@ export function routeInboundChatMessage(
       if (typeof sid !== 'string' || typeof dn !== 'string') continue
       const avatarUrl = parseInboundAvatarUrl(m.avatarUrl)
       const lastActiveAt = parseInboundLastActiveAt(m.lastActiveAt)
+      const fanSub = parseInboundFanSub(m.fanSub)
       members.push({
         sessionId: sid,
         displayName: dn,
         isHost: Boolean(m.isHost),
         ...(m.active === true ? { active: true } : m.active === false ? { active: false } : {}),
         ...(lastActiveAt !== undefined ? { lastActiveAt } : {}),
+        ...(fanSub !== undefined ? { fanSub } : {}),
         ...(avatarUrl !== undefined ? { avatarUrl } : {}),
       })
     }

--- a/apps/web/src/room/usePeopleRosterFriends.ts
+++ b/apps/web/src/room/usePeopleRosterFriends.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react'
+import { cognitoSub } from '../auth/jwtDecode'
+import {
+  cancelFriendRequest,
+  fetchFriendRosterSnapshot,
+  mapFriendRequestError,
+  sendFriendRequest,
+  type FriendRosterSnapshot,
+} from '../friends/friendsApi'
+import type { RoomSidebarTab } from './roomPageTypes'
+
+export function usePeopleRosterFriends(fanToken: string | null, activeSidebarTab: RoomSidebarTab) {
+  const [snapshot, setSnapshot] = useState<FriendRosterSnapshot | null>(null)
+  const [statusByFanSub, setStatusByFanSub] = useState<Record<string, string>>({})
+
+  const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
+
+  const refreshSnapshot = useCallback(async (signal?: AbortSignal) => {
+    if (!fanToken) {
+      setSnapshot(null)
+      return
+    }
+    const next = await fetchFriendRosterSnapshot(fanToken, signal)
+    if (!signal?.aborted) {
+      setSnapshot(next)
+    }
+  }, [fanToken])
+
+  useEffect(() => {
+    if (!fanToken || activeSidebarTab !== 'people') {
+      return
+    }
+    const controller = new AbortController()
+    let cancelled = false
+
+    void fetchFriendRosterSnapshot(fanToken, controller.signal).then((next) => {
+      if (!cancelled && !controller.signal.aborted) {
+        setSnapshot(next)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [activeSidebarTab, fanToken])
+
+  const setPeerStatus = useCallback((peerFanSub: string, message: string | null) => {
+    setStatusByFanSub((current) => {
+      if (!message) {
+        if (!(peerFanSub in current)) return current
+        const next = { ...current }
+        delete next[peerFanSub]
+        return next
+      }
+      return { ...current, [peerFanSub]: message }
+    })
+  }, [])
+
+  const invitePeer = useCallback(
+    async (peerFanSub: string) => {
+      if (!fanToken) return
+      setPeerStatus(peerFanSub, null)
+      const result = await sendFriendRequest(fanToken, peerFanSub)
+      if (result.ok) {
+        setSnapshot((current) => {
+          if (!current) {
+            return {
+              friends: [],
+              inbound: [],
+              outbound: [
+                {
+                  requestId: result.requestId,
+                  requesterSub: myFanSub ?? '',
+                  recipientSub: peerFanSub,
+                  createdAt: result.createdAt,
+                },
+              ],
+            }
+          }
+          const withoutDup = current.outbound.filter((entry) => entry.recipientSub !== peerFanSub)
+          return {
+            ...current,
+            outbound: [
+              ...withoutDup,
+              {
+                requestId: result.requestId,
+                requesterSub: myFanSub ?? '',
+                recipientSub: peerFanSub,
+                createdAt: result.createdAt,
+              },
+            ],
+          }
+        })
+        return
+      }
+      setPeerStatus(peerFanSub, mapFriendRequestError(result.code, result.error))
+      if (result.code === 'already_friends') {
+        void refreshSnapshot()
+      }
+    },
+    [fanToken, myFanSub, refreshSnapshot, setPeerStatus],
+  )
+
+  const cancelPeerRequest = useCallback(
+    async (peerFanSub: string, requestId: string) => {
+      if (!fanToken) return
+      setPeerStatus(peerFanSub, null)
+      const result = await cancelFriendRequest(fanToken, requestId)
+      if (result.ok) {
+        setSnapshot((current) =>
+          current
+            ? {
+                ...current,
+                outbound: current.outbound.filter((entry) => entry.requestId !== requestId),
+              }
+            : current,
+        )
+        return
+      }
+      setPeerStatus(peerFanSub, mapFriendRequestError(result.code, result.error))
+    },
+    [fanToken, setPeerStatus],
+  )
+
+  return {
+    snapshot,
+    myFanSub,
+    statusByFanSub,
+    invitePeer,
+    cancelPeerRequest,
+    refreshSnapshot,
+  }
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1797,6 +1797,76 @@ header#gen-header .gen-bottom-header .navbar .navbar-nav li.riffsync-catalog-nav
   background: rgb(255 255 255 / 0.035);
 }
 
+.riffsync-room-page__people-row-inner {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.riffsync-room-page__people-row-actions {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.riffsync-room-page__people-row-overflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  border-radius: 6px;
+  background: rgb(255 255 255 / 0.04);
+  color: rgb(255 255 255 / 0.85);
+  cursor: pointer;
+}
+
+.riffsync-room-page__people-row-overflow:hover,
+.riffsync-room-page__people-row-overflow:focus-visible {
+  background: rgb(255 255 255 / 0.1);
+}
+
+.riffsync-room-page__people-row-menu {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  right: 0;
+  z-index: 4;
+  min-width: 10rem;
+  padding: 0.35rem 0;
+  border-radius: 8px;
+  border: 1px solid rgb(255 255 255 / 0.16);
+  background: rgb(20 24 32 / 0.98);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.35);
+}
+
+.riffsync-room-page__people-row-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  border: 0;
+  background: transparent;
+  color: rgb(255 255 255 / 0.92);
+  text-align: left;
+  cursor: pointer;
+}
+
+.riffsync-room-page__people-row-menu-item:hover:not(:disabled),
+.riffsync-room-page__people-row-menu-item:focus-visible:not(:disabled) {
+  background: rgb(255 255 255 / 0.08);
+}
+
+.riffsync-room-page__people-row-menu-item:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.riffsync-room-page__people-row-status {
+  margin: 0.35rem 0 0;
+  font-size: 0.8125rem;
+}
+
 .riffsync-room-page__person-label {
   display: flex;
   align-items: center;

--- a/infra/cdk/lambda/ws-shared.test.ts
+++ b/infra/cdk/lambda/ws-shared.test.ts
@@ -47,13 +47,18 @@ describe('rosterFromConnectionItems', () => {
 
     const host = members.find((m) => m.sessionId === 'sess-host');
     expect(host?.isHost).toBe(true);
+    expect(host?.fanSub).toBe('host-sub');
     expect(host?.avatarUrl).toBeUndefined();
 
     const guest = members.find((m) => m.sessionId === 'sess-guest');
     expect(guest?.isHost).toBe(false);
+    expect(guest?.fanSub).toBeUndefined();
     expect(guest?.displayName).toMatch(/^Guest/);
     expect(guest?.active).toBe(false);
     expect(guest?.lastActiveAt).toBeUndefined();
+
+    const alice = members.find((m) => m.sessionId === 'sess-a');
+    expect(alice?.fanSub).toBe('fan-1');
   });
 
   it('uses max lastActiveAt across tabs and precomputes active', () => {
@@ -87,6 +92,26 @@ describe('rosterFromConnectionItems', () => {
       nowSec,
     );
     expect(members[0]?.active).toBe(false);
+  });
+
+  it('includes fanSub on signed-in fan members only (#377)', () => {
+    const { members } = rosterFromConnectionItems(
+      [
+        {
+          sessionId: 'sess-fan',
+          displayName: 'Fan B',
+          fanSub: 'fan-sub-b',
+        },
+        {
+          sessionId: 'sess-guest',
+          displayName: 'Guest',
+        },
+      ],
+      1_700_000_000,
+    );
+
+    expect(members.find((member) => member.sessionId === 'sess-fan')?.fanSub).toBe('fan-sub-b');
+    expect(members.find((member) => member.sessionId === 'sess-guest')?.fanSub).toBeUndefined();
   });
 });
 

--- a/infra/cdk/lambda/ws-shared.ts
+++ b/infra/cdk/lambda/ws-shared.ts
@@ -148,6 +148,8 @@ export type PresenceBroadcastMember = {
   active: boolean;
   /** Epoch seconds — max across tabs sharing `sessionId`; omitted when never engaged. */
   lastActiveAt?: number;
+  /** Cognito sub for signed-in fan connections only; omitted for anonymous guests. */
+  fanSub?: string;
   /** Server-trusted FanProfiles HTTPS URL; omitted when the fan has no avatar. */
   avatarUrl?: string;
 };
@@ -280,6 +282,9 @@ export function rosterFromConnectionItems(
     const member: PresenceBroadcastMember = { sessionId, displayName, isHost, active };
     if (lastActiveAt !== undefined) {
       member.lastActiveAt = lastActiveAt;
+    }
+    if (fanSub) {
+      member.fanSub = fanSub;
     }
     return member;
   });


### PR DESCRIPTION
## Summary
- Include optional `fanSub` on `presence` WebSocket members for signed-in fan connections (server broadcast + client parse).
- Add People roster context menu and keyboard **More actions** overflow for eligible peer rows to send or cancel friendship requests via `POST /v1/friends/requests`.
- Map friendship API error codes to inline roster status without exposing raw Cognito subs.

## Issues
- Closes #377
- Part of #363 (M36 friends surfaces)

## Test plan
- [x] `npm run test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [x] `npm run test --prefix infra/cdk`
- [ ] Manual: two signed-in fans in the same room; People tab shows overflow on peer row only; **Add friend** creates pending request; guest/self rows have no menu