### PR TITLE
[M37] Room create and patch gates for playback host (#392)

### DIFF
--- a/infra/cdk/lambda/catalog-room-playback-gate.test.ts
+++ b/infra/cdk/lambda/catalog-room-playback-gate.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  readCatalogPlaybackHost,
+  validateCatalogRowForRoomSeed,
+} from './catalog-room-playback-gate';
+
+const validYoutubeId = 'dQw4w9WgXcQ';
+
+describe('readCatalogPlaybackHost', () => {
+  it('defaults missing or invalid values to youtube', () => {
+    expect(readCatalogPlaybackHost(undefined)).toBe('youtube');
+    expect(readCatalogPlaybackHost(null)).toBe('youtube');
+    expect(readCatalogPlaybackHost({})).toBe('youtube');
+    expect(readCatalogPlaybackHost({ playbackHost: 'other' })).toBe('youtube');
+  });
+
+  it('returns custom when playbackHost is custom', () => {
+    expect(readCatalogPlaybackHost({ playbackHost: 'custom' })).toBe('custom');
+  });
+});
+
+describe('validateCatalogRowForRoomSeed', () => {
+  it('returns catalog_episode_not_found when row is missing', () => {
+    const result = validateCatalogRowForRoomSeed(undefined, 'missing-ep');
+    expect(result).toEqual({
+      ok: false,
+      code: 'catalog_episode_not_found',
+      error: 'Unknown catalog episode: missing-ep',
+      statusCode: 404,
+    });
+  });
+
+  it('accepts YouTube-host rows with a valid 11-char id', () => {
+    const result = validateCatalogRowForRoomSeed(
+      { playbackHost: 'youtube', youtubeVideoId: validYoutubeId },
+      'ep-yt',
+    );
+    expect(result).toEqual({
+      ok: true,
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
+  });
+
+  it('defaults legacy rows without playbackHost to YouTube validation', () => {
+    const result = validateCatalogRowForRoomSeed({ youtubeVideoId: validYoutubeId }, 'ep-legacy');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.playbackHost).toBe('youtube');
+    expect(result.customPlaybackUrl).toBeNull();
+  });
+
+  it('rejects YouTube-host rows with missing or invalid ids', () => {
+    expect(validateCatalogRowForRoomSeed({ playbackHost: 'youtube' }, 'ep-yt')).toMatchObject({
+      ok: false,
+      code: 'catalog_episode_youtube_id_missing',
+      statusCode: 400,
+    });
+    expect(
+      validateCatalogRowForRoomSeed(
+        { playbackHost: 'youtube', youtubeVideoId: 'short' },
+        'ep-yt',
+      ),
+    ).toMatchObject({
+      ok: false,
+      code: 'catalog_episode_youtube_id_missing',
+      statusCode: 400,
+    });
+  });
+
+  it('accepts Custom-host rows with HTTPS URL and no YouTube id', () => {
+    const result = validateCatalogRowForRoomSeed(
+      {
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.com/watch/123',
+      },
+      'ep-custom',
+    );
+    expect(result).toEqual({
+      ok: true,
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/123',
+    });
+  });
+
+  it('includes optional youtubeVideoId on Custom-host rows when present', () => {
+    const result = validateCatalogRowForRoomSeed(
+      {
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.com/watch/123',
+        youtubeVideoId: validYoutubeId,
+      },
+      'ep-custom',
+    );
+    expect(result).toEqual({
+      ok: true,
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/123',
+      youtubeVideoId: validYoutubeId,
+    });
+  });
+
+  it('rejects Custom-host rows with missing or non-HTTPS URLs', () => {
+    expect(
+      validateCatalogRowForRoomSeed({ playbackHost: 'custom' }, 'ep-custom'),
+    ).toMatchObject({
+      ok: false,
+      code: 'catalog_episode_custom_url_missing',
+      statusCode: 400,
+    });
+    expect(
+      validateCatalogRowForRoomSeed(
+        { playbackHost: 'custom', customPlaybackUrl: 'http://example.com/watch' },
+        'ep-custom',
+      ),
+    ).toMatchObject({
+      ok: false,
+      code: 'catalog_episode_custom_url_missing',
+      statusCode: 400,
+    });
+  });
+});

--- a/infra/cdk/lambda/catalog-room-playback-gate.ts
+++ b/infra/cdk/lambda/catalog-room-playback-gate.ts
@@ -1,0 +1,89 @@
+export type CatalogPlaybackHost = 'youtube' | 'custom';
+
+export type RoomSeedPlaybackSuccess = {
+  ok: true;
+  playbackHost: CatalogPlaybackHost;
+  customPlaybackUrl: string | null;
+  youtubeVideoId?: string;
+};
+
+export type RoomSeedPlaybackFailureCode =
+  | 'catalog_episode_not_found'
+  | 'catalog_episode_youtube_id_missing'
+  | 'catalog_episode_custom_url_missing';
+
+export type RoomSeedPlaybackFailure = {
+  ok: false;
+  code: RoomSeedPlaybackFailureCode;
+  error: string;
+  statusCode: 404 | 400;
+};
+
+export type RoomSeedPlaybackResult = RoomSeedPlaybackSuccess | RoomSeedPlaybackFailure;
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+export function readCatalogPlaybackHost(
+  row: Record<string, unknown> | undefined | null,
+): CatalogPlaybackHost {
+  if (!row) return 'youtube';
+  return row.playbackHost === 'custom' ? 'custom' : 'youtube';
+}
+
+export function validateCatalogRowForRoomSeed(
+  row: Record<string, unknown> | undefined | null,
+  catalogEpisodeId: string,
+): RoomSeedPlaybackResult {
+  if (!row) {
+    return {
+      ok: false,
+      code: 'catalog_episode_not_found',
+      error: `Unknown catalog episode: ${catalogEpisodeId}`,
+      statusCode: 404,
+    };
+  }
+
+  const playbackHost = readCatalogPlaybackHost(row);
+
+  if (playbackHost === 'custom') {
+    const url = typeof row.customPlaybackUrl === 'string' ? row.customPlaybackUrl.trim() : '';
+    if (!url.startsWith('https://')) {
+      return {
+        ok: false,
+        code: 'catalog_episode_custom_url_missing',
+        error: 'Catalog episode requires a custom HTTPS playback URL',
+        statusCode: 400,
+      };
+    }
+
+    const youtubeVideoId =
+      typeof row.youtubeVideoId === 'string' && row.youtubeVideoId.trim() !== ''
+        ? row.youtubeVideoId.trim()
+        : undefined;
+
+    return {
+      ok: true,
+      playbackHost: 'custom',
+      customPlaybackUrl: url,
+      ...(youtubeVideoId !== undefined ? { youtubeVideoId } : {}),
+    };
+  }
+
+  const youtubeVideoId =
+    typeof row.youtubeVideoId === 'string' ? row.youtubeVideoId.trim() : '';
+  if (!YOUTUBE_VIDEO_ID_PATTERN.test(youtubeVideoId)) {
+    return {
+      ok: false,
+      code: 'catalog_episode_youtube_id_missing',
+      error: 'Catalog episode requires a valid YouTube video id',
+      statusCode: 400,
+    };
+  }
+
+  return {
+    ok: true,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    youtubeVideoId,
+  };
+}

--- a/infra/cdk/lambda/lobby-get.test.ts
+++ b/infra/cdk/lambda/lobby-get.test.ts
@@ -104,4 +104,60 @@ describe('lobby-get handler', () => {
       expect.objectContaining({ roomId: 'room-named', hostDisplayName: 'Named Host' }),
     ]);
   });
