### PR TITLE
docs(ai): refine issue #389 contract updates

### DIFF
--- a/.ai/data/data_model.md
+++ b/.ai/data/data_model.md
@@ -294,11 +294,13 @@ Server-authoritative unread state for DM activity. Survives refresh and device c
 | --- | --- |
 | Storage class? | **Unchanged** — catalog episodes remain in **Dynamo Catalog**; Custom URL is durable curator data like YouTube fields. |
 | **`playbackHost` wire values?** | **`youtube`** \| **`custom`** on Dynamo, admin payload, and public catalog JSON. |
-| **`customPlaybackUrl` validation?** | **HTTPS only**, **any domain**, no staff domain allowlist at save (MVP). |
+| **`customPlaybackUrl` validation?** | **HTTPS only**, **any domain**, no staff domain allowlist at save (MVP). **Max 2048 characters** after **Unicode NFC** normalization at admin save. |
 | YouTube fields on Custom rows? | **May coexist** — optional for thumbs/metadata; ignored for playback when host is Custom. |
 | Public catalog projection? | **`customPlaybackUrl`** exposed on **`GET /v1/catalog`** (same class as **`youtubeWatchUrl`**). |
 | **`embedAllows` on Custom?** | Persisted boolean unchanged; semantics **YouTube-path only**. |
 | Seed schema authority? | **`data/catalog/catalog.schema.json`** — host-conditional required fields (see schema **`if`/`then`**). |
+| Legacy rows missing **`playbackHost`?** | Default **`youtube`** at admin POST/PATCH merge; backfill git seed **`episodes.json`** with **`playbackHost: youtube`** and **`customPlaybackUrl: null`**. Bundle stays **`version: 1`**. |
+| PATCH when switching **`playbackHost`?** | **Preserve** opposite-host fields unless the PATCH body explicitly sets them (including **`null`**). No auto-null of YouTube ids when switching to Custom. |
 
 ## Open implementation decisions
 
