### PR TITLE
[M36] Signed-out and guest friends/DM auth gates (#365)

### DIFF
--- a/apps/web/src/components/site/SiteHeader.test.tsx
+++ b/apps/web/src/components/site/SiteHeader.test.tsx
@@ -61,6 +61,7 @@ describe('SiteHeader fan session nav', () => {
     renderHeader('/catalog?era=joel')
 
     expect(container.querySelector('a[href="/account"]')).toBeNull()
+    expect(container.querySelector('.riffsync-friends-nav')).toBeNull()
     expect(container.textContent).toContain('Sign In')
     expect(container.textContent).toContain('Lobby')
     expect(container.querySelector('a[href="/download"]')?.textContent).toBe('Get App')
@@ -84,6 +85,14 @@ describe('SiteHeader fan session nav', () => {
 
     expect(container.querySelector('a[href="/account"]')?.textContent).toBe('Account')
     expect(container.querySelector('.riffsync-site-nav-sign-in')).toBeNull()
+  })
+
+  it('does not render main-site friends affordance when signed out (#365)', () => {
+    useFanSession.mockReturnValue({ fanToken: null })
+    renderHeader('/catalog')
+
+    expect(container.querySelector('.riffsync-friends-nav')).toBeNull()
+    expect(container.querySelector('[aria-label="Friends"]')).toBeNull()
   })
 
   it('hides Get App when the site is running as an installed PWA', () => {

--- a/apps/web/src/friends/FanDmSession.test.ts
+++ b/apps/web/src/friends/FanDmSession.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { FanDmSession } from './FanDmSession'
+import { FanDmSession, syncSharedFanDmSessionWithAuth } from './FanDmSession'
+
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  FAN_AUTH_CHANGED_EVENT: 'riffsync:fan-auth-changed',
+  getFanAccessToken: () => getFanAccessToken(),
+}))
 
 class MockWebSocket {
   static instances: MockWebSocket[] = []
@@ -37,6 +44,8 @@ class MockWebSocket {
 describe('FanDmSession', () => {
   beforeEach(() => {
     MockWebSocket.instances = []
+    getFanAccessToken.mockReset()
+    getFanAccessToken.mockReturnValue('fan-jwt-token')
     vi.stubGlobal('WebSocket', MockWebSocket)
     vi.stubEnv('VITE_PUBLIC_FAN_DM_WS_URL', 'wss://fan-dm.test.example/prod')
     vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
@@ -50,7 +59,7 @@ describe('FanDmSession', () => {
 
   it('connects with accessToken and sessionId query params', async () => {
     const session = new FanDmSession({}, 'tab-1')
-    session.connect('fan-jwt-token')
+    session.connect()
     await Promise.resolve()
     expect(MockWebSocket.instances).toHaveLength(1)
     const url = MockWebSocket.instances[0].url
@@ -65,7 +74,7 @@ describe('FanDmSession', () => {
     const session = new FanDmSession({
       onInboundMessage: (msg) => inbound.push(msg),
     })
-    session.connect('fan-jwt-token')
+    session.connect()
     await Promise.resolve()
     const ws = MockWebSocket.instances[0]
     ws.onmessage?.({
@@ -88,9 +97,30 @@ describe('FanDmSession', () => {
     const session = new FanDmSession({
       onDrawerError: (err) => errors.push(err.code),
     })
-    session.connect('fan-jwt-token')
+    session.connect()
     await Promise.resolve()
     MockWebSocket.instances[0].close()
     expect(errors).toContain('DM_PUSH_UNAVAILABLE')
+  })
+
+  it('does not open WebSocket when fan access token is absent', async () => {
+    getFanAccessToken.mockReturnValue(null)
+    const session = new FanDmSession()
+    session.connect()
+    await Promise.resolve()
+    expect(MockWebSocket.instances).toHaveLength(0)
+    expect(session.getStatus()).toBe('idle')
+  })
+
+  it('syncSharedFanDmSessionWithAuth disconnects without fan token', async () => {
+    getFanAccessToken.mockReturnValue('fan-jwt-token')
+    syncSharedFanDmSessionWithAuth()
+    await Promise.resolve()
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    getFanAccessToken.mockReturnValue(null)
+    syncSharedFanDmSessionWithAuth()
+    await Promise.resolve()
+    expect(MockWebSocket.instances[0].readyState).toBe(MockWebSocket.CLOSED)
   })
 })

--- a/apps/web/src/friends/FanDmSession.ts
+++ b/apps/web/src/friends/FanDmSession.ts
@@ -1,7 +1,8 @@
 import { getPublicFanDmWsUrl } from '../config/fanDmWsUrl'
-import { FAN_AUTH_CHANGED_EVENT, getFanAccessToken } from '../auth/fanTokens'
+import { FAN_AUTH_CHANGED_EVENT } from '../auth/fanTokens'
 import { dmPushUnavailableError, dmSendDroppedError, type DmDrawerError } from './dmDrawerCodes'
 import { postDmMessage, type DmSendRequest, type DmSendResponse } from './dmApi'
+import { requireFanAccessToken } from './requireFanAccessToken'
 
 const PING_MS = 25_000
 const SEND_RETRY_ATTEMPTS = 3
@@ -134,7 +135,13 @@ export class FanDmSession {
     }
   }
 
-  connect(accessToken: string): void {
+  connect(): void {
+    const accessToken = requireFanAccessToken()
+    if (!accessToken) {
+      this.disconnect()
+      return
+    }
+
     const wsBase = getPublicFanDmWsUrl()
     if (!wsBase) {
       this.setStatus('error')
@@ -188,7 +195,12 @@ export class FanDmSession {
     this.setStatus('idle')
   }
 
-  async sendMessage(accessToken: string, pairKey: string, payload: DmSendRequest): Promise<DmSendResponse | null> {
+  async sendMessage(pairKey: string, payload: DmSendRequest): Promise<DmSendResponse | null> {
+    const accessToken = requireFanAccessToken()
+    if (!accessToken) {
+      return null
+    }
+
     if (!this.isPushAvailable()) {
       this.emitDrawerError(dmPushUnavailableError())
     }
@@ -243,7 +255,7 @@ export function getSharedFanDmSession(handlers?: FanDmSessionHandlers): FanDmSes
 }
 
 export function syncSharedFanDmSessionWithAuth(): void {
-  const token = getFanAccessToken()
+  const token = requireFanAccessToken()
   const session = getSharedFanDmSession()
   if (!token) {
     session.disconnect()
@@ -252,7 +264,7 @@ export function syncSharedFanDmSessionWithAuth(): void {
   if (session.getStatus() === 'open' || session.getStatus() === 'connecting') {
     return
   }
-  session.connect(token)
+  session.connect()
 }
 
 export function installFanDmSessionAuthListener(): () => void {

--- a/apps/web/src/friends/RoomFriendsPane.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef } from 'react'
 import { FanAvatarThumb } from '../components/FanAvatarThumb'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { cognitoSub } from '../auth/jwtDecode'
-import { getFanAccessToken } from '../auth/fanTokens'
 import type { FriendEntry } from './friendsApi'
+import { requireFanAccessToken } from './requireFanAccessToken'
 import type { RoomFriendsPaneState } from './useRoomFriendsPane'
 
 type RoomFriendsPaneProps = {
@@ -15,7 +15,7 @@ export function RoomFriendsPane({ pane, visible }: RoomFriendsPaneProps) {
   const backButtonRef = useRef<HTMLButtonElement>(null)
   const openedFromRowRef = useRef<HTMLButtonElement | null>(null)
   const removeFromButtonRef = useRef<HTMLButtonElement | null>(null)
-  const fanToken = getFanAccessToken()
+  const fanToken = requireFanAccessToken()
   const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
 
   const dmSurfaceKey = pane.openPeer ? `dm:${pane.openPeer.pairKey}` : 'list'

--- a/apps/web/src/friends/dmApi.authGate.test.ts
+++ b/apps/web/src/friends/dmApi.authGate.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureDmThread,
+  fetchDmMessages,
+  markDmRead,
+  postDmMessage,
+} from './dmApi'
+import { FAN_AUTH_REQUIRED_CLIENT } from './requireFanAccessToken'
+
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
+describe('dmApi fan auth gate (#365)', () => {
+  beforeEach(() => {
+    getFanAccessToken.mockReturnValue(null)
+    vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('does not fetch when fan access token is absent', async () => {
+    const fetchMock = vi.mocked(fetch)
+
+    await expect(postDmMessage('staff-token', 'a#b', { messageId: 'm1', kind: 'text', body: 'hi' })).resolves.toEqual(
+      FAN_AUTH_REQUIRED_CLIENT,
+    )
+    await expect(ensureDmThread('staff-token', 'fan-b')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(fetchDmMessages('staff-token', 'a#b')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(markDmRead('staff-token', 'a#b', 1, 'm1')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/friends/dmApi.test.ts
+++ b/apps/web/src/friends/dmApi.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { postDmMessage } from './dmApi'
 
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
 describe('postDmMessage', () => {
   beforeEach(() => {
+    getFanAccessToken.mockReturnValue('token')
     vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
   })
 

--- a/apps/web/src/friends/dmApi.ts
+++ b/apps/web/src/friends/dmApi.ts
@@ -1,4 +1,5 @@
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+import { FAN_AUTH_REQUIRED_CLIENT, requireFanAccessToken } from './requireFanAccessToken'
 
 export type DmMessage = {
   messageId: string
@@ -55,10 +56,15 @@ export type EnsureDmThreadResult =
   | DmApiFailure
 
 export async function ensureDmThread(
-  accessToken: string,
+  _accessToken: string,
   peerSub: string,
   signal?: AbortSignal,
 ): Promise<EnsureDmThreadResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -87,10 +93,15 @@ export async function ensureDmThread(
 export type FetchDmMessagesResult = { ok: true; page: DmHistoryPage } | DmApiFailure
 
 export async function fetchDmMessages(
-  accessToken: string,
+  _accessToken: string,
   pairKey: string,
   signal?: AbortSignal,
 ): Promise<FetchDmMessagesResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -123,12 +134,17 @@ export async function fetchDmMessages(
 export type MarkDmReadResult = { ok: true; hasUnread: boolean } | DmApiFailure
 
 export async function markDmRead(
-  accessToken: string,
+  _accessToken: string,
   pairKey: string,
   lastReadSentAt: number,
   lastReadMessageId: string,
   signal?: AbortSignal,
 ): Promise<MarkDmReadResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -154,11 +170,16 @@ export async function markDmRead(
 }
 
 export async function postDmMessage(
-  accessToken: string,
+  _accessToken: string,
   pairKey: string,
   payload: DmSendRequest,
   signal?: AbortSignal,
 ): Promise<DmSendResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }

--- a/apps/web/src/friends/friendsApi.authGate.test.ts
+++ b/apps/web/src/friends/friendsApi.authGate.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  acceptFriendRequest,
+  cancelFriendRequest,
+  declineFriendRequest,
+  fetchFriendRosterSnapshot,
+  removeFriend,
+  sendFriendRequest,
+} from './friendsApi'
+import { FAN_AUTH_REQUIRED_CLIENT } from './requireFanAccessToken'
+
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
+describe('friendsApi fan auth gate (#365)', () => {
+  beforeEach(() => {
+    getFanAccessToken.mockReturnValue(null)
+    vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('does not fetch when fan access token is absent', async () => {
+    const fetchMock = vi.mocked(fetch)
+
+    expect(await fetchFriendRosterSnapshot('staff-token')).toBeNull()
+    await expect(sendFriendRequest('staff-token', 'fan-b')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(cancelFriendRequest('staff-token', 'req-1')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(acceptFriendRequest('staff-token', 'req-1')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(declineFriendRequest('staff-token', 'req-1')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+    await expect(removeFriend('staff-token', 'a#b')).resolves.toEqual(FAN_AUTH_REQUIRED_CLIENT)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/friends/friendsApi.test.ts
+++ b/apps/web/src/friends/friendsApi.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cancelFriendRequest, fetchFriendRosterSnapshot, sendFriendRequest } from './friendsApi'
 
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
 describe('friendsApi', () => {
   beforeEach(() => {
+    getFanAccessToken.mockReturnValue('token')
     vi.stubEnv('VITE_PUBLIC_API_BASE_URL', 'https://api.test.example')
   })
 

--- a/apps/web/src/friends/friendsApi.ts
+++ b/apps/web/src/friends/friendsApi.ts
@@ -1,4 +1,5 @@
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
+import { FAN_AUTH_REQUIRED_CLIENT, requireFanAccessToken } from './requireFanAccessToken'
 
 export type FriendRequestEntry = {
   requestId: string
@@ -66,9 +67,14 @@ export function mapFriendRequestError(code?: string, fallback?: string): string 
 }
 
 export async function fetchFriendRosterSnapshot(
-  accessToken: string,
+  _accessToken: string,
   signal?: AbortSignal,
 ): Promise<FriendRosterSnapshot | null> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return null
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) return null
 
@@ -129,10 +135,15 @@ export type AcceptFriendRequestResult =
   | FriendApiFailure
 
 export async function acceptFriendRequest(
-  accessToken: string,
+  _accessToken: string,
   requestId: string,
   signal?: AbortSignal,
 ): Promise<AcceptFriendRequestResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -158,10 +169,15 @@ export async function acceptFriendRequest(
 }
 
 export async function declineFriendRequest(
-  accessToken: string,
+  _accessToken: string,
   requestId: string,
   signal?: AbortSignal,
 ): Promise<{ ok: true } | FriendApiFailure> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -182,10 +198,15 @@ export async function declineFriendRequest(
 export type RemoveFriendResult = { ok: true; removedAt: number } | FriendApiFailure
 
 export async function removeFriend(
-  accessToken: string,
+  _accessToken: string,
   pairKey: string,
   signal?: AbortSignal,
 ): Promise<RemoveFriendResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -207,10 +228,15 @@ export async function removeFriend(
 }
 
 export async function sendFriendRequest(
-  accessToken: string,
+  _accessToken: string,
   recipientSub: string,
   signal?: AbortSignal,
 ): Promise<SendFriendRequestResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }
@@ -243,10 +269,15 @@ export async function sendFriendRequest(
 }
 
 export async function cancelFriendRequest(
-  accessToken: string,
+  _accessToken: string,
   requestId: string,
   signal?: AbortSignal,
 ): Promise<CancelFriendRequestResult> {
+  const accessToken = requireFanAccessToken()
+  if (!accessToken) {
+    return FAN_AUTH_REQUIRED_CLIENT
+  }
+
   const base = getPublicApiBaseUrl()
   if (!base) {
     return { ok: false, status: 0, error: 'API base URL not configured' }

--- a/apps/web/src/friends/requireFanAccessToken.test.ts
+++ b/apps/web/src/friends/requireFanAccessToken.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FAN_AUTH_REQUIRED_CLIENT, requireFanAccessToken } from './requireFanAccessToken'
+
+const getFanAccessToken = vi.fn<() => string | null>()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
+describe('requireFanAccessToken', () => {
+  beforeEach(() => {
+    getFanAccessToken.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when fan access token is absent', () => {
+    getFanAccessToken.mockReturnValue(null)
+    expect(requireFanAccessToken()).toBeNull()
+  })
+
+  it('returns the fan access token when present', () => {
+    getFanAccessToken.mockReturnValue('fan-jwt')
+    expect(requireFanAccessToken()).toBe('fan-jwt')
+  })
+
+  it('exports stable client-side fan_auth_required failure shape', () => {
+    expect(FAN_AUTH_REQUIRED_CLIENT).toEqual({
+      ok: false,
+      status: 401,
+      code: 'fan_auth_required',
+      error: 'Fan authentication required',
+    })
+  })
+})

--- a/apps/web/src/friends/requireFanAccessToken.ts
+++ b/apps/web/src/friends/requireFanAccessToken.ts
@@ -1,0 +1,13 @@
+import { getFanAccessToken } from '../auth/fanTokens'
+
+export const FAN_AUTH_REQUIRED_CLIENT = {
+  ok: false as const,
+  status: 401,
+  code: 'fan_auth_required' as const,
+  error: 'Fan authentication required',
+}
+
+/** Returns a verified fan access token, or null when the caller is signed out or expired. */
+export function requireFanAccessToken(): string | null {
+  return getFanAccessToken()
+}

--- a/apps/web/src/friends/useRoomFriendsPane.ts
+++ b/apps/web/src/friends/useRoomFriendsPane.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cognitoSub } from '../auth/jwtDecode'
-import { getFanAccessToken } from '../auth/fanTokens'
 import type { DmDrawerError } from './dmDrawerCodes'
 import { ensureDmThread, fetchDmMessages, markDmRead, type DmMessage } from './dmApi'
 import { getSharedFanDmSession, syncSharedFanDmSessionWithAuth, type InboundDmMessage } from './FanDmSession'
@@ -13,6 +12,7 @@ import {
   type FriendEntry,
   type FriendRosterSnapshot,
 } from './friendsApi'
+import { requireFanAccessToken } from './requireFanAccessToken'
 
 export type OpenDmPeer = {
   fanSub: string
@@ -100,7 +100,7 @@ export function useRoomFriendsPane(friendsTabActive: boolean, enabled: boolean):
     openPeerRef.current = openPeer
   }, [openPeer])
 
-  const fanToken = getFanAccessToken()
+  const fanToken = requireFanAccessToken()
   const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
 
   const refreshRoster = useCallback(async () => {
@@ -302,7 +302,7 @@ export function useRoomFriendsPane(friendsTabActive: boolean, enabled: boolean):
         ? crypto.randomUUID()
         : `dm-${Date.now()}`
     const session = getSharedFanDmSession()
-    const sent = await session.sendMessage(fanToken, openPeer.pairKey, {
+    const sent = await session.sendMessage(openPeer.pairKey, {
       messageId,
       kind: 'text',
       body,

--- a/infra/cdk/lambda/fan-auth-gate-matrix.test.ts
+++ b/infra/cdk/lambda/fan-auth-gate-matrix.test.ts
@@ -1,0 +1,226 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  docSend: vi.fn(),
+  verifyAccessToken: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mocks.docSend })),
+  },
+  GetCommand: vi.fn((input: unknown) => ({ input, kind: 'Get' })),
+  PutCommand: vi.fn((input: unknown) => ({ input, kind: 'Put' })),
+  DeleteCommand: vi.fn((input: unknown) => ({ input, kind: 'Delete' })),
+  QueryCommand: vi.fn((input: unknown) => ({ input, kind: 'Query' })),
+  UpdateCommand: vi.fn((input: unknown) => ({ input, kind: 'Update' })),
+  BatchGetCommand: vi.fn((input: unknown) => ({ input, kind: 'BatchGet' })),
+  TransactWriteCommand: vi.fn((input: unknown) => ({ input, kind: 'TransactWrite' })),
+}));
+
+vi.mock('./cognito-jwt', () => ({
+  verifyAccessToken: mocks.verifyAccessToken,
+}));
+
+import { handler as fanDmWsConnectHandler } from './fan-dm-ws-connect';
+import { handler as friendsListHandler } from './friends-list';
+import { handler as friendsRequestsHandler } from './friends-requests';
+import { handler as friendsRemoveHandler } from './friends-remove';
+import { handler as dmEnsureHandler } from './dm-thread-ensure';
+import { handler as dmMessagesListHandler } from './dm-messages-list';
+import { handler as dmMessagesSendHandler } from './dm-messages-send';
+import { handler as dmThreadReadHandler } from './dm-thread-read';
+
+const FAN_AUTH_REQUIRED_BODY = {
+  error: 'Fan authentication required',
+  code: 'fan_auth_required',
+};
+
+function httpEvent(
+  method: string,
+  path: string,
+  opts?: {
+    headers?: Record<string, string>;
+    body?: Record<string, unknown>;
+    pathParameters?: Record<string, string>;
+  },
+): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: `${method} ${path}`,
+    rawPath: path,
+    rawQueryString: '',
+    headers: opts?.headers ?? {},
+    body: opts?.body ? JSON.stringify(opts.body) : undefined,
+    pathParameters: opts?.pathParameters,
+    requestContext: {
+      accountId: '123',
+      apiId: 'api',
+      domainName: 'example.com',
+      domainPrefix: 'example',
+      http: {
+        method,
+        path,
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+      requestId: 'req-fan-auth-gate-1',
+      routeKey: `${method} ${path}`,
+      stage: 'prod',
+      time: '01/Jan/2025:00:00:00 +0000',
+      timeEpoch: 0,
+    } as APIGatewayProxyEventV2['requestContext'],
+    isBase64Encoded: false,
+  };
+}
+
+function wsConnectEvent(queryStringParameters?: Record<string, string>): APIGatewayProxyWebsocketEventV2 {
+  return {
+    requestContext: {
+      connectionId: 'conn-guest-1',
+    },
+    queryStringParameters,
+  } as APIGatewayProxyWebsocketEventV2;
+}
+
+describe('friends/DM fan auth gate matrix (#365)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.docSend.mockReset();
+    mocks.verifyAccessToken.mockResolvedValue(null);
+    process.env.FRIENDSHIPS_TABLE_NAME = 'Friendships';
+    process.env.FRIENDSHIP_REQUESTS_TABLE_NAME = 'FriendshipRequests';
+    process.env.FAN_PROFILES_TABLE_NAME = 'FanProfiles';
+    process.env.ROOM_PRESENCE_TABLE_NAME = 'RoomPresence';
+    process.env.FRIENDSHIP_RATE_LIMIT_TABLE_NAME = 'FriendshipRateLimits';
+    process.env.DM_UNREAD_TABLE_NAME = 'DmUnread';
+    process.env.DM_THREADS_TABLE_NAME = 'DmThreads';
+    process.env.DIRECT_MESSAGES_TABLE_NAME = 'DirectMessages';
+    process.env.FAN_CONNECTIONS_TABLE_NAME = 'FanConnections';
+    process.env.FRIEND_LIST_LIMIT_PER_MINUTE = '60';
+    process.env.DM_READ_LIMIT_PER_MINUTE = '60';
+    process.env.DM_SEND_LIMIT_PER_MINUTE = '20';
+  });
+
+  const guestHeaders = {
+    'x-session-id': 'guest-session-only',
+  };
+
+  async function expectFanAuthRequired(res: unknown): Promise<void> {
+    expect(res && typeof res === 'object' && 'statusCode' in res ? res.statusCode : 0).toBe(401);
+    expect(JSON.parse((res as { body: string }).body)).toEqual(FAN_AUTH_REQUIRED_BODY);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  }
+
+  it('GET /v1/friends rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(await friendsListHandler(httpEvent('GET', '/v1/friends', { headers: guestHeaders }), {} as never, {} as never));
+  });
+
+  it('POST /v1/friends/requests rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await friendsRequestsHandler(
+        httpEvent('POST', '/v1/friends/requests', {
+          headers: guestHeaders,
+          body: { recipientSub: 'fan-b' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('DELETE /v1/friends/{pairKey} rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await friendsRemoveHandler(
+        httpEvent('DELETE', '/v1/friends/a%23b', {
+          headers: guestHeaders,
+          pathParameters: { pairKey: 'a#b' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('PUT /v1/dm/threads/{peerSub} rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await dmEnsureHandler(
+        httpEvent('PUT', '/v1/dm/threads/fan-b', {
+          headers: guestHeaders,
+          pathParameters: { peerSub: 'fan-b' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('GET /v1/dm/threads/{pairKey}/messages rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await dmMessagesListHandler(
+        httpEvent('GET', '/v1/dm/threads/a%23b/messages', {
+          headers: guestHeaders,
+          pathParameters: { pairKey: 'a#b' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('POST /v1/dm/threads/{pairKey}/messages rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await dmMessagesSendHandler(
+        httpEvent('POST', '/v1/dm/threads/a%23b/messages', {
+          headers: guestHeaders,
+          pathParameters: { pairKey: 'a#b' },
+          body: { messageId: 'm1', kind: 'text', body: 'hello' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('POST /v1/dm/threads/{pairKey}/read rejects guest sessionId-only requests', async () => {
+    await expectFanAuthRequired(
+      await dmThreadReadHandler(
+        httpEvent('POST', '/v1/dm/threads/a%23b/read', {
+          headers: guestHeaders,
+          pathParameters: { pairKey: 'a#b' },
+          body: { lastReadSentAt: 1, lastReadMessageId: 'm1' },
+        }),
+        {} as never,
+        {} as never,
+      ),
+    );
+  });
+
+  it('Fan DM WebSocket connect rejects guest sessionId-only query params', async () => {
+    const res = await fanDmWsConnectHandler(
+      wsConnectEvent({ sessionId: 'guest-session-only' }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+    expect(mocks.verifyAccessToken).toHaveBeenCalled();
+  });
+
+  it('Fan DM WebSocket connect rejects staff bearer at verifier', async () => {
+    mocks.verifyAccessToken.mockResolvedValue(null);
+    const res = await fanDmWsConnectHandler(
+      wsConnectEvent({ accessToken: 'staff-jwt', sessionId: 'tab-1' }),
+      {} as never,
+      () => undefined,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(mocks.docSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared `requireFanAccessToken()` guard in `apps/web/src/friends/` and wire it through `dmApi`, `friendsApi`, `FanDmSession`, room Friends pane hooks, and auth sync bootstrap so friends/DM HTTP and WebSocket never start without a verified fan access token.
- Extend Vitest coverage for signed-out SiteHeader chrome, guest room sidebar (existing #364 tests), client auth short-circuit, and Fan DM session disconnect behavior.
- Add CDK `fan-auth-gate-matrix.test.ts` asserting **401 `fan_auth_required`** for guest `X-Session-Id`-only misuse across `/v1/friends/*`, `/v1/dm/*`, and Fan DM WS `$connect` (including staff bearer rejection at verifier).

Closes #365

## Test plan

- [x] `npm run test --prefix apps/web`
- [x] `npm run lint --prefix apps/web`
- [x] `npm run test --prefix infra/cdk`
- [ ] Manual QA matrix from #365 (signed-out catalog, guest room, staff-only session, signed-in fan)