+
+  it('includes playbackHost on listed rooms', async () => {
+    const nowMs = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(nowMs);
+
+    mocks.docSend
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            roomId: 'room-yt',
+            hostSub: 'host-yt',
+            catalogEpisodeId: 'ep-yt',
+            playbackHost: 'youtube',
+            youtubeVideoId: 'dQw4w9WgXcQ',
+            lastActivityAt: nowMs - 1_000,
+          },
+          {
+            roomId: 'room-custom',
+            hostSub: 'host-custom',
+            catalogEpisodeId: 'ep-custom',
+            playbackHost: 'custom',
+            customPlaybackUrl: 'https://example.com/watch/123',
+            lastActivityAt: nowMs - 1_000,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Responses: {
+          FanProfiles: [
+            { sub: 'host-yt', displayName: 'YouTube Host' },
+            { sub: 'host-custom', displayName: 'Custom Host' },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ Count: 1 })
+      .mockResolvedValueOnce({ Count: 2 });
+
+    const res = await handler({} as Parameters<typeof handler>[0], {} as Parameters<typeof handler>[1], () => undefined);
+    expect(res.statusCode).toBe(200);
+
+    const body = JSON.parse(String(res.body)) as {
+      rooms: Array<Record<string, unknown>>;
+    };
+    expect(body.rooms).toEqual([
+      expect.objectContaining({
+        roomId: 'room-yt',
+        playbackHost: 'youtube',
+        youtubeVideoId: 'dQw4w9WgXcQ',
+      }),
+      expect.objectContaining({
+        roomId: 'room-custom',
+        playbackHost: 'custom',
+      }),
+    ]);
+    expect(body.rooms[1]).not.toHaveProperty('youtubeVideoId');
+  });
 });

