### PR TITLE
[M37] SEO packaging: Custom-only watch pages stay non-indexable (#397)

### DIFF
--- a/apps/web/scripts/prerender-indexable-routes.mjs
+++ b/apps/web/scripts/prerender-indexable-routes.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { buildPrerenderDocument } from '../src/seo/buildPrerenderDocument.ts'
 import { STATIC_INDEXABLE_ROUTES, staticRouteDistPath } from '../src/seo/indexableRoutes.ts'
-import { catalogEntriesWithYoutubeLink } from '../src/catalog/mockCatalog.ts'
+import { catalogEntriesIndexableForSeo } from '../src/catalog/catalogSeo.ts'
 import {
   buildSpaShellHeadTags,
   buildStaticRouteHeadTags,
@@ -55,7 +55,7 @@ async function main() {
   const templatePath = resolve(distDir, 'index.html')
   const templateHtml = await readFile(templatePath, 'utf8')
   const episodes = await loadCatalogEntries()
-  const youtubeLinked = catalogEntriesWithYoutubeLink(episodes)
+  const indexableEpisodes = catalogEntriesIndexableForSeo(episodes)
 
   for (const route of STATIC_INDEXABLE_ROUTES) {
     const head = buildStaticRouteHeadTags(route, origin)
@@ -63,7 +63,7 @@ async function main() {
     await writePrerenderedHtml(staticRouteDistPath(route), html)
   }
 
-  for (const episode of youtubeLinked) {
+  for (const episode of indexableEpisodes) {
     const head = buildWatchRouteHeadTags(episode, origin)
     const html = buildPrerenderDocument(templateHtml, head)
     await writePrerenderedHtml(`watch/${episode.id}/index.html`, html)
@@ -73,7 +73,7 @@ async function main() {
   await writePrerenderedHtml('spa-shell.html', spaShell)
 
   console.log(
-    `Prerendered ${STATIC_INDEXABLE_ROUTES.length} static routes, ${youtubeLinked.length} watch pages, and spa-shell.html`,
+    `Prerendered ${STATIC_INDEXABLE_ROUTES.length} static routes, ${indexableEpisodes.length} watch pages, and spa-shell.html`,
   )
 }
 

--- a/apps/web/scripts/verify-seo-artifacts.mjs
+++ b/apps/web/scripts/verify-seo-artifacts.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { catalogEntriesWithYoutubeLink } from '../src/catalog/mockCatalog.ts'
+import { catalogEntriesIndexableForSeo } from '../src/catalog/catalogSeo.ts'
 import { countSitemapUrls } from '../src/seo/generateSeoArtifacts.ts'
 import { STATIC_INDEXABLE_ROUTES, staticRouteDistPath } from '../src/seo/indexableRoutes.ts'
 
@@ -87,9 +87,9 @@ async function main() {
     }
   }
 
-  const youtubeLinked = catalogEntriesWithYoutubeLink(episodes)
+  const indexableEpisodes = catalogEntriesIndexableForSeo(episodes)
   let watchPrerenderCount = 0
-  for (const episode of youtubeLinked) {
+  for (const episode of indexableEpisodes) {
     const watchPath = `watch/${episode.id}/index.html`
     try {
       await readFile(resolve(distDir, watchPath), 'utf8')
@@ -99,9 +99,9 @@ async function main() {
     }
   }
 
-  if (watchPrerenderCount !== youtubeLinked.length) {
+  if (watchPrerenderCount !== indexableEpisodes.length) {
     throw new Error(
-      `Expected ${youtubeLinked.length} watch prerender files; found ${watchPrerenderCount}`,
+      `Expected ${indexableEpisodes.length} watch prerender files; found ${watchPrerenderCount}`,
     )
   }
 

--- a/apps/web/src/catalog/catalogSeo.test.ts
+++ b/apps/web/src/catalog/catalogSeo.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { CatalogEpisode } from './catalogTypes'
+import {
+  catalogEntriesIndexableForSeo,
+  episodeIsIndexableForSeo,
+  readCatalogPlaybackHost,
+} from './catalogSeo'
+
+function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
+  return {
+    id: 'ep-1',
+    experimentNumber: 1,
+    title: 'Test',
+    catalog: 'mst3k',
+    tags: [],
+    labels: [],
+    youtubeVideoId: 'abc12345678',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc12345678',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    ...overrides,
+  }
+}
+
+describe('readCatalogPlaybackHost', () => {
+  it('defaults missing or invalid playbackHost to youtube', () => {
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'youtube' }))).toBe('youtube')
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'custom' }))).toBe('custom')
+    expect(readCatalogPlaybackHost(episode({ playbackHost: 'invalid' as 'youtube' }))).toBe('youtube')
+  })
+})
+
+describe('episodeIsIndexableForSeo', () => {
+  it('excludes Custom-host rows even when youtubeVideoId is present', () => {
+    expect(
+      episodeIsIndexableForSeo(
+        episode({
+          playbackHost: 'custom',
+          customPlaybackUrl: 'https://example.com/movie',
+          youtubeVideoId: 'abc12345678',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('includes YouTube-host rows with a non-empty video id', () => {
+    expect(episodeIsIndexableForSeo(episode({ youtubeVideoId: 'abc12345678' }))).toBe(true)
+    expect(
+      episodeIsIndexableForSeo(
+        episode({ youtubeVideoId: 'abc12345678', embedAllows: false }),
+      ),
+    ).toBe(true)
+  })
+
+  it('excludes YouTube-host rows without a video id', () => {
+    expect(episodeIsIndexableForSeo(episode({ youtubeVideoId: null }))).toBe(false)
+    expect(episodeIsIndexableForSeo(episode({ youtubeVideoId: '   ' }))).toBe(false)
+  })
+})
+
+describe('catalogEntriesIndexableForSeo', () => {
+  it('returns only SEO-indexable rows', () => {
+    const entries = [
+      episode({ id: 'yt', youtubeVideoId: 'abc12345678' }),
+      episode({
+        id: 'custom-only',
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://x.test/m',
+        youtubeVideoId: null,
+      }),
+      episode({
+        id: 'custom-with-yt',
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://x.test/m',
+        youtubeVideoId: 'abc12345678',
+      }),
+      episode({ id: 'missing', youtubeVideoId: null }),
+    ]
+    expect(catalogEntriesIndexableForSeo(entries).map((e) => e.id)).toEqual(['yt'])
+  })
+})

--- a/apps/web/src/catalog/catalogSeo.ts
+++ b/apps/web/src/catalog/catalogSeo.ts
@@ -1,0 +1,25 @@
+import type { CatalogEpisode } from './catalogTypes'
+
+/** Read-time default: missing or invalid values behave as YouTube host. */
+export function readCatalogPlaybackHost(
+  ep: Pick<CatalogEpisode, 'playbackHost'>,
+): 'youtube' | 'custom' {
+  return ep.playbackHost === 'custom' ? 'custom' : 'youtube'
+}
+
+/**
+ * Whether the episode earns a sitemap `/watch/:id` entry and watch-route prerender.
+ * Custom-host rows are never indexable. YouTube-host rows require a non-empty video id.
+ * embedAllows and customPlaybackUrl do not affect indexability.
+ */
+export function episodeIsIndexableForSeo(ep: CatalogEpisode): boolean {
+  if (readCatalogPlaybackHost(ep) === 'custom') {
+    return false
+  }
+  const id = ep.youtubeVideoId?.trim() ?? ''
+  return id !== ''
+}
+
+export function catalogEntriesIndexableForSeo(entries: CatalogEpisode[]): CatalogEpisode[] {
+  return entries.filter(episodeIsIndexableForSeo)
+}

--- a/apps/web/src/seo/generateSeoArtifacts.test.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.test.ts
@@ -65,9 +65,23 @@ describe('buildSitemapXml', () => {
     episode({ id: '101-the-crawling-eye' }),
     episode({ id: 'no-youtube', youtubeVideoId: null, youtubeWatchUrl: null }),
     episode({ id: 'blank-youtube', youtubeVideoId: '   ' }),
+    episode({
+      id: 'custom-host-only',
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/movie',
+      youtubeVideoId: null,
+      youtubeWatchUrl: null,
+    }),
+    episode({
+      id: 'custom-with-youtube-metadata',
+      playbackHost: 'custom',
+      customPlaybackUrl: 'https://example.com/movie',
+      youtubeVideoId: 'abc123',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=abc123',
+    }),
   ]
 
-  it('includes static routes and only YouTube-linked watch URLs', () => {
+  it('includes static routes and only SEO-indexable watch URLs', () => {
     const xml = buildSitemapXml('https://riffsync.tv', entries)
     for (const path of STATIC_SITEMAP_PATHS) {
       expect(xml).toContain(`<loc>${absoluteUrl('https://riffsync.tv', path)}</loc>`)
@@ -75,6 +89,8 @@ describe('buildSitemapXml', () => {
     expect(xml).toContain('<loc>https://riffsync.tv/watch/101-the-crawling-eye</loc>')
     expect(xml).not.toContain('/watch/no-youtube')
     expect(xml).not.toContain('/watch/blank-youtube')
+    expect(xml).not.toContain('/watch/custom-host-only')
+    expect(xml).not.toContain('/watch/custom-with-youtube-metadata')
   })
 
   it('escapes XML entities in loc values', () => {
@@ -86,11 +102,17 @@ describe('buildSitemapXml', () => {
 })
 
 describe('countSitemapUrls', () => {
-  it('counts static routes plus YouTube-linked episodes', () => {
+  it('counts static routes plus SEO-indexable episodes', () => {
     const entries = [
       episode({ id: 'linked-a' }),
       episode({ id: 'linked-b' }),
       episode({ id: 'missing', youtubeVideoId: null, youtubeWatchUrl: null }),
+      episode({
+        id: 'custom-host',
+        playbackHost: 'custom',
+        customPlaybackUrl: 'https://example.com/movie',
+        youtubeVideoId: 'abc123',
+      }),
     ]
     expect(countSitemapUrls(entries)).toBe(STATIC_SITEMAP_PATHS.length + 2)
   })

--- a/apps/web/src/seo/generateSeoArtifacts.ts
+++ b/apps/web/src/seo/generateSeoArtifacts.ts
@@ -1,5 +1,5 @@
 import type { CatalogEpisode } from '../catalog/catalogTypes'
-import { catalogEntriesWithYoutubeLink } from '../catalog/mockCatalog'
+import { catalogEntriesIndexableForSeo } from '../catalog/catalogSeo'
 import { STATIC_INDEXABLE_ROUTES } from './indexableRoutes'
 
 export const DEFAULT_PUBLIC_ORIGIN = 'https://riffsync.tv'
@@ -44,7 +44,7 @@ export function buildRobotsTxt(origin: string): string {
 
 export function buildSitemapXml(origin: string, episodes: CatalogEpisode[]): string {
   const locs: string[] = STATIC_SITEMAP_PATHS.map((path) => absoluteUrl(origin, path))
-  for (const episode of catalogEntriesWithYoutubeLink(episodes)) {
+  for (const episode of catalogEntriesIndexableForSeo(episodes)) {
     locs.push(absoluteUrl(origin, `/watch/${episode.id}`))
   }
 
@@ -62,7 +62,7 @@ export function buildSitemapXml(origin: string, episodes: CatalogEpisode[]): str
 }
 
 export function countSitemapUrls(episodes: CatalogEpisode[]): number {
-  return STATIC_SITEMAP_PATHS.length + catalogEntriesWithYoutubeLink(episodes).length
+  return STATIC_SITEMAP_PATHS.length + catalogEntriesIndexableForSeo(episodes).length
 }
 
 function escapeXml(value: string): string {


### PR DESCRIPTION
## Summary

- Add `catalogSeo.ts` with host-aware indexability helpers (`readCatalogPlaybackHost`, `episodeIsIndexableForSeo`, `catalogEntriesIndexableForSeo`).
- Custom-host catalog rows are excluded from sitemap and watch-route prerender output even when optional YouTube metadata is present.
- Wire SEO build modules and verification scripts to the new helper; extend unit tests for Custom-host exclusion.

Closes #397

## Test plan

- [x] `npm test --prefix apps/web -- catalogSeo generateSeoArtifacts`
- [x] `npm run build --prefix apps/web`
- [x] `npm run verify:seo-artifacts --prefix apps/web`