### PR TITLE
feat(host-extension): open host media tab without leaving the party tab

### DIFF
--- a/apps/host-extension/README.md
+++ b/apps/host-extension/README.md
@@ -13,14 +13,44 @@ panel**.
 
 ```text
 apps/host-extension/
-  manifest.json              # MV3; permissions: sidePanel only
-  background.js              # opens host control panel on toolbar action
-  host-control-panel.html    # host control panel UI shell
+  manifest.json              # MV3; permissions: sidePanel, tabs
+  background.js              # host control panel on action; media tab session
+  host-control-panel.html    # host control panel UI
+  host-control-panel.js      # bind status, media-tab open/not, open trigger
+  hostSourceTabUrl.js        # pure host-source URL resolver (SPA parity)
+  roomBind.js                # C1 /room/:roomId bind on allowed SPA origins
+  mediaTab.js                # inactive create/update + one tracked media tabId
+  package.json               # documented test command
   README.md
 ```
 
-Follow-on media-tab, library, title, and JWT work (#428–#430) lands in this
-package without relocating it.
+## Test
+
+From this directory:
+
+```bash
+npm test
+```
+
+From the riffsync repo root:
+
+```bash
+npm test --prefix apps/host-extension
+```
+
+That runs `node --test` on this package only. Helpers are local to
+`apps/host-extension` and do not import `apps/web`.
+
+## Host media tab
+
+With the active tab on `/room/:roomId` at `https://riffsync.tv` or
+`http://localhost:5173`, **Open media tab** resolves a fixture catalog row to an
+absolute host-source URL and opens or reuses one media tab with `active: false`
+so the party tab stays focused. The panel reports **Open** vs **Not open** for
+the current hosting session.
+
+Follow-on library, title, and JWT work (#429–#430) lands in this package
+without relocating it.
 
 ## Related
 

--- a/apps/host-extension/background.js
+++ b/apps/host-extension/background.js
@@ -1,5 +1,79 @@
+import {
+  createMediaTabTracker,
+  openOrNavigateHostMediaTab,
+  reportHostingMediaTab,
+} from './mediaTab.js'
+
+const tracker = createMediaTabTracker(chrome.tabs)
+
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => {
-    console.error(error);
-  });
+    console.error(error)
+  })
+
+async function getActiveTab() {
+  const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
+  return tabs[0] ?? null
+}
+
+async function currentState() {
+  const tab = await getActiveTab()
+  return reportHostingMediaTab(tracker, tab?.url)
+}
+
+function broadcastState(state) {
+  chrome.runtime.sendMessage({ type: 'hostSessionState', ...state }).catch(() => {})
+}
+
+async function refreshAndBroadcast() {
+  const state = await currentState()
+  broadcastState(state)
+  return state
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === 'getState') {
+    currentState().then(sendResponse)
+    return true
+  }
+
+  if (message?.type === 'openOrNavigate') {
+    getActiveTab()
+      .then((tab) => openOrNavigateHostMediaTab(tracker, tab?.url, message.url))
+      .then(async (result) => {
+        const state = await currentState()
+        sendResponse({ ...state, ok: result.ok })
+        broadcastState(state)
+      })
+      .catch((error) => {
+        console.error(error)
+        currentState().then((state) => {
+          sendResponse({ ...state, ok: false })
+          broadcastState(state)
+        })
+      })
+    return true
+  }
+
+  return undefined
+})
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  tracker.handleTabRemoved(tabId)
+  refreshAndBroadcast()
+})
+
+chrome.tabs.onActivated.addListener(() => {
+  refreshAndBroadcast()
+})
+
+chrome.tabs.onUpdated.addListener((_tabId, changeInfo) => {
+  if (changeInfo.url) {
+    refreshAndBroadcast()
+  }
+})
+
+chrome.windows.onFocusChanged.addListener(() => {
+  refreshAndBroadcast()
+})

--- a/apps/host-extension/host-control-panel.html
+++ b/apps/host-extension/host-control-panel.html
@@ -20,17 +20,55 @@
         margin: 0 0 0.75rem;
         font-size: 1.15rem;
       }