--- a/infra/cdk/lambda/lobby-get.ts
+++ b/infra/cdk/lambda/lobby-get.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { batchDisplayNamesByFanSub } from './fan-profile-shared';
+import { readCatalogPlaybackHost } from './catalog-room-playback-gate';
 import { shouldExcludeFromLobby } from './room-lobby-cleanup';
 import { defaultStaleRoomMs, LOBBY_PARTITION } from './room-shared';
 
@@ -81,7 +82,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (_event) => {
       playbackExpectation: r.playbackExpectation,
       lastActivityAt: r.lastActivityAt,
       catalogEpisodeId,
-      youtubeVideoId: r.youtubeVideoId,
+      playbackHost: readCatalogPlaybackHost(r),
+      ...(typeof r.youtubeVideoId === 'string' && r.youtubeVideoId.trim() !== ''
+        ? { youtubeVideoId: r.youtubeVideoId }
+        : {}),
       hostDisplayName,
       ...(trimmedDisplay !== undefined ? { displayTitle: trimmedDisplay } : {}),
       liveConnectionCount: counts[i] ?? 0,

--- a/infra/cdk/lambda/room-create.test.ts
+++ b/infra/cdk/lambda/room-create.test.ts
@@ -50,10 +50,20 @@ function createEvent(body: Record<string, unknown>, sub = 'host-sub-1'): APIGate
   };
 }
 
