### PR TITLE
fix(web): compact Friends Remove control to match People density

### DIFF
--- a/apps/web/src/friends/FriendsDropdown.test.tsx
+++ b/apps/web/src/friends/FriendsDropdown.test.tsx
@@ -106,7 +106,12 @@ describe('FriendsDropdown (#363)', () => {
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true')
     expect(container.textContent).toContain('Buddy')
-    expect(container.textContent).toContain('Online in a watch party')
+    const onlineBadge = container.querySelector('.riffsync-room-friends-online-badge')
+    expect(onlineBadge?.textContent).toContain('Online')
+    expect(onlineBadge?.getAttribute('aria-label')).toBe('Online in a watch party')
+    expect(container.querySelector('.riffsync-room-friends-remove')?.classList.contains('gen-button')).toBe(
+      false,
+    )
     expect(container.querySelector('.riffsync-friends-dropdown')).not.toBeNull()
 
     act(() => {

--- a/apps/web/src/friends/FriendsDropdown.tsx
+++ b/apps/web/src/friends/FriendsDropdown.tsx
@@ -256,25 +256,30 @@ function FriendRow({
       <div className="riffsync-room-friends-row-main">
         <button type="button" className="riffsync-room-friends-row-open" onClick={onOpenDm}>
           <span className="riffsync-room-friends-row-name">{friend.displayName}</span>
+          {friend.online ? (
+            <span
+              className="riffsync-room-friends-online-badge"
+              aria-label="Online in a watch party"
+            >
+              <span className="riffsync-room-friends-online-dot" aria-hidden />
+              Online
+            </span>
+          ) : null}
           {friend.hasUnread ? (
             <span className="riffsync-room-friends-unread-dot" aria-label="Unread messages" />
           ) : null}
         </button>
-        {friend.online ? (
-          <span className="riffsync-room-friends-online riffsync-muted">
-            <span className="riffsync-room-friends-online-dot" aria-hidden />
-            Online in a watch party
-          </span>
-        ) : null}
       </div>
-      <button
-        type="button"
-        className="riffsync-room-friends-remove gen-button"
-        aria-label={`Remove ${friend.displayName}`}
-        onClick={onRemove}
-      >
-        Remove
-      </button>
+      <div className="riffsync-room-friends-row-actions">
+        <button
+          type="button"
+          className="riffsync-room-friends-remove"
+          aria-label={`Remove ${friend.displayName}`}
+          onClick={onRemove}
+        >
+          Remove
+        </button>
+      </div>
     </li>
   )
 }

--- a/apps/web/src/friends/RoomFriendsPane.test.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.test.tsx
@@ -79,8 +79,14 @@ describe('RoomFriendsPane (#364)', () => {
     })
 
     expect(container.textContent).toContain('Buddy')
-    expect(container.textContent).toContain('Online in a watch party')
+    const onlineBadge = container.querySelector('.riffsync-room-friends-online-badge')
+    expect(onlineBadge?.textContent).toContain('Online')
+    expect(onlineBadge?.getAttribute('aria-label')).toBe('Online in a watch party')
     expect(container.querySelector('.riffsync-room-friends-unread-dot')).not.toBeNull()
+    const remove = container.querySelector('.riffsync-room-friends-remove') as HTMLButtonElement | null
+    expect(remove).not.toBeNull()
+    expect(remove?.classList.contains('gen-button')).toBe(false)
+    expect(remove?.getAttribute('aria-label')).toBe('Remove Buddy')
   })
 
   it('renders empty friends copy when roster has no friends', () => {

--- a/apps/web/src/friends/RoomFriendsPane.tsx
+++ b/apps/web/src/friends/RoomFriendsPane.tsx
@@ -255,28 +255,33 @@ function FriendRow({
           }}
         >
           <span className="riffsync-room-friends-row-name">{friend.displayName}</span>
+          {friend.online ? (
+            <span
+              className="riffsync-room-friends-online-badge"
+              aria-label="Online in a watch party"
+            >
+              <span className="riffsync-room-friends-online-dot" aria-hidden />
+              Online
+            </span>
+          ) : null}
           {friend.hasUnread ? (
             <span className="riffsync-room-friends-unread-dot" aria-label="Unread messages" />
           ) : null}
         </button>
-        {friend.online ? (
-          <span className="riffsync-room-friends-online riffsync-muted">
-            <span className="riffsync-room-friends-online-dot" aria-hidden />
-            Online in a watch party
-          </span>
-        ) : null}
       </div>
-      <button
-        ref={removeButtonRef}
-        type="button"
-        className="riffsync-room-friends-remove gen-button"
-        aria-label={`Remove ${friend.displayName}`}
-        onClick={() => {
-          if (removeButtonRef.current) onRemove(removeButtonRef.current)
-        }}
-      >
-        Remove
-      </button>
+      <div className="riffsync-room-friends-row-actions">
+        <button
+          ref={removeButtonRef}
+          type="button"
+          className="riffsync-room-friends-remove"
+          aria-label={`Remove ${friend.displayName}`}
+          onClick={() => {
+            if (removeButtonRef.current) onRemove(removeButtonRef.current)
+          }}
+        >
+          Remove
+        </button>
+      </div>
     </li>
   )
 }

--- a/apps/web/src/styles/riffsync-app.css
+++ b/apps/web/src/styles/riffsync-app.css
@@ -2077,6 +2077,46 @@ header#gen-header .gen-bottom-header .navbar .navbar-nav li.riffsync-catalog-nav
   font-size: 0.75rem;
 }
 
+.riffsync-room-friends-online-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  margin-left: 0.35rem;
+  padding: 0.12rem 0.42rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  color: rgb(120 190 130);
+  border: 1px solid rgb(120 190 130 / 0.35);
+  vertical-align: middle;
+}
+
+.riffsync-room-friends-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-height: 1.65rem;
+  padding: 0.12rem 0.42rem;
+  border: 1px solid rgb(255 255 255 / 0.18);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--primary-color);
+  font: inherit;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.riffsync-room-friends-remove:hover,
+.riffsync-room-friends-remove:focus-visible {
+  background: rgb(255 255 255 / 0.08);
+}
+
 .riffsync-room-friends-online-dot {
   width: 0.4rem;
   height: 0.4rem;


### PR DESCRIPTION
## Summary
- Shrink the Friends list **Remove** control from a full-width `gen-button` to a compact badge-sized control that matches People tab density (Host / Active style).
- Show **Online** as an inline chip next to the friend name (same visual language as People **Active**).
- Apply the same treatment in the room Friends pane and the site Friends dropdown; keep the remove confirmation dialog CTAs unchanged.

## Test plan
- [ ] Open room Friends tab: Remove is a small outlined badge, not a giant red button
- [ ] Online friends show a compact Online chip next to the name
- [ ] Remove still opens the confirmation dialog and removes the friend
- [ ] Site header Friends dropdown matches the same compact Remove / Online treatment

## Local CI
- `apps/web`: `npm run build`, `npm run verify:seo-artifacts`, `npm test` (1053 passed), `npm run lint`
- `infra/cdk`: `npm run build`, `npm test` (451 passed)