-      p {
-        margin: 0;
+      p,
+      dl {
+        margin: 0 0 0.75rem;
         color: #c8c8c8;
+      }
+      dl {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.25rem 0.75rem;
+      }
+      dt {
+        color: #9a9a9a;
+      }
+      dd {
+        margin: 0;
+        color: #f4f4f4;
+      }
+      button {
+        font: inherit;
+        padding: 0.45rem 0.75rem;
+        border: 1px solid #555;
+        border-radius: 4px;
+        background: #2a2a2a;
+        color: #f4f4f4;
+      }
+      button:disabled {
+        opacity: 0.5;
+      }
+      .error {
+        color: #f0b4b4;
+        min-height: 1.2em;
       }
     </style>
   </head>
   <body>
     <h1>Host control panel</h1>
     <p>
-      Placeholder shell. This extension does not capture media and does not
-      supply host_screen.
+      This extension does not capture media and does not supply host_screen.
     </p>
+    <dl>
+      <dt>Room</dt>
+      <dd id="bind-status">Checking bind...</dd>
+      <dt>Media tab</dt>
+      <dd id="media-tab-status">Not open</dd>
+    </dl>
+    <p>
+      <button id="open-media-tab" type="button" disabled>Open media tab</button>
+    </p>
+    <p id="error-status" class="error"></p>
+    <script type="module" src="host-control-panel.js"></script>
   </body>
 </html>

--- a/apps/host-extension/host-control-panel.js
+++ b/apps/host-extension/host-control-panel.js
@@ -1,0 +1,55 @@
+import { resolveHostSourceTabUrl } from './hostSourceTabUrl.js'
+
+const HOST_SOURCE_FIXTURE = {
+  catalogEp: {
+    id: '032-mitchell',
+    embedAllows: true,
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    youtubeVideoId: 'NXGXtm6gcxk',
+    playbackHost: 'youtube',
+  },
+  catalogEpisodeId: '032-mitchell',
+}
+
+const bindEl = document.getElementById('bind-status')
+const mediaEl = document.getElementById('media-tab-status')
+const openButton = document.getElementById('open-media-tab')
+const errorEl = document.getElementById('error-status')
+
+function render(state) {
+  const bound = Boolean(state?.bound)
+  bindEl.textContent = bound ? `Bound to room ${state.roomId}` : 'Not bound to a room'
+  mediaEl.textContent = bound && state.mediaTabOpen ? 'Open' : 'Not open'
+  openButton.disabled = !bound
+  errorEl.textContent = ''
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type === 'hostSessionState') {
+    render(message)
+  }
+})
+
+openButton.addEventListener('click', async () => {
+  errorEl.textContent = ''
+  const state = await chrome.runtime.sendMessage({ type: 'getState' })
+  if (!state?.bound || !state.origin) {
+    render({ bound: false, mediaTabOpen: false })
+    return
+  }
+
+  const url = resolveHostSourceTabUrl({
+    ...HOST_SOURCE_FIXTURE,
+    origin: state.origin,
+  })
+  const result = await chrome.runtime.sendMessage({ type: 'openOrNavigate', url })
+  render(result)
+  if (!result?.ok && !result?.bound) {
+    errorEl.textContent = 'Open refused: active tab is not a room on an allowed origin.'
+  }
+})
+
+chrome.runtime.sendMessage({ type: 'getState' }).then(render).catch((error) => {
+  console.error(error)
+  render({ bound: false, mediaTabOpen: false })
+})