-const catalogItem = {
-  id: 'ep-1',
-  title: 'Test Episode',
-  youtubeVideoId: 'abc123',
+const validYoutubeId = 'dQw4w9WgXcQ';
+
+const youtubeCatalogItem = {
+  id: 'ep-yt',
+  title: 'YouTube Episode',
+  playbackHost: 'youtube',
+  youtubeVideoId: validYoutubeId,
+};
+
+const customCatalogItem = {
+  id: 'ep-custom',
+  title: 'Custom Episode',
+  playbackHost: 'custom',
+  customPlaybackUrl: 'https://example.com/watch/123',
 };
 
 describe('room-create handler', () => {
@@ -65,12 +75,12 @@ describe('room-create handler', () => {
 
   it('seeds roomMode theater and avDisabled false on create', async () => {
     mocks.docSend
-      .mockResolvedValueOnce({ Item: catalogItem })
+      .mockResolvedValueOnce({ Item: youtubeCatalogItem })
       .mockResolvedValueOnce({});
 
     const res = await handler(
       createEvent({
-        catalogEpisodeId: 'ep-1',
+        catalogEpisodeId: 'ep-yt',
         playbackExpectation: 'free',
         visibility: 'public',
         roomMode: 'videoChat',
@@ -86,5 +96,118 @@ describe('room-create handler', () => {
     const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
     expect(body.roomMode).toBe('theater');
     expect(body.avDisabled).toBe(false);
+  });
+
+  it('creates a YouTube-host room with playback mirrors', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: youtubeCatalogItem })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      createEvent({
+        catalogEpisodeId: 'ep-yt',
+        playbackExpectation: 'free',
+        visibility: 'public',
+      }),
+    );
+
+    expect(res.statusCode).toBe(201);
+    const putCall = mocks.docSend.mock.calls[1]?.[0] as { input: { Item: Record<string, unknown> } };
+    expect(putCall.input.Item).toMatchObject({
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
+
+    const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
+    expect(body).toMatchObject({
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
+  });
+
+  it('creates a Custom-host room without requiring youtubeVideoId', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: customCatalogItem })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(
+      createEvent({
+        catalogEpisodeId: 'ep-custom',
+        playbackExpectation: 'free',
+        visibility: 'private',
+      }),
+    );
+
+    expect(res.statusCode).toBe(201);
+    const putCall = mocks.docSend.mock.calls[1]?.[0] as { input: { Item: Record<string, unknown> } };
+    expect(putCall.input.Item).toMatchObject({
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/123',
+    });
+    expect(putCall.input.Item).not.toHaveProperty('youtubeVideoId');
+
+    const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
+    expect(body).toMatchObject({
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/123',
+    });
+    expect(body).not.toHaveProperty('youtubeVideoId');
+  });
+
+  it('returns 404 catalog_episode_not_found for unknown catalog id', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(
+      createEvent({
+        catalogEpisodeId: 'missing',
+        playbackExpectation: 'free',
+      }),
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'catalog_episode_not_found',
+    });
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 catalog_episode_youtube_id_missing for YouTube-host without valid id', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Item: { id: 'ep-yt', title: 'Bad', playbackHost: 'youtube', youtubeVideoId: 'short' },
+    });
+
+    const res = await handler(
+      createEvent({
+        catalogEpisodeId: 'ep-yt',
+        playbackExpectation: 'free',
+      }),
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'catalog_episode_youtube_id_missing',
+    });
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 catalog_episode_custom_url_missing for Custom-host without HTTPS URL', async () => {
+    mocks.docSend.mockResolvedValueOnce({
+      Item: { id: 'ep-custom', title: 'Bad', playbackHost: 'custom' },
+    });
+
+    const res = await handler(
+      createEvent({
+        catalogEpisodeId: 'ep-custom',
+        playbackExpectation: 'free',
+      }),
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'catalog_episode_custom_url_missing',
+    });
+    expect(mocks.docSend).toHaveBeenCalledTimes(1);
   });
 });

--- a/infra/cdk/lambda/room-create.ts
+++ b/infra/cdk/lambda/room-create.ts
@@ -5,6 +5,7 @@ import {
   GetCommand,
   PutCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { validateCatalogRowForRoomSeed } from './catalog-room-playback-gate';
 import {
   initialDisplayTitleFromCatalog,
   lobbySortKey,
@@ -75,14 +76,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     }),
   );
   const row = cat.Item as Record<string, unknown> | undefined;
