### PR TITLE
feat(catalog): public catalog projection for playbackHost and customPlaybackUrl (#390)

### DIFF
--- a/apps/web/src/catalog/catalogApi.test.ts
+++ b/apps/web/src/catalog/catalogApi.test.ts
@@ -60,6 +60,48 @@ describe('normalizeEpisode', () => {
     })
     expect(episode.tmdbPopularity).toBeUndefined()
   })
+
+  it('defaults missing playbackHost to youtube and null customPlaybackUrl', () => {
+    const episode = normalizeEpisode({
+      id: 'ep-1',
+      experimentNumber: 1,
+      title: 'T',
+      catalog: 'mst3k',
+      tags: ['Era: Joel'],
+      labels: [],
+      youtubeVideoId: null,
+      youtubeWatchUrl: null,
+      tagline: null,
+      posterImageUrl: null,
+      backdropImageUrl: null,
+      tmdbMovieId: null,
+      tmdbArtworkSyncedAt: null,
+    })
+    expect(episode.playbackHost).toBe('youtube')
+    expect(episode.customPlaybackUrl).toBeNull()
+  })
+
+  it('parses Custom-host fields from API rows', () => {
+    const episode = normalizeEpisode({
+      id: 'ep-1',
+      experimentNumber: 1,
+      title: 'T',
+      catalog: 'mst3k',
+      tags: ['Era: Joel'],
+      labels: [],
+      youtubeVideoId: null,
+      youtubeWatchUrl: null,
+      tagline: null,
+      posterImageUrl: null,
+      backdropImageUrl: null,
+      tmdbMovieId: null,
+      tmdbArtworkSyncedAt: null,
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.test/movie',
+    })
+    expect(episode.playbackHost).toBe('custom')
+    expect(episode.customPlaybackUrl).toBe('https://example.test/movie')
+  })
 })
 
 function mockFetchResponse(init: {

--- a/apps/web/src/catalog/catalogApi.ts
+++ b/apps/web/src/catalog/catalogApi.ts
@@ -112,6 +112,11 @@ export function normalizeEpisode(raw: unknown): CatalogEpisode {
         : String(raw.tmdbArtworkSyncedAt),
     carousel: parseBooleanCatalogFlag(raw.carousel),
     spotlight: parseBooleanCatalogFlag(raw.spotlight),
+    playbackHost: raw.playbackHost === 'custom' ? 'custom' : 'youtube',
+    customPlaybackUrl:
+      raw.customPlaybackUrl === null || raw.customPlaybackUrl === undefined
+        ? null
+        : String(raw.customPlaybackUrl),
     embedAllows:
       raw.embedAllows === false ? false : raw.embedAllows === true ? true : undefined,
     playbackExpectation: parsePlaybackExpectation(raw.playbackExpectation),

--- a/apps/web/src/catalog/catalogQueries.test.ts
+++ b/apps/web/src/catalog/catalogQueries.test.ts
@@ -24,6 +24,8 @@ const episode: CatalogEpisode = {
   tmdbArtworkSyncedAt: null,
   carousel: true,
   spotlight: false,
+  playbackHost: 'youtube',
+  customPlaybackUrl: null,
 }
 
 function listCtx(client: QueryClient): QueryFunctionContext<typeof catalogListCarouselQueryKey> {

--- a/apps/web/src/catalog/catalogTypes.ts
+++ b/apps/web/src/catalog/catalogTypes.ts
@@ -61,6 +61,10 @@ export interface CatalogEpisode {
   spotlight: boolean
   /** When `false`, in-app YouTube embed should not be offered for this row. */
   embedAllows?: boolean
+  /** Playback surface for in-app watch; missing API values default to **`youtube`**. */
+  playbackHost: 'youtube' | 'custom'
+  /** HTTPS movie-page URL when **`playbackHost`** is **`custom`**; always present on public JSON. */
+  customPlaybackUrl: string | null
   /** Advisory label for ads vs Premium (honor-system). */
   playbackExpectation?: PlaybackExpectation
   /** TMDB movie popularity from reconcile; higher = more popular on TMDB. */

--- a/apps/web/src/catalog/catalogYoutubePlayback.test.ts
+++ b/apps/web/src/catalog/catalogYoutubePlayback.test.ts
@@ -24,6 +24,8 @@ function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/catalog/filterCatalogEntries.test.ts
+++ b/apps/web/src/catalog/filterCatalogEntries.test.ts
@@ -19,6 +19,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/catalog/mockCatalog.test.ts
+++ b/apps/web/src/catalog/mockCatalog.test.ts
@@ -23,6 +23,8 @@ function ep(
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     tmdbPopularity,
   }
 }

--- a/apps/web/src/catalog/mst3kTagFilters.test.ts
+++ b/apps/web/src/catalog/mst3kTagFilters.test.ts
@@ -23,6 +23,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/components/catalog/CatalogGridCard.test.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.test.tsx
@@ -33,6 +33,8 @@ function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
+++ b/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
@@ -33,6 +33,8 @@ function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/pages/CatalogPage.test.tsx
+++ b/apps/web/src/pages/CatalogPage.test.tsx
@@ -31,6 +31,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
@@ -32,6 +32,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -34,6 +34,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: true,
     spotlight: true,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/room/hostSourceTab.test.ts
+++ b/apps/web/src/room/hostSourceTab.test.ts
@@ -19,6 +19,8 @@ function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/seo/generateSeoArtifacts.test.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.test.ts
@@ -27,6 +27,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/seo/routeHeadTags.test.ts
+++ b/apps/web/src/seo/routeHeadTags.test.ts
@@ -48,6 +48,8 @@ function episode(overrides: Partial<CatalogEpisode> & Pick<CatalogEpisode, 'id'>
     tmdbArtworkSyncedAt: null,
     carousel: false,
     spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
+++ b/infra/cdk/lambda/admin-catalog-write-handlers.test.ts
@@ -212,6 +212,36 @@ describe('admin-catalog-post handler', () => {
     expect(body.entry.embedAllows).toBe(false);
   });
 
+  it('persists Custom-host fields and returns them on public projection', async () => {
+    mocks.docSend.mockResolvedValueOnce({}).mockResolvedValueOnce({
+      Attributes: { catalogGeneration: 4 },
+    });
+
+    const res = await postHandler(
+      staffEvent(
+        'POST',
+        '/v1/admin/catalog/episodes/ep-custom',
+        {
+          ...writeBody,
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.test/movie',
+        },
+        { sub: 'staff-1', 'cognito:groups': ['admin'] },
+        { id: 'ep-custom' },
+      ),
+      {} as never,
+      () => undefined,
+    );
+
+    expect(res?.statusCode).toBe(201);
+    const body = JSON.parse(res?.body ?? '');
+    expect(body.entry.playbackHost).toBe('custom');
+    expect(body.entry.customPlaybackUrl).toBe('https://example.test/movie');
+    const putInput = mocks.docSend.mock.calls[0]?.[0] as { input?: { Item?: Record<string, unknown> } };
+    expect(putInput?.input?.Item?.playbackHost).toBe('custom');
+    expect(putInput?.input?.Item?.customPlaybackUrl).toBe('https://example.test/movie');
+  });
+
   it('returns 403 when staff groups omit admin/curator', async () => {
     const res = await postHandler(
       staffEvent(

--- a/infra/cdk/lambda/catalog-public-handlers.test.ts
+++ b/infra/cdk/lambda/catalog-public-handlers.test.ts
@@ -141,6 +141,8 @@ describe('catalog-list handler cache headers', () => {
     const body = JSON.parse(res?.body ?? '');
     expect(body.entries).toHaveLength(1);
     expect(body.entries[0].id).toBe('101-the-crawling-eye');
+    expect(body.entries[0].playbackHost).toBe('youtube');
+    expect(body.entries[0].customPlaybackUrl).toBeNull();
   });
 
   it('uses carousel variant in ETag when carousel query is set', async () => {
@@ -213,5 +215,37 @@ describe('catalog-get handler cache headers', () => {
     const entry = JSON.parse(res?.body ?? '').entry;
     expect(entry.embedAllows).toBe(false);
     expect(entry).not.toHaveProperty('movieSearchTitle');
+  });
+
+  it('includes playback host fields on legacy YouTube rows', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 3 } })
+      .mockResolvedValueOnce({ Item: sampleEpisode });
+
+    const res = await getHandler(getEvent('101-the-crawling-eye'), {} as never, () => undefined);
+
+    expect(res?.statusCode).toBe(200);
+    const entry = JSON.parse(res?.body ?? '').entry;
+    expect(entry.playbackHost).toBe('youtube');
+    expect(entry.customPlaybackUrl).toBeNull();
+  });
+
+  it('includes Custom-host fields when stored', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: { id: '_meta', catalogGeneration: 3 } })
+      .mockResolvedValueOnce({
+        Item: {
+          ...sampleEpisode,
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.test/movie',
+        },
+      });
+
+    const res = await getHandler(getEvent('101-the-crawling-eye'), {} as never, () => undefined);
+
+    expect(res?.statusCode).toBe(200);
+    const entry = JSON.parse(res?.body ?? '').entry;
+    expect(entry.playbackHost).toBe('custom');
+    expect(entry.customPlaybackUrl).toBe('https://example.test/movie');
   });
 });

--- a/infra/cdk/lambda/catalog-shared.test.ts
+++ b/infra/cdk/lambda/catalog-shared.test.ts
@@ -53,4 +53,25 @@ describe('projectEpisode', () => {
     });
     expect(entry).not.toHaveProperty('movieSearchTitle');
   });
