### PR TITLE
[M37] Solo watch and party capture iframe for Custom host (#393)

### DIFF
--- a/apps/web/src/components/watch/SoloCustomIframePlayer.test.tsx
+++ b/apps/web/src/components/watch/SoloCustomIframePlayer.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SoloCustomIframePlayer } from './SoloCustomIframePlayer'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('SoloCustomIframePlayer', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderPlayer() {
+    act(() => {
+      root.render(
+        <SoloCustomIframePlayer
+          customPlaybackUrl="https://example.test/movie"
+          title="Test Movie"
+        />,
+      )
+    })
+  }
+
+  it('renders iframe with customPlaybackUrl, title, and allow attrs', () => {
+    renderPlayer()
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(iframe?.getAttribute('src')).toBe('https://example.test/movie')
+    expect(iframe?.getAttribute('title')).toBe('Test Movie')
+    expect(iframe?.getAttribute('allow')).toBe('autoplay; fullscreen; encrypted-media')
+  })
+
+  it('shows embed-blocked copy when iframe fires error', () => {
+    renderPlayer()
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+
+    act(() => {
+      iframe?.dispatchEvent(new Event('error'))
+    })
+
+    expect(container.textContent).toContain('This page could not be embedded in RiffSync.')
+    expect(container.querySelector('a[href="https://example.test/movie"]')?.textContent).toBe(
+      'Open the movie page in a new tab.',
+    )
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+
+  it('transitions from loading to ready on iframe load', () => {
+    renderPlayer()
+
+    expect(container.querySelector('.sr-only')?.textContent).toBe('Loading playback.')
+
+    const iframe = container.querySelector('iframe')
+    act(() => {
+      iframe?.dispatchEvent(new Event('load'))
+    })
+
+    expect(container.querySelector('.sr-only')).toBeNull()
+    expect(container.querySelector('iframe')).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
+++ b/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function SoloCustomIframePlayer({
+  customPlaybackUrl,
+  title,
+}: {
+  customPlaybackUrl: string
+  title: string
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+
+  useEffect(() => {
+    setStatus('loading')
+    const iframe = iframeRef.current
+    if (!iframe) return
+
+    const onLoad = () => setStatus('ready')
+    const onError = () => setStatus('error')
+    iframe.addEventListener('load', onLoad)
+    iframe.addEventListener('error', onError)
+    return () => {
+      iframe.removeEventListener('load', onLoad)
+      iframe.removeEventListener('error', onError)
+    }
+  }, [customPlaybackUrl])
+
+  return (
+    <div className="riffsync-solo-player">
+      {status === 'error' ? (
+        <div className="riffsync-solo-player__chrome" aria-live="polite">
+          <p role="alert">
+            This page could not be embedded in RiffSync.{' '}
+            <a href={customPlaybackUrl} rel="noreferrer" target="_blank">
+              Open the movie page in a new tab.
+            </a>
+          </p>
+        </div>
+      ) : null}
+      {status === 'loading' ? <span className="sr-only">Loading playback.</span> : null}
+      {status !== 'error' ? (
+        <div className="riffsync-solo-player__frame">
+          <iframe
+            ref={iframeRef}
+            src={customPlaybackUrl}
+            title={title}
+            allow="autoplay; fullscreen; encrypted-media"
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
+++ b/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
@@ -11,7 +11,6 @@ export function SoloCustomIframePlayer({
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
 
   useEffect(() => {
-    setStatus('loading')
     const iframe = iframeRef.current
     if (!iframe) return
 

--- a/apps/web/src/pages/SoloWatchPage.test.tsx
+++ b/apps/web/src/pages/SoloWatchPage.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SoloWatchPage } from './SoloWatchPage'
+import type { CatalogEpisode } from '../catalog/catalogTypes'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const useCatalogEpisodeQuery = vi.fn()
+
+vi.mock('../catalog/catalogQueries', () => ({
+  useCatalogEpisodeQuery: (...args: unknown[]) => useCatalogEpisodeQuery(...args),
+}))
+
+vi.mock('../components/watch/SoloYouTubePlayer', () => ({
+  SoloYouTubePlayer: ({ videoId, titleHint }: { videoId: string; titleHint: string }) => (
+    <div data-testid="solo-youtube-player" data-video-id={videoId} data-title={titleHint} />
+  ),
+}))
+
+function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
+  return {
+    id: '032-mitchell',
+    experimentNumber: 32,
+    title: 'Mitchell',
+    catalog: 'mst3k',
+    tags: [],
+    labels: [],
+    youtubeVideoId: 'NXGXtm6gcxk',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    ...overrides,
+  }
+}
+
+describe('SoloWatchPage', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    useCatalogEpisodeQuery.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function renderWatchPage(path = '/watch/032-mitchell') {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route path="/watch/:catalogEpisodeId" element={<SoloWatchPage />} />
+          </Routes>
+        </MemoryRouter>,
+      )
+    })
+  }
+
+  it('renders Custom-host iframe when playbackHost is custom with HTTPS URL', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+        youtubeVideoId: null,
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(iframe?.getAttribute('src')).toBe('https://example.test/movie')
+    expect(iframe?.getAttribute('title')).toBe('Mitchell')
+    expect(container.querySelector('[data-testid="solo-youtube-player"]')).toBeNull()
+  })
+
+  it('shows blocked copy when Custom-host row is missing customPlaybackUrl', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: null,
+        embedAllows: false,
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    expect(container.textContent).toContain(
+      'Playback unavailable — no custom playback URL is linked for this catalog entry.',
+    )
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+
+  it('does not apply embedAllows gate to Custom-host rows', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+        embedAllows: false,
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    expect(container.querySelector('iframe')).not.toBeNull()
+    expect(container.textContent).not.toContain('embedAllows')
+  })
+
+  it('keeps YouTube-host playback path unchanged', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({ embedAllows: true }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    const youtubePlayer = container.querySelector('[data-testid="solo-youtube-player"]')
+    expect(youtubePlayer).not.toBeNull()
+    expect(youtubePlayer?.getAttribute('data-video-id')).toBe('NXGXtm6gcxk')
+    expect(container.querySelector('iframe[src^="https://example"]')).toBeNull()
+  })
+
+  it('uses party-capture layout shell for Custom-host rows', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage('/watch/032-mitchell?partyCapture=1')
+
+    expect(container.querySelector('.riffsync-solo-watch-page--party-capture')).not.toBeNull()
+    expect(container.querySelector('.riffsync-solo-watch__player-shell')).not.toBeNull()
+    expect(container.querySelector('iframe')).not.toBeNull()
+  })
+
+  it('shows embed-blocked copy when Custom iframe reports error', () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    const iframe = container.querySelector('iframe')
+    act(() => {
+      iframe?.dispatchEvent(new Event('error'))
+    })
+
+    expect(container.textContent).toContain('This page could not be embedded in RiffSync.')
+    expect(container.querySelector('a[href="https://example.test/movie"]')).not.toBeNull()
+  })
+})

--- a/apps/web/src/pages/SoloWatchPage.tsx
+++ b/apps/web/src/pages/SoloWatchPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { SoloCustomIframePlayer } from '../components/watch/SoloCustomIframePlayer'
 import { SoloYouTubePlayer } from '../components/watch/SoloYouTubePlayer'
 import { useCatalogEpisodeQuery } from '../catalog/catalogQueries'
 import { EPISODE_UNAVAILABLE_MESSAGE, formatCatalogUserError } from '../catalog/catalogLoadError'
@@ -152,6 +153,10 @@ export function SoloWatchPage() {
     )
   }
 
+  const playbackHost = episode.playbackHost === 'custom' ? 'custom' : 'youtube'
+  const customPlaybackUrl = episode.customPlaybackUrl?.trim() ?? ''
+  const hasCustomPlaybackUrl =
+    playbackHost === 'custom' && customPlaybackUrl.startsWith('https://')
   const vid = episode.youtubeVideoId
   const canEmbed = episode.embedAllows !== false
   const backdropImageUrl = episode.backdropImageUrl?.trim()
@@ -160,7 +165,8 @@ export function SoloWatchPage() {
       ? `riffsync-solo-watch-page riffsync-solo-watch-page--backdrop${partyCapture ? ' riffsync-solo-watch-page--party-capture' : ''}`
       : `riffsync-solo-watch-page${partyCapture ? ' riffsync-solo-watch-page--party-capture' : ''}`
   const innerChrome = partyCapture ? 'riffsync-solo-watch riffsync-solo-watch--capture' : 'container riffsync-solo-watch'
-  const playbackBlocked = !vid || !canEmbed
+  const youtubePlaybackBlocked = playbackHost === 'youtube' && (!vid || !canEmbed)
+  const customPlaybackBlocked = playbackHost === 'custom' && !hasCustomPlaybackUrl
 
   return (
     <div className={pageRoot}>
@@ -183,7 +189,14 @@ export function SoloWatchPage() {
         />
       ) : null}
       <h1 className="sr-only">{episode.title}</h1>
-      {playbackBlocked ? (
+      {customPlaybackBlocked ? (
+        <div className={innerChrome}>
+          <p role="status">
+            Playback unavailable — no custom playback URL is linked for this catalog entry.
+          </p>
+        </div>
+      ) : null}
+      {youtubePlaybackBlocked ? (
         <div className={innerChrome}>
           {!vid && (
             <p role="status">Playback unavailable — no YouTube video is linked for this catalog entry.</p>
@@ -204,7 +217,12 @@ export function SoloWatchPage() {
           )}
         </div>
       ) : null}
-      {vid && canEmbed ? (
+      {hasCustomPlaybackUrl ? (
+        <div className="riffsync-solo-watch__player-shell">
+          <SoloCustomIframePlayer customPlaybackUrl={customPlaybackUrl} title={episode.title} />
+        </div>
+      ) : null}
+      {playbackHost === 'youtube' && vid && canEmbed ? (
         <div className="riffsync-solo-watch__player-shell">
           <SoloYouTubePlayer videoId={vid} titleHint={episode.title} autoPlay={false} />
         </div>

--- a/apps/web/src/pages/SoloWatchPage.tsx
+++ b/apps/web/src/pages/SoloWatchPage.tsx
@@ -219,7 +219,11 @@ export function SoloWatchPage() {
       ) : null}
       {hasCustomPlaybackUrl ? (
         <div className="riffsync-solo-watch__player-shell">
-          <SoloCustomIframePlayer customPlaybackUrl={customPlaybackUrl} title={episode.title} />
+          <SoloCustomIframePlayer
+            key={customPlaybackUrl}
+            customPlaybackUrl={customPlaybackUrl}
+            title={episode.title}
+          />
         </div>
       ) : null}
       {playbackHost === 'youtube' && vid && canEmbed ? (

--- a/apps/web/src/room/hostSourceTab.test.ts
+++ b/apps/web/src/room/hostSourceTab.test.ts
@@ -65,4 +65,20 @@ describe('resolveHostSourceTabUrl', () => {
       }),
     ).toBe('https://riffsync.tv/watch/movie%20with%20spaces?partyCapture=1')
   })
+
+  it('uses party-capture RiffSync watch URL for Custom-host rows', () => {
+    const args = {
+      catalogEp: episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.test/movie',
+        embedAllows: false,
+        youtubeVideoId: null,
+      }),
+      catalogEpisodeId: '032-mitchell',
+      origin: 'https://riffsync.tv',
+    }
+
+    expect(resolveHostSourceTabUrl(args)).toBe('https://riffsync.tv/watch/032-mitchell?partyCapture=1')
+    expect(hostSourceOpensOnYoutube(args)).toBe(false)
+  })
 })

--- a/apps/web/src/room/hostSourceTab.ts
+++ b/apps/web/src/room/hostSourceTab.ts
@@ -5,13 +5,21 @@ import {
 } from '../catalog/catalogYoutubePlayback'
 
 type HostSourceTabArgs = {
-  catalogEp: Pick<CatalogEpisode, 'id' | 'embedAllows' | 'youtubeWatchUrl' | 'youtubeVideoId'> | null | undefined
+  catalogEp:
+    | Pick<
+        CatalogEpisode,
+        'id' | 'embedAllows' | 'youtubeWatchUrl' | 'youtubeVideoId' | 'playbackHost'
+      >
+    | null
+    | undefined
   catalogEpisodeId: string
   origin: string
 }
 
 function directYoutubeWatchUrl(args: HostSourceTabArgs): string | null {
-  if (args.catalogEp?.id !== args.catalogEpisodeId || episodeAllowsInAppEmbed(args.catalogEp)) return null
+  if (args.catalogEp?.id !== args.catalogEpisodeId) return null
+  if (args.catalogEp.playbackHost === 'custom') return null
+  if (episodeAllowsInAppEmbed(args.catalogEp)) return null
   return resolveCatalogYoutubeWatchUrl(args.catalogEp)
 }
 


### PR DESCRIPTION
## Summary

- Adds `SoloCustomIframePlayer` for Custom-host catalog rows on `/watch/:catalogEpisodeId` (solo and `?partyCapture=1` layouts).
- Updates `SoloWatchPage` to branch on `playbackHost`: Custom rows use the generic HTTPS iframe; YouTube path unchanged.
- Extends `hostSourceTab` so Custom-host episodes always open the RiffSync party-capture watch URL (`hostSourceOpensOnYoutube` is false).

Closes #393

## Test plan

- [x] `npm test --prefix apps/web` (966 tests pass)
- [ ] Manual: open `/watch/{customEpisodeId}` and confirm iframe loads `customPlaybackUrl`
- [ ] Manual: open `/watch/{customEpisodeId}?partyCapture=1` and confirm party-capture layout stretches iframe
- [ ] Manual: Custom row missing URL shows blocked copy
- [ ] Manual: YouTube-host row still uses `SoloYouTubePlayer`
- [ ] Manual: start party from Custom-host room opens RiffSync watch tab (not YouTube)