-  if (!row || typeof row.youtubeVideoId !== 'string' || row.youtubeVideoId === '') {
+  const playback = validateCatalogRowForRoomSeed(row, catalogEpisodeId);
+  if (!playback.ok) {
     return {
-      statusCode: 404,
-      body: JSON.stringify({ error: `Unknown catalog episode: ${catalogEpisodeId}` }),
+      statusCode: playback.statusCode,
+      body: JSON.stringify({ code: playback.code, error: playback.error }),
     };
   }
-
-  const youtubeVideoId = row.youtubeVideoId as string;
 
   const displayTitle = initialDisplayTitleFromCatalog({
     catalogEpisodeId,
@@ -97,7 +97,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     roomId,
     hostSub,
     catalogEpisodeId,
-    youtubeVideoId,
+    playbackHost: playback.playbackHost,
+    customPlaybackUrl: playback.customPlaybackUrl,
     displayTitle,
     playbackExpectation,
     visibility,
@@ -107,6 +108,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     version,
     createdAt: now,
   };
+
+  if (playback.youtubeVideoId !== undefined) {
+    item.youtubeVideoId = playback.youtubeVideoId;
+  }
 
   if (visibility === 'public') {
     item.lobbyPk = LOBBY_PARTITION;
@@ -128,7 +133,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       roomId,
       hostSub,
       catalogEpisodeId,
-      youtubeVideoId,
+      playbackHost: playback.playbackHost,
+      customPlaybackUrl: playback.customPlaybackUrl,
+      ...(playback.youtubeVideoId !== undefined ? { youtubeVideoId: playback.youtubeVideoId } : {}),
       displayTitle,
       playbackExpectation,
       visibility,

--- a/infra/cdk/lambda/room-get.test.ts
+++ b/infra/cdk/lambda/room-get.test.ts
@@ -54,11 +54,15 @@ function getEvent(roomId: string): APIGatewayProxyEventV2 {
   };
 }
 
+const validYoutubeId = 'dQw4w9WgXcQ';
+
 const fullRoomRow = {
   roomId: 'room-1',
   hostSub: 'host-sub-1',
   catalogEpisodeId: 'ep-1',
-  youtubeVideoId: 'yt-1',
+  playbackHost: 'youtube',
+  customPlaybackUrl: null,
+  youtubeVideoId: validYoutubeId,
   displayTitle: 'Now Playing',
   playbackExpectation: 'free',
   visibility: 'public',
@@ -69,11 +73,24 @@ const fullRoomRow = {
   broadcastCaptureActive: true,
 };
 
+const customRoomRow = {
+  roomId: 'room-custom',
+  hostSub: 'host-sub-3',
+  catalogEpisodeId: 'ep-custom',
+  playbackHost: 'custom',
+  customPlaybackUrl: 'https://example.com/watch/789',
+  displayTitle: 'Custom Now Playing',
+  playbackExpectation: 'free',
+  visibility: 'public',
+  lastActivityAt: 1_700_000_200_000,
+  version: 2,
+};
+
 const legacyRoomRow = {
   roomId: 'room-legacy',
   hostSub: 'host-sub-2',
   catalogEpisodeId: 'ep-2',
-  youtubeVideoId: 'yt-2',
+  youtubeVideoId: validYoutubeId,
   playbackExpectation: 'premium',
   visibility: 'private',
   lastActivityAt: 1_700_000_100_000,
@@ -110,6 +127,25 @@ describe('room-get handler', () => {
     expect(body.room.roomMode).toBe('videoChat');
     expect(body.room.avDisabled).toBe(true);
     expect(body.room.broadcastCaptureActive).toBe(true);
+    expect(body.room).toMatchObject({
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
+  });
+
+  it('returns Custom-host playback mirrors on snapshot', async () => {
+    mocks.docSend.mockResolvedValueOnce({ Item: customRoomRow });
+
+    const res = await handler(getEvent('room-custom'));
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body ?? '{}') as { room: Record<string, unknown> };
+    expect(body.room).toMatchObject({
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/789',
+    });
+    expect(body.room).not.toHaveProperty('youtubeVideoId');
   });
 
   it('defaults missing AV attributes on legacy rows without error', async () => {
@@ -122,5 +158,10 @@ describe('room-get handler', () => {
     expect(body.room.roomMode).toBe('theater');
     expect(body.room.avDisabled).toBe(false);
     expect(body.room.broadcastCaptureActive).toBe(false);
+    expect(body.room).toMatchObject({
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
   });
 });

--- a/infra/cdk/lambda/room-get.ts
+++ b/infra/cdk/lambda/room-get.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { readCatalogPlaybackHost } from './catalog-room-playback-gate';
 import { parseRoomMode, type RoomMode } from './room-shared';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -42,6 +43,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const row = out.Item as Record<string, unknown>;
   const displayTitle =
     typeof row.displayTitle === 'string' && row.displayTitle.trim() !== '' ? row.displayTitle.trim() : undefined;
+  const playbackHost = readCatalogPlaybackHost(row);
+  const customPlaybackUrl =
+    typeof row.customPlaybackUrl === 'string' ? row.customPlaybackUrl : null;
+  const youtubeVideoId =
+    typeof row.youtubeVideoId === 'string' && row.youtubeVideoId.trim() !== ''
+      ? row.youtubeVideoId.trim()
+      : undefined;
   return {
     statusCode: 200,
     headers: { 'content-type': 'application/json; charset=utf-8' },
@@ -50,7 +58,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         roomId: row.roomId,
         hostSub: row.hostSub,
         catalogEpisodeId: row.catalogEpisodeId,
-        youtubeVideoId: row.youtubeVideoId,
+        playbackHost,
+        customPlaybackUrl,
+        ...(youtubeVideoId !== undefined ? { youtubeVideoId } : {}),
         ...(displayTitle !== undefined ? { displayTitle } : {}),
         playbackExpectation: row.playbackExpectation,
         visibility: row.visibility,

--- a/infra/cdk/lambda/room-patch.test.ts
+++ b/infra/cdk/lambda/room-patch.test.ts
@@ -43,12 +43,15 @@ vi.mock('./room-patch-fanout', async (importOriginal) => {
 import { handler } from './room-patch';
 
 const hostSub = 'host-sub-1';
+const validYoutubeId = 'dQw4w9WgXcQ';
 
 const baseRoom = {
   roomId: 'room-1',
   hostSub,
   catalogEpisodeId: 'ep-1',
-  youtubeVideoId: 'yt-1',
+  playbackHost: 'youtube',
+  customPlaybackUrl: null,
+  youtubeVideoId: validYoutubeId,
   playbackExpectation: 'free',
   visibility: 'private',
   lastActivityAt: 1_700_000_000_000,
@@ -172,7 +175,9 @@ describe('room-patch handler', () => {
       roomId: 'room-legacy',
       hostSub,
       catalogEpisodeId: 'ep-1',
-      youtubeVideoId: 'yt-1',
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
       playbackExpectation: 'free',
       visibility: 'private',
       lastActivityAt: 1_700_000_000_000,
@@ -363,5 +368,84 @@ describe('room-patch handler', () => {
       ':rm': 'videoChat',
       ':bc': null,
     });
+  });
+
+  it('switches episode to Custom-host and refreshes playback mirrors', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: baseRoom })
+      .mockResolvedValueOnce({
+        Item: {
+          id: 'ep-custom',
+          title: 'Custom Episode',
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.com/watch/456',
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(patchEvent({ catalogEpisodeId: 'ep-custom' }));
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
+    expect(body).toMatchObject({
+      catalogEpisodeId: 'ep-custom',
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/456',
+    });
+    expect(body).not.toHaveProperty('youtubeVideoId');
+
+    const updateCall = mocks.docSend.mock.calls[2]?.[0] as { input: Record<string, unknown> };
+    expect(updateCall.input.ExpressionAttributeValues).toMatchObject({
+      ':ceid': 'ep-custom',
+      ':ph': 'custom',
+      ':cpu': 'https://example.com/watch/456',
+      ':yt': null,
+    });
+  });
+
+  it('switches episode to YouTube-host and refreshes playback mirrors', async () => {
+    const customRoom = {
+      ...baseRoom,
+      catalogEpisodeId: 'ep-custom',
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/watch/456',
+      youtubeVideoId: null,
+    };
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: customRoom })
+      .mockResolvedValueOnce({
+        Item: {
+          id: 'ep-yt',
+          title: 'YouTube Episode',
+          playbackHost: 'youtube',
+          youtubeVideoId: validYoutubeId,
+        },
+      })
+      .mockResolvedValueOnce({});
+
+    const res = await handler(patchEvent({ catalogEpisodeId: 'ep-yt' }));
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body ?? '{}') as Record<string, unknown>;
+    expect(body).toMatchObject({
+      catalogEpisodeId: 'ep-yt',
+      playbackHost: 'youtube',
+      customPlaybackUrl: null,
+      youtubeVideoId: validYoutubeId,
+    });
+  });
+
+  it('returns deny codes when switching to invalid catalog episodes', async () => {
+    mocks.docSend
+      .mockResolvedValueOnce({ Item: baseRoom })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const res = await handler(patchEvent({ catalogEpisodeId: 'missing' }));
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'catalog_episode_not_found',
+    });
+    expect(mocks.docSend).toHaveBeenCalledTimes(2);
   });
 });

--- a/infra/cdk/lambda/room-patch.ts
+++ b/infra/cdk/lambda/room-patch.ts
@@ -5,6 +5,7 @@ import {
   GetCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { readCatalogPlaybackHost, validateCatalogRowForRoomSeed } from './catalog-room-playback-gate';
 import {
   readAvDisabled,
   readBroadcastCaptureActive,
@@ -105,7 +106,14 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   }
 
   let catalogEpisodeId = String(room.catalogEpisodeId ?? '');
-  let youtubeVideoId = String(room.youtubeVideoId ?? '');
+  let playbackHost = readCatalogPlaybackHost(room);
+  let customPlaybackUrl =
+    typeof room.customPlaybackUrl === 'string' ? room.customPlaybackUrl : null;
+  let youtubeVideoId: string | null =
+    typeof room.youtubeVideoId === 'string' && room.youtubeVideoId.trim() !== ''
+      ? room.youtubeVideoId.trim()
+      : null;
+
   if (typeof body.catalogEpisodeId === 'string' && body.catalogEpisodeId !== catalogEpisodeId) {
     catalogEpisodeId = body.catalogEpisodeId;
     const cat = await client.send(
@@ -115,17 +123,16 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       }),
     );
     const row = cat.Item as Record<string, unknown> | undefined;
-    if (
-      !row ||
-      typeof row.youtubeVideoId !== 'string' ||
-      (row.youtubeVideoId as string) === ''
-    ) {
+    const playback = validateCatalogRowForRoomSeed(row, catalogEpisodeId);
+    if (!playback.ok) {
       return {
-        statusCode: 404,
-        body: JSON.stringify({ error: `Unknown catalog episode: ${catalogEpisodeId}` }),
+        statusCode: playback.statusCode,
+        body: JSON.stringify({ code: playback.code, error: playback.error }),
       };
     }
-    youtubeVideoId = row.youtubeVideoId as string;
+    playbackHost = playback.playbackHost;
+    customPlaybackUrl = playback.customPlaybackUrl;
+    youtubeVideoId = playback.youtubeVideoId ?? null;
   }
 
   let playbackExpectationPatch: ReturnType<typeof parsePlaybackExpectation> | undefined;
@@ -218,6 +225,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     '#vat': 'lastActivityAt',
     '#ver': 'version',
     '#ceid': 'catalogEpisodeId',
+    '#ph': 'playbackHost',
+    '#cpu': 'customPlaybackUrl',
     '#yt': 'youtubeVideoId',
     '#visibility': 'visibility',
     '#lpk': 'lobbyPk',
@@ -231,11 +240,15 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     ':vnext': version + 1,
     ':visibility': visibility,
     ':ceid': catalogEpisodeId,
+    ':ph': playbackHost,
+    ':cpu': customPlaybackUrl,
     ':yt': youtubeVideoId,
   };
 
   const setParts = [
     '#ceid = :ceid',
+    '#ph = :ph',
+    '#cpu = :cpu',
     '#yt = :yt',
     '#visibility = :visibility',
     '#vat = :vat',
@@ -372,7 +385,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       roomId,
       version: nextVersion,
       catalogEpisodeId,
-      youtubeVideoId,
+      playbackHost,
+      customPlaybackUrl,
+      ...(youtubeVideoId !== null ? { youtubeVideoId } : {}),
       visibility,
       lastActivityAt: now,
       ...(storedDisplayTitle !== undefined ? { displayTitle: storedDisplayTitle } : {}),


### PR DESCRIPTION
## Summary

- Add `catalog-room-playback-gate.ts` with shared YouTube vs Custom validation for room seeding.
- Wire `room-create.ts` and `room-patch.ts` to the gate, persist `playbackHost`, `customPlaybackUrl`, and optional `youtubeVideoId` on Rooms, and return stable deny codes.
- Echo playback mirrors on `room-get.ts` snapshots and `playbackHost` on `lobby-get.ts` listed rooms.

Closes #392

## Test plan

- [x] `npm test --prefix infra/cdk -- room-create room-patch room-get catalog-room-playback-gate lobby-get`
- [ ] CI green on this PR