@@ -307,9 +309,7 @@ Server-authoritative unread state for DM activity. Survives refresh and device c
 - Account-closure cascade and explicit per-message user delete jobs relative to retained-after-unfriend bodies — future ops slice (not #359).
 
 ### catalog-playback-host
-- Admin PATCH partial update rules when switching **`playbackHost`** (nulling vs retaining opposite-host fields).
-- JSON Schema bundle **`version`** bump vs additive migration for existing seed files.
-- Whether **public catalog handler** field allowlist changes beyond **`customPlaybackUrl`** / **`playbackHost`** in **`catalog-shared.ts`**.
+- Whether **public catalog handler** field allowlist changes beyond **`customPlaybackUrl`** / **`playbackHost`** in **`catalog-shared.ts`** — **#390** (out of scope for schema/admin-validation issue **#389**).
 
 ## Primary code pointers (optional)
 

--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -70,7 +70,7 @@ Staff **`/admin/catalog`** form gains a **Playback host** selector per episode: 
 | Host | Fields | Contract |
 | --- | --- | --- |
 | **YouTube** | Existing YouTube watch URL / video id fields | Unchanged validation intent; **`embedAllows`** applies to YouTube in-app embed path. |
-| **Custom** | **HTTPS** movie-page URL (**`customPlaybackUrl`**) | Required when host is Custom. YouTube fields **optional** (may remain for thumbs/metadata). Switching host does not require clearing opposite-host fields unless admin validation chooses to null them (tier TW). |
+| **Custom** | **HTTPS** movie-page URL (**`customPlaybackUrl`**) | Required when host is Custom (**max 2048 chars**, NFC-normalized at save). YouTube fields **optional** (may remain for thumbs/metadata). Switching host **preserves** opposite-host fields unless staff explicitly PATCH them (including **`null`**). |
 
 ### Solo watch and party capture (`/watch/:catalogEpisodeId`)
 

--- a/.ai/operations/security.md
+++ b/.ai/operations/security.md
@@ -102,11 +102,10 @@ Defense-in-depth for a **public + anonymous** surface plus **operator** tools.
 ## Open implementation decisions
 
 ### catalog-playback-host
+- **Admin validation (`customPlaybackUrl`):** Apply **Unicode NFC** normalization before save checks. Reject URLs over **2048 characters** after normalization or with a non-**`https:`** scheme. Validation detail message: **`customPlaybackUrl must be an HTTPS URL (max 2048 characters)`**. Persist the normalized string on the catalog item.
 - Exact **CSP directive** edits in CloudFront response headers or meta tag strategy (**`operations/security.md`**, build packaging).
 - Whether generic iframe uses **`sandbox`** attribute and which tokens (**`allow-scripts`**, **`allow-same-origin`**, **`allow-popups`**) for partner players.
 - **`Referrer-Policy`** for Custom iframe navigations.
-- **Admin validation** max URL length and Unicode normalization for **`customPlaybackUrl`**.
-
 ### friends-and-direct-messaging
 - Exact **rate-limit bands** for DM send, unread mark-read, and friends-online query or push — **M35**, **#357** (remove-friend **30**/min decided #358).
 - WAF / API Gateway throttle key placement vs Lambda in-memory counters for DM HTTP (and any WS) routes.

--- a/.ai/specs/catalog-playback-host.spec.md
+++ b/.ai/specs/catalog-playback-host.spec.md
@@ -49,11 +49,25 @@ RiffSync catalog episodes can use either **YouTube** or **Custom** as the playba
 | Field | When | Notes |
 | --- | --- | --- |
 | **`playbackHost`** | Always (default **`youtube`** on legacy rows) | **`youtube`** \| **`custom`** |
-| **`customPlaybackUrl`** | Required when host is **`custom`** | HTTPS only; validated at admin save |
+| **`customPlaybackUrl`** | Required when host is **`custom`** | HTTPS only; **max 2048** chars after NFC; validated at admin save |
 | **`youtubeVideoId`**, **`youtubeWatchUrl`** | Optional on Custom rows | May remain for thumbs/metadata |
 | **`embedAllows`** | Optional boolean | **YouTube-path only** |
 
 Schema authority: **`data/catalog/catalog.schema.json`** with **`if`/`then`** for host-conditional **`customPlaybackUrl`**.
+
+### Admin save validation (`admin-catalog-validation.ts`)
+
+| Layer | Responsibility |
+| --- | --- |
+| **Writable allowlist** | **`playbackHost`**, **`customPlaybackUrl`** added to **`ADMIN_WRITABLE_KEYS`**. |
+| **POST defaults** | Missing **`playbackHost`** → **`youtube`**; missing **`customPlaybackUrl`** → **`null`**. Existing required POST keys (**`youtubeVideoId`**, **`youtubeWatchUrl`**, etc.) unchanged (nullable). |
+| **PATCH merge** | Merge writable body onto existing row; default missing **`playbackHost`** on existing legacy rows to **`youtube`** before validation. **Preserve** cross-host fields when switching host unless PATCH explicitly sets them. |
+| **AJV (`$defs.episode`)** | Enum, required keys, **`if`/`then`** Custom URL requirement, **`format: uri`**, **`^https://`**, **`maxLength: 2048`**. |
+| **Lambda extras** | NFC-normalize **`customPlaybackUrl`** strings before length/scheme checks; persist normalized value. Reject over-length or non-HTTPS with detail **`customPlaybackUrl must be an HTTPS URL (max 2048 characters)`**. |
+
+### Seed bundle migration
+
+- Keep bundle **`version: 1`**. Backfill committed **`data/catalog/episodes.json`** entries with **`playbackHost: youtube`** and **`customPlaybackUrl: null`** so CI schema validation passes.
 
 ### Client surfaces (indicative)
 
@@ -75,8 +89,8 @@ Follow repository **Node.js** and **TypeScript** versions from **`apps/web/packa
 
 ### Unit / contract
 
-- **`catalog.schema.json`**: host-conditional validation (**custom** requires HTTPS **`customPlaybackUrl`**).
-- **`admin-catalog-validation`**: writable allowlist includes new fields; Custom HTTPS rejection for non-HTTPS URLs.
+- **`catalog.schema.json`**: host-conditional validation (**custom** requires HTTPS **`customPlaybackUrl`**); **`maxLength: 2048`** on URL property; validate committed seed bundle after backfill.
+- **`admin-catalog-validation`**: writable allowlist includes **`playbackHost`** / **`customPlaybackUrl`**; POST defaults; Custom HTTPS accept/reject matrix (missing URL, `http://`, over 2048 chars, valid HTTPS); PATCH host switch preserves cross-host fields; NFC normalization persisted.
 - **`hostSourceTab`**: Custom rows resolve party-capture URL on RiffSync watch route.
 
 ### Integration


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #389
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.