### PR TITLE
[M36] Main-site person-icon friends dropdown and DM panel (#363)

### DIFF
--- a/apps/web/src/components/site/SiteHeader.test.tsx
+++ b/apps/web/src/components/site/SiteHeader.test.tsx
@@ -9,6 +9,7 @@ import { SiteHeader } from './SiteHeader'
 const startFanHostedUiSignIn = vi.fn<(returnPath: string) => Promise<void>>()
 const useFanSession = vi.fn()
 const useShowGetAppNav = vi.fn()
+const getFanAccessToken = vi.fn<() => string | null>()
 
 vi.mock('../../auth/fanHostedUiPkce', () => ({
   startFanHostedUiSignIn: (returnPath: string) => startFanHostedUiSignIn(returnPath),
@@ -18,12 +19,43 @@ vi.mock('../../auth/useFanSession', () => ({
   useFanSession: () => useFanSession(),
 }))
 
+vi.mock('../../auth/fanTokens', () => ({
+  getFanAccessToken: () => getFanAccessToken(),
+}))
+
 vi.mock('../../pwa/useShowGetAppNav', () => ({
   useShowGetAppNav: () => useShowGetAppNav(),
 }))
 
 vi.mock('../../room/useRoomChrome', () => ({
   useRoomChromeOptional: () => null,
+}))
+
+vi.mock('../../friends/useRoomFriendsPane', () => ({
+  useRoomFriendsPane: () => ({
+    loading: false,
+    loadError: false,
+    snapshot: { friends: [], inbound: [], outbound: [], anyUnread: false },
+    openPeer: null,
+    dmMessages: [],
+    dmClosed: false,
+    dmLoading: false,
+    dmDraft: '',
+    dmComposeError: null,
+    removeTarget: null,
+    anyUnread: false,
+    setDmDraft: () => undefined,
+    refreshRoster: () => undefined,
+    acceptRequest: () => undefined,
+    declineRequest: () => undefined,
+    cancelRequest: () => undefined,
+    openDm: () => undefined,
+    closeDm: () => undefined,
+    confirmRemove: () => undefined,
+    cancelRemove: () => undefined,
+    executeRemove: () => undefined,
+    sendDm: () => undefined,
+  }),
 }))
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -36,6 +68,7 @@ describe('SiteHeader fan session nav', () => {
     startFanHostedUiSignIn.mockReset()
     startFanHostedUiSignIn.mockResolvedValue(undefined)
     useShowGetAppNav.mockReturnValue(true)
+    getFanAccessToken.mockReturnValue(null)
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -79,19 +112,25 @@ describe('SiteHeader fan session nav', () => {
     expect(startFanHostedUiSignIn).toHaveBeenCalledWith('/lobby')
   })
 
-  it('shows Account link when signed in', () => {
+  it('shows Account link and person-icon friends control when signed in (#363)', () => {
     useFanSession.mockReturnValue({ fanToken: 'fan-token' })
+    getFanAccessToken.mockReturnValue('fan-token')
     renderHeader()
 
     expect(container.querySelector('a[href="/account"]')?.textContent).toBe('Account')
     expect(container.querySelector('.riffsync-site-nav-sign-in')).toBeNull()
+    expect(container.querySelector('.riffsync-friends-nav')).not.toBeNull()
+    expect(container.querySelector('#gen-user-btn')).not.toBeNull()
+    expect(container.querySelector('.fa-user')).not.toBeNull()
   })
 
   it('does not render main-site friends affordance when signed out (#365)', () => {
     useFanSession.mockReturnValue({ fanToken: null })
+    getFanAccessToken.mockReturnValue(null)
     renderHeader('/catalog')
 
     expect(container.querySelector('.riffsync-friends-nav')).toBeNull()
+    expect(container.querySelector('#gen-user-btn')).toBeNull()
     expect(container.querySelector('[aria-label="Friends"]')).toBeNull()
   })
 

--- a/apps/web/src/components/site/SiteHeader.tsx
+++ b/apps/web/src/components/site/SiteHeader.tsx
@@ -4,6 +4,7 @@ import {
   startFanHostedUiSignIn,
 } from '../../auth/fanHostedUiPkce'
 import { useFanSession } from '../../auth/useFanSession'
+import { FriendsDropdown } from '../../friends/FriendsDropdown'
 import { useShowGetAppNav } from '../../pwa/useShowGetAppNav'
 import { useRoomChromeOptional } from '../../room/useRoomChrome'
 import { CatalogNavItem } from './CatalogNavItem'
@@ -108,16 +109,19 @@ export function SiteHeader({ compact = false }: { compact?: boolean }) {
                     </ul>
                   </div>
                 </div>
-                <button
-                  className="navbar-toggler"
-                  type="button"
-                  onClick={() => setMobileOpen((o) => !o)}
-                  aria-controls="navbarSupportedContent"
-                  aria-expanded={mobileOpen}
-                  aria-label="Toggle navigation"
-                >
-                  <i className="fas fa-bars" aria-hidden />
-                </button>
+                <div className="gen-header-info-box riffsync-header-info-box">
+                  {fanToken ? <FriendsDropdown /> : null}
+                  <button
+                    className="navbar-toggler"
+                    type="button"
+                    onClick={() => setMobileOpen((o) => !o)}
+                    aria-controls="navbarSupportedContent"
+                    aria-expanded={mobileOpen}
+                    aria-label="Toggle navigation"
+                  >
+                    <i className="fas fa-bars" aria-hidden />
+                  </button>
+                </div>
               </nav>
             </div>
           </div>

--- a/apps/web/src/friends/FriendsDropdown.test.tsx
+++ b/apps/web/src/friends/FriendsDropdown.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FriendsDropdown } from './FriendsDropdown'
+import type { RoomFriendsPaneState } from './useRoomFriendsPane'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const mockUseRoomFriendsPane = vi.fn()
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: () => 'fan-jwt',
+}))
+
+vi.mock('../auth/jwtDecode', () => ({
+  cognitoSub: () => 'fan-a',
+}))
+
+vi.mock('./useRoomFriendsPane', () => ({
+  useRoomFriendsPane: (...args: unknown[]) => mockUseRoomFriendsPane(...args),
+}))
+
+function buildPaneState(overrides: Partial<RoomFriendsPaneState> = {}): RoomFriendsPaneState {
+  return {
+    loading: false,
+    loadError: false,
+    snapshot: {
+      friends: [
+        {
+          fanSub: 'fan-b',
+          pairKey: 'a#b',
+          displayName: 'Buddy',
+          online: true,
+          hasUnread: true,
+          createdAt: 1,
+        },
+      ],
+      inbound: [],
+      outbound: [],
+      anyUnread: true,
+    },
+    openPeer: null,
+    dmMessages: [],
+    dmClosed: false,
+    dmLoading: false,
+    dmDraft: '',
+    dmComposeError: null,
+    removeTarget: null,
+    anyUnread: true,
+    setDmDraft: vi.fn(),
+    refreshRoster: vi.fn(),
+    acceptRequest: vi.fn(),
+    declineRequest: vi.fn(),
+    cancelRequest: vi.fn(),
+    openDm: vi.fn(),
+    closeDm: vi.fn(),
+    confirmRemove: vi.fn(),
+    cancelRemove: vi.fn(),
+    executeRemove: vi.fn(),
+    sendDm: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('FriendsDropdown (#363)', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    mockUseRoomFriendsPane.mockReset()
+    mockUseRoomFriendsPane.mockReturnValue(buildPaneState())
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('renders person-icon trigger with aggregate unread dot', () => {
+    act(() => {
+      root.render(<FriendsDropdown />)
+    })
+
+    const trigger = container.querySelector('#gen-user-btn') as HTMLButtonElement
+    expect(trigger).not.toBeNull()
+    expect(trigger.getAttribute('aria-label')).toBe('Friends')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('.fa-user')).not.toBeNull()
+    expect(container.querySelector('.riffsync-friends-nav__unread-dot')).not.toBeNull()
+  })
+
+  it('toggles dropdown disclosure with aria-expanded', () => {
+    act(() => {
+      root.render(<FriendsDropdown />)
+    })
+
+    const trigger = container.querySelector('#gen-user-btn') as HTMLButtonElement
+    act(() => {
+      trigger.click()
+    })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain('Buddy')
+    expect(container.textContent).toContain('Online in a watch party')
+    expect(container.querySelector('.riffsync-friends-dropdown')).not.toBeNull()
+
+    act(() => {
+      trigger.click()
+    })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('.riffsync-friends-dropdown')).toBeNull()
+  })
+
+  it('opens DM overlay from friend row and shows empty durable copy', () => {
+    const openDm = vi.fn()
+    mockUseRoomFriendsPane.mockReturnValue(
+      buildPaneState({
+        openDm,
+        openPeer: {
+          fanSub: 'fan-b',
+          pairKey: 'a#b',
+          displayName: 'Buddy',
+        },
+        dmMessages: [],
+        dmLoading: false,
+      }),
+    )
+
+    act(() => {
+      root.render(<FriendsDropdown />)
+    })
+
+    const trigger = container.querySelector('#gen-user-btn') as HTMLButtonElement
+    act(() => {
+      trigger.click()
+    })
+
+    // Re-render path: after click, openDm is invoked; simulate pending+openPeer via next mock.
+    mockUseRoomFriendsPane.mockReturnValue(
+      buildPaneState({
+        openDm,
+        openPeer: {
+          fanSub: 'fan-b',
+          pairKey: 'a#b',
+          displayName: 'Buddy',
+        },
+        dmMessages: [],
+      }),
+    )
+
+    const openButton = container.querySelector('.riffsync-room-friends-row-open') as HTMLButtonElement
+    act(() => {
+      openButton.click()
+    })
+
+    expect(openDm).toHaveBeenCalled()
+    expect(document.body.textContent).toContain('No messages yet. Say hello.')
+    expect(document.querySelector('.riffsync-friends-dm-overlay')).not.toBeNull()
+  })
+
+  it('shows remove confirm dialog copy', () => {
+    mockUseRoomFriendsPane.mockReturnValue(
+      buildPaneState({
+        removeTarget: {
+          fanSub: 'fan-b',
+          pairKey: 'a#b',
+          displayName: 'Buddy',
+          online: false,
+          hasUnread: false,
+          createdAt: 1,
+        },
+      }),
+    )
+
+    act(() => {
+      root.render(<FriendsDropdown />)
+    })
+
+    expect(document.body.textContent).toContain('Remove friend?')
+    expect(document.body.textContent).toContain('This removes Buddy for both of you')
+  })
+})

--- a/apps/web/src/friends/FriendsDropdown.tsx
+++ b/apps/web/src/friends/FriendsDropdown.tsx
@@ -1,0 +1,446 @@
+import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
+import { FanAvatarThumb } from '../components/FanAvatarThumb'
+import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
+import { cognitoSub } from '../auth/jwtDecode'
+import type { FriendEntry } from './friendsApi'
+import { requireFanAccessToken } from './requireFanAccessToken'
+import { useRoomFriendsPane, type RoomFriendsPaneState } from './useRoomFriendsPane'
+
+/**
+ * Main-site person-icon friends entry (#363).
+ * Template chrome: `gen-account-holder` / `#gen-user-btn` / `fa-user`.
+ */
+export function FriendsDropdown() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [dmSurfaceOpen, setDmSurfaceOpen] = useState(false)
+  const [pendingPeer, setPendingPeer] = useState<FriendEntry | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const panelId = useId()
+  const fanToken = requireFanAccessToken()
+  const pane = useRoomFriendsPane(menuOpen || dmSurfaceOpen, Boolean(fanToken))
+  const { closeDm } = pane
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false)
+  }, [])
+
+  const toggleMenu = useCallback(() => {
+    setMenuOpen((current) => !current)
+  }, [])
+
+  const closeDmSurface = useCallback(() => {
+    closeDm()
+    setPendingPeer(null)
+    setDmSurfaceOpen(false)
+    triggerRef.current?.focus()
+  }, [closeDm])
+
+  const onTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      toggleMenu()
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeMenu()
+      triggerRef.current?.focus()
+    }
+  }
+
+  useEffect(() => {
+    if (!menuOpen) return
+
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (rootRef.current && !rootRef.current.contains(target)) {
+        const overlay = document.querySelector('.riffsync-friends-dm-overlay')
+        const dialog = document.querySelector('.riffsync-friends-remove-dialog--site')
+        if (overlay?.contains(target) || dialog?.contains(target)) return
+        closeMenu()
+      }
+    }
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape' && !pane.openPeer && !pane.removeTarget) {
+        event.preventDefault()
+        closeMenu()
+        triggerRef.current?.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [closeMenu, menuOpen, pane.openPeer, pane.removeTarget])
+
+  const onOpenDm = (friend: FriendEntry) => {
+    closeMenu()
+    setPendingPeer(friend)
+    setDmSurfaceOpen(true)
+    pane.openDm(friend)
+  }
+
+  const overlayPeer =
+    pane.openPeer ??
+    (pendingPeer
+      ? {
+          fanSub: pendingPeer.fanSub,
+          pairKey: pendingPeer.pairKey,
+          displayName: pendingPeer.displayName,
+          avatarUrl: pendingPeer.avatarUrl,
+        }
+      : null)
+
+  return (
+    <>
+      <div className="gen-account-holder riffsync-friends-nav" ref={rootRef}>
+        <button
+          ref={triggerRef}
+          type="button"
+          id="gen-user-btn"
+          className="riffsync-friends-nav__trigger"
+          aria-label="Friends"
+          aria-haspopup="true"
+          aria-expanded={menuOpen}
+          aria-controls={panelId}
+          onClick={toggleMenu}
+          onKeyDown={onTriggerKeyDown}
+        >
+          <i className="fa fa-user" aria-hidden />
+          {pane.anyUnread ? (
+            <span className="riffsync-friends-nav__unread-dot" aria-label="Unread messages" />
+          ) : null}
+        </button>
+        {menuOpen ? (
+          <div
+            id={panelId}
+            className="riffsync-friends-dropdown gen-account-menu gen-form-show"
+            role="region"
+            aria-label="Friends"
+          >
+            <FriendsDropdownList pane={pane} onOpenDm={onOpenDm} />
+          </div>
+        ) : null}
+      </div>
+      {dmSurfaceOpen && overlayPeer ? (
+        <FriendsDmOverlay pane={pane} peer={overlayPeer} onClose={closeDmSurface} />
+      ) : null}
+      {pane.removeTarget ? (
+        <RemoveFriendDialog
+          displayName={pane.removeTarget.displayName}
+          onCancel={pane.cancelRemove}
+          onConfirm={() => void pane.executeRemove()}
+        />
+      ) : null}
+    </>
+  )
+}
+
+function FriendsDropdownList({
+  pane,
+  onOpenDm,
+}: {
+  pane: RoomFriendsPaneState
+  onOpenDm: (friend: FriendEntry) => void
+}) {
+  return (
+    <div className="riffsync-friends-dropdown__body">
+      {pane.loading ? (
+        <p className="riffsync-muted riffsync-room-friends-status" role="status">
+          Loading friends…
+        </p>
+      ) : null}
+      {pane.loadError ? (
+        <div className="riffsync-room-friends-load-err">
+          <p role="alert">Could not load friends. Try again.</p>
+          <button type="button" className="gen-button" onClick={() => pane.refreshRoster()}>
+            Try again
+          </button>
+        </div>
+      ) : null}
+      {!pane.loading && !pane.loadError ? (
+        <>
+          {pane.snapshot &&
+          (pane.snapshot.inbound.length > 0 || pane.snapshot.outbound.length > 0) ? (
+            <section className="riffsync-room-friends-section" aria-label="Pending friend requests">
+              <h3 className="riffsync-room-friends-section-title">Pending requests</h3>
+              <ul className="riffsync-room-friends-list">
+                {pane.snapshot.inbound.map((request) => (
+                  <li key={request.requestId} className="riffsync-room-friends-row">
+                    <span className="riffsync-room-friends-row-name">Friend request</span>
+                    <div className="riffsync-room-friends-row-actions">
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.acceptRequest(request.requestId)}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.declineRequest(request.requestId)}
+                      >
+                        Decline
+                      </button>
+                    </div>
+                  </li>
+                ))}
+                {pane.snapshot.outbound.map((request) => (
+                  <li key={request.requestId} className="riffsync-room-friends-row">
+                    <span className="riffsync-room-friends-row-name">Request pending</span>
+                    <div className="riffsync-room-friends-row-actions">
+                      <button
+                        type="button"
+                        className="gen-button"
+                        onClick={() => void pane.cancelRequest(request.requestId)}
+                      >
+                        Cancel request
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          {pane.snapshot && pane.snapshot.friends.length > 0 ? (
+            <ul className="riffsync-room-friends-list" aria-label="Friends">
+              {pane.snapshot.friends.map((friend) => (
+                <FriendRow
+                  key={friend.pairKey}
+                  friend={friend}
+                  onOpenDm={() => onOpenDm(friend)}
+                  onRemove={() => pane.confirmRemove(friend)}
+                />
+              ))}
+            </ul>
+          ) : (
+            <p className="riffsync-room-friends-empty" role="status">
+              No friends yet.
+            </p>
+          )}
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function FriendRow({
+  friend,
+  onOpenDm,
+  onRemove,
+}: {
+  friend: FriendEntry
+  onOpenDm: () => void
+  onRemove: () => void
+}) {
+  return (
+    <li className="riffsync-room-friends-row">
+      <FanAvatarThumb displayName={friend.displayName} avatarUrl={friend.avatarUrl} />
+      <div className="riffsync-room-friends-row-main">
+        <button type="button" className="riffsync-room-friends-row-open" onClick={onOpenDm}>
+          <span className="riffsync-room-friends-row-name">{friend.displayName}</span>
+          {friend.hasUnread ? (
+            <span className="riffsync-room-friends-unread-dot" aria-label="Unread messages" />
+          ) : null}
+        </button>
+        {friend.online ? (
+          <span className="riffsync-room-friends-online riffsync-muted">
+            <span className="riffsync-room-friends-online-dot" aria-hidden />
+            Online in a watch party
+          </span>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="riffsync-room-friends-remove gen-button"
+        aria-label={`Remove ${friend.displayName}`}
+        onClick={onRemove}
+      >
+        Remove
+      </button>
+    </li>
+  )
+}
+
+function FriendsDmOverlay({
+  pane,
+  peer,
+  onClose,
+}: {
+  pane: RoomFriendsPaneState
+  peer: { fanSub: string; pairKey: string; displayName: string; avatarUrl?: string }
+  onClose: () => void
+}) {
+  const fanToken = requireFanAccessToken()
+  const myFanSub = fanToken ? cognitoSub(fanToken) : undefined
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const dmSurfaceKey = `site-dm:${peer.pairKey}`
+  const {
+    logRef: dmLogRef,
+    showJumpToLatest,
+    jumpToLatestLabel,
+    jumpToLatest,
+  } = useChatLogStickToBottom(pane.dmMessages.length, Boolean(peer), dmSurfaceKey)
+
+  useEffect(() => {
+    closeButtonRef.current?.focus()
+  }, [peer?.pairKey])
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape' && !pane.removeTarget) {
+        event.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose, pane.removeTarget])
+
+  return (
+    <div
+      className="riffsync-friends-dm-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Direct messages with ${peer.displayName}`}
+    >
+      <div className="riffsync-friends-dm-overlay__panel">
+        <div className="riffsync-room-friends-dm-header">
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="riffsync-room-friends-dm-back gen-button"
+            aria-label="Close conversation"
+            onClick={onClose}
+          >
+            Close
+          </button>
+          <span className="riffsync-room-friends-dm-peer">{peer.displayName}</span>
+        </div>
+        {pane.dmLoading ? (
+          <p className="riffsync-muted riffsync-room-friends-status" role="status">
+            Loading messages…
+          </p>
+        ) : null}
+        {pane.dmClosed ? (
+          <p className="riffsync-room-friends-closed" role="status">
+            This conversation is closed.
+          </p>
+        ) : (
+          <>
+            <ul
+              ref={dmLogRef}
+              className="riffsync-room-chat-log riffsync-room-friends-dm-log"
+              aria-label={`Direct messages with ${peer.displayName}`}
+            >
+              {pane.dmMessages.length === 0 && !pane.dmLoading ? (
+                <li className="riffsync-room-friends-empty">
+                  <p role="status">No messages yet. Say hello.</p>
+                </li>
+              ) : null}
+              {pane.dmMessages.map((message) => {
+                const isMine = message.senderSub === myFanSub
+                return (
+                  <li
+                    key={message.messageId}
+                    className={`riffsync-room-chat-log__row${isMine ? ' riffsync-room-chat-log__row--mine' : ' riffsync-room-chat-log__row--theirs'}`}
+                  >
+                    <div className="riffsync-room-chat-log__entry">
+                      <div className="riffsync-room-chat-log__bubble">
+                        <div className="riffsync-room-chat-log__body">{message.body}</div>
+                      </div>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+            {showJumpToLatest ? (
+              <button
+                type="button"
+                className="riffsync-room-chat-jump-latest gen-button riffsync-room-friends-dm-jump"
+                aria-label="Jump to latest messages"
+                onClick={jumpToLatest}
+              >
+                {jumpToLatestLabel}
+              </button>
+            ) : null}
+            <div className="riffsync-room-friends-dm-compose">
+              <input
+                type="text"
+                maxLength={2000}
+                value={pane.dmDraft}
+                placeholder="Say something…"
+                aria-label="Direct message"
+                onChange={(e) => pane.setDmDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void pane.sendDm()
+                }}
+              />
+              <button type="button" className="gen-button" onClick={() => void pane.sendDm()}>
+                Send
+              </button>
+            </div>
+            {pane.dmComposeError ? (
+              <p className="riffsync-room-friends-dm-err" role="status" aria-live="polite">
+                {pane.dmComposeError}
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RemoveFriendDialog({
+  displayName,
+  onCancel,
+  onConfirm,
+}: {
+  displayName: string
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus()
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onCancel])
+
+  return (
+    <div
+      className="riffsync-room-friends-remove-dialog riffsync-friends-remove-dialog--site"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="site-remove-friend-title"
+    >
+      <div className="riffsync-room-friends-remove-dialog-panel">
+        <h2 id="site-remove-friend-title">Remove friend?</h2>
+        <p>
+          This removes {displayName} for both of you. You will not be able to message each other unless you
+          become friends again.
+        </p>
+        <div className="riffsync-room-friends-remove-dialog-actions">
+          <button ref={cancelButtonRef} type="button" className="gen-button" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="gen-button riffsync-room-friends-remove-confirm" onClick={onConfirm}>
+            Remove friend
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -627,6 +627,114 @@ footer#gen-footer .widget .riffsync-footer-wordmark {
   }
 }
 
+/* Main-site friends person icon (#363) — template gen-account-holder / #gen-user-btn */
+.riffsync-header-info-box.gen-header-info-box {
+  display: flex;
+  align-items: center;
+  margin-left: 0.75rem;
+  flex-shrink: 0;
+}
+
+.riffsync-friends-nav.gen-account-holder {
+  position: relative;
+  margin-right: 0.75rem;
+  line-height: normal;
+}
+
+.riffsync-friends-nav__trigger {
+  appearance: none;
+  border: none;
+  height: 45px;
+  width: 45px;
+  min-height: 44px;
+  min-width: 44px;
+  line-height: 45px;
+  text-align: center;
+  background: var(--primary-color);
+  color: var(--white-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 90px;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+}
+
+.riffsync-friends-nav__trigger:hover,
+.riffsync-friends-nav__trigger:focus-visible {
+  filter: brightness(1.08);
+  outline: none;
+}
+
+.riffsync-friends-nav__unread-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--white-color);
+  box-shadow: 0 0 0 2px var(--primary-color);
+}
+
+.riffsync-friends-dropdown {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  width: min(100vw - 1rem, 22rem);
+  max-height: min(70vh, 24rem);
+  overflow: hidden;
+  display: flex !important;
+  flex-direction: column;
+  z-index: 1100;
+  background: var(--dark-color);
+  border: 1px solid rgb(255 255 255 / 0.12);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.35);
+}
+
+.riffsync-friends-dropdown__body {
+  max-height: min(70vh, 24rem);
+  overflow-y: auto;
+}
+
+.riffsync-friends-dropdown .riffsync-room-friends-list {
+  overflow: visible;
+}
+
+.riffsync-friends-dm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  justify-content: flex-end;
+  background: rgb(0 0 0 / 0.45);
+}
+
+.riffsync-friends-dm-overlay__panel {
+  width: min(100vw, 24rem);
+  height: 100%;
+  max-height: 100dvh;
+  background: rgb(22 27 34);
+  border-left: 1px solid rgb(255 255 255 / 0.12);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+@media (max-width: 575px) {
+  .riffsync-friends-dm-overlay__panel {
+    width: 100vw;
+  }
+}
+
+.riffsync-friends-remove-dialog--site {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+}
+
 @media (max-width: 991px) {
   header#gen-header .gen-bottom-header .navbar .navbar-collapse.show {
     display: block;


### PR DESCRIPTION
## Summary
- Add design-template person-icon (`gen-account-holder` / `#gen-user-btn` / `fa-user`) to the main-site header for signed-in fans
- Open friends dropdown (accepted + pending, unread/online, remove confirm) and a right-side DM overlay from friend rows
- Keep Account nav unchanged; omit the affordance when signed out

Closes #363

## Test plan
- [x] `npm run test --prefix apps/web -- --run src/friends/FriendsDropdown.test.tsx src/components/site/SiteHeader.test.tsx src/friends/RoomFriendsPane.test.tsx`
- [x] `npm run lint --prefix apps/web`
- [ ] Manual: signed out on `/catalog` — no person icon
- [ ] Manual: signed in — red person icon appears; dropdown lists friends; open DM overlay; unread clear on view; remove confirm works