### PR TITLE
feat(host-extension): Chrome MV3 host control panel scaffold

### DIFF
--- a/apps/host-extension/README.md
+++ b/apps/host-extension/README.md
@@ -1,0 +1,28 @@
+# RiffSync Host extension
+
+Unpacked Chrome MV3 package for the **host control panel**. Load this directory
+from `chrome://extensions` (Developer mode, then Load unpacked).
+
+This extension **does not capture** media and does not supply `host_screen`.
+Capture remains out of this package (ADR-001).
+
+The Chrome Side Panel API hosts the UI. Product-facing copy uses **host control
+panel**.
+
+## Layout
+
+```text
+apps/host-extension/
+  manifest.json              # MV3; permissions: sidePanel only
+  background.js              # opens host control panel on toolbar action
+  host-control-panel.html    # host control panel UI shell
+  README.md
+```
+
+Follow-on media-tab, library, title, and JWT work (#428–#430) lands in this
+package without relocating it.
+
+## Related
+
+- Epic: https://github.com/StacksOnTheRacks/riffsync/issues/426
+- Product spec: `product/specs/host-chrome-extension.spec.md`

--- a/apps/host-extension/background.js
+++ b/apps/host-extension/background.js
@@ -1,0 +1,5 @@
+chrome.sidePanel
+  .setPanelBehavior({ openPanelOnActionClick: true })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/apps/host-extension/host-control-panel.html
+++ b/apps/host-extension/host-control-panel.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Host control panel</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        padding: 1.25rem;
+        font-family: system-ui, sans-serif;
+        line-height: 1.4;
+        background: #111;
+        color: #f4f4f4;
+      }
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+      p {
+        margin: 0;
+        color: #c8c8c8;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Host control panel</h1>
+    <p>
+      Placeholder shell. This extension does not capture media and does not
+      supply host_screen.
+    </p>
+  </body>
+</html>

--- a/apps/host-extension/manifest.json
+++ b/apps/host-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "RiffSync Host",
+  "version": "0.1.0",
+  "description": "Host control panel for RiffSync room hosts. Does not capture media.",
+  "permissions": ["sidePanel"],
+  "action": {
+    "default_title": "Open host control panel"
+  },
+  "side_panel": {
+    "default_path": "host-control-panel.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a static Chrome MV3 package at `apps/host-extension` (parallel to `apps/web`) so a host can load it unpacked and open a **host control panel** UI shell from the toolbar action.
- Manifest is `manifest_version` 3 with `"permissions": ["sidePanel"]` only. No `tabs`, no `host_permissions`, no capture APIs (`tabCapture`, `desktopCapture`, `host_screen`).
- Package README states no capture, points at epic #426 and `product/specs/host-chrome-extension.spec.md`, and uses the term **host control panel**.

Closes #427.

## Test plan

- [ ] `python3 -m json.tool apps/host-extension/manifest.json` succeeds; `manifest_version` is 3; permissions are only `sidePanel`.
- [ ] From repo root, capture forbid-list grep is clean:
  `rg -n -i 'tabCapture|desktopCapture|chrome\.tabCapture|chrome\.desktopCapture' apps/host-extension`
- [ ] README greps match `does not capture` / `host_screen` / `ADR-001`, `426` / `host-chrome-extension.spec`, and `host control panel`.
- [ ] Chrome → `chrome://extensions` → Developer mode → Load unpacked → `apps/host-extension`: no load errors; toolbar action opens the host control panel shell.
- [ ] Extension details do not request media capture / screen sharing.
