### PR TITLE
[M36] Watch-party Friends pane beside room chat (#364)

### DIFF
--- a/apps/web/src/friends/FanDmSession.ts
+++ b/apps/web/src/friends/FanDmSession.ts
@@ -77,6 +77,7 @@ export class FanDmSession {
   private status: FanDmSessionStatus = 'idle'
   private readonly sessionId: string
   private readonly handlers: FanDmSessionHandlers
+  private readonly handlerSubs = new Set<FanDmSessionHandlers>()
 
   constructor(handlers: FanDmSessionHandlers = {}, sessionId?: string) {
     this.handlers = handlers
@@ -85,6 +86,34 @@ export class FanDmSession {
       (typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
         : `fan-dm-${Date.now()}`)
+  }
+
+  registerHandlers(handlers: FanDmSessionHandlers): () => void {
+    this.handlerSubs.add(handlers)
+    return () => {
+      this.handlerSubs.delete(handlers)
+    }
+  }
+
+  private emitInboundMessage(message: InboundDmMessage): void {
+    this.handlers.onInboundMessage?.(message)
+    for (const sub of this.handlerSubs) {
+      sub.onInboundMessage?.(message)
+    }
+  }
+
+  private emitStatusChange(status: FanDmSessionStatus): void {
+    this.handlers.onStatusChange?.(status)
+    for (const sub of this.handlerSubs) {
+      sub.onStatusChange?.(status)
+    }
+  }
+
+  private emitDrawerError(error: DmDrawerError): void {
+    this.handlers.onDrawerError?.(error)
+    for (const sub of this.handlerSubs) {
+      sub.onDrawerError?.(error)
+    }
   }
 
   getStatus(): FanDmSessionStatus {
@@ -99,9 +128,9 @@ export class FanDmSession {
     if (this.status === next) return
     const wasOpen = this.status === 'open'
     this.status = next
-    this.handlers.onStatusChange?.(next)
+    this.emitStatusChange(next)
     if (wasOpen && next !== 'open') {
-      this.handlers.onDrawerError?.(dmPushUnavailableError())
+      this.emitDrawerError(dmPushUnavailableError())
     }
   }
 
@@ -109,7 +138,7 @@ export class FanDmSession {
     const wsBase = getPublicFanDmWsUrl()
     if (!wsBase) {
       this.setStatus('error')
-      this.handlers.onDrawerError?.(dmPushUnavailableError(new Error('Fan DM WebSocket URL not configured')))
+      this.emitDrawerError(dmPushUnavailableError(new Error('Fan DM WebSocket URL not configured')))
       return
     }
 
@@ -130,7 +159,7 @@ export class FanDmSession {
       try {
         const parsed = parseInboundDmMessage(JSON.parse(String(event.data)))
         if (parsed) {
-          this.handlers.onInboundMessage?.(parsed)
+          this.emitInboundMessage(parsed)
         }
       } catch {
         // ignore malformed push frames
@@ -161,7 +190,7 @@ export class FanDmSession {
 
   async sendMessage(accessToken: string, pairKey: string, payload: DmSendRequest): Promise<DmSendResponse | null> {
     if (!this.isPushAvailable()) {
-      this.handlers.onDrawerError?.(dmPushUnavailableError())
+      this.emitDrawerError(dmPushUnavailableError())
     }
 
     let lastFailure: unknown
@@ -172,7 +201,7 @@ export class FanDmSession {
           return result.message
         }
         if (result.status >= 400 && result.status < 500 && result.status !== 429) {
-          this.handlers.onDrawerError?.(dmSendDroppedError(result))
+          this.emitDrawerError(dmSendDroppedError(result))
           return null
         }
         lastFailure = result
@@ -184,7 +213,7 @@ export class FanDmSession {
       }
     }
 
-    this.handlers.onDrawerError?.(dmSendDroppedError(lastFailure))
+    this.emitDrawerError(dmSendDroppedError(lastFailure))
     return null
   }
 

--- a/apps/web/src/friends/RoomFriendsPane.test.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RoomFriendsPane } from './RoomFriendsPane'
+import type { RoomFriendsPaneState } from './useRoomFriendsPane'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => 'fan-jwt',
+}))
+
+vi.mock('../auth/jwtDecode', () => ({
+  cognitoSub: () => 'fan-a',
+}))
+
+function buildPaneState(overrides: Partial<RoomFriendsPaneState> = {}): RoomFriendsPaneState {
+  return {
+    loading: false,
+    loadError: false,
+    snapshot: {
+      friends: [
+        {
+          fanSub: 'fan-b',
+          pairKey: 'a#b',
+          displayName: 'Buddy',
+          online: true,
+          hasUnread: true,
+          createdAt: 1,
+        },
+      ],
+      inbound: [],
+      outbound: [],
+      anyUnread: true,
+    },
+    openPeer: null,
+    dmMessages: [],
+    dmClosed: false,
+    dmLoading: false,
+    dmDraft: '',
+    dmComposeError: null,
+    removeTarget: null,
+    anyUnread: true,
+    setDmDraft: vi.fn(),
+    refreshRoster: vi.fn(),
+    acceptRequest: vi.fn(),
+    declineRequest: vi.fn(),
+    openDm: vi.fn(),
+    closeDm: vi.fn(),
+    confirmRemove: vi.fn(),
+    cancelRemove: vi.fn(),
+    executeRemove: vi.fn(),
+    sendDm: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('RoomFriendsPane (#364)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('renders friends list with online label and unread dot', () => {
+    act(() => {
+      root.render(<RoomFriendsPane pane={buildPaneState()} visible />)
+    })
+
+    expect(container.textContent).toContain('Buddy')
+    expect(container.textContent).toContain('Online in a watch party')
+    expect(container.querySelector('.riffsync-room-friends-unread-dot')).not.toBeNull()
+  })
+
+  it('renders empty friends copy when roster has no friends', () => {
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            snapshot: { friends: [], inbound: [], outbound: [], anyUnread: false },
+          })}
+          visible
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('No friends yet.')
+  })
+
+  it('renders nested DM thread with back control and empty copy', () => {
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            openPeer: {
+              fanSub: 'fan-b',
+              pairKey: 'a#b',
+              displayName: 'Buddy',
+            },
+            dmMessages: [],
+          })}
+          visible
+        />,
+      )
+    })
+
+    expect(container.querySelector('.riffsync-room-friends-dm-header')).not.toBeNull()
+    expect(container.textContent).toContain('Back to friends')
+    expect(container.textContent).toContain('No messages yet. Say hello.')
+    expect(container.querySelector('.riffsync-room-friends-dm-compose')).not.toBeNull()
+  })
+
+  it('shows closed conversation copy after remove', () => {
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            openPeer: {
+              fanSub: 'fan-b',
+              pairKey: 'a#b',
+              displayName: 'Buddy',
+            },
+            dmClosed: true,
+          })}
+          visible
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('This conversation is closed.')
+    expect(container.querySelector('.riffsync-room-friends-dm-compose')).toBeNull()
+  })
+
+  it('shows load failure copy with retry', () => {
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({ loadError: true, snapshot: null })}
+          visible
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('Could not load friends. Try again.')
+  })
+})

--- a/apps/web/src/friends/RoomFriendsPane.test.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.test.tsx
@@ -46,6 +46,7 @@ function buildPaneState(overrides: Partial<RoomFriendsPaneState> = {}): RoomFrie
     refreshRoster: vi.fn(),
     acceptRequest: vi.fn(),
     declineRequest: vi.fn(),
+    cancelRequest: vi.fn(),
     openDm: vi.fn(),
     closeDm: vi.fn(),
     confirmRemove: vi.fn(),
@@ -94,6 +95,85 @@ describe('RoomFriendsPane (#364)', () => {
     })
 
     expect(container.textContent).toContain('No friends yet.')