+
+  it('defaults playbackHost to youtube when omitted on legacy rows', () => {
+    const entry = projectEpisode(baseItem);
+    expect(entry.playbackHost).toBe('youtube');
+    expect(entry.customPlaybackUrl).toBeNull();
+  });
+
+  it('projects Custom-host rows with normalized customPlaybackUrl', () => {
+    const entry = projectEpisode({
+      ...baseItem,
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.test/movie',
+    });
+    expect(entry.playbackHost).toBe('custom');
+    expect(entry.customPlaybackUrl).toBe('https://example.test/movie');
+  });
+
+  it('defaults invalid playbackHost to youtube', () => {
+    const entry = projectEpisode({ ...baseItem, playbackHost: 'vimeo' });
+    expect(entry.playbackHost).toBe('youtube');
+  });
 });

--- a/infra/cdk/lambda/catalog-shared.ts
+++ b/infra/cdk/lambda/catalog-shared.ts
@@ -23,6 +23,10 @@ export interface CatalogEpisode {
   readonly spotlight: boolean;
   /** When false, SPA should not offer in-app YouTube embed; omitted when not stored on the row. */
   readonly embedAllows?: boolean;
+  /** Playback surface for in-app watch; missing/invalid Dynamo values default to **`youtube`**. */
+  readonly playbackHost: 'youtube' | 'custom';
+  /** HTTPS movie-page URL when **`playbackHost`** is **`custom`**; always present on public JSON. */
+  readonly customPlaybackUrl: string | null;
   readonly tmdbOverview?: string | null;
   readonly tmdbPopularity?: number | null;
   readonly tmdbPosterPath?: string | null;
@@ -79,6 +83,8 @@ export function projectEpisode(item: Record<string, unknown>): CatalogEpisode {
       ? item.embedAllows
       : undefined;
 
+  const playbackHost = item.playbackHost === 'custom' ? 'custom' : 'youtube';
+
   return {
     id,
     experimentNumber,
@@ -95,6 +101,8 @@ export function projectEpisode(item: Record<string, unknown>): CatalogEpisode {
     tmdbArtworkSyncedAt: optionalString(item.tmdbArtworkSyncedAt),
     carousel: parseBooleanCatalogFlag(item.carousel),
     spotlight: parseBooleanCatalogFlag(item.spotlight),
+    playbackHost,
+    customPlaybackUrl: optionalString(item.customPlaybackUrl),
     ...(embedAllows !== undefined ? { embedAllows } : {}),
     tmdbOverview: optionalStringField(item.tmdbOverview),
     tmdbPopularity: optionalNumberField(item.tmdbPopularity),

--- a/infra/cdk/scripts/export-catalog-dynamodb-to-json.ts
+++ b/infra/cdk/scripts/export-catalog-dynamodb-to-json.ts
@@ -38,6 +38,8 @@ const SCHEMA_FIELDS = [
   'spotlight',
   'movieSearchTitle',
   'embedAllows',
+  'playbackHost',
+  'customPlaybackUrl',
 ] as const;
 
 function resolveRegion(): string {


### PR DESCRIPTION
## Summary

- Extend `CatalogEpisode` / `projectEpisode` to always emit `playbackHost` (`youtube` | `custom`) and `customPlaybackUrl` (`string | null`) on anonymous `GET /v1/catalog` responses.
- Legacy Dynamo rows without `playbackHost` project `playbackHost: "youtube"` at read time; no migration job in this change.
- Add host fields to the Dynamo export script `SCHEMA_FIELDS` and web `normalizeEpisode` parsing with defensive youtube default.

Closes #390

## Test plan

- [x] `npm test --prefix infra/cdk` (418 tests)
- [x] `npm test --prefix apps/web`
- [x] New coverage in `catalog-shared`, `catalog-public-handlers`, `admin-catalog-write-handlers`, and `catalogApi` for Custom-host projection, legacy youtube default, and admin Custom POST round-trip