### PR TITLE
docs(ai): catalog custom playback host contract updates

### DIFF
--- a/.ai/business_logic/domain_model.md
+++ b/.ai/business_logic/domain_model.md
@@ -4,8 +4,8 @@ Business concepts and rules (language-agnostic). UI maps here via **`docs/archit
 
 ## Core entities
 
-- **Episode (catalog row):** a stable **`id`** and **`experimentNumber`**, MST-flavored **`title`/`catalog`**, YouTube linkage, enrichment from TMDB and optional YouTube thumb URL.
-- **Room:** shared viewing session on **`/room/:id`** with a **mutable current catalog episode** (**`catalogEpisodeId`** / **`videoId`** on the room document — seeded when the **signed-in** host creates the room, then changeable via **in-room picker**); the host (**room admin**) renders **embedded YouTube** for that selection and may **publish** a captured **`MediaStream`** to guests over **WebRTC**; guests consume that stream—**not** parallel iframe timelines kept in sync server-side. The room also carries **host-authoritative layout policy**: **`roomMode`** (**Theater** default | **Video Chat**) and **`avDisabled`** (room-wide participant A/V kill switch), both **durable** on the room document and returned on snapshot/join.
+- **Episode (catalog row):** a stable **`id`** and **`experimentNumber`**, MST-flavored **`title`/`catalog`**, staff-selected **playback host** (**YouTube** | **Custom**), playback URL fields for the active host, optional YouTube enrichment (thumbs/metadata may coexist on Custom rows), and TMDB artwork fields.
+- **Room:** shared viewing session on **`/room/:id`** with a **mutable current catalog episode** (**`catalogEpisodeId`** / **`videoId`** on the room document — seeded when the **signed-in** host creates the room, then changeable via **in-room picker**); the host (**room admin**) renders **in-app playback** for that selection (**YouTube IFrame API** when **`playbackHost` is YouTube**, **generic HTTPS iframe** when **`playbackHost` is Custom**) and may **publish** a captured **`MediaStream`** to guests over **WebRTC**; guests consume that stream—**not** parallel iframe timelines kept in sync server-side. The room also carries **host-authoritative layout policy**: **`roomMode`** (**Theater** default | **Video Chat**) and **`avDisabled`** (room-wide participant A/V kill switch), both **durable** on the room document and returned on snapshot/join.
 - **Local Cast session:** optional per-viewer Chromecast viewing state for Cast-capable senders. It is **session-only** client state, entered only from the normal room view, and never persisted on the room document, replayed on join, or fanned out as room state. A local Cast session launches the custom RiffSync receiver presentation, reusing the expanded-view stage-primary plus chat-overlay composition while the sender remains joined as the same participant. Native media-only Cast or YouTube-only Cast is not the current RiffSync Cast maturity behavior.
 - **Participant A/V (camera / microphone):** optional **signed-in fan** publish of **`getUserMedia`** streams over the same SFU path as host capture; **default off** until the fan explicitly enables each control. **Anonymous guests** may **subscribe** to participant A/V when **`avDisabled`** is false but **must not publish** participant camera or microphone. Participant A/V is **parallel** to host tab-capture movie broadcast—not a replacement for embed/capture lawful playback.
 - **Participant:** **`sessionId`** + display name (**anonymous**) or **`sub`** (**signed-in optional**) with optional **`avatarUrl`** (public HTTPS, one image per **`sub`**).
@@ -28,7 +28,7 @@ Business concepts and rules (language-agnostic). UI maps here via **`docs/archit
   | --- | --- |
   | **`/`**, **`/catalog`**, **`/catalog/mst3k`**, **`/catalog/community`**, **`/catalog/riff-material`**, **`/catalog/movie-night`**, **`/download`**, **`/watch/:catalogEpisodeId`**, **`/how-to-host-a-watchparty`**, **`/terms`**, **`/privacy`** | **`/room/:roomId`** (and **`/room/:roomId/experimental/:experimental`**), **`/lobby`**, **`/account`**, **`/admin/*`**, **`/cast/receiver`**, **`/privacy/data-removal`**, **`/auth/callback`**, **`/admin/auth/callback`** |
 
-  Ephemeral, authenticated, and receiver-only routes carry no durable identity worth surfacing to crawlers — this mirrors the existing **Identity modes** boundary below, not a new access rule. **`/watch/:catalogEpisodeId`** is indexable only for episodes satisfying the existing lawful-playback YouTube-link filter (**Invariant 1**) — an episode without a live YouTube link has no lawful surface to summarize or link to and is excluded from indexing and the sitemap until a link exists.
+  Ephemeral, authenticated, and receiver-only routes carry no durable identity worth surfacing to crawlers — this mirrors the existing **Identity modes** boundary below, not a new access rule. **`/watch/:catalogEpisodeId`** is indexable only for episodes satisfying the existing lawful-playback discoverability filter (**Invariant 1**) — an episode **without a live YouTube link** (including **Custom-host** rows with no YouTube enrichment) has no indexable surface under today's SEO packaging and is **excluded from indexing and the sitemap** until a YouTube link exists for discoverability purposes. **Custom playback** does not by itself add `/watch/:id` to the sitemap.
 
   **Catalog browse IA:** Hub **`/catalog`** is the mixed (all-titles) catalog browse entry. Subcategory routes own filtered views: **MST3K**, **Community**, **Riff Material**, and **Movie Night**. **`/catalog/mst3k`** is a browse-IA aggregation over the existing host-catalog values **`joel`**, **`mike`**, **`jonah`**, and **`emily`** — not a new Episode field, enum value, or persisted grouping. **Riff Material** is the public label and route slug only; the persisted **`catalog`** value remains **`riff_material`**. Each episode retains a single discrete **`catalog`**, so a title appears in at most one subcategory grid. Per-subcategory visual customization is out of scope for this surface (shared shell only).
 
@@ -78,11 +78,12 @@ Three coexisting modes (see **`integration/authorization.md`**):
 ## Enumerations
 
 - **`playbackExpectation`:** **`premium`** | **`free-ad-supported`** — **advisory**; not verified subscription state.
+- **`playbackHost` (catalog episode):** **`youtube`** | **`custom`** — **per-catalog-episode** staff setting (not a per-room override at create). **`youtube`** rows use YouTube URL / video id and retain YouTube playable checks at room create. **`custom`** rows use a staff-curated **HTTPS** movie-page URL in a generic iframe; **`youtubeVideoId` is not required** for room create when host is **`custom`**.
 - **`roomMode`:** **`theater`** (default on room open) | **`videoChat`** — host-authoritative layout policy; one current value per room; fan-out to all connected participants and late joiners via durable room document + realtime sync. While **`avDisabled`** is false, **Video Chat** remains selectable in the host control bar as a normal A/V room mode, not a **Beta** or **Experimental** mode.
 
 ## Invariants
 
