### PR TITLE
feat(catalog): add RiffTrax category with Movies and Shorts browse

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -50,6 +50,9 @@ export function AppRoutes() {
         <Route path="/catalog/mst3k/season/:seasonNumber" element={<CatalogSubcategoryPage />} />
         <Route path="/catalog/mst3k/era/:eraSlug" element={<CatalogSubcategoryPage />} />
         <Route path="/catalog/mst3k/shorts" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/rifftrax" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/rifftrax/movies" element={<CatalogSubcategoryPage />} />
+        <Route path="/catalog/rifftrax/shorts" element={<CatalogSubcategoryPage />} />
         <Route path="/catalog/community" element={<CatalogSubcategoryPage />} />
         <Route path="/catalog/riff-ready" element={<Navigate to="/catalog/riff-material" replace />} />
         <Route path="/catalog/riff-material" element={<CatalogSubcategoryPage />} />

--- a/apps/web/src/catalog/catalogBrowseIa.ts
+++ b/apps/web/src/catalog/catalogBrowseIa.ts
@@ -1,7 +1,9 @@
-import type { CatalogCategory } from './catalogTypes'
+import type { CatalogCategory, CatalogEpisode } from './catalogTypes'
 
 export const MST3K_DEFAULT_SUBTITLE = '"Push the button, Frank"'
 export const MST3K_SHORT_LABEL = 'Short'
+/** Same badge string MST3K uses; RiffTrax Movies/Shorts split on this label. */
+export const RIFFTRAX_SHORT_LABEL = MST3K_SHORT_LABEL
 
 export const MST3K_SEASON_NAV_LINKS = Array.from({ length: 12 }, (_, index) => {
   const seasonNumber = index + 1
@@ -51,11 +53,28 @@ export const MST3K_SHORTS_NAV_LINK = {
   labelFilter: MST3K_SHORT_LABEL,
 } as const
 
+export const RIFFTRAX_MOVIES_NAV_LINK = {
+  label: 'Movies',
+  href: '/catalog/rifftrax/movies',
+  subtitle: 'RiffTrax Movies',
+} as const
+
+export const RIFFTRAX_SHORTS_NAV_LINK = {
+  label: 'Shorts',
+  href: '/catalog/rifftrax/shorts',
+  subtitle: 'RiffTrax Shorts',
+  labelFilter: RIFFTRAX_SHORT_LABEL,
+} as const
+
 export type Mst3kCatalogRouteFilter =
   | { kind: 'all' }
   | { kind: 'season'; tag: string; seasonNumber: number }
   | { kind: 'era'; tag: string; slug: string }
   | { kind: 'shorts'; label: typeof MST3K_SHORT_LABEL }
+
+export type RifftraxCatalogRouteFilter =
+  | { kind: 'movies' }
+  | { kind: 'shorts'; label: typeof RIFFTRAX_SHORT_LABEL }
 
 /**
  * Route-fixed subcategory browse destinations (M32 browse IA).
@@ -69,6 +88,13 @@ export const CATALOG_SUBCATEGORIES = [
     label: 'MST3K',
     subtitle: MST3K_DEFAULT_SUBTITLE,
     catalog: 'mst3k' as const satisfies CatalogCategory,
+  },
+  {
+    slug: 'rifftrax',
+    path: '/catalog/rifftrax',
+    label: 'RiffTrax',
+    subtitle: RIFFTRAX_MOVIES_NAV_LINK.subtitle,
+    catalog: 'rifftrax' as const satisfies CatalogCategory,
   },
   {
     slug: 'community',
@@ -104,10 +130,26 @@ export interface CatalogBrowseView {
   title: CatalogSubcategory['label']
   subtitle: string
   mst3kRouteFilter?: Mst3kCatalogRouteFilter
+  rifftraxRouteFilter?: RifftraxCatalogRouteFilter
 }
 
 function getMst3kSubcategory(): CatalogSubcategory {
   return CATALOG_SUBCATEGORIES[0]
+}
+
+function getRifftraxSubcategory(): CatalogSubcategory {
+  return CATALOG_SUBCATEGORIES[1]
+}
+
+export function filterRifftraxCatalogEntriesByRouteFilter(
+  entries: readonly CatalogEpisode[],
+  routeFilter: RifftraxCatalogRouteFilter = { kind: 'movies' },
+): CatalogEpisode[] {
+  if (routeFilter.kind === 'shorts') {
+    return entries.filter((entry) => entry.labels.includes(routeFilter.label))
+  }
+
+  return entries.filter((entry) => !entry.labels.includes(RIFFTRAX_SHORT_LABEL))
 }
 
 export function getCatalogBrowseViewByPath(pathname: string): CatalogBrowseView | undefined {
@@ -118,6 +160,7 @@ export function getCatalogBrowseViewByPath(pathname: string): CatalogBrowseView 
       title: exactSubcategory.label,
       subtitle: exactSubcategory.subtitle,
       mst3kRouteFilter: exactSubcategory.slug === 'mst3k' ? { kind: 'all' } : undefined,
+      rifftraxRouteFilter: exactSubcategory.slug === 'rifftrax' ? { kind: 'movies' } : undefined,
     }
   }
 
@@ -164,6 +207,28 @@ export function getCatalogBrowseViewByPath(pathname: string): CatalogBrowseView 
       mst3kRouteFilter: {
         kind: 'shorts',
         label: MST3K_SHORTS_NAV_LINK.labelFilter,
+      },
+    }
+  }
+
+  const rifftraxSubcategory = getRifftraxSubcategory()
+  if (pathname === RIFFTRAX_MOVIES_NAV_LINK.href) {
+    return {
+      subcategory: rifftraxSubcategory,
+      title: rifftraxSubcategory.label,
+      subtitle: RIFFTRAX_MOVIES_NAV_LINK.subtitle,
+      rifftraxRouteFilter: { kind: 'movies' },
+    }
+  }
+
+  if (pathname === RIFFTRAX_SHORTS_NAV_LINK.href) {
+    return {
+      subcategory: rifftraxSubcategory,
+      title: rifftraxSubcategory.label,
+      subtitle: RIFFTRAX_SHORTS_NAV_LINK.subtitle,
+      rifftraxRouteFilter: {
+        kind: 'shorts',
+        label: RIFFTRAX_SHORTS_NAV_LINK.labelFilter,
       },
     }
   }

--- a/apps/web/src/catalog/catalogTypes.ts
+++ b/apps/web/src/catalog/catalogTypes.ts
@@ -4,6 +4,7 @@
  */
 export type CatalogCategory =
   | 'mst3k'
+  | 'rifftrax'
   | 'community'
   | 'riff_material'
   | 'movie_night'
@@ -12,6 +13,7 @@ export type CatalogCategory =
 
 export const CATALOG_CATEGORIES: readonly CatalogCategory[] = [
   'mst3k',
+  'rifftrax',
   'community',
   'riff_material',
   'movie_night',
@@ -27,12 +29,14 @@ export const CATALOG_CATEGORIES: readonly CatalogCategory[] = [
  */
 export const PUBLIC_CATALOG_CATEGORIES: readonly CatalogCategory[] = [
   'mst3k',
+  'rifftrax',
   'community',
   'riff_material',
 ]
 
 const CATALOG_CATEGORY_LABELS: Record<CatalogCategory, string> = {
   mst3k: 'MST3K',
+  rifftrax: 'RiffTrax',
   community: 'Community',
   riff_material: 'Riff Material',
   movie_night: 'Movie Night',

--- a/apps/web/src/catalog/filterCatalogEntries.test.ts
+++ b/apps/web/src/catalog/filterCatalogEntries.test.ts
@@ -111,6 +111,7 @@ describe('filterCatalogEntries', () => {
   })
 
   it('excludes other and movie_night from public catalog category chips', () => {
+    expect(PUBLIC_CATALOG_CATEGORIES).toContain('rifftrax')
     expect(PUBLIC_CATALOG_CATEGORIES).toContain('riff_material')
     expect(PUBLIC_CATALOG_CATEGORIES).not.toContain('other')
     expect(PUBLIC_CATALOG_CATEGORIES).not.toContain('movie_night')

--- a/apps/web/src/components/site/CatalogNavItem.test.tsx
+++ b/apps/web/src/components/site/CatalogNavItem.test.tsx
@@ -8,6 +8,8 @@ import {
   MST3K_ERA_NAV_LINKS,
   MST3K_SEASON_NAV_LINKS,
   MST3K_SHORTS_NAV_LINK,
+  RIFFTRAX_MOVIES_NAV_LINK,
+  RIFFTRAX_SHORTS_NAV_LINK,
 } from '../../catalog/catalogBrowseIa'
 import { CatalogNavItem } from './CatalogNavItem'
 
@@ -88,6 +90,8 @@ describe('CatalogNavItem', () => {
         ...MST3K_SEASON_NAV_LINKS.map((entry) => entry.href),
         ...MST3K_ERA_NAV_LINKS.map((entry) => entry.href),
         MST3K_SHORTS_NAV_LINK.href,
+        RIFFTRAX_MOVIES_NAV_LINK.href,
+        RIFFTRAX_SHORTS_NAV_LINK.href,
       ]),
     )
     expect(subcategoryLabels(submenu!)).toEqual(
@@ -98,6 +102,8 @@ describe('CatalogNavItem', () => {
         'Joel',
         'Emily',
         'Shorts',
+        'RiffTrax',
+        'Movies',
         'Community',
         'Riff Material',
       ]),
@@ -170,6 +176,8 @@ describe('CatalogNavItem', () => {
         ...MST3K_SEASON_NAV_LINKS.map((entry) => entry.href),
         ...MST3K_ERA_NAV_LINKS.map((entry) => entry.href),
         MST3K_SHORTS_NAV_LINK.href,
+        RIFFTRAX_MOVIES_NAV_LINK.href,
+        RIFFTRAX_SHORTS_NAV_LINK.href,
       ]),
     )
 

--- a/apps/web/src/components/site/CatalogNavItem.tsx
+++ b/apps/web/src/components/site/CatalogNavItem.tsx
@@ -6,6 +6,8 @@ import {
   MST3K_ERA_NAV_LINKS,
   MST3K_SEASON_NAV_LINKS,
   MST3K_SHORTS_NAV_LINK,
+  RIFFTRAX_MOVIES_NAV_LINK,
+  RIFFTRAX_SHORTS_NAV_LINK,
 } from '../../catalog/catalogBrowseIa'
 
 function onDisclosureKeyDown({
@@ -100,7 +102,10 @@ function NestedDisclosureItem({
 
 function CatalogSubcategoryLinks() {
   const mst3kSubcategory = CATALOG_SUBCATEGORIES.find((entry) => entry.slug === 'mst3k')
-  const leafSubcategories = CATALOG_SUBCATEGORIES.filter((entry) => entry.slug !== 'mst3k')
+  const rifftraxSubcategory = CATALOG_SUBCATEGORIES.find((entry) => entry.slug === 'rifftrax')
+  const leafSubcategories = CATALOG_SUBCATEGORIES.filter(
+    (entry) => entry.slug !== 'mst3k' && entry.slug !== 'rifftrax',
+  )
 
   return (
     <>
@@ -131,6 +136,24 @@ function CatalogSubcategoryLinks() {
           <li className="menu-item">
             <NavLink to={MST3K_SHORTS_NAV_LINK.href} end>
               {MST3K_SHORTS_NAV_LINK.label}
+            </NavLink>
+          </li>
+        </NestedDisclosureItem>
+      ) : null}
+      {rifftraxSubcategory ? (
+        <NestedDisclosureItem
+          label={rifftraxSubcategory.label}
+          linkTo={rifftraxSubcategory.path}
+          ariaLabel="Show RiffTrax catalog filters"
+        >
+          <li className="menu-item">
+            <NavLink to={RIFFTRAX_MOVIES_NAV_LINK.href} end>
+              {RIFFTRAX_MOVIES_NAV_LINK.label}
+            </NavLink>
+          </li>
+          <li className="menu-item">
+            <NavLink to={RIFFTRAX_SHORTS_NAV_LINK.href} end>
+              {RIFFTRAX_SHORTS_NAV_LINK.label}
             </NavLink>
           </li>
         </NestedDisclosureItem>

--- a/apps/web/src/components/site/SiteHeader.test.tsx
+++ b/apps/web/src/components/site/SiteHeader.test.tsx
@@ -8,6 +8,8 @@ import {
   MST3K_ERA_NAV_LINKS,
   MST3K_SEASON_NAV_LINKS,
   MST3K_SHORTS_NAV_LINK,
+  RIFFTRAX_MOVIES_NAV_LINK,
+  RIFFTRAX_SHORTS_NAV_LINK,
 } from '../../catalog/catalogBrowseIa'
 import { SiteHeader } from './SiteHeader'
 
@@ -165,6 +167,8 @@ describe('SiteHeader fan session nav', () => {
       ...MST3K_SEASON_NAV_LINKS.map(({ href }) => href),
       ...MST3K_ERA_NAV_LINKS.map(({ href }) => href),
       MST3K_SHORTS_NAV_LINK.href,
+      RIFFTRAX_MOVIES_NAV_LINK.href,
+      RIFFTRAX_SHORTS_NAV_LINK.href,
     ]
 
     expect(container.querySelectorAll('.riffsync-catalog-nav > .sub-menu a')).toHaveLength(

--- a/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.test.tsx
@@ -77,6 +77,19 @@ const catalogFixtures: CatalogEpisode[] = [
     title: 'Riff Material Classic',
     catalog: 'riff_material',
   }),
+  episode({
+    id: 'ep-rifftrax-movie',
+    experimentNumber: 700,
+    title: 'RiffTrax Feature',
+    catalog: 'rifftrax',
+  }),
+  episode({
+    id: 'ep-rifftrax-short',
+    experimentNumber: 701,
+    title: 'RiffTrax Short Feature',
+    catalog: 'rifftrax',
+    labels: ['Short'],
+  }),
   episode({ id: 'ep-movie-night', experimentNumber: 1500, title: 'Movie Night Pick', catalog: 'movie_night' }),
   episode({ id: 'ep-other', experimentNumber: 999, title: 'Other Experiment', catalog: 'other' }),
 ]
@@ -125,7 +138,7 @@ describe('CatalogSubcategoryPage', () => {
   }
 
   it.each(
-    CATALOG_SUBCATEGORIES.filter((entry) => entry.slug !== 'mst3k').map(
+    CATALOG_SUBCATEGORIES.filter((entry) => entry.slug !== 'mst3k' && entry.slug !== 'rifftrax').map(
       (entry) => [entry.path, entry.label, entry.subtitle] as const,
     ),
   )(
@@ -233,6 +246,39 @@ describe('CatalogSubcategoryPage', () => {
       (link) => link.textContent?.trim(),
     )
     expect(titles).toEqual(['Robot Rumpus'])
+  })
+
+  it.each(['/catalog/rifftrax', '/catalog/rifftrax/movies'] as const)(
+    'locks RiffTrax Movies route %s to rows without the Short label',
+    (path) => {
+      renderSubcategoryPage(path)
+
+      expect(container.querySelector('h1')?.textContent).toBe('RiffTrax')
+      expect(container.querySelector('.riffsync-catalog-page-header__subtitle')?.textContent).toBe(
+        'RiffTrax Movies',
+      )
+      expect(container.querySelector('.riffsync-catalog-filter-bar__tag-groups')).toBeNull()
+
+      const titles = Array.from(container.querySelectorAll('.riffsync-catalog-card h3 a')).map(
+        (link) => link.textContent?.trim(),
+      )
+      expect(titles).toEqual(['RiffTrax Feature'])
+    },
+  )
+
+  it('locks the RiffTrax Shorts route to rows labeled Short', () => {
+    renderSubcategoryPage('/catalog/rifftrax/shorts')
+
+    expect(container.querySelector('h1')?.textContent).toBe('RiffTrax')
+    expect(container.querySelector('.riffsync-catalog-page-header__subtitle')?.textContent).toBe(
+      'RiffTrax Shorts',
+    )
+    expect(container.querySelector('.riffsync-catalog-filter-bar__tag-groups')).toBeNull()
+
+    const titles = Array.from(container.querySelectorAll('.riffsync-catalog-card h3 a')).map(
+      (link) => link.textContent?.trim(),
+    )
+    expect(titles).toEqual(['RiffTrax Short Feature'])
   })
 
   it('combines Era and Season pill filters with AND semantics', () => {

--- a/apps/web/src/pages/CatalogSubcategoryPage.tsx
+++ b/apps/web/src/pages/CatalogSubcategoryPage.tsx
@@ -1,7 +1,10 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useMemo, useState } from 'react'
 import { useCatalogListQuery } from '../catalog/catalogQueries'
-import { getCatalogBrowseViewByPath } from '../catalog/catalogBrowseIa'
+import {
+  filterRifftraxCatalogEntriesByRouteFilter,
+  getCatalogBrowseViewByPath,
+} from '../catalog/catalogBrowseIa'
 import { CatalogLoadErrorPanel } from '../components/catalog/CatalogLoadErrorPanel'
 import { CatalogFilterBar } from '../components/catalog/CatalogFilterBar'
 import { Mst3kCatalogTagFilterBar } from '../components/catalog/Mst3kCatalogTagFilterBar'
@@ -29,6 +32,8 @@ export function CatalogSubcategoryPage() {
   const [titleQuery, setTitleQuery] = useState('')
   const [selectedTagPills, setSelectedTagPills] = useState<SelectedMst3kTagPills>(EMPTY_MST3K_TAG_PILLS)
   const isMst3kRoute = subcategory?.slug === 'mst3k'
+  const isRifftraxRoute = subcategory?.slug === 'rifftrax'
+  const usesRouteFilter = isMst3kRoute || isRifftraxRoute
   const showMst3kTagPills = browseView?.mst3kRouteFilter?.kind === 'all'
 
   useResumePendingPartyRoom(data, navigate)
@@ -45,16 +50,21 @@ export function CatalogSubcategoryPage() {
         : [],
     [playableEntries, subcategory],
   )
-  const routeCatalogEntries = useMemo(
-    () =>
-      isMst3kRoute
-        ? filterMst3kCatalogEntriesByRouteFilter(
-            baseCatalogEntries,
-            browseView?.mst3kRouteFilter,
-          )
-        : baseCatalogEntries,
-    [baseCatalogEntries, browseView, isMst3kRoute],
-  )
+  const routeCatalogEntries = useMemo(() => {
+    if (isMst3kRoute) {
+      return filterMst3kCatalogEntriesByRouteFilter(
+        baseCatalogEntries,
+        browseView?.mst3kRouteFilter,
+      )
+    }
+    if (isRifftraxRoute) {
+      return filterRifftraxCatalogEntriesByRouteFilter(
+        baseCatalogEntries,
+        browseView?.rifftraxRouteFilter,
+      )
+    }
+    return baseCatalogEntries
+  }, [baseCatalogEntries, browseView, isMst3kRoute, isRifftraxRoute])
   const filteredEntries = useMemo(
     () =>
       subcategory
@@ -64,7 +74,12 @@ export function CatalogSubcategoryPage() {
               catalogs: [subcategory.catalog],
               selectedTagPills: showMst3kTagPills ? selectedTagPills : EMPTY_MST3K_TAG_PILLS,
             })
-          : filterCatalogEntries(playableEntries, { titleQuery, catalogs: [subcategory.catalog] })
+          : usesRouteFilter
+            ? filterCatalogEntries(routeCatalogEntries, {
+                titleQuery,
+                catalogs: [subcategory.catalog],
+              })
+            : filterCatalogEntries(playableEntries, { titleQuery, catalogs: [subcategory.catalog] })
         : [],
     [
       routeCatalogEntries,
@@ -72,6 +87,7 @@ export function CatalogSubcategoryPage() {
       titleQuery,
       subcategory,
       isMst3kRoute,
+      usesRouteFilter,
       selectedTagPills,
       showMst3kTagPills,
     ],
@@ -80,7 +96,7 @@ export function CatalogSubcategoryPage() {
   const filterBarDisabled = isPending && !data
   const hasActiveTagPills =
     showMst3kTagPills && (selectedTagPills.Era.length > 0 || selectedTagPills.Season.length > 0)
-  const isFilterNoMatch = isMst3kRoute
+  const isFilterNoMatch = usesRouteFilter
     ? routeCatalogEntries.length > 0 && filteredEntries.length === 0
     : playableEntries.length > 0 && filteredEntries.length === 0
 

--- a/apps/web/src/seo/applyRouteHeadTags.test.ts
+++ b/apps/web/src/seo/applyRouteHeadTags.test.ts
@@ -24,7 +24,7 @@ describe('applyRouteHeadTags', () => {
 
     expect(document.title).toBe('RiffSync Catalog - Browse the Library')
     expect(document.head.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
-      'Browse RiffSync episodes across MST3K, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
+      'Browse RiffSync episodes across MST3K, RiffTrax, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
     )
     expect(document.head.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
       'https://riffsync.tv/catalog',

--- a/apps/web/src/seo/indexableRoutes.ts
+++ b/apps/web/src/seo/indexableRoutes.ts
@@ -3,6 +3,7 @@ export const STATIC_INDEXABLE_ROUTES = [
   '/',
   '/catalog',
   '/catalog/mst3k',
+  '/catalog/rifftrax',
   '/catalog/community',
   '/catalog/riff-material',
   '/download',

--- a/apps/web/src/seo/routeHeadTags.test.ts
+++ b/apps/web/src/seo/routeHeadTags.test.ts
@@ -80,7 +80,7 @@ describe('buildStaticRouteHeadTags', () => {
     const head = buildStaticRouteHeadTags('/catalog', 'https://riffsync.tv')
     expect(head.documentTitle).toBe('RiffSync Catalog - Browse the Library')
     expect(head.description).toBe(
-      'Browse RiffSync episodes across MST3K, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
+      'Browse RiffSync episodes across MST3K, RiffTrax, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
     )
     expect(head.canonicalUrl).toBe('https://riffsync.tv/catalog')
   })
@@ -103,6 +103,13 @@ describe('buildStaticRouteHeadTags', () => {
         description:
           'Browse Mystery Science Theater 3000 episodes on RiffSync — Joel, Mike, Jonah, and Emily catalogs with lawful YouTube embeds. Unofficial fan project.',
         canonical: 'https://riffsync.tv/catalog/mst3k',
+      },
+      {
+        route: '/catalog/rifftrax' as const,
+        title: 'RiffTrax - RiffSync Catalog',
+        description:
+          'Browse RiffTrax movies on RiffSync with lawful YouTube embeds. Pick a title and start a watch party. Unofficial fan project.',
+        canonical: 'https://riffsync.tv/catalog/rifftrax',
       },
       {
         route: '/catalog/community' as const,
@@ -129,8 +136,8 @@ describe('buildStaticRouteHeadTags', () => {
     }
   })
 
-  it('indexes nine static routes without dynamic Live entries', () => {
-    expect(STATIC_INDEXABLE_ROUTES).toHaveLength(9)
+  it('indexes ten static routes without dynamic Live entries', () => {
+    expect(STATIC_INDEXABLE_ROUTES).toHaveLength(10)
     expect(STATIC_INDEXABLE_ROUTES).not.toContain('/live/mst3k-forever-a-thon')
   })
 })

--- a/apps/web/src/seo/routeHeadTags.ts
+++ b/apps/web/src/seo/routeHeadTags.ts
@@ -16,12 +16,17 @@ const STATIC_ROUTE_COPY = {
   '/catalog': {
     title: 'RiffSync Catalog - Browse the Library',
     description:
-      'Browse RiffSync episodes across MST3K, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
+      'Browse RiffSync episodes across MST3K, RiffTrax, Community, and Riff Material. Pick a title and start a lawful YouTube watch party. Unofficial fan project.',
   },
   '/catalog/mst3k': {
     title: 'MST3K - RiffSync Catalog',
     description:
       'Browse Mystery Science Theater 3000 episodes on RiffSync — Joel, Mike, Jonah, and Emily catalogs with lawful YouTube embeds. Unofficial fan project.',
+  },
+  '/catalog/rifftrax': {
+    title: 'RiffTrax - RiffSync Catalog',
+    description:
+      'Browse RiffTrax movies on RiffSync with lawful YouTube embeds. Pick a title and start a watch party. Unofficial fan project.',
   },
   '/catalog/community': {
     title: 'Community - RiffSync Catalog',

--- a/data/catalog/catalog.schema.json
+++ b/data/catalog/catalog.schema.json
@@ -61,7 +61,7 @@
         },
         "catalog": {
           "type": "string",
-          "enum": ["mst3k", "community", "riff_material", "movie_night", "other", "live"],
+          "enum": ["mst3k", "rifftrax", "community", "riff_material", "movie_night", "other", "live"],
           "description": "Top-level catalog page assignment. `live` is staff-only (official Live channel sources; omitted from public catalog browse)."
         },
         "tags": {

--- a/infra/cdk/lambda/catalog-shared.ts
+++ b/infra/cdk/lambda/catalog-shared.ts
@@ -7,7 +7,7 @@ export interface CatalogEpisode {
   readonly id: string;
   readonly experimentNumber: number;
   readonly title: string;
-  readonly catalog: 'mst3k' | 'community' | 'riff_material' | 'movie_night' | 'other' | 'live';
+  readonly catalog: 'mst3k' | 'rifftrax' | 'community' | 'riff_material' | 'movie_night' | 'other' | 'live';
   readonly tags: string[];
   readonly labels: string[];
   readonly youtubeVideoId: string | null;
@@ -33,7 +33,15 @@ export interface CatalogEpisode {
   readonly tmdbBackdropPath?: string | null;
 }
 
-const CATALOGS = new Set(['mst3k', 'community', 'riff_material', 'movie_night', 'other', 'live']);
+const CATALOGS = new Set([
+  'mst3k',
+  'rifftrax',
+  'community',
+  'riff_material',
+  'movie_night',
+  'other',
+  'live',
+]);
 
 /** Dynamo / hand-edited rows may use BOOL, or accidentally String/Number — treat like UI expectations. */
 function parseBooleanCatalogFlag(v: unknown): boolean {


### PR DESCRIPTION
## Summary
- Adds `rifftrax` as a first-class catalog category (schema, API projection, admin select, public browse).
- Places **RiffTrax** second under MST3K in Catalog nav/hub with **Movies** and **Shorts** subsections.
- Movies shows `rifftrax` rows without the `Short` label; Shorts shows the opposite (same label used for MST3K shorts).

## Test plan
- [ ] Admin create/edit episode: choose **RiffTrax** from the catalog dropdown and save.
- [ ] Catalog nav order is MST3K, RiffTrax, Community, Riff Material.
- [ ] `/catalog/rifftrax` and `/catalog/rifftrax/movies` list only non-`Short` RiffTrax titles.
- [ ] `/catalog/rifftrax/shorts` lists only RiffTrax titles with the `Short` label.
- [ ] Hub entry link for RiffTrax appears and routes correctly.