--- a/apps/host-extension/hostSourceTabUrl.js
+++ b/apps/host-extension/hostSourceTabUrl.js
@@ -1,0 +1,71 @@
+const YOUTUBE_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/
+
+function parseYoutubeWatchUrl(raw) {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  let url
+  try {
+    url = new URL(trimmed)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+
+  const host = url.hostname.replace(/^www\./, '').toLowerCase()
+  let videoId = null
+
+  if (host === 'youtu.be') {
+    videoId = url.pathname.split('/').filter(Boolean)[0] ?? null
+  } else if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+    if (url.pathname === '/watch') {
+      videoId = url.searchParams.get('v')
+    } else {
+      const [kind, id] = url.pathname.split('/').filter(Boolean)
+      if (kind === 'embed' || kind === 'shorts' || kind === 'live') {
+        videoId = id ?? null
+      }
+    }
+  }
+
+  if (!videoId || !YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) return null
+
+  return {
+    videoId,
+    canonicalWatchUrl: `https://www.youtube.com/watch?v=${videoId}`,
+  }
+}
+
+function episodeAllowsInAppEmbed(ep) {
+  return ep.embedAllows !== false
+}
+
+function resolveCatalogYoutubeWatchUrl(ep) {
+  const parsedWatchUrl = ep.youtubeWatchUrl ? parseYoutubeWatchUrl(ep.youtubeWatchUrl) : null
+  if (parsedWatchUrl) return parsedWatchUrl.canonicalWatchUrl
+
+  const videoId = ep.youtubeVideoId?.trim()
+  if (!videoId || !YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) return null
+
+  return `https://www.youtube.com/watch?v=${videoId}`
+}
+
+function directYoutubeWatchUrl(args) {
+  if (args.catalogEp?.id !== args.catalogEpisodeId) return null
+  if (args.catalogEp.playbackHost === 'custom') return null
+  if (episodeAllowsInAppEmbed(args.catalogEp)) return null
+  return resolveCatalogYoutubeWatchUrl(args.catalogEp)
+}
+
+export function hostSourceOpensOnYoutube(args) {
+  return directYoutubeWatchUrl(args) !== null
+}
+
+export function resolveHostSourceTabUrl(args) {
+  const youtubeWatchUrl = directYoutubeWatchUrl(args)
+  if (youtubeWatchUrl) return youtubeWatchUrl
+
+  const origin = args.origin.replace(/\/+$/, '')
+  return `${origin}/watch/${encodeURIComponent(args.catalogEpisodeId)}?partyCapture=1`
+}

--- a/apps/host-extension/hostSourceTabUrl.test.js
+++ b/apps/host-extension/hostSourceTabUrl.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  hostSourceOpensOnYoutube,
+  resolveHostSourceTabUrl,
+} from './hostSourceTabUrl.js'
+
+function episode(overrides = {}) {
+  return {
+    id: '032-mitchell',
+    embedAllows: undefined,
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    youtubeVideoId: 'NXGXtm6gcxk',
+    playbackHost: 'youtube',
+    ...overrides,
+  }
+}
+
+describe('resolveHostSourceTabUrl', () => {
+  it('opens YouTube directly for the current non-embeddable catalog episode', () => {
+    const args = {
+      catalogEp: episode({ embedAllows: false }),
+      catalogEpisodeId: '032-mitchell',
+      origin: 'https://riffsync.tv',
+    }
+
+    assert.equal(resolveHostSourceTabUrl(args), 'https://www.youtube.com/watch?v=NXGXtm6gcxk')
+    assert.equal(hostSourceOpensOnYoutube(args), true)
+  })
+
+  it('keeps the party-capture tab for embeddable episodes', () => {
+    const args = {
+      catalogEp: episode({ embedAllows: true }),
+      catalogEpisodeId: '032-mitchell',
+      origin: 'https://riffsync.tv/',
+    }
+
+    assert.equal(
+      resolveHostSourceTabUrl(args),
+      'https://riffsync.tv/watch/032-mitchell?partyCapture=1',
+    )
+    assert.equal(hostSourceOpensOnYoutube(args), false)
+  })
+
+  it('keeps the party-capture tab when the loaded catalog row is stale or missing', () => {
+    assert.equal(
+      resolveHostSourceTabUrl({
+        catalogEp: episode({ id: 'not-current', embedAllows: false }),
+        catalogEpisodeId: '032-mitchell',
+        origin: 'https://riffsync.tv',
+      }),
+      'https://riffsync.tv/watch/032-mitchell?partyCapture=1',
+    )
+
+    assert.equal(
+      resolveHostSourceTabUrl({
+        catalogEp: undefined,
+        catalogEpisodeId: 'movie with spaces',
+        origin: 'https://riffsync.tv',
+      }),
+      'https://riffsync.tv/watch/movie%20with%20spaces?partyCapture=1',
+    )
+  })
+
+  it('uses party-capture RiffSync watch URL for Custom-host rows', () => {
+    const args = {
+      catalogEp: episode({
+        playbackHost: 'custom',
+        embedAllows: false,
+        youtubeVideoId: null,
+      }),
+      catalogEpisodeId: '032-mitchell',
+      origin: 'https://riffsync.tv',
+    }
+
+    assert.equal(
+      resolveHostSourceTabUrl(args),
+      'https://riffsync.tv/watch/032-mitchell?partyCapture=1',
+    )
+    assert.equal(hostSourceOpensOnYoutube(args), false)
+  })
+})

