### PR TITLE
fix(web): harden YouTube embed failures on Live and Solo (#416)

### DIFF
--- a/apps/web/src/components/watch/SoloYouTubePlayer.test.tsx
+++ b/apps/web/src/components/watch/SoloYouTubePlayer.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SoloYouTubePlayer,
+  YOUTUBE_EMBED_BROKEN_MESSAGE,
+} from './SoloYouTubePlayer'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+type PlayerHandlers = {
+  onReady?: (e: { target: { playVideo: () => void; destroy: () => void } }) => void
+  onError?: (e: { data: number }) => void
+}
+
+describe('SoloYouTubePlayer', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let lastHandlers: PlayerHandlers | undefined
+  let constructShouldThrow = false
+  let destroyImpl: (() => void) | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    lastHandlers = undefined
+    constructShouldThrow = false
+    destroyImpl = undefined
+
+    const FakePlayer = class {
+      playVideo = vi.fn()
+      destroy = vi.fn()
+
+      constructor(_host: string | HTMLElement, options: { events?: PlayerHandlers }) {
+        if (constructShouldThrow) {
+          throw new Error('YT.Player construct failed')
+        }
+        lastHandlers = options.events
+        this.playVideo = vi.fn()
+        this.destroy = vi.fn(() => {
+          destroyImpl?.()
+        })
+      }
+    }
+
+    window.YT = {
+      Player: FakePlayer as unknown as NonNullable<Window['YT']>['Player'],
+    }
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    delete window.YT
+    delete window.onYouTubeIframeAPIReady
+    document.querySelectorAll(`script[src="https://www.youtube.com/iframe_api"]`).forEach((el) => {
+      el.remove()
+    })
+  })
+
+  function renderPlayer(watchUrl?: string | null) {
+    act(() => {
+      root.render(
+        <SoloYouTubePlayer
+          videoId="badVideoId1"
+          titleHint="Broken stream"
+          autoPlay={false}
+          watchUrl={watchUrl}
+        />,
+      )
+    })
+  }
+
+  it('shows friendly broken-link copy and Open on YouTube on IFrame API onError', async () => {
+    renderPlayer('https://www.youtube.com/watch?v=badVideoId1')
+
+    await vi.waitFor(() => {
+      expect(lastHandlers?.onError).toBeTypeOf('function')
+    })
+
+    act(() => {
+      lastHandlers?.onError?.({ data: 150 })
+    })
+
+    expect(container.textContent).toContain(YOUTUBE_EMBED_BROKEN_MESSAGE)
+    expect(container.textContent).not.toMatch(/Playback error/)
+    const link = container.querySelector('a[href="https://www.youtube.com/watch?v=badVideoId1"]')
+    expect(link?.textContent).toBe('Open on YouTube')
+    expect(container.querySelector('.riffsync-solo-player__frame')).toBeNull()
+  })
+
+  it('recovers from YT.Player construct throw without uncaught render crash', async () => {
+    constructShouldThrow = true
+    renderPlayer(null)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(YOUTUBE_EMBED_BROKEN_MESSAGE)
+    })
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull()
+    expect(container.querySelector('.riffsync-solo-player')).not.toBeNull()
+    expect(container.querySelector('a')).toBeNull()
+  })
+
+  it('recovers when destroy throws during onError cleanup', async () => {
+    destroyImpl = () => {
+      throw new Error('destroy failed')
+    }
+    renderPlayer('https://www.youtube.com/watch?v=badVideoId1')
+
+    await vi.waitFor(() => {
+      expect(lastHandlers?.onError).toBeTypeOf('function')
+    })
+
+    act(() => {
+      lastHandlers?.onError?.({ data: 100 })
+    })
+
+    expect(container.textContent).toContain(YOUTUBE_EMBED_BROKEN_MESSAGE)
+    expect(container.querySelector('.riffsync-solo-player')).not.toBeNull()
+  })
+
+  it('keeps a React-owned outer frame while the host mounts', async () => {
+    renderPlayer()
+
+    await vi.waitFor(() => {
+      expect(lastHandlers?.onReady).toBeTypeOf('function')
+    })
+
+    expect(container.querySelector('.riffsync-solo-player__frame')).not.toBeNull()
+
+    act(() => {
+      lastHandlers?.onReady?.({
+        target: {
+          playVideo: vi.fn(),
+          destroy: vi.fn(),
+        },
+      })
+    })
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(container.querySelector('.riffsync-solo-player__frame')).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/watch/SoloYouTubePlayer.tsx
+++ b/apps/web/src/components/watch/SoloYouTubePlayer.tsx
@@ -1,6 +1,9 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Component, type ReactNode, useCallback, useEffect, useId, useRef, useState } from 'react'
 
 const IFRAME_API_SRC = 'https://www.youtube.com/iframe_api'
+
+/** Production-facing copy when the embed cannot play. */
+export const YOUTUBE_EMBED_BROKEN_MESSAGE = 'This video link is broken.'
 
 type YtPlayerInstance = {
   playVideo(): void
@@ -45,23 +48,76 @@ function loadYoutubeIframeApi(): Promise<void> {
   })
 }
 