+  })
+
+  it('renders outbound pending with cancel and keeps empty friends copy', () => {
+    const cancelRequest = vi.fn()
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            snapshot: {
+              friends: [],
+              inbound: [],
+              outbound: [
+                {
+                  requestId: 'req-out-1',
+                  requesterSub: 'fan-a',
+                  recipientSub: 'fan-c',
+                  createdAt: 3,
+                },
+              ],
+              anyUnread: false,
+            },
+            cancelRequest,
+          })}
+          visible
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('Pending requests')
+    expect(container.textContent).toContain('Request pending')
+    expect(container.textContent).toContain('Cancel request')
+    expect(container.textContent).toContain('No friends yet.')
+
+    const cancelButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('Cancel request'),
+    )
+    expect(cancelButton).not.toBeUndefined()
+    cancelButton?.click()
+    expect(cancelRequest).toHaveBeenCalledWith('req-out-1')
+  })
+
+  it('renders inbound pending accept and decline actions', () => {
+    const acceptRequest = vi.fn()
+    const declineRequest = vi.fn()
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            snapshot: {
+              friends: [],
+              inbound: [
+                {
+                  requestId: 'req-in-1',
+                  requesterSub: 'fan-c',
+                  recipientSub: 'fan-a',
+                  createdAt: 2,
+                },
+              ],
+              outbound: [],
+              anyUnread: false,
+            },
+            acceptRequest,
+            declineRequest,
+          })}
+          visible
+        />,
+      )
+    })
+
+    const acceptButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('Accept'),
+    )
+    const declineButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('Decline'),
+    )
+    acceptButton?.click()
+    declineButton?.click()
+    expect(acceptRequest).toHaveBeenCalledWith('req-in-1')
+    expect(declineRequest).toHaveBeenCalledWith('req-in-1')
   })
 
   it('renders nested DM thread with back control and empty copy', () => {

--- a/apps/web/src/friends/RoomFriendsPane.test.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.test.tsx
@@ -232,4 +232,36 @@ describe('RoomFriendsPane (#364)', () => {
 
     expect(container.textContent).toContain('Could not load friends. Try again.')
   })
+
+  it('focuses Cancel and dismisses remove dialog on Escape', () => {
+    const cancelRemove = vi.fn()
+    act(() => {
+      root.render(
+        <RoomFriendsPane
+          pane={buildPaneState({
+            removeTarget: {
+              fanSub: 'fan-b',
+              pairKey: 'a#b',
+              displayName: 'Buddy',
+              online: false,
+              hasUnread: false,
+              createdAt: 1,
+            },
+            cancelRemove,
+          })}
+          visible
+        />,
+      )
+    })
+
+    const cancelButton = Array.from(container.querySelectorAll('button')).find((node) =>
+      node.textContent?.includes('Cancel'),
+    )
+    expect(document.activeElement).toBe(cancelButton)
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+    expect(cancelRemove).toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/friends/RoomFriendsPane.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useRef } from 'react'
+import { FanAvatarThumb } from '../components/FanAvatarThumb'
+import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
+import { cognitoSub } from '../auth/jwtDecode'
+import { getFanAccessToken } from '../auth/fanTokens'
+import type { FriendEntry } from './friendsApi'
+import type { RoomFriendsPaneState } from './useRoomFriendsPane'
+
+type RoomFriendsPaneProps = {
+  pane: RoomFriendsPaneState
+  visible: boolean
+}
+
+export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
+  const backButtonRef = useRef<HTMLButtonElement>(null)
+  const openedFromRowRef = useRef<HTMLButtonElement | null>(null)
+  const fanToken = getFanAccessToken()
+  const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
+
+  const dmSurfaceKey = pane.openPeer ? `dm:${pane.openPeer.pairKey}` : 'list'
+  const {
+    logRef: dmLogRef,
+    showJumpToLatest,
+    jumpToLatestLabel,
+    jumpToLatest,
+  } = useChatLogStickToBottom(pane.dmMessages.length, Boolean(pane.openPeer && visible), dmSurfaceKey)
+
+  useEffect(() => {
+    if (!visible || !pane.openPeer) return
+    backButtonRef.current?.focus()
+  }, [visible, pane.openPeer])
+
+  useEffect(() => {
+    if (visible || !openedFromRowRef.current) return
+    openedFromRowRef.current.focus()
+    openedFromRowRef.current = null
+  }, [visible])
+
+  if (!visible) return null
+
+  if (pane.openPeer) {
+    return (
+      <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--friends riffsync-room-friends-pane">
+        <div className="riffsync-room-friends-dm-header">
+          <button
+            ref={backButtonRef}
+            type="button"
+            className="riffsync-room-friends-dm-back gen-button"
+            aria-label="Back to friends"
+            onClick={pane.closeDm}
+          >
+            Back to friends
+          </button>
+          <span className="riffsync-room-friends-dm-peer">{pane.openPeer.displayName}</span>
+        </div>
+        {pane.dmLoading ? (
+          <p className="riffsync-muted riffsync-room-friends-status" role="status">
+            Loading messages…
+          </p>
+        ) : null}
+        {pane.dmClosed ? (
+          <p className="riffsync-room-friends-closed" role="status">
+            This conversation is closed.
+          </p>
+        ) : (
+          <>
+            <ul
+              ref={dmLogRef}
+              className="riffsync-room-chat-log riffsync-room-friends-dm-log"
+              aria-label={`Direct messages with ${pane.openPeer.displayName}`}
+            >
+              {pane.dmMessages.length === 0 && !pane.dmLoading ? (
+                <li className="riffsync-room-friends-empty">
+                  <p role="status">No messages yet. Say hello.</p>
+                </li>
+              ) : null}
+              {pane.dmMessages.map((message) => {
+                const isMine = message.senderSub === myFanSub
+                return (
+                  <li
+                    key={message.messageId}
+                    className={`riffsync-room-chat-log__row${isMine ? ' riffsync-room-chat-log__row--mine' : ' riffsync-room-chat-log__row--theirs'}`}
+                  >
+                    <div className="riffsync-room-chat-log__entry">
+                      <div className="riffsync-room-chat-log__bubble">
+                        <div className="riffsync-room-chat-log__body">{message.body}</div>
+                      </div>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+            {showJumpToLatest ? (
+              <button
+                type="button"
+                className="riffsync-room-chat-jump-latest gen-button riffsync-room-friends-dm-jump"
+                aria-label="Jump to latest messages"
+                onClick={jumpToLatest}
+              >
+                {jumpToLatestLabel}
+              </button>
+            ) : null}
+            <div className="riffsync-room-friends-dm-compose">
+              <input
+                type="text"
+                maxLength={2000}
+                value={pane.dmDraft}
+                placeholder="Say something…"
+                aria-label="Direct message"
+                onChange={(e) => pane.setDmDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void pane.sendDm()
+                }}
+              />
+              <button type="button" className="gen-button" onClick={() => void pane.sendDm()}>
+                Send
+              </button>
+            </div>
+            {pane.dmComposeError ? (
+              <p className="riffsync-room-friends-dm-err" role="status" aria-live="polite">
+                {pane.dmComposeError}
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="riffsync-room-page__tab-panel riffsync-room-page__tab-panel--friends riffsync-room-friends-pane">
+      {pane.loading ? (
+        <p className="riffsync-muted riffsync-room-friends-status" role="status">
+          Loading friends…
+        </p>
+      ) : null}
+      {pane.loadError ? (
+        <div className="riffsync-room-friends-load-err">
+          <p role="alert">Could not load friends. Try again.</p>
+          <button type="button" className="gen-button" onClick={() => pane.refreshRoster()}>
+            Try again
+          </button>
+        </div>
+      ) : null}
+      {!pane.loading && !pane.loadError ? (
+        <>
+          {pane.snapshot && pane.snapshot.inbound.length > 0 ? (
+            <section className="riffsync-room-friends-section" aria-label="Pending friend requests">
+              <h3 className="riffsync-room-friends-section-title">Pending requests</h3>
+              <ul className="riffsync-room-friends-list">
+                {pane.snapshot.inbound.map((request) => (
+                  <li key={request.requestId} className="riffsync-room-friends-row">
+                    <span className="riffsync-room-friends-row-name">Friend request</span>
+                    <div className="riffsync-room-friends-row-actions">
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.acceptRequest(request.requestId)}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.declineRequest(request.requestId)}
+                      >
+                        Decline
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          {pane.snapshot && pane.snapshot.friends.length > 0 ? (
+            <ul className="riffsync-room-friends-list" aria-label="Friends">
+              {pane.snapshot.friends.map((friend) => (
+                <FriendRow
+                  key={friend.pairKey}
+                  friend={friend}
+                  onOpenDm={(rowRef) => {
+                    openedFromRowRef.current = rowRef
+                    pane.openDm(friend)
+                  }}
+                  onRemove={() => pane.confirmRemove(friend)}
+                />
+              ))}
+            </ul>
+          ) : (
+            <p className="riffsync-room-friends-empty" role="status">
+              No friends yet.
+            </p>
+          )}
+        </>
+      ) : null}
+      {pane.removeTarget ? (
+        <RemoveFriendDialog
+          displayName={pane.removeTarget.displayName}
+          onCancel={pane.cancelRemove}
+          onConfirm={() => void pane.executeRemove()}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function FriendRow({
+  friend,
+  onOpenDm,
+  onRemove,
+}: {
+  friend: FriendEntry
+  onOpenDm: (rowRef: HTMLButtonElement) => void
+  onRemove: () => void
+}) {
+  const openButtonRef = useRef<HTMLButtonElement>(null)
+
+  return (
+    <li className="riffsync-room-friends-row">
+      <FanAvatarThumb displayName={friend.displayName} avatarUrl={friend.avatarUrl} />
+      <div className="riffsync-room-friends-row-main">
+        <button
+          ref={openButtonRef}
+          type="button"
+          className="riffsync-room-friends-row-open"
+          onClick={() => {
+            if (openButtonRef.current) onOpenDm(openButtonRef.current)
+          }}
+        >
+          <span className="riffsync-room-friends-row-name">{friend.displayName}</span>
+          {friend.hasUnread ? (
+            <span className="riffsync-room-friends-unread-dot" aria-label="Unread messages" />
+          ) : null}
+        </button>
+        {friend.online ? (
+          <span className="riffsync-room-friends-online riffsync-muted">
+            <span className="riffsync-room-friends-online-dot" aria-hidden />
+            Online in a watch party
+          </span>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="riffsync-room-friends-remove gen-button"
+        aria-label={`Remove ${friend.displayName}`}
+        onClick={onRemove}
+      >
+        Remove
+      </button>
+    </li>
+  )
+}
+
+function RemoveFriendDialog({
+  displayName,
+  onCancel,
+  onConfirm,
+}: {
+  displayName: string
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <div className="riffsync-room-friends-remove-dialog" role="dialog" aria-labelledby="remove-friend-title">
+      <div className="riffsync-room-friends-remove-dialog-panel">
+        <h2 id="remove-friend-title">Remove friend?</h2>
+        <p>
+          This removes {displayName} for both of you. You will not be able to message each other unless you
+          become friends again.
+        </p>
+        <div className="riffsync-room-friends-remove-dialog-actions">
+          <button type="button" className="gen-button" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="gen-button riffsync-room-friends-remove-confirm" onClick={onConfirm}>
+            Remove friend
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/friends/RoomFriendsPane.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.tsx
@@ -14,6 +14,7 @@ type RoomFriendsPaneProps = {
 export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
   const backButtonRef = useRef<HTMLButtonElement>(null)
   const openedFromRowRef = useRef<HTMLButtonElement | null>(null)
+  const removeFromButtonRef = useRef<HTMLButtonElement | null>(null)
   const fanToken = getFanAccessToken()
   const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
 
@@ -197,7 +198,10 @@ export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
                     openedFromRowRef.current = rowRef
                     pane.openDm(friend)
                   }}
-                  onRemove={() => pane.confirmRemove(friend)}
+                  onRemove={(rowRef) => {
+                    removeFromButtonRef.current = rowRef
+                    pane.confirmRemove(friend)
+                  }}
                 />
               ))}
             </ul>
@@ -211,7 +215,11 @@ export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
       {pane.removeTarget ? (
         <RemoveFriendDialog
           displayName={pane.removeTarget.displayName}
-          onCancel={pane.cancelRemove}
+          onCancel={() => {
+            pane.cancelRemove()
+            removeFromButtonRef.current?.focus()
+            removeFromButtonRef.current = null
+          }}
           onConfirm={() => void pane.executeRemove()}
         />
       ) : null}
@@ -226,9 +234,10 @@ function FriendRow({
 }: {
   friend: FriendEntry
   onOpenDm: (rowRef: HTMLButtonElement) => void
-  onRemove: () => void
+  onRemove: (rowRef: HTMLButtonElement) => void
 }) {
   const openButtonRef = useRef<HTMLButtonElement>(null)
+  const removeButtonRef = useRef<HTMLButtonElement>(null)
 
   return (
     <li className="riffsync-room-friends-row">
@@ -255,10 +264,13 @@ function FriendRow({
         ) : null}
       </div>
       <button
+        ref={removeButtonRef}
         type="button"
         className="riffsync-room-friends-remove gen-button"
         aria-label={`Remove ${friend.displayName}`}
-        onClick={onRemove}
+        onClick={() => {
+          if (removeButtonRef.current) onRemove(removeButtonRef.current)
+        }}
       >
         Remove
       </button>
@@ -275,8 +287,24 @@ function RemoveFriendDialog({
   onCancel: () => void
   onConfirm: () => void
 }) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus()
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onCancel])
+
   return (
-    <div className="riffsync-room-friends-remove-dialog" role="dialog" aria-labelledby="remove-friend-title">
+    <div
+      className="riffsync-room-friends-remove-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="remove-friend-title"
+    >
       <div className="riffsync-room-friends-remove-dialog-panel">
         <h2 id="remove-friend-title">Remove friend?</h2>
         <p>
@@ -284,7 +312,7 @@ function RemoveFriendDialog({
           become friends again.
         </p>
         <div className="riffsync-room-friends-remove-dialog-actions">
-          <button type="button" className="gen-button" onClick={onCancel}>
+          <button ref={cancelButtonRef} type="button" className="gen-button" onClick={onCancel}>
             Cancel
           </button>
           <button type="button" className="gen-button riffsync-room-friends-remove-confirm" onClick={onConfirm}>

--- a/apps/web/src/friends/RoomFriendsPane.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.tsx
@@ -144,7 +144,8 @@ export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
       ) : null}
       {!pane.loading && !pane.loadError ? (
         <>
-          {pane.snapshot && pane.snapshot.inbound.length > 0 ? (
+          {pane.snapshot &&
+          (pane.snapshot.inbound.length > 0 || pane.snapshot.outbound.length > 0) ? (
             <section className="riffsync-room-friends-section" aria-label="Pending friend requests">
               <h3 className="riffsync-room-friends-section-title">Pending requests</h3>
               <ul className="riffsync-room-friends-list">
@@ -165,6 +166,20 @@ export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
                         onClick={() => void pane.declineRequest(request.requestId)}
                       >
                         Decline
+                      </button>
+                    </div>
+                  </li>
+                ))}
+                {pane.snapshot.outbound.map((request) => (
+                  <li key={request.requestId} className="riffsync-room-friends-row">
+                    <span className="riffsync-room-friends-row-name">Request pending</span>
+                    <div className="riffsync-room-friends-row-actions">
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.cancelRequest(request.requestId)}
+                      >
+                        Cancel request
                       </button>
                     </div>
                   </li>

--- a/apps/web/src/friends/dmApi.ts
+++ b/apps/web/src/friends/dmApi.ts
@@ -1,5 +1,25 @@
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 
+export type DmMessage = {
+  messageId: string
+  senderSub: string
+  kind: 'text'
+  body: string
+  sentAt: number
+}
+
+export type DmHistoryPage = {
+  messages: DmMessage[]
+  nextCursor: string | null
+}
+
+export type DmApiFailure = {
+  ok: false
+  status: number
+  code?: string
+  error?: string
+}
+
 export type DmSendRequest = {
   messageId: string
   kind: 'text'
@@ -15,14 +35,123 @@ export type DmSendResponse = {
   sentAt: number
 }
 
-export type DmSendFailure = {
-  ok: false
-  status: number
-  code?: string
-  error?: string
+export type DmSendResult = { ok: true; message: DmSendResponse } | DmApiFailure
+
+async function parseDmFailure(res: Response): Promise<DmApiFailure> {
+  let code: string | undefined
+  let error: string | undefined
+  try {
+    const json = (await res.json()) as { code?: unknown; error?: unknown }
+    code = typeof json.code === 'string' ? json.code : undefined
+    error = typeof json.error === 'string' ? json.error : undefined
+  } catch {
+    // ignore parse errors
+  }
+  return { ok: false, status: res.status, code, error }
 }
 
-export type DmSendResult = { ok: true; message: DmSendResponse } | DmSendFailure
+export type EnsureDmThreadResult =
+  | { ok: true; pairKey: string; peerSub: string; status: string }
+  | DmApiFailure
+
+export async function ensureDmThread(
+  accessToken: string,
+  peerSub: string,
+  signal?: AbortSignal,
+): Promise<EnsureDmThreadResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/dm/threads/${encodeURIComponent(peerSub)}`, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseDmFailure(res)
+  }
+
+  const json = (await res.json()) as { pairKey?: unknown; peerSub?: unknown; status?: unknown }
+  const pairKey = typeof json.pairKey === 'string' ? json.pairKey : ''
+  const resolvedPeerSub = typeof json.peerSub === 'string' ? json.peerSub : peerSub
+  const status = typeof json.status === 'string' ? json.status : 'open'
+  if (!pairKey) {
+    return { ok: false, status: res.status, error: 'Unexpected response from server' }
+  }
+  return { ok: true, pairKey, peerSub: resolvedPeerSub, status }
+}
+
+export type FetchDmMessagesResult = { ok: true; page: DmHistoryPage } | DmApiFailure
+
+export async function fetchDmMessages(
+  accessToken: string,
+  pairKey: string,
+  signal?: AbortSignal,
+): Promise<FetchDmMessagesResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/dm/threads/${encodeURIComponent(pairKey)}/messages`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseDmFailure(res)
+  }
+
+  const json = (await res.json()) as { messages?: unknown; nextCursor?: unknown }
+  const messages = Array.isArray(json.messages)
+    ? json.messages.filter(
+        (entry): entry is DmMessage =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          typeof (entry as DmMessage).messageId === 'string' &&
+          typeof (entry as DmMessage).senderSub === 'string' &&
+          (entry as DmMessage).kind === 'text',
+      )
+    : []
+  const nextCursor = typeof json.nextCursor === 'string' ? json.nextCursor : null
+  return { ok: true, page: { messages, nextCursor } }
+}
+
+export type MarkDmReadResult = { ok: true; hasUnread: boolean } | DmApiFailure
+
+export async function markDmRead(
+  accessToken: string,
+  pairKey: string,
+  lastReadSentAt: number,
+  lastReadMessageId: string,
+  signal?: AbortSignal,
+): Promise<MarkDmReadResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/dm/threads/${encodeURIComponent(pairKey)}/read`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ lastReadSentAt, lastReadMessageId }),
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseDmFailure(res)
+  }
+
+  const json = (await res.json()) as { hasUnread?: unknown }
+  const hasUnread = typeof json.hasUnread === 'boolean' ? json.hasUnread : false
+  return { ok: true, hasUnread }
+}
 
 export async function postDmMessage(
   accessToken: string,
@@ -47,16 +176,7 @@ export async function postDmMessage(
   })
 
   if (!res.ok) {
-    let code: string | undefined
-    let error: string | undefined
-    try {
-      const json = (await res.json()) as { code?: unknown; error?: unknown }
-      code = typeof json.code === 'string' ? json.code : undefined
-      error = typeof json.error === 'string' ? json.error : undefined
-    } catch {
-      // ignore parse errors
-    }
-    return { ok: false, status: res.status, code, error }
+    return parseDmFailure(res)
   }
 
   const message = (await res.json()) as DmSendResponse

--- a/apps/web/src/friends/friendsApi.test.ts
+++ b/apps/web/src/friends/friendsApi.test.ts
@@ -62,6 +62,7 @@ describe('friendsApi', () => {
             ok: true,
             json: async () => ({
               friends: [{ fanSub: 'fan-b', pairKey: 'a#b', displayName: 'B', online: true, hasUnread: false, createdAt: 1 }],
+              anyUnread: false,
             }),
           }
         }

--- a/apps/web/src/friends/friendsApi.ts
+++ b/apps/web/src/friends/friendsApi.ts
@@ -21,6 +21,7 @@ export type FriendRosterSnapshot = {
   friends: FriendEntry[]
   inbound: FriendRequestEntry[]
   outbound: FriendRequestEntry[]
+  anyUnread: boolean
 }
 
 export type FriendApiFailure = {
@@ -107,14 +108,102 @@ export async function fetchFriendRosterSnapshot(
           )
         : []
 
+    const anyUnread =
+      typeof (friendsJson as { anyUnread?: unknown }).anyUnread === 'boolean'
+        ? (friendsJson as { anyUnread: boolean }).anyUnread
+        : friends.some((entry) => entry.hasUnread)
+
     return {
       friends,
       inbound: parseRequests(requestsJson.inbound),
       outbound: parseRequests(requestsJson.outbound),
+      anyUnread,
     }
   } catch {
     return null
   }
+}
+
+export type AcceptFriendRequestResult =
+  | { ok: true; pairKey: string; createdAt: number }
+  | FriendApiFailure
+
+export async function acceptFriendRequest(
+  accessToken: string,
+  requestId: string,
+  signal?: AbortSignal,
+): Promise<AcceptFriendRequestResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/friends/requests/${encodeURIComponent(requestId)}/accept`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseFailure(res)
+  }
+
+  const json = (await res.json()) as { pairKey?: unknown; createdAt?: unknown }
+  const pairKey = typeof json.pairKey === 'string' ? json.pairKey : ''
+  const createdAt = typeof json.createdAt === 'number' ? json.createdAt : Date.now()
+  if (!pairKey) {
+    return { ok: false, status: res.status, error: 'Unexpected response from server' }
+  }
+  return { ok: true, pairKey, createdAt }
+}
+
+export async function declineFriendRequest(
+  accessToken: string,
+  requestId: string,
+  signal?: AbortSignal,
+): Promise<{ ok: true } | FriendApiFailure> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/friends/requests/${encodeURIComponent(requestId)}/decline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseFailure(res)
+  }
+  return { ok: true }
+}
+
+export type RemoveFriendResult = { ok: true; removedAt: number } | FriendApiFailure
+
+export async function removeFriend(
+  accessToken: string,
+  pairKey: string,
+  signal?: AbortSignal,
+): Promise<RemoveFriendResult> {
+  const base = getPublicApiBaseUrl()
+  if (!base) {
+    return { ok: false, status: 0, error: 'API base URL not configured' }
+  }
+
+  const res = await fetch(`${base}/v1/friends/${encodeURIComponent(pairKey)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  })
+
+  if (!res.ok) {
+    return parseFailure(res)
+  }
+
+  const json = (await res.json()) as { removedAt?: unknown }
+  const removedAt = typeof json.removedAt === 'number' ? json.removedAt : Date.now()
+  return { ok: true, removedAt }
 }
 
 export async function sendFriendRequest(

--- a/apps/web/src/friends/useRoomFriendsPane.ts
+++ b/apps/web/src/friends/useRoomFriendsPane.ts
@@ -6,6 +6,7 @@ import { ensureDmThread, fetchDmMessages, markDmRead, type DmMessage } from './d
 import { getSharedFanDmSession, syncSharedFanDmSessionWithAuth, type InboundDmMessage } from './FanDmSession'
 import {
   acceptFriendRequest,
+  cancelFriendRequest,
   declineFriendRequest,
   fetchFriendRosterSnapshot,
   removeFriend,
@@ -36,6 +37,7 @@ export type RoomFriendsPaneState = {
   refreshRoster: () => void
   acceptRequest: (requestId: string) => void
   declineRequest: (requestId: string) => void
+  cancelRequest: (requestId: string) => void
   openDm: (friend: FriendEntry) => void
   closeDm: () => void
   confirmRemove: (friend: FriendEntry) => void
@@ -238,6 +240,21 @@ export function useRoomFriendsPane(friendsTabActive: boolean, enabled: boolean):
     [fanToken],
   )
 
+  const cancelRequest = useCallback(
+    async (requestId: string) => {
+      if (!fanToken) return
+      const result = await cancelFriendRequest(fanToken, requestId)
+      if (result.ok) {
+        setSnapshot((current) =>
+          current
+            ? { ...current, outbound: current.outbound.filter((entry) => entry.requestId !== requestId) }
+            : current,
+        )
+      }
+    },
+    [fanToken],
+  )
+
   const openDm = useCallback(
     (friend: FriendEntry) => {
       void loadDmThread(friend)
@@ -324,6 +341,7 @@ export function useRoomFriendsPane(friendsTabActive: boolean, enabled: boolean):
     refreshRoster,
     acceptRequest,
     declineRequest,
+    cancelRequest,
     openDm,
     closeDm,
     confirmRemove,

--- a/apps/web/src/friends/useRoomFriendsPane.ts
+++ b/apps/web/src/friends/useRoomFriendsPane.ts
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { cognitoSub } from '../auth/jwtDecode'
+import { getFanAccessToken } from '../auth/fanTokens'
+import type { DmDrawerError } from './dmDrawerCodes'
+import { ensureDmThread, fetchDmMessages, markDmRead, type DmMessage } from './dmApi'
+import { getSharedFanDmSession, syncSharedFanDmSessionWithAuth, type InboundDmMessage } from './FanDmSession'
+import {
+  acceptFriendRequest,
+  declineFriendRequest,
+  fetchFriendRosterSnapshot,
+  removeFriend,
+  type FriendEntry,
+  type FriendRosterSnapshot,
+} from './friendsApi'
+
+export type OpenDmPeer = {
+  fanSub: string
+  pairKey: string
+  displayName: string
+  avatarUrl?: string
+}
+
+export type RoomFriendsPaneState = {
+  loading: boolean
+  loadError: boolean
+  snapshot: FriendRosterSnapshot | null
+  openPeer: OpenDmPeer | null
+  dmMessages: DmMessage[]
+  dmClosed: boolean
+  dmLoading: boolean
+  dmDraft: string
+  dmComposeError: string | null
+  removeTarget: FriendEntry | null
+  anyUnread: boolean
+  setDmDraft: (draft: string) => void
+  refreshRoster: () => void
+  acceptRequest: (requestId: string) => void
+  declineRequest: (requestId: string) => void
+  openDm: (friend: FriendEntry) => void
+  closeDm: () => void
+  confirmRemove: (friend: FriendEntry) => void
+  cancelRemove: () => void
+  executeRemove: () => void
+  sendDm: () => void
+}
+
+function sortDmMessages(messages: DmMessage[]): DmMessage[] {
+  return [...messages].sort((a, b) => a.sentAt - b.sentAt || a.messageId.localeCompare(b.messageId))
+}
+
+function mergeInboundMessage(existing: DmMessage[], inbound: InboundDmMessage): DmMessage[] {
+  if (existing.some((m) => m.messageId === inbound.messageId)) {
+    return existing
+  }
+  return sortDmMessages([
+    ...existing,
+    {
+      messageId: inbound.messageId,
+      senderSub: inbound.senderSub,
+      kind: 'text',
+      body: inbound.body,
+      sentAt: inbound.sentAt,
+    },
+  ])
+}
+
+async function markPeerMessagesRead(
+  fanToken: string,
+  pairKey: string,
+  messages: DmMessage[],
+  myFanSub: string | undefined,
+  onUnreadCleared: () => void,
+): Promise<void> {
+  if (messages.length === 0) return
+  const latest = messages[messages.length - 1]
+  if (latest.senderSub === myFanSub) return
+  const result = await markDmRead(fanToken, pairKey, latest.sentAt, latest.messageId)
+  if (result.ok && !result.hasUnread) {
+    onUnreadCleared()
+  }
+}
+
+export function useRoomFriendsPane(friendsTabActive: boolean, enabled: boolean): RoomFriendsPaneState {
+  const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [snapshot, setSnapshot] = useState<FriendRosterSnapshot | null>(null)
+  const [openPeer, setOpenPeer] = useState<OpenDmPeer | null>(null)
+  const [dmMessages, setDmMessages] = useState<DmMessage[]>([])
+  const [dmClosed, setDmClosed] = useState(false)
+  const [dmLoading, setDmLoading] = useState(false)
+  const [dmDraft, setDmDraft] = useState('')
+  const [dmComposeError, setDmComposeError] = useState<string | null>(null)
+  const [removeTarget, setRemoveTarget] = useState<FriendEntry | null>(null)
+  const bootstrappedRef = useRef(false)
+  const openPeerRef = useRef<OpenDmPeer | null>(null)
+
+  useEffect(() => {
+    openPeerRef.current = openPeer
+  }, [openPeer])
+
+  const fanToken = getFanAccessToken()
+  const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
+
+  const refreshRoster = useCallback(async () => {
+    if (!fanToken) {
+      setSnapshot(null)
+      return
+    }
+    setLoading(true)
+    setLoadError(false)
+    const next = await fetchFriendRosterSnapshot(fanToken)
+    setLoading(false)
+    if (!next) {
+      setLoadError(true)
+      return
+    }
+    setSnapshot(next)
+  }, [fanToken])
+
+  const loadDmThread = useCallback(
+    async (friend: FriendEntry) => {
+      if (!fanToken) return
+      setDmLoading(true)
+      setDmClosed(false)
+      setDmComposeError(null)
+      const ensured = await ensureDmThread(fanToken, friend.fanSub)
+      if (!ensured.ok) {
+        setDmLoading(false)
+        if (
+          ensured.code === 'friendship_not_active' ||
+          ensured.code === 'dm_thread_closed' ||
+          ensured.status === 403
+        ) {
+          setDmClosed(true)
+          setDmMessages([])
+        }
+        return
+      }
+      const history = await fetchDmMessages(fanToken, ensured.pairKey)
+      setDmLoading(false)
+      if (!history.ok) {
+        if (
+          history.code === 'friendship_not_active' ||
+          history.code === 'dm_thread_closed' ||
+          history.status === 403
+        ) {
+          setDmClosed(true)
+          setDmMessages([])
+        }
+        return
+      }
+      const sorted = sortDmMessages(history.page.messages)
+      const peer: OpenDmPeer = {
+        fanSub: friend.fanSub,
+        pairKey: ensured.pairKey,
+        displayName: friend.displayName,
+        avatarUrl: friend.avatarUrl,
+      }
+      setOpenPeer(peer)
+      setDmMessages(sorted)
+      void markPeerMessagesRead(fanToken, peer.pairKey, sorted, myFanSub, () => {
+        void refreshRoster()
+      })
+    },
+    [fanToken, myFanSub, refreshRoster],
+  )
+
+  useEffect(() => {
+    if (!enabled || !fanToken) return
+    if (!bootstrappedRef.current && friendsTabActive) {
+      bootstrappedRef.current = true
+      syncSharedFanDmSessionWithAuth()
+    }
+    const timer = window.setTimeout(() => {
+      if (friendsTabActive) {
+        void refreshRoster()
+      } else {
+        void fetchFriendRosterSnapshot(fanToken).then((next) => {
+          if (next) {
+            setSnapshot((current) => current ?? next)
+          }
+        })
+      }
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [enabled, friendsTabActive, fanToken, refreshRoster])
+
+  useEffect(() => {
+    if (!enabled || !fanToken) return
+    const session = getSharedFanDmSession()
+    return session.registerHandlers({
+      onInboundMessage: (message) => {
+        const peer = openPeerRef.current
+        if (peer && message.pairKey === peer.pairKey) {
+          setDmMessages((current) => {
+            const next = mergeInboundMessage(current, message)
+            void markPeerMessagesRead(fanToken, peer.pairKey, next, myFanSub, () => {
+              void refreshRoster()
+            })
+            return next
+          })
+        }
+        void refreshRoster()
+      },
+      onDrawerError: (error: DmDrawerError) => {
+        if (error.code === 'DM_SEND_DROPPED') {
+          setDmComposeError('Message could not be sent. Try again.')
+        } else if (error.code === 'DM_PUSH_UNAVAILABLE') {
+          setDmComposeError('Live delivery unavailable. Messages still send when you retry.')
+        }
+      },
+    })
+  }, [enabled, fanToken, myFanSub, refreshRoster])
+
+  const acceptRequest = useCallback(
+    async (requestId: string) => {
+      if (!fanToken) return
+      const result = await acceptFriendRequest(fanToken, requestId)
+      if (result.ok) {
+        void refreshRoster()
+      }
+    },
+    [fanToken, refreshRoster],
+  )
+
+  const declineRequest = useCallback(
+    async (requestId: string) => {
+      if (!fanToken) return
+      const result = await declineFriendRequest(fanToken, requestId)
+      if (result.ok) {
+        setSnapshot((current) =>
+          current
+            ? { ...current, inbound: current.inbound.filter((entry) => entry.requestId !== requestId) }
+            : current,
+        )
+      }
+    },
+    [fanToken],
+  )
+
+  const openDm = useCallback(
+    (friend: FriendEntry) => {
+      void loadDmThread(friend)
+    },
+    [loadDmThread],
+  )
+
+  const closeDm = useCallback(() => {
+    setOpenPeer(null)
+    setDmMessages([])
+    setDmClosed(false)
+    setDmDraft('')
+    setDmComposeError(null)
+  }, [])
+
+  const confirmRemove = useCallback((friend: FriendEntry) => {
+    setRemoveTarget(friend)
+  }, [])
+
+  const cancelRemove = useCallback(() => {
+    setRemoveTarget(null)
+  }, [])
+
+  const executeRemove = useCallback(async () => {
+    if (!fanToken || !removeTarget) return
+    const target = removeTarget
+    setRemoveTarget(null)
+    const result = await removeFriend(fanToken, target.pairKey)
+    if (result.ok) {
+      if (openPeerRef.current?.pairKey === target.pairKey) {
+        setDmClosed(true)
+        setDmComposeError(null)
+      }
+      void refreshRoster()
+    }
+  }, [fanToken, removeTarget, refreshRoster])
+
+  const sendDm = useCallback(async () => {
+    if (!fanToken || !openPeer || dmClosed) return
+    const body = dmDraft.trim()
+    if (!body) return
+    setDmComposeError(null)
+    const messageId =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `dm-${Date.now()}`
+    const session = getSharedFanDmSession()
+    const sent = await session.sendMessage(fanToken, openPeer.pairKey, {
+      messageId,
+      kind: 'text',
+      body,
+    })
+    if (sent) {
+      setDmMessages((current) =>
+        mergeInboundMessage(current, {
+          type: 'dm_message',
+          schemaVersion: 1,
+          pairKey: openPeer.pairKey,
+          messageId: sent.messageId,
+          senderSub: sent.senderSub,
+          kind: 'text',
+          body: sent.body,
+          sentAt: sent.sentAt,
+        }),
+      )
+      setDmDraft('')
+      void refreshRoster()
+    }
+  }, [fanToken, openPeer, dmClosed, dmDraft, refreshRoster])
+
+  return {
+    loading,
+    loadError,
+    snapshot,
+    openPeer,
+    dmMessages,
+    dmClosed,
+    dmLoading,
+    dmDraft,
+    dmComposeError,
+    removeTarget,
+    anyUnread: snapshot?.anyUnread ?? false,
+    setDmDraft,
+    refreshRoster,
+    acceptRequest,
+    declineRequest,
+    openDm,
+    closeDm,
+    confirmRemove,
+    cancelRemove,
+    executeRemove,
+    sendDm,
+  }
+}

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -255,7 +255,9 @@ export function RoomPage() {
   }, [isPublisher, roomMode, setRoom, stopCapture])
 
   const activeSidebarTab =
-    !fanToken && roomSidebarTab === 'profile' ? 'chat' : roomSidebarTab
+    !fanToken && (roomSidebarTab === 'profile' || roomSidebarTab === 'friends')
+      ? 'chat'
+      : roomSidebarTab
   const viewportWide = useViewportWide()
   const expandToggleRef = useRef<HTMLButtonElement>(null)
   const castAvailability = useCastAvailability(Boolean(room) && experimentalFeatures)

--- a/apps/web/src/room/RoomPageSidebar.friends.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.friends.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../friends/useRoomFriendsPane', () => ({
     refreshRoster: vi.fn(),
     acceptRequest: vi.fn(),
     declineRequest: vi.fn(),
+    cancelRequest: vi.fn(),
     openDm: vi.fn(),
     closeDm: vi.fn(),
     confirmRemove: vi.fn(),

--- a/apps/web/src/room/RoomPageSidebar.friends.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.friends.test.tsx
@@ -14,36 +14,38 @@ const mockRoomFriendsPane = vi.fn((props: { visible: boolean }) => {
   return null
 })
 
-vi.mock('../friends/useRoomFriendsPane', () => ({
-  useRoomFriendsPane: () => ({
-    loading: false,
-    loadError: false,
-    snapshot: {
-      friends: [{ fanSub: 'fan-b', pairKey: 'a#b', displayName: 'Buddy', online: true, hasUnread: true, createdAt: 1 }],
-      inbound: [{ requestId: 'req-1', requesterSub: 'fan-c', recipientSub: 'fan-a', createdAt: 2 }],
-      outbound: [],
-      anyUnread: true,
-    },
-    openPeer: null,
-    dmMessages: [],
-    dmClosed: false,
-    dmLoading: false,
-    dmDraft: '',
-    dmComposeError: null,
-    removeTarget: null,
+const mockUseRoomFriendsPane = vi.fn(() => ({
+  loading: false,
+  loadError: false,
+  snapshot: {
+    friends: [{ fanSub: 'fan-b', pairKey: 'a#b', displayName: 'Buddy', online: true, hasUnread: true, createdAt: 1 }],
+    inbound: [{ requestId: 'req-1', requesterSub: 'fan-c', recipientSub: 'fan-a', createdAt: 2 }],
+    outbound: [],
     anyUnread: true,
-    setDmDraft: vi.fn(),
-    refreshRoster: vi.fn(),
-    acceptRequest: vi.fn(),
-    declineRequest: vi.fn(),
-    cancelRequest: vi.fn(),
-    openDm: vi.fn(),
-    closeDm: vi.fn(),
-    confirmRemove: vi.fn(),
-    cancelRemove: vi.fn(),
-    executeRemove: vi.fn(),
-    sendDm: vi.fn(),
-  }),
+  },
+  openPeer: null,
+  dmMessages: [],
+  dmClosed: false,
+  dmLoading: false,
+  dmDraft: '',
+  dmComposeError: null,
+  removeTarget: null,
+  anyUnread: true,
+  setDmDraft: vi.fn(),
+  refreshRoster: vi.fn(),
+  acceptRequest: vi.fn(),
+  declineRequest: vi.fn(),
+  cancelRequest: vi.fn(),
+  openDm: vi.fn(),
+  closeDm: vi.fn(),
+  confirmRemove: vi.fn(),
+  cancelRemove: vi.fn(),
+  executeRemove: vi.fn(),
+  sendDm: vi.fn(),
+}))
+
+vi.mock('../friends/useRoomFriendsPane', () => ({
+  useRoomFriendsPane: () => mockUseRoomFriendsPane(),
 }))
 
 vi.mock('../friends/RoomFriendsPane', () => ({
@@ -162,6 +164,7 @@ describe('RoomPageSidebar friends tab (#364)', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     mockRoomFriendsPane.mockClear()
+    mockUseRoomFriendsPane.mockClear()
   })
 
   afterEach(() => {
@@ -209,6 +212,47 @@ describe('RoomPageSidebar friends tab (#364)', () => {
       node.textContent?.includes('Friends'),
     )
     expect(friendsTab?.querySelector('.riffsync-room-page__tab-unread-dot')).not.toBeNull()
+    expect(friendsTab?.getAttribute('aria-label')).toBe('Friends, unread messages')
+  })
+
+  it('uses plain Friends accessible name when no unread activity', () => {
+    mockUseRoomFriendsPane.mockReturnValueOnce({
+      loading: false,
+      loadError: false,
+      snapshot: {
+        friends: [],
+        inbound: [],
+        outbound: [],
+        anyUnread: false,
+      },
+      openPeer: null,
+      dmMessages: [],
+      dmClosed: false,
+      dmLoading: false,
+      dmDraft: '',
+      dmComposeError: null,
+      removeTarget: null,
+      anyUnread: false,
+      setDmDraft: vi.fn(),
+      refreshRoster: vi.fn(),
+      acceptRequest: vi.fn(),
+      declineRequest: vi.fn(),
+      cancelRequest: vi.fn(),
+      openDm: vi.fn(),
+      closeDm: vi.fn(),
+      confirmRemove: vi.fn(),
+      cancelRemove: vi.fn(),
+      executeRemove: vi.fn(),
+      sendDm: vi.fn(),
+    })
+
+    renderSidebar()
+
+    const friendsTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find((node) =>
+      node.textContent?.includes('Friends'),
+    )
+    expect(friendsTab?.getAttribute('aria-label')).toBe('Friends')
+    expect(friendsTab?.querySelector('.riffsync-room-page__tab-unread-dot')).toBeNull()
   })
 
   it('mounts RoomFriendsPane when Friends tab is active', () => {

--- a/apps/web/src/room/RoomPageSidebar.friends.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.friends.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { RoomPageSidebar } from './RoomPageSidebar'
+import type { ParticipantAvController } from './sfu/participantAvSession'
+import type { ChatLine } from './roomPageTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const mockRoomFriendsPane = vi.fn((props: { visible: boolean }) => {
+  void props
+  return null
+})
+
+vi.mock('../friends/useRoomFriendsPane', () => ({
+  useRoomFriendsPane: () => ({
+    loading: false,
+    loadError: false,
+    snapshot: {
+      friends: [{ fanSub: 'fan-b', pairKey: 'a#b', displayName: 'Buddy', online: true, hasUnread: true, createdAt: 1 }],
+      inbound: [{ requestId: 'req-1', requesterSub: 'fan-c', recipientSub: 'fan-a', createdAt: 2 }],
+      outbound: [],
+      anyUnread: true,
+    },
+    openPeer: null,
+    dmMessages: [],
+    dmClosed: false,
+    dmLoading: false,
+    dmDraft: '',
+    dmComposeError: null,
+    removeTarget: null,
+    anyUnread: true,
+    setDmDraft: vi.fn(),
+    refreshRoster: vi.fn(),
+    acceptRequest: vi.fn(),
+    declineRequest: vi.fn(),
+    openDm: vi.fn(),
+    closeDm: vi.fn(),
+    confirmRemove: vi.fn(),
+    cancelRemove: vi.fn(),
+    executeRemove: vi.fn(),
+    sendDm: vi.fn(),
+  }),
+}))
+
+vi.mock('../friends/RoomFriendsPane', () => ({
+  RoomFriendsPane: (props: { visible: boolean }) => {
+    mockRoomFriendsPane(props)
+    return <div data-testid="room-friends-pane">Friends pane</div>
+  },
+}))
+
+vi.mock('./usePeopleRosterFriends', () => ({
+  usePeopleRosterFriends: () => ({
+    snapshot: { friends: [], inbound: [], outbound: [], anyUnread: false },
+    myFanSub: 'fan-a',
+    statusByFanSub: {},
+    invitePeer: vi.fn(),
+    cancelPeerRequest: vi.fn(),
+    refreshSnapshot: vi.fn(),
+  }),
+}))
+
+function createParticipantAvControllerStub(): ParticipantAvController {
+  const state = {
+    cameraEnabled: false,
+    micEnabled: false,
+    micMuted: false,
+    canPublish: true,
+    needsProducerToken: false,
+    error: null,
+    busy: false,
+  }
+  return {
+    getState: () => state,
+    getLocalPreviewStream: () => null,
+    subscribe: () => () => undefined,
+    refreshPublishGate: vi.fn(),
+    attachSession: vi.fn(),
+    resetOnReconnect: vi.fn(),
+    teardownPublishing: vi.fn(),
+    enableCamera: vi.fn().mockResolvedValue(undefined),
+    disableCamera: vi.fn(),
+    enableMic: vi.fn().mockResolvedValue(undefined),
+    disableMic: vi.fn(),
+    toggleMicMute: vi.fn(),
+    failPublish: vi.fn(),
+    clearError: vi.fn(),
+  }
+}
+
+function buildSidebarProps(overrides: Partial<Parameters<typeof RoomPageSidebar>[0]> = {}) {
+  return {
+    wsBase: 'wss://ws.test.example',
+    fanToken: 'fan-jwt',
+    roomId: 'room-test-1',
+    sessionId: 'sess-test-1',
+    myAvatarUrl: null,
+    activeSidebarTab: 'chat' as const,
+    setRoomSidebarTab: vi.fn(),
+    viewerCount: 2,
+    chat: [] as ChatLine[],
+    chatReactions: {},
+    remoteTyping: [],
+    chatMemberLabels: new Map<string, string>(),
+    chatDraft: '',
+    setChatDraft: vi.fn(),
+    notifyComposeBlur: vi.fn(),
+    chatLogRef: { current: null },
+    chatInputRef: { current: null },
+    showJumpToLatest: false,
+    jumpToLatestLabel: '',
+    jumpToLatest: vi.fn(),
+    chatDrawerBanner: null,
+    chatComposeStatus: { message: null, disableSubmit: false },
+    sendChat: vi.fn(),
+    sendChatGif: vi.fn(),
+    toggleChatReaction: vi.fn(),
+    peopleShown: [],
+    participantProducerBySessionId: new Map(),
+    speakingBySessionId: new Map(),
+    isPublisher: false,
+    experimentalFeatures: true,
+    shareHint: null,
+    onCopyShare: vi.fn(),
+    onOpenRenameModal: vi.fn(),
+    roomVisibility: 'public' as const,
+    visibilityBusy: false,
+    visibilityErr: null,
+    onSelectRoomVisibility: vi.fn(),
+    avDisabled: false,
+    participantAvController: createParticipantAvControllerStub(),
+    announceRoomA11y: vi.fn(),
+    profileDraft: '',
+    setProfileDraft: vi.fn(),
+    profileSaveErr: null,
+    profileSaving: false,
+    profileAvatarUrl: null,
+    profileAvatarLoading: false,
+    profileAvatarUploading: false,
+    profileAvatarErr: null,
+    profileAvatarInputRef: { current: null },
+    saveProfileDisplayName: vi.fn(),
+    onProfileAvatarSelected: vi.fn(),
+    castAvailability: 'checking' as const,
+    castStartLifecycle: 'idle' as const,
+    onCastToTvClick: vi.fn(),
+    castToTvButtonRef: { current: null },
+    ...overrides,
+  }
+}
+
+describe('RoomPageSidebar friends tab (#364)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    mockRoomFriendsPane.mockClear()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderSidebar(overrides: Partial<Parameters<typeof RoomPageSidebar>[0]> = {}) {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPageSidebar {...buildSidebarProps(overrides)} />
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('omits Friends tab for guests', () => {
+    renderSidebar({ fanToken: null })
+
+    const labels = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).map(
+      (node) => node.textContent?.trim(),
+    )
+    expect(labels).toEqual(['Chat', 'People (2)', 'Room'])
+    expect(container.querySelector('.riffsync-room-page__tab-unread-dot')).toBeNull()
+  })
+
+  it('shows Friends tab in order Chat, People, Friends, Room, Profile for signed-in fans', () => {
+    renderSidebar()
+
+    const labels = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).map((node) =>
+      node.textContent?.replace(/\s+/g, ' ').trim(),
+    )
+    expect(labels[0]).toBe('Chat')
+    expect(labels[1]).toBe('People (2)')
+    expect(labels[2]).toMatch(/^Friends/)
+    expect(labels[3]).toBe('Room')
+    expect(labels[4]).toBe('Profile')
+  })
+
+  it('shows aggregate unread dot on Friends tab when anyUnread', () => {
+    renderSidebar()
+
+    const friendsTab = Array.from(container.querySelectorAll('.riffsync-room-page__tab')).find((node) =>
+      node.textContent?.includes('Friends'),
+    )
+    expect(friendsTab?.querySelector('.riffsync-room-page__tab-unread-dot')).not.toBeNull()
+  })
+
+  it('mounts RoomFriendsPane when Friends tab is active', () => {
+    renderSidebar({ activeSidebarTab: 'friends' })
+
+    expect(container.querySelector('[data-testid="room-friends-pane"]')).not.toBeNull()
+    expect(mockRoomFriendsPane).toHaveBeenCalledWith(
+      expect.objectContaining({ visible: true }),
+    )
+  })
+
+  it('keeps RoomFriendsPane mounted but hidden when another tab is active', () => {
+    renderSidebar({ activeSidebarTab: 'chat' })
+
+    expect(mockRoomFriendsPane).toHaveBeenCalledWith(
+      expect.objectContaining({ visible: false }),
+    )
+  })
+})
+
+describe('RoomPageSidebar expanded overlay friends absence (#364)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    mockRoomFriendsPane.mockClear()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('does not render Friends tab strip in expanded overlay', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <RoomPageSidebar {...buildSidebarProps({ presentation: 'overlay' })} />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(container.querySelector('.riffsync-room-page__tabs')).toBeNull()
+    expect(mockRoomFriendsPane).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/room/RoomPageSidebar.peopleFriendMenu.test.tsx
+++ b/apps/web/src/room/RoomPageSidebar.peopleFriendMenu.test.tsx
@@ -22,6 +22,7 @@ vi.mock('./usePeopleRosterFriends', () => ({
       friends: [],
       inbound: [],
       outbound: [],
+      anyUnread: false,
     },
     myFanSub: 'fan-a',
     loading: false,

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -198,11 +198,12 @@ export function RoomPageSidebar({
                 type="button"
                 className={`riffsync-room-page__tab${activeSidebarTab === 'friends' ? ' riffsync-room-page__tab--on' : ''}`}
                 aria-pressed={activeSidebarTab === 'friends'}
+                aria-label={friendsAnyUnread ? 'Friends, unread messages' : 'Friends'}
                 onClick={() => setRoomSidebarTab('friends')}
               >
                 Friends
                 {friendsAnyUnread ? (
-                  <span className="riffsync-room-page__tab-unread-dot" aria-label="Unread direct messages" />
+                  <span className="riffsync-room-page__tab-unread-dot" aria-hidden="true" />
                 ) : null}
               </button>
             ) : null}

--- a/apps/web/src/room/RoomPageSidebar.tsx
+++ b/apps/web/src/room/RoomPageSidebar.tsx
@@ -18,6 +18,8 @@ import { EMPTY_PARTICIPANT_PRODUCER_SNAPSHOT } from './participantProducerRegist
 import { PeopleRosterRow } from './PeopleRosterRow'
 import { peopleRowSpeakingClass, shouldShowPeopleAvIndicators } from './peoplePresentation'
 import { usePeopleRosterFriends } from './usePeopleRosterFriends'
+import { RoomFriendsPane } from '../friends/RoomFriendsPane'
+import { useRoomFriendsPane } from '../friends/useRoomFriendsPane'
 import type { GiphySearchResult } from '../api/giphySearchApi'
 import {
   RIFFSYNC_CHAT_COMPOSE_STATUS_ID,
@@ -147,6 +149,8 @@ export function RoomPageSidebar({
   castToTvButtonRef,
 }: RoomPageSidebarProps) {
   const peopleFriends = usePeopleRosterFriends(fanToken, activeSidebarTab)
+  const roomFriends = useRoomFriendsPane(activeSidebarTab === 'friends', Boolean(fanToken))
+  const friendsAnyUnread = roomFriends.anyUnread
 
   const chatPlane = (
     <section
@@ -189,6 +193,19 @@ export function RoomPageSidebar({
             >
               People ({viewerCount})
             </button>
+            {fanToken ? (
+              <button
+                type="button"
+                className={`riffsync-room-page__tab${activeSidebarTab === 'friends' ? ' riffsync-room-page__tab--on' : ''}`}
+                aria-pressed={activeSidebarTab === 'friends'}
+                onClick={() => setRoomSidebarTab('friends')}
+              >
+                Friends
+                {friendsAnyUnread ? (
+                  <span className="riffsync-room-page__tab-unread-dot" aria-label="Unread direct messages" />
+                ) : null}
+              </button>
+            ) : null}
             <button
               type="button"
               className={`riffsync-room-page__tab${activeSidebarTab === 'room' ? ' riffsync-room-page__tab--on' : ''}`}
@@ -348,6 +365,10 @@ export function RoomPageSidebar({
               })}
             </ul>
           </div>
+        ) : null}
+
+        {presentation === 'sidebar' && fanToken ? (
+          <RoomFriendsPane pane={roomFriends} visible={activeSidebarTab === 'friends'} />
         ) : null}
 
         {presentation === 'sidebar' && activeSidebarTab === 'room' ? (

--- a/apps/web/src/room/roomPageTypes.ts
+++ b/apps/web/src/room/roomPageTypes.ts
@@ -17,7 +17,7 @@ export type PresenceMember = {
 
 export type { RemoteTypingEntry }
 
-export type RoomSidebarTab = 'chat' | 'people' | 'room' | 'profile'
+export type RoomSidebarTab = 'chat' | 'people' | 'friends' | 'room' | 'profile'
 
 export function resolveMemberAvatarUrl(
   memberSessionId: string,

--- a/apps/web/src/room/usePeopleRosterFriends.ts
+++ b/apps/web/src/room/usePeopleRosterFriends.ts
@@ -76,6 +76,7 @@ export function usePeopleRosterFriends(fanToken: string | null, activeSidebarTab
                   createdAt: result.createdAt,
                 },
               ],
+              anyUnread: false,
             }
           }
           const withoutDup = current.outbound.filter((entry) => entry.recipientSub !== peerFanSub)

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -1775,6 +1775,226 @@ header#gen-header .gen-bottom-header .navbar .navbar-nav li.riffsync-catalog-nav
   color: var(--primary-color);
 }
 
+.riffsync-room-page__tab-unread-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-left: 0.25rem;
+  border-radius: 50%;
+  background: var(--primary-color);
+  vertical-align: middle;
+}
+
+.riffsync-room-page__tab-panel--friends {
+  overflow: hidden;
+  position: relative;
+}
+
+.riffsync-room-friends-pane {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.riffsync-room-friends-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.riffsync-room-friends-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 6px;
+  border: 1px solid rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.035);
+}
+
+.riffsync-room-friends-row + .riffsync-room-friends-row {
+  margin-top: 0.35rem;
+}
+
+.riffsync-room-friends-row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.riffsync-room-friends-row-open {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font: inherit;
+  font-weight: 600;
+}
+
+.riffsync-room-friends-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.riffsync-room-friends-row-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.riffsync-room-friends-online {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+}
+
+.riffsync-room-friends-online-dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: #3ddc84;
+}
+
+.riffsync-room-friends-unread-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--primary-color);
+  flex-shrink: 0;
+}
+
+.riffsync-room-friends-empty {
+  padding: 0.75rem 0.65rem;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.riffsync-room-friends-load-err {
+  padding: 0.75rem 0.65rem;
+}
+
+.riffsync-room-friends-section-title {
+  margin: 0;
+  padding: 0.5rem 0.65rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.75;
+}
+
+.riffsync-room-friends-dm-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  flex-shrink: 0;
+}
+
+.riffsync-room-friends-dm-back {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.riffsync-room-friends-dm-peer {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.riffsync-room-friends-dm-log {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.riffsync-room-friends-dm-jump {
+  align-self: center;
+  margin: 0.25rem 0;
+}
+
+.riffsync-room-friends-dm-compose {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.5rem 0.65rem;
+  border-top: 1px solid rgb(255 255 255 / 0.08);
+  flex-shrink: 0;
+}
+
+.riffsync-room-friends-dm-compose input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.riffsync-room-friends-dm-err {
+  padding: 0 0.65rem 0.5rem;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #f87171;
+}
+
+.riffsync-room-friends-closed {
+  padding: 0.75rem 0.65rem;
+  margin: 0;
+}
+
+.riffsync-room-friends-remove-dialog {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.55);
+  z-index: 2;
+}
+
+.riffsync-room-friends-remove-dialog-panel {
+  background: rgb(22 27 34);
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 8px;
+  padding: 1rem;
+  max-width: 18rem;
+  margin: 0.65rem;
+}
+
+.riffsync-room-friends-remove-dialog-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.riffsync-room-friends-remove-dialog-panel p {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.riffsync-room-friends-remove-dialog-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.riffsync-room-friends-remove-confirm {
+  background: #b62324;
+  border-color: #b62324;
+}
+
 .riffsync-room-page__people-list {
   list-style: none;
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- Adds a **Friends** sidebar tab for signed-in fans in watch parties (order: Chat, People, Friends, Room, Profile); guests never see the tab.
- Implements `RoomFriendsPane` with friends list parity (pending accept/decline, online label, unread dots, remove confirm) and in-column nested DM threads with Back to friends, stick-to-bottom, and text compose.
- Bootstraps `FanDmSession` on first Friends tab visit; session and open thread state persist across tab switches without affecting room ChatSession or SFU.

## Test plan
- [x] `npm run test --prefix apps/web` (929 tests)
- [x] `npm run lint --prefix apps/web`
- [x] `npm run build --prefix apps/web`
- [ ] Manual: signed-in fan opens Friends tab, accepts pending request, opens DM, switches to Chat and back
- [ ] Manual: guest in `/room/:id` confirms Friends tab absent

Closes #364