--- a/apps/host-extension/manifest.json
+++ b/apps/host-extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "RiffSync Host",
   "version": "0.1.0",
   "description": "Host control panel for RiffSync room hosts. Does not capture media.",
-  "permissions": ["sidePanel"],
+  "permissions": ["sidePanel", "tabs"],
   "action": {
     "default_title": "Open host control panel"
   },
@@ -11,6 +11,7 @@
     "default_path": "host-control-panel.html"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   }
 }

--- a/apps/host-extension/mediaTab.js
+++ b/apps/host-extension/mediaTab.js
@@ -1,0 +1,116 @@
+import { parseRoomBind } from './roomBind.js'
+
+function isAbsoluteHttpUrl(url) {
+  if (typeof url !== 'string') return false
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function createMediaTabTracker(tabs) {
+  let mediaTabId = null
+
+  async function tabExists(tabId) {
+    try {
+      await tabs.get(tabId)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async function openOrNavigate(url) {
+    if (!isAbsoluteHttpUrl(url)) {
+      throw new Error('openOrNavigate requires an absolute http(s) URL')
+    }
+
+    if (mediaTabId != null && (await tabExists(mediaTabId))) {
+      await tabs.update(mediaTabId, { url, active: false })
+      return { tabId: mediaTabId, reused: true }
+    }
+
+    const tab = await tabs.create({ url, active: false })
+    mediaTabId = tab.id
+    return { tabId: mediaTabId, reused: false }
+  }
+
+  function handleTabRemoved(tabId) {
+    if (tabId === mediaTabId) {
+      mediaTabId = null
+    }
+  }
+
+  function clearMediaTabId() {
+    mediaTabId = null
+  }
+
+  function getMediaTabId() {
+    return mediaTabId
+  }
+
+  function isMediaTabOpen() {
+    return mediaTabId != null
+  }
+
+  async function reportOpen() {
+    if (mediaTabId == null) return false
+    if (!(await tabExists(mediaTabId))) {
+      mediaTabId = null
+      return false
+    }
+    return true
+  }
+
+  return {
+    openOrNavigate,
+    handleTabRemoved,
+    clearMediaTabId,
+    getMediaTabId,
+    isMediaTabOpen,
+    reportOpen,
+  }
+}
+
+export async function reportHostingMediaTab(tracker, activeTabUrl) {
+  const bind = parseRoomBind(activeTabUrl)
+  if (!bind) {
+    return {
+      bound: false,
+      roomId: null,
+      origin: null,
+      mediaTabOpen: false,
+    }
+  }
+
+  return {
+    bound: true,
+    roomId: bind.roomId,
+    origin: bind.origin,
+    mediaTabOpen: await tracker.reportOpen(),
+  }
+}
+
+export async function openOrNavigateHostMediaTab(tracker, activeTabUrl, url) {
+  const bind = parseRoomBind(activeTabUrl)
+  if (!bind) {
+    return {
+      ok: false,
+      bound: false,
+      roomId: null,
+      origin: null,
+      mediaTabOpen: false,
+    }
+  }
+
+  await tracker.openOrNavigate(url)
+  return {
+    ok: true,
+    bound: true,
+    roomId: bind.roomId,
+    origin: bind.origin,
+    mediaTabOpen: true,
+  }
+}

--- a/apps/host-extension/mediaTab.test.js
+++ b/apps/host-extension/mediaTab.test.js
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  createMediaTabTracker,
+  openOrNavigateHostMediaTab,
+  reportHostingMediaTab,
+} from './mediaTab.js'
+
+function createMockTabs() {
+  const records = new Map()
+  let nextId = 1
+  const calls = { create: [], update: [] }
+
+  return {
+    calls,
+    remove(tabId) {
+      records.delete(tabId)
+    },
+    api: {
+      async create({ url, active }) {
+        calls.create.push({ url, active })
+        const id = nextId++
+        const tab = { id, url, active }
+        records.set(id, tab)
+        return tab
+      },
+      async update(tabId, { url, active }) {
+        calls.update.push({ tabId, url, active })
+        const tab = records.get(tabId)
+        if (!tab) throw new Error('No tab')
+        tab.url = url
+        if (active !== undefined) tab.active = active
+        return tab
+      },
+      async get(tabId) {
+        const tab = records.get(tabId)
+        if (!tab) throw new Error('No tab')
+        return tab
+      },
+    },
+  }
+}
+
+const ROOM_URL = 'https://riffsync.tv/room/party-1'
+const MEDIA_URL_A = 'https://riffsync.tv/watch/032-mitchell?partyCapture=1'
+const MEDIA_URL_B = 'https://riffsync.tv/watch/other?partyCapture=1'
+
+describe('media tab state', () => {
+  it('creates and records a media tab when none is tracked, and reports open', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    const result = await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+
+    assert.equal(result.ok, true)
+    assert.equal(result.mediaTabOpen, true)
+    assert.equal(mock.calls.create.length, 1)
+    assert.deepEqual(mock.calls.create[0], { url: MEDIA_URL_A, active: false })
+    assert.equal(mock.calls.update.length, 0)
+    assert.equal(tracker.getMediaTabId(), 1)
+    assert.equal(tracker.isMediaTabOpen(), true)
+
+    const reported = await reportHostingMediaTab(tracker, ROOM_URL)
+    assert.equal(reported.mediaTabOpen, true)
+    assert.equal(reported.bound, true)
+  })
+
+  it('reuses a live media tab with update, not a second create, and reports open', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+    const firstId = tracker.getMediaTabId()
+    const result = await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_B)
+
+    assert.equal(result.ok, true)
+    assert.equal(result.mediaTabOpen, true)
+    assert.equal(tracker.getMediaTabId(), firstId)
+    assert.equal(mock.calls.create.length, 1)
+    assert.equal(mock.calls.update.length, 1)
+    assert.deepEqual(mock.calls.update[0], {
+      tabId: firstId,
+      url: MEDIA_URL_B,
+      active: false,
+    })
+  })
+
+  it('creates again when the tracked tab is gone', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+    const goneId = tracker.getMediaTabId()
+    mock.remove(goneId)
+
+    const result = await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_B)
+
+    assert.equal(result.ok, true)
+    assert.equal(mock.calls.create.length, 2)
+    assert.equal(mock.calls.update.length, 0)
+    assert.notEqual(tracker.getMediaTabId(), goneId)
+    assert.deepEqual(mock.calls.create[1], { url: MEDIA_URL_B, active: false })
+  })
+
+  it('reports not open after the media tab is closed or the id is cleared', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+    const tabId = tracker.getMediaTabId()
+    mock.remove(tabId)
+    tracker.handleTabRemoved(tabId)
+
+    assert.equal(tracker.isMediaTabOpen(), false)
+    assert.equal(tracker.getMediaTabId(), null)
+
+    const afterClose = await reportHostingMediaTab(tracker, ROOM_URL)
+    assert.equal(afterClose.mediaTabOpen, false)
+
+    await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+    tracker.clearMediaTabId()
+    const afterClear = await reportHostingMediaTab(tracker, ROOM_URL)
+    assert.equal(afterClear.mediaTabOpen, false)
+  })
+
+  it('always passes active: false on create and update', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    await tracker.openOrNavigate(MEDIA_URL_A)
+    await tracker.openOrNavigate(MEDIA_URL_B)
+
+    assert.ok(mock.calls.create.length >= 1)
+    assert.ok(mock.calls.update.length >= 1)
+    for (const call of mock.calls.create) {
+      assert.equal(call.active, false)
+    }
+    for (const call of mock.calls.update) {
+      assert.equal(call.active, false)
+    }
+  })
+
+  it('refuses open/navigate and does not claim open when the room is unbound', async () => {
+    const mock = createMockTabs()
+    const tracker = createMediaTabTracker(mock.api)
+
+    const refused = await openOrNavigateHostMediaTab(
+      tracker,
+      'https://example.com/room/party-1',
+      MEDIA_URL_A,
+    )
+
+    assert.equal(refused.ok, false)
+    assert.equal(refused.bound, false)
+    assert.equal(refused.mediaTabOpen, false)
+    assert.equal(mock.calls.create.length, 0)
+
+    await openOrNavigateHostMediaTab(tracker, ROOM_URL, MEDIA_URL_A)
+    const unboundReport = await reportHostingMediaTab(tracker, 'https://riffsync.tv/watch/x')
+    assert.equal(unboundReport.bound, false)
+    assert.equal(unboundReport.mediaTabOpen, false)
+  })
+})

