### PR TITLE
feat(web): host-aware catalog card actions for Custom playback (#396)

### DIFF
--- a/apps/web/src/catalog/catalogPlayback.test.ts
+++ b/apps/web/src/catalog/catalogPlayback.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { CatalogEpisode } from './catalogTypes'
+import {
+  catalogEntriesPlayableInApp,
+  episodeIsPlayableInApp,
+  readCatalogPlaybackHost,
+} from './catalogPlayback'
+
+function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
+  return {
+    id: 'ep-1',
+    experimentNumber: 1,
+    title: 'Test',
+    catalog: 'mst3k',
+    tags: [],
+    labels: [],
+    youtubeVideoId: 'abc12345678',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc12345678',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    ...overrides,
+  }
+}
+
+describe('readCatalogPlaybackHost', () => {
+  it('defaults missing or invalid playbackHost to youtube', () => {
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'youtube' }))).toBe('youtube')
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'custom' }))).toBe('custom')
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'invalid' as 'youtube' }))).toBe('youtube')
+  })
+})
+
+describe('episodeIsPlayableInApp', () => {
+  it('treats Custom-host rows with HTTPS customPlaybackUrl as playable', () => {
+    expect(
+      episodeIsPlayableInApp(
+        episode({
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.com/movie',
+          youtubeVideoId: null,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects Custom-host rows with missing or non-HTTPS customPlaybackUrl', () => {
+    expect(
+      episodeIsPlayableInApp(
+        episode({
+          playbackHost: 'custom',
+          customPlaybackUrl: null,
+          youtubeVideoId: 'abc12345678',
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      episodeIsPlayableInApp(
+        episode({
+          playbackHost: 'custom',
+          customPlaybackUrl: 'http://example.com/movie',
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      episodeIsPlayableInApp(
+        episode({
+          playbackHost: 'custom',
+          customPlaybackUrl: '   ',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('treats YouTube-host rows with a non-empty video id as playable', () => {
+    expect(episodeIsPlayableInApp(episode({ youtubeVideoId: 'abc12345678' }))).toBe(true)
+    expect(
+      episodeIsPlayableInApp(
+        episode({ youtubeVideoId: 'abc12345678', embedAllows: false }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects YouTube-host rows without a video id', () => {
+    expect(episodeIsPlayableInApp(episode({ youtubeVideoId: null }))).toBe(false)
+    expect(episodeIsPlayableInApp(episode({ youtubeVideoId: '   ' }))).toBe(false)
+  })
+
+  it('defaults legacy rows missing playbackHost to youtube host rules', () => {
+    expect(
+      episodeIsPlayableInApp(
+        episode({
+          playbackHost: undefined as unknown as 'youtube',
+          youtubeVideoId: 'abc12345678',
+        }),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('catalogEntriesPlayableInApp', () => {
+  it('returns only playable rows', () => {
+    const entries = [
+      episode({ id: 'yt', youtubeVideoId: 'abc12345678' }),
+      episode({ id: 'custom', playbackHost: 'custom', customPlaybackUrl: 'https://x.test/m', youtubeVideoId: null }),
+      episode({ id: 'missing', youtubeVideoId: null }),
+      episode({ id: 'bad-custom', playbackHost: 'custom', customPlaybackUrl: null }),
+    ]
+    expect(catalogEntriesPlayableInApp(entries).map((e) => e.id)).toEqual(['yt', 'custom'])
+  })
+})

--- a/apps/web/src/catalog/catalogPlayback.ts
+++ b/apps/web/src/catalog/catalogPlayback.ts
@@ -1,0 +1,27 @@
+import type { CatalogEpisode } from './catalogTypes'
+
+/** Read-time default: missing or invalid values behave as YouTube host. */
+export function readCatalogPlaybackHost(
+  ep: Pick<CatalogEpisode, 'playbackHost'>,
+): 'youtube' | 'custom' {
+  return ep.playbackHost === 'custom' ? 'custom' : 'youtube'
+}
+
+/**
+ * Whether the episode may appear in fan browse surfaces and enable tile actions.
+ * Custom-host: trimmed HTTPS customPlaybackUrl. YouTube-host: non-empty youtubeVideoId.
+ * embedAllows does not affect browse inclusion or tile enablement.
+ */
+export function episodeIsPlayableInApp(ep: CatalogEpisode): boolean {
+  const host = readCatalogPlaybackHost(ep)
+  if (host === 'custom') {
+    const url = ep.customPlaybackUrl?.trim() ?? ''
+    return url.startsWith('https://')
+  }
+  const id = ep.youtubeVideoId?.trim() ?? ''
+  return id !== ''
+}
+
+export function catalogEntriesPlayableInApp(entries: CatalogEpisode[]): CatalogEpisode[] {
+  return entries.filter(episodeIsPlayableInApp)
+}

--- a/apps/web/src/catalog/mockCatalog.ts
+++ b/apps/web/src/catalog/mockCatalog.ts
@@ -1,29 +1,40 @@
 import type { CatalogCategory, CatalogEpisode } from './catalogTypes'
+import { episodeIsPlayableInApp } from './catalogPlayback'
 
-const ERA_YOUTUBE_ROW_CAP = 10
+const ERA_PLAYABLE_ROW_CAP = 10
 
-/** True when the episode has a non-empty YouTube video id (in-app watch + thumbnails). */
+/** @deprecated SEO scripts (#397) still import this; fan browse uses catalogPlayback helpers. */
 export function episodeHasYoutubeLink(ep: CatalogEpisode): boolean {
   return ep.youtubeVideoId != null && ep.youtubeVideoId.trim() !== ''
 }
 
+/** @deprecated SEO scripts (#397) still import this; fan browse uses catalogEntriesPlayableInApp. */
 export function catalogEntriesWithYoutubeLink(entries: CatalogEpisode[]): CatalogEpisode[] {
   return entries.filter(episodeHasYoutubeLink)
 }
 
 /**
- * Episodes for a metadata tag that have a playable YouTube id, in experiment order.
+ * Episodes for a metadata tag that are playable in-app, in experiment order.
  * Uses the full **`GET /v1/catalog`** list (already loaded on the home page).
  */
+export function firstEpisodesPlayableForTag(
+  entries: CatalogEpisode[],
+  tag: string,
+  limit: number = ERA_PLAYABLE_ROW_CAP,
+): CatalogEpisode[] {
+  return entries
+    .filter((e) => e.tags.includes(tag) && episodeIsPlayableInApp(e))
+    .sort((a, b) => a.experimentNumber - b.experimentNumber)
+    .slice(0, limit)
+}
+
+/** @deprecated Use firstEpisodesPlayableForTag on fan browse paths. */
 export function firstEpisodesWithYoutubeForTag(
   entries: CatalogEpisode[],
   tag: string,
-  limit: number = ERA_YOUTUBE_ROW_CAP,
+  limit: number = ERA_PLAYABLE_ROW_CAP,
 ): CatalogEpisode[] {
-  return entries
-    .filter((e) => e.tags.includes(tag) && episodeHasYoutubeLink(e))
-    .sort((a, b) => a.experimentNumber - b.experimentNumber)
-    .slice(0, limit)
+  return firstEpisodesPlayableForTag(entries, tag, limit)
 }
 
 /** YouTube poster fallback when `posterImageUrl` / `backdropImageUrl` are null (dev/catalog seed). */

--- a/apps/web/src/components/catalog/CatalogGridCard.test.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.test.tsx
@@ -88,7 +88,7 @@ describe('CatalogGridCard', () => {
     expect(container.textContent).toContain('Another: Shape')
   })
 
-  it('renders no advisory slot when tags are empty', () => {
+  it('renders no advisory slot when tags are empty and embed is allowed', () => {
     renderCard(episode({ tags: [], playbackExpectation: 'ad_supported' }))
 
     expect(container.querySelector('.riffsync-catalog-card__advisory')).toBeNull()
@@ -97,7 +97,7 @@ describe('CatalogGridCard', () => {
     expect(container.textContent).not.toContain('Likely ad-supported')
   })
 
-  it('does not render playback advisory or not-embeddable copy', () => {
+  it('shows YouTube embed advisory for YouTube-host rows when embedAllows is false', () => {
     renderCard(
       episode({
         tags: ['Era: Mike'],
@@ -106,22 +106,24 @@ describe('CatalogGridCard', () => {
       }),
     )
 
-    expect(container.textContent).not.toContain('Ads may appear')
-    expect(container.textContent).not.toContain('Premium-friendly')
-    expect(container.textContent).not.toContain('Likely ad-supported')
-    expect(container.textContent).not.toContain('Not embeddable')
+    expect(container.textContent).toContain('In-app YouTube embed is not available for this episode.')
+    expect(container.textContent).toContain('Era: Mike')
   })
 
-  it('still gates in-app embed actions when embedAllows is false', () => {
+  it('does not show embed advisory on Custom-host rows when embedAllows is false', () => {
+    renderCard(
+      episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.com/movie',
+        embedAllows: false,
+      }),
+    )
+
+    expect(container.textContent).not.toContain('In-app YouTube embed is not available')
+  })
+
+  it('keeps Watch Solo enabled via internal link when embedAllows is false on YouTube-host rows', () => {
     renderCard(episode({ embedAllows: false }))
-
-    const watchSolo = container.querySelector('button.gen-button--ghost') as HTMLButtonElement | null
-    expect(watchSolo).not.toBeNull()
-    expect(container.querySelector('a.gen-button--ghost[href="/watch/032-mitchell"]')).toBeNull()
-  })
-
-  it('keeps the internal watch link for embeddable episodes', () => {
-    renderCard(episode({ embedAllows: true }))
 
     const watchSolo = container.querySelector('a.gen-button--ghost') as HTMLAnchorElement | null
     expect(watchSolo?.getAttribute('href')).toBe('/watch/032-mitchell')

--- a/apps/web/src/components/catalog/CatalogGridCard.tsx
+++ b/apps/web/src/components/catalog/CatalogGridCard.tsx
@@ -1,11 +1,15 @@
 import { Link } from 'react-router-dom'
 import { catalogCardImageUrl } from '../../catalog/mockCatalog'
+import { readCatalogPlaybackHost } from '../../catalog/catalogPlayback'
 import { formatCatalogLabel, type CatalogEpisode } from '../../catalog/catalogTypes'
 import { EpisodeTileActions } from './EpisodeTileActions'
 
 export function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
   const img = catalogCardImageUrl(episode)
   const labels = episode.labels.length > 0 ? episode.labels : [formatCatalogLabel(episode.catalog)]
+  const showYoutubeEmbedAdvisory =
+    readCatalogPlaybackHost(episode) === 'youtube' && episode.embedAllows === false
+
   return (
     <article className="riffsync-catalog-card movie type-movie status-publish has-post-thumbnail hentry">
       <div className="gen-carousel-movies-style-3 movie-grid style-3">
@@ -30,8 +34,13 @@ export function CatalogGridCard({ episode }: { episode: CatalogEpisode }) {
                 ))}
               </ul>
             </div>
-            {episode.tags.length > 0 && (
+            {(episode.tags.length > 0 || showYoutubeEmbedAdvisory) && (
               <div className="riffsync-catalog-card__advisory">
+                {showYoutubeEmbedAdvisory ? (
+                  <span className="riffsync-catalog-card__tag riffsync-catalog-card__tag--embed-advisory">
+                    In-app YouTube embed is not available for this episode.
+                  </span>
+                ) : null}
                 {episode.tags.map((tag) => (
                   <span key={tag} className="riffsync-catalog-card__tag">
                     {tag}

--- a/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
+++ b/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
@@ -66,29 +66,52 @@ describe('EpisodeTileActions', () => {
     })
   }
 
-  it('opens YouTube directly for non-embeddable episodes with a watch URL', () => {
+  it('links Watch Solo to /watch/:id for playable YouTube rows even when embedAllows is false', () => {
     renderActions(episode({ embedAllows: false }))
-
-    const watchSolo = container.querySelector('button.gen-button--ghost') as HTMLButtonElement | null
-    expect(watchSolo).not.toBeNull()
-
-    act(() => {
-      watchSolo?.click()
-    })
-
-    expect(window.open).toHaveBeenCalledWith(
-      'https://www.youtube.com/watch?v=NXGXtm6gcxk',
-      '_blank',
-      'noopener,noreferrer',
-    )
-    expect(container.querySelector('a[href="/watch/032-mitchell"]')).toBeNull()
-  })
-
-  it('keeps the internal watch link for embeddable episodes', () => {
-    renderActions(episode({ embedAllows: true }))
 
     const watchSolo = container.querySelector('a.gen-button--ghost') as HTMLAnchorElement | null
     expect(watchSolo?.getAttribute('href')).toBe('/watch/032-mitchell')
     expect(container.querySelector('button.gen-button--ghost')).toBeNull()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it('enables both actions for Custom-host rows with HTTPS customPlaybackUrl', () => {
+    renderActions(
+      episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.com/movie',
+        youtubeVideoId: null,
+      }),
+    )
+
+    const watchSolo = container.querySelector('a.gen-button--ghost') as HTMLAnchorElement | null
+    expect(watchSolo?.getAttribute('href')).toBe('/watch/032-mitchell')
+    const startParty = container.querySelector('button.gen-button:not(.gen-button--ghost)') as HTMLButtonElement
+    expect(startParty.disabled).toBe(false)
+  })
+
+  it('disables both actions when Custom-host row has no valid customPlaybackUrl', () => {
+    renderActions(
+      episode({
+        playbackHost: 'custom',
+        customPlaybackUrl: null,
+        youtubeVideoId: 'NXGXtm6gcxk',
+      }),
+    )
+
+    const watchSolo = container.querySelector('button.gen-button--ghost') as HTMLButtonElement
+    const startParty = container.querySelector('button.gen-button:not(.gen-button--ghost)') as HTMLButtonElement
+    expect(watchSolo.disabled).toBe(true)
+    expect(startParty.disabled).toBe(true)
+    expect(container.querySelector('a.gen-button--ghost')).toBeNull()
+  })
+
+  it('disables both actions when YouTube-host row has no video id', () => {
+    renderActions(episode({ youtubeVideoId: null, youtubeWatchUrl: null }))
+
+    const watchSolo = container.querySelector('button.gen-button--ghost') as HTMLButtonElement
+    const startParty = container.querySelector('button.gen-button:not(.gen-button--ghost)') as HTMLButtonElement
+    expect(watchSolo.disabled).toBe(true)
+    expect(startParty.disabled).toBe(true)
   })
 })

--- a/apps/web/src/components/catalog/EpisodeTileActions.tsx
+++ b/apps/web/src/components/catalog/EpisodeTileActions.tsx
@@ -1,14 +1,10 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import type { CatalogEpisode } from '../../catalog/catalogTypes'
+import { episodeIsPlayableInApp } from '../../catalog/catalogPlayback'
 import { catalogToRoomPlayback, createRoom } from '../../api/roomsApi'
 import { getFanAccessToken } from '../../auth/fanTokens'
 import { startFanHostedUiSignIn } from '../../auth/fanHostedUiPkce'
 import { PENDING_PARTY_EPISODE_KEY } from '../../catalog/pendingPartyStorage'
-import {
-  episodeAllowsInAppEmbed,
-  openCatalogYoutubeWatch,
-  resolveCatalogYoutubeWatchUrl,
-} from '../../catalog/catalogYoutubePlayback'
 
 export function EpisodeTileActions({
   episode,
@@ -22,10 +18,10 @@ export function EpisodeTileActions({
   const location = useLocation()
   const token = getFanAccessToken()
   const returnPath = `${location.pathname}${location.search}` || '/'
-  const directYoutubeWatchUrl = episodeAllowsInAppEmbed(episode) ? null : resolveCatalogYoutubeWatchUrl(episode)
+  const playable = episodeIsPlayableInApp(episode)
 
   const startParty = async () => {
-    if (!token) return
+    if (!token || !playable) return
     try {
       const room = await createRoom(token, {
         catalogEpisodeId: episode.id,
@@ -39,6 +35,7 @@ export function EpisodeTileActions({
   }
 
   const signInThenStartParty = () => {
+    if (!playable) return
     sessionStorage.setItem(PENDING_PARTY_EPISODE_KEY, episode.id)
     void startFanHostedUiSignIn(returnPath)
   }
@@ -51,20 +48,21 @@ export function EpisodeTileActions({
           : 'riffsync-episode-tile-actions'
       }
     >
-      {directYoutubeWatchUrl ? (
-        <button
-          type="button"
-          className="gen-button gen-button--ghost"
-          onClick={() => openCatalogYoutubeWatch(directYoutubeWatchUrl)}
-        >
-          Watch Solo
-        </button>
-      ) : (
+      {playable ? (
         <Link to={`/watch/${episode.id}`} className="gen-button gen-button--ghost">
           Watch Solo
         </Link>
+      ) : (
+        <button type="button" className="gen-button gen-button--ghost" disabled>
+          Watch Solo
+        </button>
       )}
-      <button type="button" className="gen-button" onClick={token ? () => void startParty() : signInThenStartParty}>
+      <button
+        type="button"
+        className="gen-button"
+        disabled={!playable}
+        onClick={playable ? (token ? () => void startParty() : signInThenStartParty) : undefined}
+      >
         Start Party
       </button>
     </div>

--- a/apps/web/src/pages/CatalogPage.test.tsx
+++ b/apps/web/src/pages/CatalogPage.test.tsx
@@ -125,6 +125,50 @@ describe('CatalogPage', () => {
     expect(container.querySelector('.riffsync-catalog-filter-bar__era')).toBeNull()
   })
 
+  it('includes Custom-host playable rows in the hub grid', () => {
+    useCatalogListQuery.mockReturnValue({
+      data: [
+        ...catalogFixtures,
+        episode({
+          id: 'ep-custom',
+          title: 'Custom Host Film',
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.com/movie',
+          youtubeVideoId: null,
+        }),
+      ],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderCatalogPage()
+
+    const cards = container.querySelectorAll('.riffsync-catalog-card')
+    expect(cards).toHaveLength(3)
+    expect(container.textContent).toContain('Custom Host Film')
+  })
+
+  it('shows host-aware empty copy when no episodes are playable in-app', () => {
+    useCatalogListQuery.mockReturnValue({
+      data: [
+        episode({
+          id: 'ep-unplayable',
+          playbackHost: 'custom',
+          customPlaybackUrl: null,
+          youtubeVideoId: null,
+        }),
+      ],
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    renderCatalogPage()
+
+    expect(container.textContent).toContain('No episodes are available for in-app playback yet.')
+  })
+
   it('keeps the mixed grid unfiltered by catalog on the hub', () => {
     renderCatalogPage()
 

--- a/apps/web/src/pages/CatalogPage.tsx
+++ b/apps/web/src/pages/CatalogPage.tsx
@@ -7,7 +7,7 @@ import { CatalogPageHeader } from '../components/catalog/CatalogPageHeader'
 import { CatalogHubEntryLinks } from '../components/catalog/CatalogHubEntryLinks'
 import { CatalogGridCard } from '../components/catalog/CatalogGridCard'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
-import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
+import { catalogEntriesPlayableInApp } from '../catalog/catalogPlayback'
 import { filterCatalogEntries } from '../catalog/filterCatalogEntries'
 import type { CatalogEpisode } from '../catalog/catalogTypes'
 
@@ -21,17 +21,17 @@ export function CatalogPage() {
   useResumePendingPartyRoom(data, navigate)
 
   const allEntries = data ?? EMPTY_CATALOG_ENTRIES
-  const youtubeEntries = useMemo(
-    () => catalogEntriesWithYoutubeLink(allEntries),
+  const playableEntries = useMemo(
+    () => catalogEntriesPlayableInApp(allEntries),
     [allEntries],
   )
   const filteredEntries = useMemo(
-    () => filterCatalogEntries(youtubeEntries, { titleQuery, catalogs: [] }),
-    [youtubeEntries, titleQuery],
+    () => filterCatalogEntries(playableEntries, { titleQuery, catalogs: [] }),
+    [playableEntries, titleQuery],
   )
 
   const filterBarDisabled = isPending && !data
-  const isFilterNoMatch = youtubeEntries.length > 0 && filteredEntries.length === 0
+  const isFilterNoMatch = playableEntries.length > 0 && filteredEntries.length === 0
 
   if (isPending && !data) {
     return (
@@ -72,11 +72,11 @@ export function CatalogPage() {
               <CatalogGridCard key={ep.id} episode={ep} />
             ))}
           </div>
-          {youtubeEntries.length === 0 && (
+          {playableEntries.length === 0 && (
             <p>
               {allEntries.length === 0
                 ? 'No episodes in the catalog yet.'
-                : 'No episodes with a YouTube link are listed yet.'}
+                : 'No episodes are available for in-app playback yet.'}
             </p>
           )}
           {isFilterNoMatch && (

--- a/apps/web/src/pages/CatalogSubcategoryPage.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.tsx
@@ -8,7 +8,7 @@ import { Mst3kCatalogTagFilterBar } from '../components/catalog/Mst3kCatalogTagF
 import { CatalogPageHeader } from '../components/catalog/CatalogPageHeader'
 import { CatalogGridCard } from '../components/catalog/CatalogGridCard'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
-import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
+import { catalogEntriesPlayableInApp } from '../catalog/catalogPlayback'
 import {
   EMPTY_MST3K_TAG_PILLS,
   filterMst3kCatalogEntries,
@@ -31,16 +31,16 @@ export function CatalogSubcategoryPage() {
   useResumePendingPartyRoom(data, navigate)
 
   const allEntries = data ?? EMPTY_CATALOG_ENTRIES
-  const youtubeEntries = useMemo(
-    () => catalogEntriesWithYoutubeLink(allEntries),
+  const playableEntries = useMemo(
+    () => catalogEntriesPlayableInApp(allEntries),
     [allEntries],
   )
   const routeCatalogEntries = useMemo(
     () =>
       subcategory
-        ? filterCatalogEntries(youtubeEntries, { titleQuery: '', catalogs: [subcategory.catalog] })
+        ? filterCatalogEntries(playableEntries, { titleQuery: '', catalogs: [subcategory.catalog] })
         : [],
-    [youtubeEntries, subcategory],
+    [playableEntries, subcategory],
   )
   const filteredEntries = useMemo(
     () =>
@@ -51,9 +51,9 @@ export function CatalogSubcategoryPage() {
               catalogs: [subcategory.catalog],
               selectedTagPills,
             })
-          : filterCatalogEntries(youtubeEntries, { titleQuery, catalogs: [subcategory.catalog] })
+          : filterCatalogEntries(playableEntries, { titleQuery, catalogs: [subcategory.catalog] })
         : [],
-    [routeCatalogEntries, youtubeEntries, titleQuery, subcategory, isMst3kRoute, selectedTagPills],
+    [routeCatalogEntries, playableEntries, titleQuery, subcategory, isMst3kRoute, selectedTagPills],
   )
 
   const filterBarDisabled = isPending && !data
@@ -61,7 +61,7 @@ export function CatalogSubcategoryPage() {
     selectedTagPills.Era.length > 0 || selectedTagPills.Season.length > 0
   const isFilterNoMatch = isMst3kRoute
     ? routeCatalogEntries.length > 0 && filteredEntries.length === 0
-    : youtubeEntries.length > 0 && filteredEntries.length === 0
+    : playableEntries.length > 0 && filteredEntries.length === 0
 
   if (!subcategory) {
     return (
@@ -122,11 +122,11 @@ export function CatalogSubcategoryPage() {
               <CatalogGridCard key={ep.id} episode={ep} />
             ))}
           </div>
-          {youtubeEntries.length === 0 && (
+          {playableEntries.length === 0 && (
             <p>
               {allEntries.length === 0
                 ? 'No episodes in the catalog yet.'
-                : 'No episodes with a YouTube link are listed yet.'}
+                : 'No episodes are available for in-app playback yet.'}
             </p>
           )}
           {isFilterNoMatch && (

--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -160,10 +160,10 @@ describe('HomePage', () => {
     expect(headings[0]?.textContent).toBe('RiffSync')
   })
 
-  it('renders exactly one sr-only H1 when no episodes have a YouTube link', () => {
+  it('renders exactly one sr-only H1 when no episodes are playable in-app', () => {
     mockCatalogQueries({
       list: {
-        data: [episode({ id: 'ep-no-yt', youtubeVideoId: null, youtubeWatchUrl: null })],
+        data: [episode({ id: 'ep-no-playback', youtubeVideoId: null, youtubeWatchUrl: null })],
         isPending: false,
         isError: false,
         error: null,
@@ -175,5 +175,26 @@ describe('HomePage', () => {
     const headings = srOnlyHeadings()
     expect(headings).toHaveLength(1)
     expect(headings[0]?.textContent).toBe('RiffSync')
+    expect(container.textContent).toContain('No episodes are available for in-app playback yet.')
+  })
+
+  it('includes Custom-host playable rows in home carousel and rows', () => {
+    const customEpisode = episode({
+      id: 'ep-custom',
+      title: 'Custom Host Film',
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/movie',
+      youtubeVideoId: null,
+      carousel: true,
+      spotlight: true,
+    })
+    mockCatalogQueries({
+      list: { data: [customEpisode], isPending: false, isError: false, error: null, refetch: vi.fn() },
+      carousel: { data: [customEpisode] },
+      spotlight: { data: [customEpisode] },
+    })
+    renderHomePage()
+
+    expect(container.textContent).toContain('Custom Host Film')
   })
 })

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -6,10 +6,10 @@ import {
 } from '../catalog/catalogQueries'
 import { CatalogLoadErrorPanel } from '../components/catalog/CatalogLoadErrorPanel'
 import { useResumePendingPartyRoom } from '../catalog/useResumePendingPartyRoom'
+import { catalogEntriesPlayableInApp } from '../catalog/catalogPlayback'
 import {
   buildHeroSlides,
-  catalogEntriesWithYoutubeLink,
-  firstEpisodesWithYoutubeForTag,
+  firstEpisodesPlayableForTag,
   topEpisodesForHomeMostPopular,
 } from '../catalog/mockCatalog'
 import { HomeHeroBanner } from './home/HomeHeroBanner'
@@ -25,7 +25,7 @@ function HomePageDocumentHeading() {
  * **`GET /v1/catalog?carousel=true`**; spotlight from **`GET /v1/catalog?spotlight=true`**
  * when **`VITE_PUBLIC_API_BASE_URL`** is set.
  * In **`vite dev`** without that var, all load from **`data/catalog/episodes.json`** (filtered client-side).
- * Rows use only episodes that include a **YouTube** id (same filter as **`/catalog`**).
+ * Rows use only episodes playable in-app (same host-aware filter as **`/catalog`**).
  * **Most Popular** ranks playable **`mst3k`** episodes by reconciled **`tmdbPopularity`** (unreconciled rows trail in experiment order).
  * Era strips take the first **10** per Joel / Mike / Jonah tag from that playable set.
  */
@@ -66,9 +66,9 @@ export function HomePage() {
   const entries = data ?? []
   const carouselEntries = carouselQ.data ?? []
   const spotlightEntries = spotlightQ.data ?? []
-  const playableEntries = catalogEntriesWithYoutubeLink(entries)
-  const carouselWithYoutube = catalogEntriesWithYoutubeLink(carouselEntries)
-  const spotlightWithYoutube = catalogEntriesWithYoutubeLink(spotlightEntries)
+  const playableEntries = catalogEntriesPlayableInApp(entries)
+  const carouselPlayable = catalogEntriesPlayableInApp(carouselEntries)
+  const spotlightPlayable = catalogEntriesPlayableInApp(spotlightEntries)
 
   if (entries.length === 0) {
     return (
@@ -83,16 +83,16 @@ export function HomePage() {
     return (
       <div className="riffsync-home">
         <HomePageDocumentHeading />
-        <p className="container">No episodes with a YouTube link are available yet.</p>
+        <p className="container">No episodes are available for in-app playback yet.</p>
       </div>
     )
   }
 
-  const heroSlides = buildHeroSlides(carouselWithYoutube)
+  const heroSlides = buildHeroSlides(carouselPlayable)
 
-  const joelYoutubeRow = firstEpisodesWithYoutubeForTag(playableEntries, 'Era: Joel', 10)
-  const mikeYoutubeRow = firstEpisodesWithYoutubeForTag(playableEntries, 'Era: Mike', 10)
-  const jonahYoutubeRow = firstEpisodesWithYoutubeForTag(playableEntries, 'Era: Jonah', 10)
+  const joelRow = firstEpisodesPlayableForTag(playableEntries, 'Era: Joel', 10)
+  const mikeRow = firstEpisodesPlayableForTag(playableEntries, 'Era: Mike', 10)
+  const jonahRow = firstEpisodesPlayableForTag(playableEntries, 'Era: Jonah', 10)
 
   return (
     <div className="riffsync-home">
@@ -103,26 +103,26 @@ export function HomePage() {
         title="Most Popular"
         episodes={topEpisodesForHomeMostPopular(playableEntries, 12)}
       />
-      <HomeSpotlightBanner episodes={spotlightWithYoutube} />
-      {joelYoutubeRow.length > 0 ? (
+      <HomeSpotlightBanner episodes={spotlightPlayable} />
+      {joelRow.length > 0 ? (
         <HomeMovieRowSection
           sectionId="home-joel-era"
           title="Joel-era experiments"
-          episodes={joelYoutubeRow}
+          episodes={joelRow}
         />
       ) : null}
-      {mikeYoutubeRow.length > 0 ? (
+      {mikeRow.length > 0 ? (
         <HomeMovieRowSection
           sectionId="home-mike-era"
           title="Mike-era experiments"
-          episodes={mikeYoutubeRow}
+          episodes={mikeRow}
         />
       ) : null}
-      {jonahYoutubeRow.length > 0 ? (
+      {jonahRow.length > 0 ? (
         <HomeMovieRowSection
           sectionId="home-jonah-era"
           title="Jonah-era experiments"
-          episodes={jonahYoutubeRow}
+          episodes={jonahRow}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

- Add `catalogPlayback.ts` with `readCatalogPlaybackHost`, `episodeIsPlayableInApp`, and `catalogEntriesPlayableInApp` for host-aware browse filtering.
- Wire `CatalogPage`, `HomePage`, and `CatalogSubcategoryPage` to list playable Custom-host and YouTube-host episodes; update empty-state copy.
- Update `EpisodeTileActions` to enable Watch Solo (`/watch/:id`) and Start Party when playable, disabled otherwise; show YouTube-only embed advisory on `CatalogGridCard`.

Closes #396

## Test plan

- [x] `npm test --prefix apps/web -- catalogPlayback EpisodeTileActions CatalogGridCard CatalogPage HomePage`
- [x] `npm run lint --prefix apps/web`
- [x] `npm test --prefix apps/web` (full suite)
- [ ] Manual: `/catalog` shows Custom-host row with valid HTTPS `customPlaybackUrl`; tile actions navigate/create room
- [ ] Manual: Custom row missing URL excluded from grid; forced fixture shows disabled tile actions
- [ ] Manual: YouTube row with `embedAllows: false` still listed with enabled actions and embed advisory on card