-1. **Lawful playback:** app never hosts MST episode files as a communal CDN; the **admin** uses **official embeds** (or future lawful backends), and guests receive **browser-mediated realtime media** derived from that viewing surface—not a separate licensed file library operated by RiffSync.
+1. **Lawful playback:** app never hosts MST episode files as a communal CDN; the **admin** uses **official embeds** or **staff-curated lawful HTTPS pages** loaded in RiffSync iframes (**YouTube IFrame API** or **generic iframe** for **Custom** host), and guests receive **browser-mediated realtime media** derived from that viewing surface—not a separate licensed file library operated by RiffSync. RiffSync does not rehost or transcode third-party video for Custom host.
 2. **Admin control:** guests cannot assume **publisher** role (host tab-capture **or** participant camera/mic) or change **authoritative** room metadata (except leave room / chat per policy). Only **`JWT.sub === hostSub`** may change **`roomMode`**, **`avDisabled`**, tab-capture, and durable playback metadata. Signed-in non-host fans may publish **participant A/V only**.
 3. **Participant A/V eligibility:** only **signed-in fans** with active room presence may publish participant camera/microphone. Anonymous guests remain **subscribe-only** for participant A/V.
 4. **Room mode vs kill switch:** while **`avDisabled`** is true, the room behaves as **Theater-equivalent movie + text chat** (pre-initiative participant A/V behavior); **Video Chat** selection is **unavailable or inert** until A/V is re-enabled. Server enforces kill switch: deny new participant producer grants, tear down active participant producers, broadcast authoritative disabled state.