--- a/apps/host-extension/package.json
+++ b/apps/host-extension/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@riffsync/host-extension",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/apps/host-extension/roomBind.js
+++ b/apps/host-extension/roomBind.js
@@ -1,0 +1,31 @@
+export const ALLOWED_SPA_ORIGINS = [
+  'https://riffsync.tv',
+  'http://localhost:5173',
+]
+
+export function parseRoomBind(tabUrl) {
+  if (typeof tabUrl !== 'string' || tabUrl.length === 0) return null
+
+  let url
+  try {
+    url = new URL(tabUrl)
+  } catch {
+    return null
+  }
+
+  if (!ALLOWED_SPA_ORIGINS.includes(url.origin)) return null
+
+  const match = url.pathname.match(/^\/room\/([^/]+)\/?$/)
+  if (!match) return null
+
+  let roomId
+  try {
+    roomId = decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+
+  if (!roomId) return null
+
+  return { roomId, origin: url.origin }
+}

--- a/apps/host-extension/roomBind.test.js
+++ b/apps/host-extension/roomBind.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { parseRoomBind } from './roomBind.js'
+
+describe('parseRoomBind', () => {
+  it('binds roomId from https://riffsync.tv/room/:roomId', () => {
+    assert.deepEqual(parseRoomBind('https://riffsync.tv/room/abc-123'), {
+      roomId: 'abc-123',
+      origin: 'https://riffsync.tv',
+    })
+  })
+
+  it('binds roomId from the localhost SPA origin', () => {
+    assert.deepEqual(parseRoomBind('http://localhost:5173/room/local-room'), {
+      roomId: 'local-room',
+      origin: 'http://localhost:5173',
+    })
+  })
+
+  it('allows a trailing slash on the room path', () => {
+    assert.equal(parseRoomBind('https://riffsync.tv/room/abc-123/')?.roomId, 'abc-123')
+  })
+
+  it('returns null when the origin is not allowed', () => {
+    assert.equal(parseRoomBind('https://example.com/room/abc-123'), null)
+    assert.equal(parseRoomBind('http://127.0.0.1:5173/room/abc-123'), null)
+  })
+
+  it('returns null when the path is not /room/:roomId', () => {
+    assert.equal(parseRoomBind('https://riffsync.tv/watch/032-mitchell'), null)
+    assert.equal(parseRoomBind('https://riffsync.tv/'), null)
+    assert.equal(parseRoomBind('https://riffsync.tv/room/'), null)
+  })
+})


### PR DESCRIPTION
## Summary

- Host control panel binds `roomId` from the active tab `/room/:roomId` on `https://riffsync.tv` and `http://localhost:5173`. Unbound sessions refuse open/navigate and do not claim media-tab open.
- Ports SPA `resolveHostSourceTabUrl` into a pure extension helper (no `apps/web` import, no HTTP). Fixture catalog fields build the absolute URL for the trigger.
- Opens or reuses one media tab via tracked `tabId` with `chrome.tabs.create` / `update` and `active: false` so the party tab stays focused. Panel reports Open vs Not open.
- Manifest permissions are `sidePanel` + `tabs` only. No `host_permissions`. No capture APIs.

Closes #428.

## Test plan

- [ ] `npm test --prefix apps/host-extension` passes.
- [ ] From repo root, capture forbid-list grep is clean (no `tabCapture` / `desktopCapture` except explicit do-not-use docs).
- [ ] `manifest.json` has `"sidePanel"` and `"tabs"`; no `host_permissions`.
- [ ] `active: false` is used on create and update.
- [ ] Manual Chrome steps in https://github.com/StacksOnTheRacks/riffsync/issues/428 (unpacked load, party tab stays focused, reuse, close reports Not open, unbound refuse, page getDisplayMedia still works).