-export function SoloYouTubePlayer({
-  videoId,
-  titleHint,
-  /** Rooms default autoplay so guests join in-motion; solo watch disables it so viewers use native YouTube play. */
-  autoPlay = true,
+function formatEmbedBrokenMessage(devHint?: string | number | null): string {
+  if (import.meta.env.DEV && devHint != null && String(devHint).trim() !== '') {
+    return `${YOUTUBE_EMBED_BROKEN_MESSAGE} (code: ${devHint})`
+  }
+  return YOUTUBE_EMBED_BROKEN_MESSAGE
+}
+
+function safeDestroyPlayer(player: YtPlayerInstance | null): void {
+  if (!player) return
+  try {
+    player.destroy()
+  } catch {
+    // YT may throw if the host node was already replaced or detached.
+  }
+}
+
+function OpenOnYouTubeLink({ watchUrl }: { watchUrl: string }) {
+  return (
+    <a href={watchUrl} rel="noreferrer" target="_blank">
+      Open on YouTube
+    </a>
+  )
+}
+
+function EmbedBrokenChrome({
+  message,
+  watchUrl,
 }: {
+  message: string
+  watchUrl?: string | null
+}) {
+  const trimmedWatchUrl = watchUrl?.trim() || null
+  return (
+    <div className="riffsync-solo-player__chrome" aria-live="polite">
+      <p role="alert">
+        {message}
+        {trimmedWatchUrl ? (
+          <>
+            {' '}
+            <OpenOnYouTubeLink watchUrl={trimmedWatchUrl} />
+          </>
+        ) : null}
+      </p>
+    </div>
+  )
+}
+
+type SoloYouTubePlayerProps = {
   videoId: string
   titleHint: string
+  /** Rooms default autoplay so guests join in-motion; solo watch disables it so viewers use native YouTube play. */
   autoPlay?: boolean
-}) {
+  /** Optional watch URL for the Open on YouTube escape hatch when the embed fails. */
+  watchUrl?: string | null
+}
+
+function SoloYouTubePlayerInner({
+  videoId,
+  titleHint,
+  autoPlay = true,
+  watchUrl,
+}: SoloYouTubePlayerProps) {
   const domId = useId().replace(/:/g, '')
+  const hostRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<YtPlayerInstance | null>(null)
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
   const [errorDetail, setErrorDetail] = useState<string | null>(null)
 
   const destroyPlayer = useCallback(() => {
-    playerRef.current?.destroy()
+    safeDestroyPlayer(playerRef.current)
     playerRef.current = null
   }, [])
 
@@ -76,7 +132,8 @@ export function SoloYouTubePlayer({
       } catch (err) {
         if (!cancelled) {
           setStatus('error')
-          setErrorDetail(err instanceof Error ? err.message : 'Could not start playback.')
+          const hint = err instanceof Error ? err.message : 'bootstrap'
+          setErrorDetail(formatEmbedBrokenMessage(hint))
         }
         return
       }
@@ -85,39 +142,59 @@ export function SoloYouTubePlayer({
 
       if (!window.YT?.Player) {
         setStatus('error')
-        setErrorDetail('YouTube API unavailable')
+        setErrorDetail(formatEmbedBrokenMessage('YouTube API unavailable'))
+        return
+      }
+
+      const host = hostRef.current
+      if (!host) {
+        setStatus('error')
+        setErrorDetail(formatEmbedBrokenMessage('player host missing'))
         return
       }
 
       destroyPlayer()
 
-      playerRef.current = new window.YT.Player(domId, {
-        videoId,
-        width: '100%',
-        height: '100%',
-        playerVars: {
-          fs: 1,
-          playsinline: 1,
-          rel: 0,
-          autoplay: autoPlay ? 1 : 0,
-          modestbranding: 1,
-        },
-        events: {
-          onReady: (e) => {
-            if (cancelled) return
-            setStatus('ready')
-            if (autoPlay) {
-              e.target.playVideo()
-            }
+      try {
+        playerRef.current = new window.YT.Player(host, {
+          videoId,
+          width: '100%',
+          height: '100%',
+          playerVars: {
+            fs: 1,
+            playsinline: 1,
+            rel: 0,
+            autoplay: autoPlay ? 1 : 0,
+            modestbranding: 1,
           },
-          onError: (e) => {
-            if (!cancelled) {
+          events: {
+            onReady: (e) => {
+              if (cancelled) return
+              setStatus('ready')
+              if (autoPlay) {
+                try {
+                  e.target.playVideo()
+                } catch {
+                  // Autoplay may be blocked; native controls remain available when ready.
+                }
+              }
+            },
+            onError: (e) => {
+              if (cancelled) return
+              destroyPlayer()
               setStatus('error')
-              setErrorDetail(`Playback error (${e.data}). This video may be unavailable to embed.`)
-            }
+              setErrorDetail(formatEmbedBrokenMessage(e.data))
+            },
           },
-        },
-      })
+        })
+      } catch (err) {
+        if (!cancelled) {
+          destroyPlayer()
+          setStatus('error')
+          const hint = err instanceof Error ? err.message : 'construct'
+          setErrorDetail(formatEmbedBrokenMessage(hint))
+        }
+      }
     }
 
     void boot()
@@ -126,17 +203,71 @@ export function SoloYouTubePlayer({
       cancelled = true
       destroyPlayer()
     }
-  }, [autoPlay, videoId, domId, destroyPlayer])
+  }, [autoPlay, videoId, destroyPlayer])
 
   return (
     <div className="riffsync-solo-player">
       {status === 'error' && errorDetail ? (
-        <div className="riffsync-solo-player__chrome" aria-live="polite">
-          <p role="alert">{errorDetail}</p>
-        </div>
+        <EmbedBrokenChrome message={errorDetail} watchUrl={watchUrl} />
       ) : null}
       {status === 'loading' ? <span className="sr-only">Loading video player.</span> : null}
-      <div className="riffsync-solo-player__frame" id={domId} title={titleHint} />
+      {status !== 'error' ? (
+        <div className="riffsync-solo-player__frame" title={titleHint}>
+          {/*
+            Outer frame is React-owned. YT.Player may replace the inner host node with an iframe;
+            keeping the replaceable node as a child avoids removeChild crashes on unmount/update.
+          */}
+          <div id={domId} ref={hostRef} />
+        </div>
+      ) : null}
     </div>
+  )
+}
+
+type BoundaryState = { hasError: boolean }
+
+/**
+ * Narrow boundary so a render-time player failure stays in the stage and does not blank Live/Solo shells.
+ */
+class SoloYouTubePlayerBoundary extends Component<
+  SoloYouTubePlayerProps & { children: ReactNode },
+  BoundaryState
+> {
+  state: BoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): BoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidUpdate(prevProps: SoloYouTubePlayerProps): void {
+    if (
+      this.state.hasError &&
+      (prevProps.videoId !== this.props.videoId || prevProps.watchUrl !== this.props.watchUrl)
+    ) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="riffsync-solo-player">
+          <EmbedBrokenChrome
+            message={formatEmbedBrokenMessage('render')}
+            watchUrl={this.props.watchUrl}
+          />
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+export function SoloYouTubePlayer(props: SoloYouTubePlayerProps) {
+  return (
+    <SoloYouTubePlayerBoundary {...props}>
+      {/* Remount on videoId so a prior error state cannot leave the YT host unmounted. */}
+      <SoloYouTubePlayerInner key={props.videoId} {...props} />
+    </SoloYouTubePlayerBoundary>
   )
 }

--- a/apps/web/src/pages/LiveChannelPage.test.tsx
+++ b/apps/web/src/pages/LiveChannelPage.test.tsx
@@ -36,10 +36,37 @@ vi.mock('../session/guestSession', () => ({
   setGuestDisplayName: (displayName: string) => setGuestDisplayName(displayName),
 }))
 
+const youtubePlayerFail = vi.hoisted(() => ({ value: false }))
+
 vi.mock('../components/watch/SoloYouTubePlayer', () => ({
-  SoloYouTubePlayer: ({ videoId }: { videoId: string }) => (
-    <div data-testid="yt-player">{videoId}</div>
-  ),
+  SoloYouTubePlayer: ({
+    videoId,
+    watchUrl,
+  }: {
+    videoId: string
+    watchUrl?: string | null
+  }) =>
+    youtubePlayerFail.value ? (
+      <div className="riffsync-solo-player" data-testid="yt-player-error">
+        <div className="riffsync-solo-player__chrome" aria-live="polite">
+          <p role="alert">
+            This video link is broken.
+            {watchUrl ? (
+              <>
+                {' '}
+                <a href={watchUrl} rel="noreferrer" target="_blank">
+                  Open on YouTube
+                </a>
+              </>
+            ) : null}
+          </p>
+        </div>
+      </div>
+    ) : (
+      <div data-testid="yt-player" data-watch-url={watchUrl ?? ''}>
+        {videoId}
+      </div>
+    ),
 }))
 
 vi.mock('../room/ChatComposeMediaPicker', () => ({
@@ -70,6 +97,7 @@ describe('LiveChannelPage', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    youtubePlayerFail.value = false
     fetchLiveChannel.mockReset()
     fetchFanProfile.mockReset()
     useFanSession.mockReset()
@@ -184,5 +212,41 @@ describe('LiveChannelPage', () => {
       expect(fetchLiveChannel).toHaveBeenCalledWith('not-a-channel')
       expect(container.textContent).toContain('Live channel not found')
     })
+  })
+
+  it('keeps chat chrome when the YouTube embed reports a broken link', async () => {
+    youtubePlayerFail.value = true
+    fetchLiveChannel.mockResolvedValue({
+      slug: 'mst3k-forever-a-thon',
+      path: '/live/mst3k-forever-a-thon',
+      roomId: 'live-mst3k-forever-a-thon',
+      catalogEpisodeId: 'mst3k-forever-a-thon',
+      enabled: true,
+      title: 'MST3K Forever-A-Thon',
+      tagline: '24/7',
+      posterImageUrl: null,
+      backdropImageUrl: null,
+      youtubeVideoId: 'retiredLiveId',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=retiredLiveId',
+      embedAllows: true,
+      playbackHost: 'youtube',
+    })
+
+    await act(async () => {
+      renderLive(root, '/live/mst3k-forever-a-thon', queryClient)
+    })
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="yt-player-error"]')).not.toBeNull()
+    })
+
+    expect(container.textContent).toContain('This video link is broken.')
+    expect(
+      container.querySelector('a[href="https://www.youtube.com/watch?v=retiredLiveId"]')?.textContent,
+    ).toBe('Open on YouTube')
+    expect(container.textContent).toContain('People (2)')
+    expect(container.textContent).toContain('Sign In to Chat')
+    expect(container.querySelector('.riffsync-live-page__chat .riffsync-room-page__chat')).not.toBeNull()
+    expect(container.querySelector('.riffsync-live-page__layout')).not.toBeNull()
   })
 })