@@ -381,9 +382,34 @@ Friends online is room-presence-derived and aggregate across rooms. It is not a 
 | **Re-friend history?** | Prior **DmThread** history stays inaccessible (default). |
 | **Notification?** | Silent API (#358); M36 presentation. |
 
+## Decisions (answered — catalog playback host)
+
+| Question | Decision |
+| --- | --- |
+| Playback host scope? | **Per catalog episode** — staff set **`playbackHost`** on the catalog row; not a per-room override at create. |
+| Custom URL validation? | **HTTPS only**, **any domain**, **no staff domain allowlist** for MVP. Staff enter **known embeddable** URLs (product policy). |
+| Custom room create gate? | **Skip YouTube playable / video-id checks** when **`playbackHost` is `custom`**; still require resolvable catalog row and non-empty validated **`customPlaybackUrl`**. |
+| YouTube room create gate? | **Unchanged in intent** — YouTube playable / video-id validation applies when **`playbackHost` is `youtube`**. |
+| Guest Custom URL load? | **No** — guests watch **host WebRTC tab share**; they do not load the third-party Custom URL directly. |
+| Host presentation (Custom)? | **Generic iframe** on the same RiffSync pages as YouTube solo/party-capture; **tab-sharing workflow unchanged** (host shares **`/watch/:catalogEpisodeId?partyCapture=1`**). |
+| Iframe embed failure (X-Frame-Options)? | **No product runtime fallback** beyond honest error UI; staff policy is embeddable URLs only. |
+| YouTube fields on Custom rows? | **May coexist** — **`customPlaybackUrl` drives playback**; YouTube fields optional for thumbs/metadata and **ignored for playback** when host is Custom. |
+| **`embedAllows` on Custom host?** | Applies **YouTube-path only** — Custom in-app playback is gated by **`playbackHost: custom` + valid HTTPS URL**, not **`embedAllows`**. |
+| Public catalog Custom URL? | **Expose `customPlaybackUrl` on `GET /v1/catalog`** (same visibility class as **`youtubeWatchUrl`**) because public solo watch loads catalog client-side. |
+| Custom-only `/watch/:id` SEO? | **Exclude** from sitemap/index until product expands discoverability beyond YouTube linkage (same posture as no-YouTube rows today). |
+| Cast receiver Custom iframe? | **Out of scope** for MVP — Cast continues **`host_screen` SFU consume** when Theater share is active. |
+| YouTube IFrame API sync for Custom? | **Out of scope** — no server-side timeline sync for generic iframe URLs. |
+
 ## Open implementation decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### catalog-playback-host
+- Exact **room-create / room-patch error codes** when Custom URL missing vs YouTube playable check fails.
+- Whether **playable** helper names (**`episodeAllowsInAppEmbed`**, etc.) split by host or gain a host-aware wrapper.
+- **Room denormalization**: which playback fields copy onto **Rooms** at create/patch (mirror today's **`youtubeVideoId`** pattern).
+- **Catalog card / Start Party** gating rules and UI copy when Custom URL present but YouTube fields null.
+- **SEO meta copy** referencing "lawful YouTube embeds" on static routes when Custom episodes exist (marketing/legal wording refresh scope).
 
 ### friends-and-direct-messaging
 - **DirectMessage v1 kinds (#359):** **`text` only** — unicode emoji inline in **`body`**, max **2000** chars (room **`chat`** precedent). **Giphy GIF** and **reactions** deferred to post-M35 follow-on.

--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -9,7 +9,9 @@ Curator + enrichment merged for **`GET /v1/catalog`** output.
 | Field group | Fields | Notes |
 | --- | --- | --- |
 | **Identity** | **`id`**, **`experimentNumber`**, **`title`**, **`catalog`** | **`title`** never overwritten from TMDB. **`catalog`** enum: **`joel`**, **`mike`**, **`jonah`**, **`emily`**, **`community`**, **`movie_night`**, **`riff_material`**, **`other`**. All public-facing catalog displays omit **`other`** (staff curation bucket). Public subcategory browse IA (`mst3k` / `community` / `riff-ready` / `movie-night`) is route/display grouping over this flat enum (no parent/group field; MST3K is a display-time union of **`joel`** / **`mike`** / **`jonah`** / **`emily`**). Display label for persisted **`riff_material`** may be **Riff Material** without changing the stored value. |
-| **YouTube** | **`youtubeVideoId`**, **`youtubeWatchUrl`** | Nullable when unknown. |
+| **Playback host** | **`playbackHost`**, **`customPlaybackUrl`** | **`playbackHost`**: **`youtube`** \| **`custom`** (required on new/updated rows after schema migration; seed backfill defaults missing values to **`youtube`**). **`customPlaybackUrl`**: HTTPS movie-page URL when host is **`custom`**; validated at admin save (**HTTPS only**, any domain). **`customPlaybackUrl` drives playback** when host is Custom; YouTube linkage fields may remain for thumbs/metadata. |
+| **YouTube** | **`youtubeVideoId`**, **`youtubeWatchUrl`** | Nullable when unknown. **Not required** for persistence or room create when **`playbackHost` is `custom`**. May coexist on Custom rows for optional enrichment. |
+| **Embed policy** | **`embedAllows`** | Optional boolean; applies **YouTube in-app embed path only**. Custom in-app playback does **not** consult **`embedAllows`**. |
 | **TMDB-aligned (nullable keys always on row in seed)** | **`tagline`**, **`posterImageUrl`**, **`backdropImageUrl`**, **`tmdbMovieId`**, **`tmdbArtworkSyncedAt`** | Filled by reconcile; see contracts. |
 | **Dynamo-only (optional on seed)** | **`tmdbOverview`**, **`tmdbPopularity`**, raw **`tmdbPosterPath`**, **`tmdbBackdropPath`** | Per **`docs/architecture.catalog-images.md`**. |
 | **Thumb (optional)** | **`youtubeThumbnailUrl`** | Resolved from **`img.youtube.com`** in reconcile when enabled. |
@@ -21,7 +23,7 @@ Authoritative server state for **room identity**, **catalog selection**, **admin
 | Concept | Contract |
 | --- | --- |
 | **`roomId`** | Stable, shareable (**UUID v4 or equivalent**); never recycled for a different party in confusing ways. |
-| **Catalog / playback intent** | **`catalogEpisodeId`** / **`videoId`** — **current** title for the room (**mutable** by **room admin** via picker; seeded at room create). Optional **`currentTime`**, **`playing`**, **`playbackRate`** if persisted for admin reconnect UX—**room admin** mutates via HTTP or WS per contracts; guests do **not** advance timeline via parallel embed state in MVP. Episode **changes** fan-out so lobby/listing metadata can track **Now watching**. |
+| **Catalog / playback intent** | **`catalogEpisodeId`** / **`videoId`** — **current** title for the room (**mutable** by **room admin** via picker; seeded at room create). Optional denormalized playback fields sufficient for host reconnect without re-fetching catalog (today includes YouTube ids; Custom host may add **`playbackHost`** / **`customPlaybackUrl`** mirrors — exact attribute names tier TW). Optional **`currentTime`**, **`playing`**, **`playbackRate`** if persisted for admin reconnect UX—**room admin** mutates via HTTP or WS per contracts; guests do **not** advance timeline via parallel embed state in MVP. Episode **changes** fan-out so lobby/listing metadata can track **Now watching**. |
 | **`playbackExpectation`** | Enum **`premium` \| free-ad-supported`** — advisory, admin-set. |
 | **`visibility`** | **`public`** \| **`private`** — **`public`** rooms may appear on **`GET /v1/lobby`** while active; **`private`** rooms are link-only (no lobby index). Host **`PATCH`** may toggle after create; **`POST /v1/rooms`** defaults **`public`** from catalog. Direct **`/room/:roomId`** join is unchanged for either value. |
 | **`hostSub`** | Cognito **`sub`** of the user who **`POST /v1/rooms`** — immutable host binding for MVP; only this principal may **publish host tab-capture WebRTC** and mutate authoritative room admin fields. |
@@ -286,11 +288,28 @@ Server-authoritative unread state for DM activity. Survives refresh and device c
 | **DirectMessage v1 kinds?** | **`text` only**; GIF/reactions deferred post-M35. |
 | **Account-closure / explicit delete purge?** | **Out of scope** for #359 — future ops/EventBridge slice; unfriend retain-on-storage decided #358. |
 
+## Decisions (answered — catalog playback host)
+
+| Question | Decision |
+| --- | --- |
+| Storage class? | **Unchanged** — catalog episodes remain in **Dynamo Catalog**; Custom URL is durable curator data like YouTube fields. |
+| **`playbackHost` wire values?** | **`youtube`** \| **`custom`** on Dynamo, admin payload, and public catalog JSON. |
+| **`customPlaybackUrl` validation?** | **HTTPS only**, **any domain**, no staff domain allowlist at save (MVP). |
+| YouTube fields on Custom rows? | **May coexist** — optional for thumbs/metadata; ignored for playback when host is Custom. |
+| Public catalog projection? | **`customPlaybackUrl`** exposed on **`GET /v1/catalog`** (same class as **`youtubeWatchUrl`**). |
+| **`embedAllows` on Custom?** | Persisted boolean unchanged; semantics **YouTube-path only**. |
+| Seed schema authority? | **`data/catalog/catalog.schema.json`** — host-conditional required fields (see schema **`if`/`then`**). |
+
 ## Open implementation decisions
 
 - SFU **`listProducerSummaries`** (or successor) payload fields for Theater strip / Video Chat grid (**`sessionId`**, **`fanSub`**, producer class) beyond today's **`{ producerId, kind }`** — **#102** / layout runtime (#104/#105).
 - Future scaling (out of scope for catalog subcategory browse IA): if the full catalog bundle grows large enough that client-side fetch + `filterCatalogEntries({ catalogs })` becomes a performance concern, consider a server-side **`catalog`** / **`catalogs`** query parameter on **`GET /v1/catalog`**. Current access pattern remains full-bundle fetch with client Set-membership filter; hub mixed grid uses no catalog constraint (`catalogs: []`).
 - Account-closure cascade and explicit per-message user delete jobs relative to retained-after-unfriend bodies — future ops slice (not #359).
+
+### catalog-playback-host
+- Admin PATCH partial update rules when switching **`playbackHost`** (nulling vs retaining opposite-host fields).
+- JSON Schema bundle **`version`** bump vs additive migration for existing seed files.
+- Whether **public catalog handler** field allowlist changes beyond **`customPlaybackUrl`** / **`playbackHost`** in **`catalog-shared.ts`**.
 
 ## Primary code pointers (optional)
 

--- a/.ai/data/serialization.md
+++ b/.ai/data/serialization.md
@@ -19,8 +19,8 @@ HMAC JWT payload today: **`env`**, **`roomId`**, **`sessionId`**, **`role`** (**
 
 | Artifact | Role |
 | --- | --- |
-| **`data/catalog/catalog.schema.json`** | **Git bundle** episodes — CI validation target. |
-| **API responses** | **Superset** of seed fields allowed (**Dynamo** columns); breaking removals require **`/v2`** or deprecation window. |
+| **`data/catalog/catalog.schema.json`** | **Git bundle** episodes — CI validation target. Includes **`playbackHost`** (**`youtube`** \| **`custom`**) and host-conditional **`customPlaybackUrl`** (required when host is **`custom`**). |
+| **Public catalog JSON** | Includes **`playbackHost`**, **`youtubeWatchUrl`**, **`customPlaybackUrl`** when set — handler projection matches **`GET /v1/catalog`** contract. |
 
 ## Decisions (answered)
 

--- a/.ai/integration/api_contracts.md
+++ b/.ai/integration/api_contracts.md
@@ -11,9 +11,9 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 
 | Surface | Auth | Purpose |
 | --- | --- | --- |
-| **`GET /v1/catalog`** | None required (public). | Canonical episode rows: curator fields + TMDB-derived + optional **`youtubeThumbnailUrl`** when implemented. **Caching:** **`Cache-Control`** with deployment-appropriate **max-age**; **`ETag`** weak validator derived from a **catalog generation** counter or **`max(updatedAt)`** in Dynamo so clients can **`If-None-Match`** (reduces egress cost when paired with CloudFront). **SPA subcategory browse** (`/catalog/mst3k`, `/catalog/community`, `/catalog/riff-material`, `/catalog/movie-night`) reuses this public full list with **client-side** catalog filtering; it does **not** add **`catalog`** / **`catalogs`** query parameters. Wire **`catalog`** values stay unchanged (**`riff_material`** remains on the wire for Riff Material). |
+| **`GET /v1/catalog`** | None required (public). | Canonical episode rows: curator fields + TMDB-derived + optional **`youtubeThumbnailUrl`** when implemented. Includes **`playbackHost`**, **`youtubeWatchUrl`**, and **`customPlaybackUrl`** (when set) for client solo watch and browse. **Caching:** **`Cache-Control`** with deployment-appropriate **max-age**; **`ETag`** weak validator derived from a **catalog generation** counter or **`max(updatedAt)`** in Dynamo so clients can **`If-None-Match`** (reduces egress cost when paired with CloudFront). **SPA subcategory browse** (`/catalog/mst3k`, `/catalog/community`, `/catalog/riff-material`, `/catalog/movie-night`) reuses this public full list with **client-side** catalog filtering; it does **not** add **`catalog`** / **`catalogs`** query parameters. Wire **`catalog`** values stay unchanged (**`riff_material`** remains on the wire for Riff Material). |
 | **`GET /v1/lists`**, **`GET /v1/lists/{slug}`** | None (public) when shipped. | Curated collections; **`slug`** URL-safe. |
-| **`POST /v1/rooms` (create)** | **Fan Cognito JWT** — **`hostSub`** on new room **= JWT `sub`**. **`sessionId`** optional telemetry only—**not** host binding. | Mint **`roomId`**, seed **`catalogEpisodeId`** / visibility / **`playbackExpectation`** per payload. Server sets **`roomMode: theater`** and **`avDisabled: false`** on the Dynamo item; **`201`** echoes both. |
+| **`POST /v1/rooms` (create)** | **Fan Cognito JWT** — **`hostSub`** on new room **= JWT `sub`**. **`sessionId`** optional telemetry only—**not** host binding. | Mint **`roomId`**, seed **`catalogEpisodeId`** / visibility / **`playbackExpectation`** per payload. Apply **YouTube playable / video-id validation only when the seeded catalog episode's `playbackHost` is `youtube`**. When **`playbackHost` is `custom`**, require resolvable catalog row and non-empty validated **`customPlaybackUrl`**; **do not** require **`youtubeVideoId`**. Server sets **`roomMode: theater`** and **`avDisabled: false`** on the Dynamo item; **`201`** echoes both. |
 | **`GET /v1/rooms/{roomId}`** | **`sessionId`** via **`X-Session-Id`** optional; no JWT required for read. | Room snapshot including **`roomMode`**, **`avDisabled`**, **`broadcastCaptureActive`**, and **`version`**. Legacy rows missing AV attributes default **`theater`** / **`false`**. |
 | **`GET /v1/lobby`**, lobby joins | **`sessionId`** via **`X-Session-Id`** (guest); optional JWT if viewer signs in. | Lobby rows for discovery/join validation — **no** **`roomMode`** or **`avDisabled`** on listing payload (#101). |
 | **`PATCH /v1/rooms/{roomId}`** | **Fan JWT**; **`JWT.sub === room.hostSub`**. | **Mutable current episode**, advisory labels, visibility flags—conditional **`version`** writes (**`409`** on stale **`version`**). Same host-only gate for durable **`roomMode`** (**`theater`** \| **`videoChat`**) and **`avDisabled`** (boolean kill switch). Partial body: omit keys to leave fields unchanged; **`roomMode`** / **`avDisabled`** reject **`null`** (**`400`**). **`broadcastCaptureActive`** retains existing boolean or **`null`**-clear semantics. One request may atomically update **`roomMode`**, **`avDisabled`**, and **`broadcastCaptureActive`** (#109). **`200`** echoes **`roomMode`**, **`avDisabled`**, **`broadcastCaptureActive`**, and bumped **`version`**. |
@@ -31,7 +31,7 @@ Normative boundaries for client ↔ RiffSync backend. Repo detail: **`docs/archi
 | Verb / path | Purpose |
 | --- | --- |
 | **`GET /v1/admin/session`** | **Auth-slice probe** (staff JWT): returns operator identity from JWT claims (**`sub`**, **`email`**, **`groups`**). Proves staff authorizer + group check path end-to-end before catalog handlers ship. **403** when JWT is valid but caller lacks required **`cognito:groups`** membership; **401** when authorizer rejects token (wrong pool/audience/expiry). |
-| **`POST`**, **`PATCH`**, **`DELETE /v1/admin/catalog/episodes/:id`** | Catalog CRUD; payload compatible with **`data/catalog/catalog.schema.json`** (+ Dynamo-only fields per **`docs/architecture.catalog-images.md`**). |
+| **`POST`**, **`PATCH`**, **`DELETE /v1/admin/catalog/episodes/:id`** | Catalog CRUD; payload compatible with **`data/catalog/catalog.schema.json`** (+ Dynamo-only fields per **`docs/architecture.catalog-images.md`**). Accepts **`playbackHost`**, **`customPlaybackUrl`**, and existing YouTube fields; host-conditional validation at save. |
 | **`POST /v1/admin/catalog/import`** | Bulk import before promoting catalog (**multipart** or **S3**-referenced payload—see admin doc). |
 | **`POST`**, **`PATCH /v1/admin/lists`** | Create/update curated list meta (**`slug`**, **`title`**, **`visibility`**, **`sortRule`**, optional hero). |
 | **`PUT /v1/admin/lists/{slug}/order`** | Replace membership ordering. |
@@ -545,6 +545,15 @@ Stable JSON field names for PR harness assertions and fan-visible status mapping
 | Speaking indicator scope? | **Video tiles plus People tab** — speaking affordance on Theater strip and Video Chat grid when video is on; **mic-only** participants show speaking state on **People** roster rows only (no new stage chrome). |
 | SFU decoupling depth? | **Single SFU signaling WebSocket per tab** with **mandatory per-class send transport isolation** — not dual signaling WebSockets. |
 
+## Decisions (answered — catalog playback host)
+
+| Question | Decision |
+| --- | --- |
+| Public **`customPlaybackUrl`?** | **Yes** on **`GET /v1/catalog`** — same visibility class as **`youtubeWatchUrl`**. |
+| Room create YouTube gate? | **YouTube-host episodes only** — Custom-host skips YouTube id/playable gate. |
+| Custom URL probe at save? | **Format validation only** for MVP — no HEAD/probe against third-party URL required. |
+| Guest third-party URL fetch? | **No** parallel guest playback plane — guests consume **host WebRTC** share. |
+
 ## Open implementation details
 
 - Concrete **OpenAPI** / generated types land with first implementation.
@@ -553,6 +562,12 @@ Stable JSON field names for PR harness assertions and fan-visible status mapping
 ## Open implementation decisions
 
 - **Server-side catalog `catalog` / `catalogs` query params:** **Out of scope** for catalog subcategory SPA browse. If a future initiative moves catalog filtering to the API (for payload size or cache variants), that is a new contract change; do not treat subcategory routes as requiring it now.
+
+### catalog-playback-host
+- Server-side **YouTube playable check** function boundaries (Lambda imports, timeout, error mapping) when host is YouTube only.
+- **Public catalog handler** field allowlist in **`catalog-shared.ts`** for **`playbackHost`** and **`customPlaybackUrl`**.
+- **OpenAPI / typed client** updates for catalog episode and room snapshot playback fields.
+- **`Referrer-Policy` / iframe `sandbox`** attributes on generic iframe element (security review).
 
 ### friends-and-direct-messaging (paths, envelopes, codes)
 

--- a/.ai/integration/external_systems.md
+++ b/.ai/integration/external_systems.md
@@ -6,9 +6,22 @@ Outbound and third-party boundaries. Legal posture: **unofficial fan app**; hono
 
 | Use | Mechanism | Contract |
 | --- | --- | --- |
-| **Playback (admin)** | **IFrame / IFrame API** on **room admin** client; `videoId` from catalog / room snapshot. | No download/rehost by RiffSync; embed eligibility may change per video—UI handles failures. |
-| **Guest viewing** | **WebRTC** **`MediaStream`** from host tab-capture and, when enabled, **participant A/V** over **self-hosted mediasoup SFU** on **`RiffSyncTurn`** — **`POST /v1/webrtc/sfu-token`** + **coturn**. | **SFU mandatory in all environments** (dev, CI, production). **Mesh WebRTC removed.** Multi-producer registry (host screen + N participant cameras/mics). Theater audio mixing is **client-side** (server-side mix **deferred**). Honor browser permission and autoplay policies. |
-| **Thumbnails (optional)** | **`https://img.youtube.com/vi/{id}/{hqdefault|maxresdefault|…}.jpg`** | Reconcile job **`HEAD`** fallback chain; persist resolved URL on catalog row (**`docs/architecture.catalog-images.md`**). No YouTube Data API required for thumbs. |
+| **Playback (YouTube-host episodes)** | **IFrame / IFrame API** on **room admin** and solo/party-capture clients when catalog **`playbackHost` is `youtube`**; `videoId` from catalog / room snapshot. | No download/rehost by RiffSync; embed eligibility may change per video—UI handles failures. YouTube **playable / embed checks** at room create apply **only** for YouTube-host rows. |
+| **Thumbnails (optional)** | **`https://img.youtube.com/vi/{id}/{hqdefault|maxresdefault|…}.jpg`** | Reconcile job **`HEAD`** fallback chain when **`youtubeVideoId` present**; persist resolved URL on catalog row (**`docs/architecture.catalog-images.md`**). No YouTube Data API required for thumbs. Custom-only rows without YouTube id skip thumb reconcile. |
+
+## Custom playback (staff-curated HTTPS pages)
+
+| Use | Mechanism | Contract |
+| --- | --- | --- |
+| **Playback (Custom-host episodes)** | **Generic HTTPS iframe** on **`/watch/:catalogEpisodeId`**, party-capture (**`?partyCapture=1`**), and in-room host presentation when catalog **`playbackHost` is `custom`**. | Staff enter **known embeddable** HTTPS movie-page URLs (**HTTPS only**, any domain, no domain allowlist at validation). RiffSync does **not** rehost or transcode. **No YouTube IFrame API sync** for Custom URLs. Iframe embed failure (X-Frame-Options): honest error UI; no product runtime fallback beyond staff policy. |
+| **Guest viewing** | **Unchanged** — guests consume **WebRTC `host_screen`** from host tab-capture of the RiffSync watch/party-capture tab; they do **not** load the Custom URL directly. | Party capture tab URL stays **`{origin}/watch/{catalogEpisodeId}?partyCapture=1`**; inner player is generic iframe for Custom. **`hostSourceOpensOnYoutube`** is false for Custom rows. |
+| **Cast (MVP)** | **Unchanged `host_screen` SFU path** | Custom iframe on TV receiver is **out of scope** for MVP unless a later Cast spec says otherwise. |
+
+## WebRTC media (all playback hosts)
+
+| Use | Mechanism | Contract |
+| --- | --- | --- |
+| **Guest viewing (both hosts)** | **WebRTC** **`MediaStream`** from host tab-capture and, when enabled, **participant A/V** over **self-hosted mediasoup SFU** on **`RiffSyncTurn`** — **`POST /v1/webrtc/sfu-token`** + **coturn**. | **SFU mandatory in all environments** (dev, CI, production). **Mesh WebRTC removed.** Multi-producer registry (host screen + N participant cameras/mics). Theater audio mixing is **client-side** (server-side mix **deferred**). Honor browser permission and autoplay policies. Tab-sharing workflow for watch parties is **unchanged** for Custom host. |
 
 ## Google Cast / Chromecast
 
@@ -146,6 +159,7 @@ The receiver render-confirmation acknowledgement is Google Cast sender/receiver 
 | Mesh dev fallback? | **No** — SFU + TURN in all environments; mesh removed. |
 | Server-side theater audio mix? | **Deferred** — client-side Web Audio remains default (**`api_contracts.md`**). |
 | Chromecast boundary? | **Viewer-local only.** Optional sender/receiver integration; no room API, WebSocket fan-out, `share_state`, or room-authority change. |
+| Custom playback on Cast receiver? | **Out of scope MVP** — receiver uses **`host_screen` SFU consume** when Theater share is active; no Custom iframe on TV in this slice. |
 | External social graph for friends/DM? | **No** — Dynamo-backed inside RiffSync; fan Cognito **`sub`** identity only. |
 | New IdP for friends/DM? | **No** — existing fan Cognito pool + fan JWT authorizer. |
 | Staff access to DM bodies via admin tools? | **No** for this slice — staff pool remains catalog/ops only. |
@@ -174,6 +188,9 @@ The receiver render-confirmation acknowledgement is Google Cast sender/receiver 
 ## Open implementation decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### catalog-playback-host
+- Exact **CSP `frame-src`** directive syntax for arbitrary HTTPS Custom origins (coordinate with **operations/security.md**).
 
 ### friends-dm-aws-surfaces
 - Whether DM realtime adds a **new** API Gateway WebSocket API / stage vs reusing the room WS API with non-room routes (must stay explicit if shared).

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -8,7 +8,7 @@ UI-level contract for layout states, honest failure surfaces, and **cost-conscio
 | --- | --- |
 | **Catalog loading** | Skeleton or **in-catalog placeholders** for rows; avoid blocking the whole shell on **`GET /v1/catalog`** when possible (progressive render). |
 | **Empty catalog** | Clear **“nothing to show yet”** copy for operators/contributors—never a silent blank. |
-| **Signed-in host / solo room** | **WebSocket** + **JWT** for admin paths; embed errors surface **embed blocked** + **open on YouTube** escape hatch (**`error_state.md`**). |
+| **Signed-in host / solo room** | **WebSocket** + **JWT** for admin paths; embed errors surface **embed blocked** with host-aware escape hatch (**open on YouTube** for YouTube-host, **open custom URL in new tab** for Custom-host — **`error_state.md`**). |
 | **Room / lobby** | **Room-admin** controls only when **`JWT.sub === hostSub`**; anonymous guests see **read-only** player/chat chrome (**picker hidden**, subscribe-only WebRTC). |
 | **Theater fullscreen** | Optional **wrapper fullscreen** ( **`requestFullscreen`** on a container that includes the player, optional Theater camera row, and RiffSync chrome) — **not** YouTube iframe-native fullscreen, which cannot show RiffSync chrome. |
 | **Share** | **Copy `/room/:id` URL**; show advisory **`playbackExpectation`** near share affordance. |
@@ -62,6 +62,33 @@ Meta titles/descriptions/OG for **`/watch/:id`** always use the catalog **`title
 ### Catalog card browse metadata
 
 **`CatalogGridCard`** renders **`episode.tags`** in the card metadata area in the exact order received from the API. Tag strings are displayed as provided (namespace-agnostic; no hard-coded **`Season`**, **`Era`**, or **`Genre`** rendering rules). When **`episode.tags`** is empty, the card shows no fallback playback-advisory copy (**`Ads may appear`**, **`Premium-friendly`**, **`Likely ad-supported`**, or equivalent). Catalog cards do **not** show a visible not-embeddable message; **`embedAllows === false`** continues to gate in-app embed affordances through **`EpisodeTileActions`** / watch routing only.
+
+### Admin catalog playback host
+
+Staff **`/admin/catalog`** form gains a **Playback host** selector per episode: **YouTube** | **Custom**.
+
+| Host | Fields | Contract |
+| --- | --- | --- |
+| **YouTube** | Existing YouTube watch URL / video id fields | Unchanged validation intent; **`embedAllows`** applies to YouTube in-app embed path. |
+| **Custom** | **HTTPS** movie-page URL (**`customPlaybackUrl`**) | Required when host is Custom. YouTube fields **optional** (may remain for thumbs/metadata). Switching host does not require clearing opposite-host fields unless admin validation chooses to null them (tier TW). |
+
+### Solo watch and party capture (`/watch/:catalogEpisodeId`)
+
+| Concern | Contract |
+| --- | --- |
+| **YouTube-host** | Existing **`SoloYouTubePlayer`** / YouTube iframe path when **`playbackHost` is `youtube`** and YouTube embed rules allow in-app playback. |
+| **Custom-host** | Same page shell; **generic HTTPS iframe** replaces YouTube player, pointing at **`customPlaybackUrl`**. |
+| **Party capture** | URL remains **`{origin}/watch/{catalogEpisodeId}?partyCapture=1`**; inner player swaps to generic iframe for Custom. **Tab-sharing workflow unchanged** — host shares this RiffSync tab via browser picker + WebRTC. |
+| **Guests** | Unchanged — watch host screen share; no direct Custom URL chrome. |
+| **Iframe failure** | Honest blocked/error state; no special X-Frame-Options fallback UI beyond staff embeddable-URL policy. |
+
+### Room host presentation
+
+When the room admin's selected catalog episode has **`playbackHost: custom`**, host presentation loads **`customPlaybackUrl`** in an **iframe** in the presentation area (not external-tab-only for Custom). YouTube-host episodes retain existing YouTube embed / capture behavior.
+
+### Catalog card actions
+
+Custom episodes with valid **`customPlaybackUrl`** offer in-app watch / **Start Party** like embeddable YouTube rows. **`embedAllows === false`** gates **YouTube-path** in-app embed only; Custom playback is gated by **`playbackHost` + HTTPS URL**.
 
 ### `/watch/:catalogEpisodeId` heading
 
@@ -509,6 +536,15 @@ The render-confirmation slice gates the sender's active Cast UI after #302 reach
 ## Open implementation decisions
 
 Implementation-level items not yet fully specified. `/refine-issue` resolves these into timeless contract prose and removes or collapses bullets when done.
+
+### catalog-playback-host
+- Admin form control order, labels ("Playback host", field visibility when switching host), validation messages.
+- Component split: dedicated **generic iframe player** vs extending **`SoloYouTubePlayer`**.
+- **`TheaterPlayback` / `RoomPlaybackPanel`** iframe mount for host presentation vs capture tab inner iframe.
+- **`partyCapture` bare layout** CSS for generic iframe aspect ratio.
+- **Catalog card** metadata: whether to show playback host badge on staff admin list vs public cards.
+- **Static SEO table** copy referencing "lawful YouTube embeds" — marketing/legal refresh when Custom episodes ship (Custom-only `/watch/:id` remains excluded from sitemap).
+- **Accessibility**: iframe **`title`** from episode **`title`**; focus order on admin host selector.
 
 ### existing-room-polish
 - **Theater audio resume control:** persistent **Enable party audio** chrome when **`THEATER_AUDIO_SUSPENDED`** — deferred; current room runtime uses implicit gesture resume per **`execution_model.md`**.

--- a/.ai/knowledge_map.json
+++ b/.ai/knowledge_map.json
@@ -82,7 +82,8 @@
             ".ai/specs/public-site-seo.spec.md",
             ".ai/specs/catalog-browse-ia.spec.md",
             ".ai/specs/pwa-install.spec.md",
-            ".ai/specs/friends-and-direct-messaging.spec.md"
+            ".ai/specs/friends-and-direct-messaging.spec.md",
+            ".ai/specs/catalog-playback-host.spec.md"
           ]
         }
       ]

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -64,6 +64,15 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 | **TURN credentials** | **`GET /v1/webrtc/ice`** REST credentials via **`riffsync/turn-static-auth-secret`**; more publishers increase relay load on the shared TURN instance. |
 | **Transport** | TLS on API Gateway; **`wss://`** SFU signaling via Caddy when **`PROD_SFU_SIGNALING_HOSTNAME`** is set. |
 
+## CSP and third-party framing (SPA)
+
+| Topic | Contract |
+| --- | --- |
+| **Custom playback iframes** | Solo watch, party-capture, and in-room host presentation may embed **arbitrary HTTPS origins** staff curate (**no domain allowlist** at catalog validation). CSP **`frame-src`** (or equivalent) must permit framing those HTTPS Custom origins — prefer an explicit contract note over ad-hoc wildcard edits in deploy scripts. |
+| **YouTube iframes** | Existing YouTube embed allowances unchanged for YouTube-host episodes. |
+| **Cast receiver CSP** | Unchanged for MVP Custom iframe scope — receiver uses **`host_screen` SFU**, not Custom iframe on TV. |
+| **Logging** | Do not log full **Custom playback URLs** at INFO if they carry signed/query tokens; aggregate errors only. |
+
 ## Viewer-local Cast
 
 | Topic | Contract |
@@ -91,6 +100,12 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 | **Metrics** | **`RiffSync/Media/sfu_token_denied`** with **`reason`** dimension. |
 
 ## Open implementation decisions
+
+### catalog-playback-host
+- Exact **CSP directive** edits in CloudFront response headers or meta tag strategy (**`operations/security.md`**, build packaging).
+- Whether generic iframe uses **`sandbox`** attribute and which tokens (**`allow-scripts`**, **`allow-same-origin`**, **`allow-popups`**) for partner players.
+- **`Referrer-Policy`** for Custom iframe navigations.
+- **Admin validation** max URL length and Unicode normalization for **`customPlaybackUrl`**.
 
 ### friends-and-direct-messaging
 - Exact **rate-limit bands** for DM send, unread mark-read, and friends-online query or push — **M35**, **#357** (remove-friend **30**/min decided #358).

--- a/.ai/specs/catalog-browse-ia.spec.md
+++ b/.ai/specs/catalog-browse-ia.spec.md
@@ -6,7 +6,7 @@ Fans browse the RiffSync catalog through a hub at `/catalog` plus four dedicated
 
 **Audience:** public fans discovering titles; maintainers extending subcategory pages in later milestones.
 
-**Related capabilities:** `public-site-seo` (indexable route matrix, sitemap/prerender/head tags for these paths); `viewer-local-cast` (unrelated presentation layer).
+**Related capabilities:** `public-site-seo` (indexable route matrix, sitemap/prerender/head tags for these paths); `catalog-playback-host` (Custom-host card actions and in-app watch when `customPlaybackUrl` is set); `viewer-local-cast` (unrelated presentation layer).
 
 **Non-goals:** per-subcategory visual redesign beyond the shared Streamlab-style header + subtitle + title-search/sort + title grid; admin/operator catalog tooling changes; API or persisted `catalog` enum renames; watch-party, lobby, or SEO packaging (M33 owns sitemap/prerender/head tags for subcategory routes).
 

--- a/.ai/specs/catalog-playback-host.spec.md
+++ b/.ai/specs/catalog-playback-host.spec.md
@@ -1,0 +1,102 @@
+# Catalog Playback Host
+
+## Introduction
+
+RiffSync catalog episodes can use either **YouTube** or **Custom** as the playback host. Staff choose the host per episode in admin; the SPA and room create flows branch on **`playbackHost`** while guest viewing stays on the existing **WebRTC tab-share** model.
+
+**Audience:** staff curators (admin catalog form), signed-in hosts starting parties, and fans using solo watch.
+
+**Related capabilities:** `catalog-browse-ia` (card actions and browse filters), `public-site-seo` (Custom-only `/watch/:id` sitemap exclusion), `viewer-local-cast` (no Custom iframe on TV receiver in MVP).
+
+**Non-goals:** RiffSync rehosting/transcoding third-party video; YouTube IFrame API sync for Custom URLs; guest-direct load of Custom URLs; anonymous catalog writes; per-room playback host override at create time.
+
+## Functional Specification
+
+### Admin catalog
+
+- Staff set **Playback host** to **YouTube** or **Custom** per episode.
+- **YouTube path:** existing watch URL / video id fields; **`embedAllows`** gates YouTube in-app embed.
+- **Custom path:** staff enter an **HTTPS** movie-page URL (**any domain**; staff policy: known embeddable pages only).
+- YouTube enrichment fields **may coexist** on Custom rows; **`customPlaybackUrl` drives playback** when host is Custom.
+
+### Public catalog and solo watch
+
+- **`GET /v1/catalog`** exposes **`playbackHost`**, **`youtubeWatchUrl`**, and **`customPlaybackUrl`** (when set).
+- **`/watch/:catalogEpisodeId`** uses YouTube iframe for YouTube-host rows and a **generic HTTPS iframe** for Custom-host rows.
+- Party capture (**`?partyCapture=1`**) uses the same page; host shares the RiffSync capture tab via unchanged tab-share workflow.
+
+### Room create and host presentation
+
+- **`POST /v1/rooms`** applies YouTube playable / video-id validation **only when `playbackHost` is `youtube`**.
+- Custom-host create requires resolvable catalog row and validated **`customPlaybackUrl`**; **`youtubeVideoId` not required**.
+- In-room host presentation loads Custom URLs in an iframe (not external-tab-only).
+
+### Guests, Cast, SEO
+
+- Guests watch **host WebRTC screen share**; they do not fetch Custom URLs directly.
+- **Cast MVP:** continues **`host_screen` SFU consume**; Custom iframe on TV receiver is out of scope.
+- **Custom-only** `/watch/:id` (no YouTube link) stays **excluded from sitemap/index** (same posture as no-YouTube rows today).
+
+### Error semantics
+
+- Iframe embed failure (X-Frame-Options): honest blocked UI; no product runtime fallback beyond staff embeddable-URL policy.
+- Missing Custom URL at admin save or playback: validation or playback error per **`error_state.md`** patterns.
+
+## Technical Specification
+
+### Data shape
+
+| Field | When | Notes |
+| --- | --- | --- |
+| **`playbackHost`** | Always (default **`youtube`** on legacy rows) | **`youtube`** \| **`custom`** |
+| **`customPlaybackUrl`** | Required when host is **`custom`** | HTTPS only; validated at admin save |
+| **`youtubeVideoId`**, **`youtubeWatchUrl`** | Optional on Custom rows | May remain for thumbs/metadata |
+| **`embedAllows`** | Optional boolean | **YouTube-path only** |
+
+Schema authority: **`data/catalog/catalog.schema.json`** with **`if`/`then`** for host-conditional **`customPlaybackUrl`**.
+
+### Client surfaces (indicative)
+
+- **`AdminCatalogForm.tsx`** — playback host selector and conditional fields.
+- **`SoloWatchPage.tsx`** — host-aware player shell (YouTube vs generic iframe).
+- **`hostSourceTab.ts`** — capture URL stays on RiffSync watch route for Custom.
+- **`RoomPlaybackPanel.tsx` / `TheaterPlayback`** — host presentation iframe for Custom.
+
+### Operations
+
+- CSP must allow framing **HTTPS Custom origins** consistent with no domain allowlist at validation (**`operations/security.md`**).
+- No new AWS services; URLs are Dynamo catalog fields served via existing CloudFront + SPA.
+
+### Runtime versions
+
+Follow repository **Node.js** and **TypeScript** versions from **`apps/web/package.json`**, **`infra/cdk`**, and CI workflows. No version change is required for this capability boundary.
+
+## Testing Strategy
+
+### Unit / contract
+
+- **`catalog.schema.json`**: host-conditional validation (**custom** requires HTTPS **`customPlaybackUrl`**).
+- **`admin-catalog-validation`**: writable allowlist includes new fields; Custom HTTPS rejection for non-HTTPS URLs.
+- **`hostSourceTab`**: Custom rows resolve party-capture URL on RiffSync watch route.
+
+### Integration
+
+- Room create: YouTube-host rejects missing playable id; Custom-host succeeds with HTTPS URL and no YouTube id.
+- **`GET /v1/catalog`**: projects **`playbackHost`** and **`customPlaybackUrl`**.
+
+### Manual / smoke
+
+- Admin save YouTube vs Custom rows; solo watch iframe render for Custom HTTPS URL.
+- Party capture tab share with Custom inner iframe.
+- CSP smoke: Custom origin loads in iframe on staging/prod headers.
+
+## References
+
+- `.ai/business_logic/domain_model.md` — playback host enum, lawful playback invariant, discoverability
+- `.ai/data/data_model.md` — catalog playback field group
+- `.ai/data/serialization.md` — public catalog JSON fields
+- `.ai/integration/api_contracts.md` — room create gate, public catalog exposure
+- `.ai/integration/external_systems.md` — YouTube vs Custom vs WebRTC boundaries
+- `.ai/interface/presentation.md` — admin form, solo watch, party capture, room presentation
+- `.ai/operations/security.md` — CSP and Custom iframe framing
+- `data/catalog/catalog.schema.json` — seed and admin validation schema

--- a/.ai/specs/index.md
+++ b/.ai/specs/index.md
@@ -9,3 +9,4 @@ Durable capability-level architecture and behavior specifications for RiffSync.
 | `catalog-browse-ia` | Catalog Browse Information Architecture | Defines the public catalog hub and subcategory routes, nav dropdown, catalog grouping, and Riff Material labeling. | draft |
 | `pwa-install` | PWA Install | Defines the installable web app manifest, minimal service worker, `/download` instructions page, and Get App promotion behavior. | draft |
 | `friends-and-direct-messaging` | Friends and Direct Messaging | Defines invite/accept friendships, room-derived friends online, account-lifetime 1:1 DMs, mutual remove-friend, and auth-gated friends UX beside room chat. | draft |
+| `catalog-playback-host` | Catalog Playback Host | Defines per-episode YouTube vs Custom playback host, admin curation, room-create gates, solo/party-capture iframe playback, and unchanged guest WebRTC viewing. | draft |

--- a/.ai/specs/public-site-seo.spec.md
+++ b/.ai/specs/public-site-seo.spec.md
@@ -20,7 +20,7 @@ RiffSync's public catalog and marketing surfaces - home, catalog hub, catalog su
 
 Catalog subcategory routes are first-class indexable entries alongside the `/catalog` hub. `/download` is a durable public app install instructions page and joins the same sitemap/prerender/head-tag pipeline. Browse IA (hub links, filters, labels) is owned by `catalog-browse-ia`; this capability owns discoverability packaging for those paths.
 
-`/watch/:catalogEpisodeId` is indexable only for episodes with a live YouTube link (the existing `episodeHasYoutubeLink` filter) — an episode without a lawful embed carries no surface worth summarizing or linking to and is excluded from indexing and the sitemap until a link exists.
+`/watch/:catalogEpisodeId` is indexable only for episodes with a live YouTube link (the existing `episodeHasYoutubeLink` filter) — an episode without a YouTube link (including **Custom-host** rows with no YouTube enrichment) carries no surface worth summarizing or linking to under today's SEO packaging and is excluded from indexing and the sitemap until a YouTube link exists for discoverability. Custom playback alone does not add `/watch/:id` to the sitemap.
 
 ### Per-route head tags
 

--- a/data/catalog/catalog.schema.json
+++ b/data/catalog/catalog.schema.json
@@ -33,6 +33,7 @@
         "catalog",
         "tags",
         "labels",
+        "playbackHost",
         "youtubeVideoId",
         "youtubeWatchUrl",
         "tagline",
@@ -152,9 +153,43 @@
         },
         "embedAllows": {
           "type": "boolean",
-          "description": "When false, SPA should not offer in-app YouTube embed; exposed on public catalog when stored."
+          "description": "When false, SPA should not offer in-app YouTube embed; applies to YouTube playback path only. Custom in-app playback is gated by playbackHost and customPlaybackUrl."
+        },
+        "playbackHost": {
+          "type": "string",
+          "enum": ["youtube", "custom"],
+          "description": "Staff-selected playback source for this episode. Defaults to youtube when omitted in legacy seed rows (migration/backfill)."
+        },
+        "customPlaybackUrl": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https://",
+              "description": "HTTPS movie-page URL when playbackHost is custom. Required non-null when playbackHost is custom."
+            }
+          ]
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "playbackHost": { "const": "custom" } },
+            "required": ["playbackHost"]
+          },
+          "then": {
+            "properties": {
+              "customPlaybackUrl": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^https://"
+              }
+            },
+            "required": ["customPlaybackUrl"]
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Contract-only PR from ideation (`/ideate`).

- **Initiative:** catalog-custom-playback-host
- **Scope:** `.ai` contract updates and `data/catalog/catalog.schema.json`; no application code
- **Summary:** Staff can set playback host to YouTube or Custom per catalog episode. Custom uses HTTPS iframe on solo watch, party capture, and host presentation; room create skips YouTube playable gate for Custom; guests unchanged (WebRTC tab share).
- **Review:** confirm timeless contract prose, schema conditionals, and CSP notes before merge

Merge before `/plan-roadmap` when downstream work should read merged contracts on `main`.