### PR TITLE
[M37] Admin catalog form playback host selector (#391)

### DIFF
--- a/apps/web/src/api/staffAdminCatalogApi.ts
+++ b/apps/web/src/api/staffAdminCatalogApi.ts
@@ -29,6 +29,8 @@ export interface StaffCatalogEpisode {
   embedAllows: boolean | null
   tmdbNeedsReview?: boolean | null
   youtubeThumbnailUrl: string | null
+  playbackHost: 'youtube' | 'custom'
+  customPlaybackUrl: string | null
 }
 
 export interface StaffCatalogListResponse {
@@ -53,6 +55,8 @@ export interface StaffCatalogEpisodeWrite {
   movieSearchTitle?: string | null
   tmdbMovieId?: number | null
   embedAllows?: boolean
+  playbackHost?: 'youtube' | 'custom'
+  customPlaybackUrl?: string | null
 }
 
 export class StaffCatalogValidationError extends Error {

--- a/apps/web/src/catalog/filterStaffCatalogEntries.test.ts
+++ b/apps/web/src/catalog/filterStaffCatalogEntries.test.ts
@@ -21,6 +21,8 @@ function episode(overrides: Partial<StaffCatalogEpisode> & Pick<StaffCatalogEpis
     movieSearchTitle: null,
     embedAllows: true,
     youtubeThumbnailUrl: null,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
     ...overrides,
   }
 }

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.test.ts
@@ -120,4 +120,63 @@ describe('validateCatalogEpisodeForm', () => {
     const result = validateCatalogEpisodeForm({ ...validCreate, tmdbMovieId: 'abc' }, 'edit')
     expect(result.fieldErrors.tmdbMovieId).toBeTruthy()
   })
+
+  it('requires customPlaybackUrl when playbackHost is custom', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, playbackHost: 'custom', customPlaybackUrl: '' },
+      'create',
+    )
+    expect(result.fieldErrors.customPlaybackUrl).toBe(
+      'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+    )
+  })
+
+  it('rejects non-HTTPS customPlaybackUrl', () => {
+    const result = validateCatalogEpisodeForm(
+      { ...validCreate, playbackHost: 'custom', customPlaybackUrl: 'http://example.test/movie' },
+      'create',
+    )
+    expect(result.fieldErrors.customPlaybackUrl).toBe(
+      'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+    )
+  })
+
+  it('rejects customPlaybackUrl over max NFC length', () => {
+    const result = validateCatalogEpisodeForm(
+      {
+        ...validCreate,
+        playbackHost: 'custom',
+        customPlaybackUrl: `https://example.test/${'a'.repeat(2048)}`,
+      },
+      'create',
+    )
+    expect(result.fieldErrors.customPlaybackUrl).toBe(
+      'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+    )
+  })
+
+  it('accepts valid HTTPS customPlaybackUrl', () => {
+    const result = validateCatalogEpisodeForm(
+      {
+        ...validCreate,
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+      },
+      'create',
+    )
+    expect(result.fieldErrors).toEqual({})
+  })
+
+  it('maps server validation details for customPlaybackUrl path', () => {
+    expect(
+      mapValidationDetailsToFieldErrors([
+        {
+          instancePath: '/customPlaybackUrl',
+          message: 'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+        },
+      ]),
+    ).toEqual({
+      customPlaybackUrl: 'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+    })
+  })
 })

--- a/apps/web/src/catalog/validateCatalogEpisodeForm.ts
+++ b/apps/web/src/catalog/validateCatalogEpisodeForm.ts
@@ -4,6 +4,8 @@ import { parseYoutubeWatchUrl } from './youtubeUrl'
 const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 export type CatalogEpisodeFormMode = 'create' | 'edit'
 
+export type CatalogPlaybackHost = 'youtube' | 'custom'
+
 export type CatalogEpisodeFormValues = {
   id: string
   experimentNumber: string
@@ -11,7 +13,9 @@ export type CatalogEpisodeFormValues = {
   catalog: CatalogCategory
   tags: string[]
   labels: string[]
+  playbackHost: CatalogPlaybackHost
   youtubeWatchUrl: string
+  customPlaybackUrl: string
   carousel: boolean
   spotlight: boolean
   movieSearchTitle: string
@@ -20,6 +24,9 @@ export type CatalogEpisodeFormValues = {
 }
 
 const MOVIE_SEARCH_TITLE_MAX_LENGTH = 256
+const CUSTOM_PLAYBACK_URL_MAX_LENGTH = 2048
+const CUSTOM_PLAYBACK_URL_ERROR =
+  'customPlaybackUrl must be an HTTPS URL (max 2048 characters)'
 const TAG_MAX_COUNT = 32
 const TAG_MAX_LENGTH = 64
 const LABEL_MAX_COUNT = 8
@@ -37,7 +44,9 @@ export const EMPTY_CATALOG_EPISODE_FORM_VALUES: CatalogEpisodeFormValues = {
   catalog: 'other',
   tags: [],
   labels: [],
+  playbackHost: 'youtube',
   youtubeWatchUrl: '',
+  customPlaybackUrl: '',
   carousel: false,
   spotlight: false,
   movieSearchTitle: '',
@@ -83,6 +92,24 @@ function validateYoutubeWatchUrl(raw: string): string | undefined {
   if (!trimmed) return undefined
   if (!parseYoutubeWatchUrl(trimmed)) {
     return 'Enter a valid YouTube watch URL or leave empty.'
+  }
+  return undefined
+}
+
+export function normalizeCustomPlaybackUrlField(raw: string): string | null {
+  const normalized = raw.normalize('NFC').trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function validateCustomPlaybackUrl(raw: string): string | undefined {
+  const normalized = raw.normalize('NFC').trim()
+  if (!normalized) return CUSTOM_PLAYBACK_URL_ERROR
+  if (normalized.length > CUSTOM_PLAYBACK_URL_MAX_LENGTH) return CUSTOM_PLAYBACK_URL_ERROR
+  try {
+    const url = new URL(normalized)
+    if (url.protocol !== 'https:') return CUSTOM_PLAYBACK_URL_ERROR
+  } catch {
+    return CUSTOM_PLAYBACK_URL_ERROR
   }
   return undefined
 }
@@ -171,6 +198,11 @@ export function validateCatalogEpisodeForm(
   const watchUrlError = validateYoutubeWatchUrl(values.youtubeWatchUrl)
   if (watchUrlError) fieldErrors.youtubeWatchUrl = watchUrlError
 
+  if (values.playbackHost === 'custom') {
+    const customUrlError = validateCustomPlaybackUrl(values.customPlaybackUrl)
+    if (customUrlError) fieldErrors.customPlaybackUrl = customUrlError
+  }
+
   const tagsError = validateStringList(values.tags, 'Tags', TAG_MAX_COUNT, TAG_MAX_LENGTH)
   if (tagsError) fieldErrors.tags = tagsError
 
@@ -218,6 +250,8 @@ export function catalogEpisodeToFormValues(
     labels?: string[] | null
     youtubeVideoId: string | null
     youtubeWatchUrl: string | null
+    playbackHost?: CatalogPlaybackHost | null
+    customPlaybackUrl?: string | null
     carousel: boolean
     spotlight?: boolean
     movieSearchTitle?: string | null
@@ -232,7 +266,9 @@ export function catalogEpisodeToFormValues(
     catalog: entry.catalog,
     tags: entry.tags ?? [],
     labels: entry.labels ?? [],
+    playbackHost: entry.playbackHost === 'custom' ? 'custom' : 'youtube',
     youtubeWatchUrl: entry.youtubeWatchUrl ?? '',
+    customPlaybackUrl: entry.customPlaybackUrl ?? '',
     carousel: entry.carousel,
     spotlight: entry.spotlight === true,
     movieSearchTitle: entry.movieSearchTitle ?? '',

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -451,6 +451,46 @@ describe('AdminCatalogForm', () => {
     expect(patchBody).not.toHaveProperty('customPlaybackUrl')
   })
 
+  it('edit PATCH sends playbackHost when toggled Custom to YouTube without clearing customPlaybackUrl', async () => {
+    const episode: StaffCatalogEpisode = {
+      ...baseEpisode,
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.test/stored-custom',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      youtubeVideoId: 'dQw4w9WgXcQ',
+    }
+    renderForm({
+      mode: 'edit',
+      initialEpisode: episode,
+      initialValues: catalogEpisodeToFormValues(episode),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    const hostSelect = container.querySelector('#catalog-form-playback-host') as HTMLSelectElement
+    await act(async () => {
+      setSelectValue(hostSelect, 'youtube')
+    })
+
+    expect(container.querySelector('#catalog-form-custom-playback-url')).toBeNull()
+    expect(container.querySelector('#catalog-form-youtube-url')).not.toBeNull()
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
+        playbackHost: 'youtube',
+      })
+    })
+    const patchBody = patchStaffCatalogEpisode.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(patchBody).not.toHaveProperty('customPlaybackUrl')
+    expect(patchBody).not.toHaveProperty('youtubeWatchUrl')
+    expect(patchBody).not.toHaveProperty('youtubeVideoId')
+  })
+
   it('host switch preserves opposite-host URL values in form state', async () => {
     const episode: StaffCatalogEpisode = {
       ...baseEpisode,

--- a/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.test.tsx
@@ -70,6 +70,12 @@ function uncheckCheckbox(checkbox: HTMLInputElement): void {
   }
 }
 
+function setSelectValue(select: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set
+  setter?.call(select, value)
+  select.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
 const baseEpisode: StaffCatalogEpisode = {
   id: 'ep-1',
   experimentNumber: 101,
@@ -89,6 +95,8 @@ const baseEpisode: StaffCatalogEpisode = {
   movieSearchTitle: 'Manos',
   embedAllows: true,
   youtubeThumbnailUrl: null,
+  playbackHost: 'youtube',
+  customPlaybackUrl: null,
 }
 
 describe('AdminCatalogForm', () => {
@@ -168,6 +176,8 @@ describe('AdminCatalogForm', () => {
           spotlight: false,
           movieSearchTitle: null,
           embedAllows: true,
+          playbackHost: 'youtube',
+          customPlaybackUrl: null,
         }),
       )
     })
@@ -359,6 +369,163 @@ describe('AdminCatalogForm', () => {
       expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
         tmdbMovieId: 603,
       })
+    })
+  })
+
+  it('create Custom-host episode sends playbackHost and customPlaybackUrl in POST body', async () => {
+    renderForm({ mode: 'create' })
+
+    const idInput = container.querySelector('#catalog-form-id') as HTMLInputElement
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    const experimentInput = container.querySelector('#catalog-form-experiment') as HTMLInputElement
+    const hostSelect = container.querySelector('#catalog-form-playback-host') as HTMLSelectElement
+
+    await act(async () => {
+      setInputValue(idInput, 'custom-ep')
+      setInputValue(experimentInput, '42')
+      setInputValue(titleInput, 'Custom movie')
+      setSelectValue(hostSelect, 'custom')
+    })
+
+    const customUrlInput = container.querySelector(
+      '#catalog-form-custom-playback-url',
+    ) as HTMLInputElement
+    await act(async () => {
+      setInputValue(customUrlInput, 'https://example.test/embed/movie')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(createStaffCatalogEpisode).toHaveBeenCalledWith(
+        'staff-token',
+        'custom-ep',
+        expect.objectContaining({
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.test/embed/movie',
+        }),
+      )
+    })
+  })
+
+  it('edit PATCH sends playbackHost when toggled without clearing YouTube fields', async () => {
+    const episode: StaffCatalogEpisode = {
+      ...baseEpisode,
+      playbackHost: 'youtube',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      youtubeVideoId: 'dQw4w9WgXcQ',
+      customPlaybackUrl: 'https://example.test/stored-custom',
+    }
+    renderForm({
+      mode: 'edit',
+      initialEpisode: episode,
+      initialValues: catalogEpisodeToFormValues(episode),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    const hostSelect = container.querySelector('#catalog-form-playback-host') as HTMLSelectElement
+    await act(async () => {
+      setSelectValue(hostSelect, 'custom')
+    })
+
+    expect(container.querySelector('#catalog-form-youtube-url')).toBeNull()
+    expect(container.querySelector('#catalog-form-custom-playback-url')).not.toBeNull()
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(patchStaffCatalogEpisode).toHaveBeenCalledWith('staff-token', 'ep-1', {
+        playbackHost: 'custom',
+      })
+    })
+    const patchBody = patchStaffCatalogEpisode.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(patchBody).not.toHaveProperty('youtubeWatchUrl')
+    expect(patchBody).not.toHaveProperty('youtubeVideoId')
+    expect(patchBody).not.toHaveProperty('customPlaybackUrl')
+  })
+
+  it('host switch preserves opposite-host URL values in form state', async () => {
+    const episode: StaffCatalogEpisode = {
+      ...baseEpisode,
+      playbackHost: 'youtube',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      youtubeVideoId: 'dQw4w9WgXcQ',
+      customPlaybackUrl: 'https://example.test/stored-custom',
+    }
+    renderForm({
+      mode: 'edit',
+      initialEpisode: episode,
+      initialValues: catalogEpisodeToFormValues(episode),
+      breadcrumbLeaf: 'Edit',
+      pageTitle: 'Edit episode',
+    })
+
+    const hostSelect = container.querySelector('#catalog-form-playback-host') as HTMLSelectElement
+    await act(async () => {
+      setSelectValue(hostSelect, 'custom')
+    })
+
+    const customUrlInput = container.querySelector(
+      '#catalog-form-custom-playback-url',
+    ) as HTMLInputElement
+    expect(customUrlInput.value).toBe('https://example.test/stored-custom')
+
+    await act(async () => {
+      setSelectValue(hostSelect, 'youtube')
+    })
+
+    const youtubeUrlInput = container.querySelector('#catalog-form-youtube-url') as HTMLInputElement
+    expect(youtubeUrlInput.value).toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+  })
+
+  it('maps server validation errors for customPlaybackUrl path', async () => {
+    const { StaffCatalogValidationError } = await import('../../api/staffAdminCatalogApi')
+    createStaffCatalogEpisode.mockRejectedValue(
+      new StaffCatalogValidationError([
+        {
+          instancePath: '/customPlaybackUrl',
+          message: 'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+        },
+      ]),
+    )
+
+    renderForm({ mode: 'create' })
+
+    const idInput = container.querySelector('#catalog-form-id') as HTMLInputElement
+    const titleInput = container.querySelector('#catalog-form-title') as HTMLInputElement
+    const experimentInput = container.querySelector('#catalog-form-experiment') as HTMLInputElement
+    const hostSelect = container.querySelector('#catalog-form-playback-host') as HTMLSelectElement
+
+    await act(async () => {
+      setInputValue(idInput, 'new-ep')
+      setInputValue(experimentInput, '1')
+      setInputValue(titleInput, 'Ok title')
+      setSelectValue(hostSelect, 'custom')
+    })
+
+    const customUrlInput = container.querySelector(
+      '#catalog-form-custom-playback-url',
+    ) as HTMLInputElement
+    await act(async () => {
+      setInputValue(customUrlInput, 'https://example.test/movie')
+    })
+
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        'customPlaybackUrl must be an HTTPS URL (max 2048 characters)',
+      )
     })
   })
 })

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -22,12 +22,14 @@ import {
 } from '../../catalog/catalogTypes'
 import {
   mapValidationDetailsToFieldErrors,
+  normalizeCustomPlaybackUrlField,
   normalizeNullableTextField,
   normalizeStringListField,
   normalizeTmdbMovieIdField,
   validateCatalogEpisodeForm,
   type CatalogEpisodeFormMode,
   type CatalogEpisodeFormValues,
+  type CatalogPlaybackHost,
 } from '../../catalog/validateCatalogEpisodeForm'
 import { parseYoutubeWatchUrl } from '../../catalog/youtubeUrl'
 import { invalidatePublicCatalogQueries } from '../../catalog/catalogQueries'
@@ -37,7 +39,7 @@ const RECONCILE_HELPER =
   'These fields are updated by the scheduled reconcile job. Pin a TMDB movie id or set a search title in Operator hints; art and tagline refresh on the next reconcile run.'
 
 const OPERATOR_HINTS_HELPER =
-  'Operator hints stored in Dynamo. tmdbMovieId locks reconcile to GET /movie/{id}; movieSearchTitle guides search when no id is set; embedAllows controls fan in-app embed.'
+  'Operator hints stored in Dynamo. tmdbMovieId locks reconcile to GET /movie/{id}; movieSearchTitle guides search when no id is set; embedAllows controls fan in-app YouTube embed only (not Custom playback).'
 
 function formValuesToWriteBody(
   values: CatalogEpisodeFormValues,
@@ -53,6 +55,11 @@ function formValuesToWriteBody(
     movieSearchTitle: normalizeNullableTextField(values.movieSearchTitle),
     tmdbMovieId: normalizeTmdbMovieIdField(values.tmdbMovieId),
     embedAllows: values.embedAllows,
+    playbackHost: values.playbackHost,
+    customPlaybackUrl:
+      values.playbackHost === 'custom'
+        ? normalizeCustomPlaybackUrlField(values.customPlaybackUrl)
+        : null,
   }
   const youtube = parseYoutubeWatchUrl(values.youtubeWatchUrl)
   if (youtube) {
@@ -83,6 +90,14 @@ function buildPatchBody(
   if (next.youtubeVideoId !== baseline.youtubeVideoId) body.youtubeVideoId = next.youtubeVideoId
   if (next.youtubeWatchUrl !== baseline.youtubeWatchUrl) {
     body.youtubeWatchUrl = next.youtubeWatchUrl
+  }
+  const baselinePlaybackHost = baseline.playbackHost === 'custom' ? 'custom' : 'youtube'
+  if (next.playbackHost !== baselinePlaybackHost) {
+    body.playbackHost = next.playbackHost
+  }
+  const baselineCustomUrl = baseline.customPlaybackUrl ?? null
+  if (next.customPlaybackUrl !== baselineCustomUrl) {
+    body.customPlaybackUrl = next.customPlaybackUrl
   }
   if (next.carousel !== baseline.carousel) body.carousel = next.carousel
   if (next.spotlight !== baseline.spotlight) body.spotlight = next.spotlight
@@ -466,32 +481,90 @@ export function AdminCatalogForm({
         </fieldset>
 
         <fieldset className="riffsync-admin-form-section">
-          <legend>YouTube</legend>
+          <legend>Playback</legend>
           <div className="riffsync-admin-form-field">
-            <label htmlFor="catalog-form-youtube-url">YouTube watch URL</label>
-            <input
-              id="catalog-form-youtube-url"
-              name="youtubeWatchUrl"
-              type="url"
-              value={values.youtubeWatchUrl}
-              onChange={(e) => setField('youtubeWatchUrl', e.target.value)}
-              aria-invalid={fieldErrors.youtubeWatchUrl ? true : undefined}
+            <label htmlFor="catalog-form-playback-host">Playback host</label>
+            <select
+              id="catalog-form-playback-host"
+              name="playbackHost"
+              value={values.playbackHost}
+              onChange={(e) => setField('playbackHost', e.target.value as CatalogPlaybackHost)}
+              aria-invalid={fieldErrors.playbackHost ? true : undefined}
               aria-describedby={
-                fieldErrors.youtubeWatchUrl ? 'catalog-form-youtube-url-error' : undefined
+                fieldErrors.playbackHost ? 'catalog-form-playback-host-error' : undefined
               }
               disabled={saving}
-              placeholder="https://www.youtube.com/watch?v=xxxxxxxxxxx"
-            />
-            {fieldErrors.youtubeWatchUrl ? (
+            >
+              <option value="youtube">YouTube</option>
+              <option value="custom">Custom</option>
+            </select>
+            {fieldErrors.playbackHost ? (
               <p
-                id="catalog-form-youtube-url-error"
+                id="catalog-form-playback-host-error"
                 className="riffsync-admin-form-field-error"
                 role="alert"
               >
-                {fieldErrors.youtubeWatchUrl}
+                {fieldErrors.playbackHost}
               </p>
             ) : null}
           </div>
+
+          {values.playbackHost === 'youtube' ? (
+            <div className="riffsync-admin-form-field">
+              <label htmlFor="catalog-form-youtube-url">YouTube watch URL</label>
+              <input
+                id="catalog-form-youtube-url"
+                name="youtubeWatchUrl"
+                type="url"
+                value={values.youtubeWatchUrl}
+                onChange={(e) => setField('youtubeWatchUrl', e.target.value)}
+                aria-invalid={fieldErrors.youtubeWatchUrl ? true : undefined}
+                aria-describedby={
+                  fieldErrors.youtubeWatchUrl ? 'catalog-form-youtube-url-error' : undefined
+                }
+                disabled={saving}
+                placeholder="https://www.youtube.com/watch?v=xxxxxxxxxxx"
+              />
+              {fieldErrors.youtubeWatchUrl ? (
+                <p
+                  id="catalog-form-youtube-url-error"
+                  className="riffsync-admin-form-field-error"
+                  role="alert"
+                >
+                  {fieldErrors.youtubeWatchUrl}
+                </p>
+              ) : null}
+            </div>
+          ) : (
+            <div className="riffsync-admin-form-field">
+              <label htmlFor="catalog-form-custom-playback-url">Custom playback URL</label>
+              <input
+                id="catalog-form-custom-playback-url"
+                name="customPlaybackUrl"
+                type="url"
+                required
+                value={values.customPlaybackUrl}
+                onChange={(e) => setField('customPlaybackUrl', e.target.value)}
+                aria-invalid={fieldErrors.customPlaybackUrl ? true : undefined}
+                aria-describedby={
+                  fieldErrors.customPlaybackUrl
+                    ? 'catalog-form-custom-playback-url-error'
+                    : undefined
+                }
+                disabled={saving}
+                placeholder="https://example.com/movie"
+              />
+              {fieldErrors.customPlaybackUrl ? (
+                <p
+                  id="catalog-form-custom-playback-url-error"
+                  className="riffsync-admin-form-field-error"
+                  role="alert"
+                >
+                  {fieldErrors.customPlaybackUrl}
+                </p>
+              ) : null}
+            </div>
+          )}
         </fieldset>
 
         <fieldset className="riffsync-admin-form-section">

--- a/apps/web/src/pages/admin/AdminCatalogForm.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogForm.tsx
@@ -95,9 +95,11 @@ function buildPatchBody(
   if (next.playbackHost !== baselinePlaybackHost) {
     body.playbackHost = next.playbackHost
   }
-  const baselineCustomUrl = baseline.customPlaybackUrl ?? null
-  if (next.customPlaybackUrl !== baselineCustomUrl) {
-    body.customPlaybackUrl = next.customPlaybackUrl
+  if (values.playbackHost === 'custom') {
+    const baselineCustomUrl = baseline.customPlaybackUrl ?? null
+    if (next.customPlaybackUrl !== baselineCustomUrl) {
+      body.customPlaybackUrl = next.customPlaybackUrl
+    }
   }
   if (next.carousel !== baseline.carousel) body.carousel = next.carousel
   if (next.spotlight !== baseline.spotlight) body.spotlight = next.spotlight

--- a/apps/web/src/pages/admin/AdminCatalogListPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminCatalogListPage.test.tsx
@@ -45,6 +45,8 @@ const baseEpisode: StaffCatalogEpisode = {
   movieSearchTitle: null,
   embedAllows: true,
   youtubeThumbnailUrl: null,
+  playbackHost: 'youtube',
+  customPlaybackUrl: null,
 }
 
 describe('AdminCatalogListPage', () => {


### PR DESCRIPTION
## Summary

- Add **Playback host** selector (YouTube | Custom) to the staff admin catalog create/edit form with host-conditional URL inputs.
- Extend form types, client validation (HTTPS + 2048 NFC), and POST/PATCH body mapping for `playbackHost` and `customPlaybackUrl`.
- Host toggle preserves opposite-host URL values in form state; PATCH sends only changed fields without auto-nulling stored metadata.

Closes #391

## Test plan

- [x] `npm test --prefix apps/web` (955 tests pass, including new validation and form coverage)
- [x] `npm run lint --prefix apps/web`
- [ ] Manual: create YouTube-host and Custom-host episodes at `/admin/catalog/new`
- [ ] Manual: edit existing row, toggle host, confirm opposite URL preserved and reload shows persisted host