--- a/apps/web/src/pages/LiveChannelPage.tsx
+++ b/apps/web/src/pages/LiveChannelPage.tsx
@@ -175,6 +175,7 @@ function LiveChannelReady(props: {
             videoId={channel.youtubeVideoId}
             titleHint={channel.title}
             autoPlay
+            watchUrl={channel.youtubeWatchUrl}
           />
         ) : (
           <p className="riffsync-live-page__status" role="status">

--- a/apps/web/src/pages/SoloWatchPage.test.tsx
+++ b/apps/web/src/pages/SoloWatchPage.test.tsx
@@ -16,10 +16,42 @@ vi.mock('../catalog/catalogQueries', () => ({
   useCatalogListQuery: (...args: unknown[]) => useCatalogListQuery(...args),
 }))
 
+const youtubePlayerFail = vi.hoisted(() => ({ value: false }))
+
 vi.mock('../components/watch/SoloYouTubePlayer', () => ({
-  SoloYouTubePlayer: ({ videoId, titleHint }: { videoId: string; titleHint: string }) => (
-    <div data-testid="solo-youtube-player" data-video-id={videoId} data-title={titleHint} />
-  ),
+  SoloYouTubePlayer: ({
+    videoId,
+    titleHint,
+    watchUrl,
+  }: {
+    videoId: string
+    titleHint: string
+    watchUrl?: string | null
+  }) =>
+    youtubePlayerFail.value ? (
+      <div className="riffsync-solo-player" data-testid="solo-youtube-player-error">
+        <div className="riffsync-solo-player__chrome" aria-live="polite">
+          <p role="alert">
+            This video link is broken.
+            {watchUrl ? (
+              <>
+                {' '}
+                <a href={watchUrl} rel="noreferrer" target="_blank">
+                  Open on YouTube
+                </a>
+              </>
+            ) : null}
+          </p>
+        </div>
+      </div>
+    ) : (
+      <div
+        data-testid="solo-youtube-player"
+        data-video-id={videoId}
+        data-title={titleHint}
+        data-watch-url={watchUrl ?? ''}
+      />
+    ),
 }))
 
 function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
@@ -53,6 +85,7 @@ describe('SoloWatchPage', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
+    youtubePlayerFail.value = false
     useCatalogEpisodeQuery.mockReset()
     useCatalogListQuery.mockReset()
     useCatalogListQuery.mockReturnValue({
@@ -275,5 +308,27 @@ describe('SoloWatchPage', () => {
 
     expect(container.textContent).toContain('This page could not be embedded in RiffSync.')
     expect(container.querySelector('a[href="https://example.test/movie"]')).not.toBeNull()
+  })
+
+  it('keeps Solo page shell when the YouTube embed reports a broken link', () => {
+    youtubePlayerFail.value = true
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({ embedAllows: true }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    expect(container.querySelector('.riffsync-solo-watch-page')).not.toBeNull()
+    expect(container.querySelector('.riffsync-solo-watch__player-shell')).not.toBeNull()
+    expect(container.querySelector('[data-testid="solo-youtube-player-error"]')).not.toBeNull()
+    expect(container.textContent).toContain('This video link is broken.')
+    expect(
+      container.querySelector('a[href="https://www.youtube.com/watch?v=NXGXtm6gcxk"]')?.textContent,
+    ).toBe('Open on YouTube')
+    expect(container.querySelector('h1.sr-only')?.textContent).toBe('Mitchell')
   })
 })

--- a/apps/web/src/pages/SoloWatchPage.tsx
+++ b/apps/web/src/pages/SoloWatchPage.tsx
@@ -258,7 +258,12 @@ export function SoloWatchPage() {
       ) : null}
       {playbackHost === 'youtube' && vid && canEmbed ? (
         <div className="riffsync-solo-watch__player-shell">
-          <SoloYouTubePlayer videoId={vid} titleHint={episode.title} autoPlay={false} />
+          <SoloYouTubePlayer
+            videoId={vid}
+            titleHint={episode.title}
+            autoPlay={false}
+            watchUrl={episode.youtubeWatchUrl}
+          />
         </div>
       ) : null}
     </div>

--- a/apps/web/src/types/youtube-iframe-api.d.ts
+++ b/apps/web/src/types/youtube-iframe-api.d.ts
@@ -4,7 +4,10 @@ export {}
 declare global {
   interface Window {
     YT?: {
-      Player: new (elementId: string, options: YtPlayerOptions) => YtPlayer
+      Player: new (
+        elementIdOrElement: string | HTMLElement,
+        options: YtPlayerOptions,
+      ) => YtPlayer
     }
     onYouTubeIframeAPIReady?: () => void
   }


### PR DESCRIPTION
## Summary

- Isolate YouTube IFrame API / construct / destroy failures inside `SoloYouTubePlayer` so Live and Solo shells do not white-screen.
- Show friendly "This video link is broken." copy with Open on YouTube when a watch URL exists.
- Keep Live chat and Solo page chrome usable when only the embed fails.
- Add player unit tests plus Live/Solo shell smoke coverage for the embed-failure path.

Closes #416

## Test plan

- [ ] Point a Solo watch episode at an invalid / non-embeddable YouTube id; open `/watch/:id` and confirm friendly broken-link message in the player region with surrounding Solo chrome intact.
- [ ] Point a Live catalog episode `youtubeVideoId` at a retired/invalid live id; open `/live/:slug` and confirm the same player messaging with chat/sidebar still usable.
- [ ] Confirm Open on YouTube appears when a watch URL is present.
- [ ] Happy path: valid embeddable id still plays on both routes.
- [ ] CI green (`verify:push` / web tests including new SoloYouTubePlayer failure coverage).