### PR TITLE
docs(ai): refine issue #391 contract updates

### DIFF
--- a/.ai/interface/presentation.md
+++ b/.ai/interface/presentation.md
@@ -72,6 +72,21 @@ Staff **`/admin/catalog`** form gains a **Playback host** selector per episode: 
 | **YouTube** | Existing YouTube watch URL / video id fields | Unchanged validation intent; **`embedAllows`** applies to YouTube in-app embed path. |
 | **Custom** | **HTTPS** movie-page URL (**`customPlaybackUrl`**) | Required when host is Custom (**max 2048 chars**, NFC-normalized at save). YouTube fields **optional** (may remain for thumbs/metadata). Switching host **preserves** opposite-host fields unless staff explicitly PATCH them (including **`null`**). |
 
+**Form layout (create + edit):**
+
+| Order | Control | Contract |
+| --- | --- | --- |
+| 1 | **Episode identity** fieldset | Unchanged (`id` create-only, experiment #, title, catalog, tags, labels). |
+| 2 | **Playback** fieldset | **Playback host** labeled select: **YouTube** (`youtube`) \| **Custom** (`custom`). Default **`youtube`** on create and when legacy row omits host on load. |
+| 3 | Host-conditional URL | **YouTube:** **YouTube watch URL** input (same validation as today — valid watch URL or empty). **Custom:** **Custom playback URL** (`type="url"`) — required before save; client rejects empty, non-HTTPS, or NFC-normalized length **> 2048** with **`customPlaybackUrl must be an HTTPS URL (max 2048 characters)`** (same detail string as Lambda). |
+| 4 | **Featured on home page** | Unchanged. |
+| 5 | **Reconcile (read-only)** | Edit only; unchanged. |
+| 6 | **Operator hints** | Unchanged placement; **`embedAllows`** stays here. When host is **Custom**, helper copy states **`embedAllows` gates YouTube in-app embed only** — it does not block Custom playback. YouTube watch URL and **`embedAllows`** remain editable on Custom rows (optional enrichment). |
+
+**Host-switch UX:** Toggling **Playback host** in the form **does not clear** the other host's URL fields in local state. Save sends **`playbackHost`** when changed; server PATCH merge retains stored opposite-host attributes unless the body explicitly sets them.
+
+**Admin catalog list:** Playback-host column or badge on **`AdminCatalogListPage`** is **optional** and **out of scope** for the admin-form issue — follow-up if staff need list-at-a-glance host filtering.
+
 ### Solo watch and party capture (`/watch/:catalogEpisodeId`)
 
 | Concern | Contract |

--- a/.ai/specs/catalog-playback-host.spec.md
+++ b/.ai/specs/catalog-playback-host.spec.md
@@ -80,9 +80,21 @@ Schema authority: **`data/catalog/catalog.schema.json`** with **`if`/`then`** fo
 
 - Keep bundle **`version: 1`**. Backfill committed **`data/catalog/episodes.json`** entries with **`playbackHost: youtube`** and **`customPlaybackUrl: null`** so CI schema validation passes.
 
-### Client surfaces (indicative)
+### Admin catalog form (`AdminCatalogForm.tsx`, issue **#391**)
 
-- **`AdminCatalogForm.tsx`** — playback host selector and conditional fields.
+| Concern | Contract |
+| --- | --- |
+| **Types** | Extend **`CatalogEpisodeFormValues`**, **`StaffCatalogEpisode`**, **`StaffCatalogEpisodeWrite`** with **`playbackHost`** and **`customPlaybackUrl`**. |
+| **Load** | **`catalogEpisodeToFormValues`**: default missing **`playbackHost`** to **`youtube`**; map **`customPlaybackUrl`** to string (empty when null). |
+| **Layout** | **Playback** fieldset after **Episode identity** — see **`.ai/interface/presentation.md`** → *Admin catalog playback host* (control order table). |
+| **Create POST** | Body includes **`playbackHost`** (default **`youtube`**) and **`customPlaybackUrl`** (NFC-normalized HTTPS or **`null`**). Existing YouTube id/url derivation unchanged when watch URL present. |
+| **Edit PATCH** | **`buildPatchBody`** diffs **`playbackHost`** and **`customPlaybackUrl`** against loaded episode; omit unchanged keys. Host toggle without URL edits still PATCHes **`playbackHost`** only. |
+| **Client validation** | **`validateCatalogEpisodeForm`**: when **`playbackHost === 'custom'`**, require trimmed URL; NFC-normalize; enforce **`https:`** and max **2048** chars with message **`customPlaybackUrl must be an HTTPS URL (max 2048 characters)`**. YouTube host keeps optional watch URL validation. |
+| **Server errors** | Map **`StaffCatalogValidationError`** **`/playbackHost`** and **`/customPlaybackUrl`** paths via existing **`mapValidationDetailsToFieldErrors`**. |
+| **Out of scope** | **`AdminCatalogListPage`** playback-host column/badge (optional follow-up). |
+
+### Other client surfaces (indicative)
+
 - **`SoloWatchPage.tsx`** — host-aware player shell (YouTube vs generic iframe).
 - **`hostSourceTab.ts`** — capture URL stays on RiffSync watch route for Custom.
 - **`RoomPlaybackPanel.tsx` / `TheaterPlayback`** — host presentation iframe for Custom.
@@ -102,6 +114,8 @@ Follow repository **Node.js** and **TypeScript** versions from **`apps/web/packa
 
 - **`catalog.schema.json`**: host-conditional validation (**custom** requires HTTPS **`customPlaybackUrl`**); **`maxLength: 2048`** on URL property; validate committed seed bundle after backfill.
 - **`admin-catalog-validation`**: writable allowlist includes **`playbackHost`** / **`customPlaybackUrl`**; POST defaults; Custom HTTPS accept/reject matrix (missing URL, `http://`, over 2048 chars, valid HTTPS); PATCH host switch preserves cross-host fields; NFC normalization persisted.
+- **`validateCatalogEpisodeForm`** / **`AdminCatalogForm.test.tsx`**: Custom URL required when host Custom; rejects `http://` and over-2048 NFC length; accepts valid HTTPS; create POST includes host fields; edit PATCH sends **`playbackHost`** on toggle without clearing YouTube fields in body; host-switch preserves form state; **`embedAllows`** still PATCHable on Custom rows.
+- **`staffAdminCatalogApi`**: types include host fields on **`StaffCatalogEpisode`** / write body.
 - **`hostSourceTab`**: Custom rows resolve party-capture URL on RiffSync watch route.
 
 ### Integration
@@ -113,7 +127,8 @@ Follow repository **Node.js** and **TypeScript** versions from **`apps/web/packa
 
 ### Manual / smoke
 
-- Admin save YouTube vs Custom rows; solo watch iframe render for Custom HTTPS URL.
+- Staff admin UI: create YouTube-host and Custom-host episodes; edit host toggle retains opposite URL in form; reload edit shows persisted host + URLs from **`GET /v1/admin/catalog/episodes/:id`**.
+- Solo watch iframe render for Custom HTTPS URL (separate issue).
 - Party capture tab share with Custom inner iframe.
 - CSP smoke: Custom origin loads in iframe on staging/prod headers.
 


### PR DESCRIPTION
Contract-only PR from issue refinement (`/refine-issue`).

- **Issue:** #391
- **Scope:** `.ai` contract updates only; no application code
- **Review:** confirm timeless contract prose and issue alignment before merge

Merge before `/build-from-github` when implementation should read merged contracts on `main`.