### PR TITLE
Host control panel: load RiffSync catalog library

### DIFF
--- a/apps/host-extension/README.md
+++ b/apps/host-extension/README.md
@@ -13,16 +13,32 @@ panel**.
 
 ```text
 apps/host-extension/
-  manifest.json              # MV3; permissions: sidePanel, tabs
+  manifest.json              # MV3; sidePanel, tabs; host_permissions for public API
   background.js              # host control panel on action; media tab session
   host-control-panel.html    # host control panel UI
-  host-control-panel.js      # bind status, media-tab open/not, open trigger
+  host-control-panel.js      # bind, media-tab, catalog library browse/select
+  config.js                  # PUBLIC_API_BASE_URL (match SPA API origin)
+  publicApiBaseUrl.js        # HTTPS origin helper (trim, strip trailing slash)
+  catalogApi.js              # anonymous GET /v1/catalog + normalize
   hostSourceTabUrl.js        # pure host-source URL resolver (SPA parity)
   roomBind.js                # C1 /room/:roomId bind on allowed SPA origins
   mediaTab.js                # inactive create/update + one tracked media tabId
   package.json               # documented test command
   README.md
 ```
+
+## Public API origin
+
+Set `PUBLIC_API_BASE_URL` in `config.js` to the same HTTPS origin as the SPA
+env `VITE_PUBLIC_API_BASE_URL` for the target environment (trailing slash is
+stripped). Update `manifest.json` `host_permissions` to that same origin with
+path `/*` (for example `https://{api-id}.execute-api.{region}.amazonaws.com/*`).
+
+Do not add SPA origins, YouTube, `https://*/*`, or capture permissions. The
+placeholder default matches the example execute-api shape; replace both values
+before using a real environment. The panel loads the public catalog with
+anonymous `GET {base}/v1/catalog` under that host permission (no JWT, no CORS
+allowlist change for `chrome-extension://`).
 
 ## Test
 
@@ -49,8 +65,9 @@ absolute host-source URL and opens or reuses one media tab with `active: false`
 so the party tab stays focused. The panel reports **Open** vs **Not open** for
 the current hosting session.
 
-Follow-on library, title, and JWT work (#429–#430) lands in this package
-without relocating it.
+The host control panel **Library** section loads the public catalog and stores
+a selected title in panel-local state. Title change PATCH and JWT work stay in
+#430.
 
 ## Related
 

--- a/apps/host-extension/catalogApi.js
+++ b/apps/host-extension/catalogApi.js
@@ -1,0 +1,128 @@
+import { getPublicApiBaseUrl } from './publicApiBaseUrl.js'
+
+const CATALOG_CATEGORIES = [
+  'mst3k',
+  'rifftrax',
+  'community',
+  'riff_material',
+  'movie_night',
+  'other',
+  'live',
+]
+
+export const CATALOG_UNAVAILABLE_MESSAGE = 'Could not load the catalog library.'
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null
+}
+
+function asCatalogCategory(value) {
+  const s = typeof value === 'string' ? value : ''
+  if (CATALOG_CATEGORIES.includes(s)) return s
+  return 'other'
+}
+
+function asStringArray(value) {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((entry) => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function asNullableString(value) {
+  if (value === null || value === undefined) return null
+  return String(value)
+}
+
+export function normalizeEpisode(raw) {
+  if (!isRecord(raw) || typeof raw.id !== 'string' || raw.id.length === 0) {
+    throw new Error('Catalog episode missing id')
+  }
+
+  return {
+    id: raw.id,
+    experimentNumber: Number(raw.experimentNumber),
+    title: String(raw.title ?? ''),
+    catalog: asCatalogCategory(raw.catalog),
+    tags: asStringArray(raw.tags),
+    labels: asStringArray(raw.labels),
+    youtubeVideoId: asNullableString(raw.youtubeVideoId),
+    youtubeWatchUrl: asNullableString(raw.youtubeWatchUrl),
+    tagline: asNullableString(raw.tagline),
+    posterImageUrl: asNullableString(raw.posterImageUrl),
+    embedAllows:
+      raw.embedAllows === false ? false : raw.embedAllows === true ? true : undefined,
+    playbackHost: raw.playbackHost === 'custom' ? 'custom' : 'youtube',
+    customPlaybackUrl: asNullableString(raw.customPlaybackUrl),
+  }
+}
+
+function catalogListUrl(base) {
+  return `${base}/v1/catalog`
+}
+
+function errorResult(reason, message = CATALOG_UNAVAILABLE_MESSAGE) {
+  return { ok: false, status: 'error', reason, message, entries: [] }
+}
+
+export function selectCatalogRow(entries, id) {
+  const row = Array.isArray(entries) ? entries.find((entry) => entry.id === id) : undefined
+  if (!row) return { id: null, row: null }
+  return { id: row.id, row }
+}
+
+export async function fetchPublicCatalog(baseUrl, fetchImpl = globalThis.fetch) {
+  const base = getPublicApiBaseUrl(baseUrl)
+  if (!base) {
+    return errorResult('invalid-base-url', 'Public API base URL is missing or invalid.')
+  }
+
+  let response
+  try {
+    response = await fetchImpl(catalogListUrl(base), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return errorResult('network')
+  }
+
+  if (!response || typeof response.ok !== 'boolean' || !response.ok) {
+    return errorResult('http')
+  }
+
+  let body
+  try {
+    body = await response.json()
+  } catch {
+    return errorResult('malformed')
+  }
+
+  if (!isRecord(body) || !Array.isArray(body.entries)) {
+    return errorResult('malformed')
+  }
+
+  let entries
+  try {
+    entries = body.entries.map(normalizeEpisode)
+  } catch {
+    return errorResult('malformed')
+  }
+
+  if (entries.length === 0) {
+    return {
+      ok: true,
+      status: 'empty',
+      version: body.version,
+      entries,
+    }
+  }
+
+  return {
+    ok: true,
+    status: 'ok',
+    version: body.version,
+    entries,
+  }
+}

--- a/apps/host-extension/catalogApi.test.js
+++ b/apps/host-extension/catalogApi.test.js
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { fetchPublicCatalog, normalizeEpisode, selectCatalogRow } from './catalogApi.js'
+import { getPublicApiBaseUrl } from './publicApiBaseUrl.js'
+
+const BASE = 'https://xxxx.execute-api.us-east-1.amazonaws.com'
+const LIST_URL = `${BASE}/v1/catalog`
+
+function episodeRaw(overrides = {}) {
+  return {
+    id: '032-mitchell',
+    title: 'Mitchell',
+    experimentNumber: 32,
+    catalog: 'mst3k',
+    tags: ['mst3k'],
+    labels: ['classic'],
+    youtubeVideoId: 'NXGXtm6gcxk',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    posterImageUrl: 'https://example.com/poster.jpg',
+    tagline: 'A movie',
+    embedAllows: true,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    ...overrides,
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+  }
+}
+
+describe('getPublicApiBaseUrl', () => {
+  it('trims and strips a trailing slash on an HTTPS origin', () => {
+    assert.equal(getPublicApiBaseUrl(`  ${BASE}/  `), BASE)
+  })
+
+  it('returns undefined for missing, empty, or invalid values', () => {
+    assert.equal(getPublicApiBaseUrl(undefined), undefined)
+    assert.equal(getPublicApiBaseUrl(''), undefined)
+    assert.equal(getPublicApiBaseUrl('   '), undefined)
+    assert.equal(getPublicApiBaseUrl('not-a-url'), undefined)
+    assert.equal(getPublicApiBaseUrl('http://api.example.com'), undefined)
+    assert.equal(getPublicApiBaseUrl('https://'), undefined)
+  })
+})
+
+describe('fetchPublicCatalog', () => {
+  it('GETs {base}/v1/catalog with no auth header and no carousel/spotlight filters', async () => {
+    const calls = []
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init })
+      return jsonResponse({ version: 1, entries: [episodeRaw()] })
+    }
+
+    const result = await fetchPublicCatalog(`${BASE}/`, fetchImpl)
+
+    assert.equal(result.status, 'ok')
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].url, LIST_URL)
+    assert.equal(new URL(calls[0].url).search, '')
+    assert.equal(calls[0].init?.method, 'GET')
+    const headers = calls[0].init?.headers ?? {}
+    const headerNames = Object.keys(headers).map((name) => name.toLowerCase())
+    assert.equal(headerNames.includes('authorization'), false)
+    assert.equal(headers.Authorization, undefined)
+    assert.equal(headers.authorization, undefined)
+  })
+
+  it('returns list data so selection can store id and rows have title', async () => {
+    const fetchImpl = async () => jsonResponse({ version: 1, entries: [episodeRaw()] })
+
+    const result = await fetchPublicCatalog(BASE, fetchImpl)
+    const selected = selectCatalogRow(result.entries, '032-mitchell')
+
+    assert.equal(result.status, 'ok')
+    assert.equal(result.entries.length, 1)
+    assert.equal(result.entries[0].id, '032-mitchell')
+    assert.equal(result.entries[0].title, 'Mitchell')
+    assert.equal(selected.id, '032-mitchell')
+    assert.equal(selected.row.title, 'Mitchell')
+    assert.equal(selected.row.youtubeVideoId, 'NXGXtm6gcxk')
+    assert.equal(selected.row.embedAllows, true)
+  })
+
+  it('returns empty (not error) when entries is an empty array', async () => {
+    const fetchImpl = async () => jsonResponse({ version: 1, entries: [] })
+
+    const result = await fetchPublicCatalog(BASE, fetchImpl)
+
+    assert.equal(result.ok, true)
+    assert.equal(result.status, 'empty')
+    assert.deepEqual(result.entries, [])
+    assert.notEqual(result.status, 'error')
+  })
+
+  it('returns error for non-OK HTTP, network throw, invalid JSON, and missing entries', async () => {
+    const http = await fetchPublicCatalog(BASE, async () => jsonResponse({ version: 1, entries: [] }, 500))
+    assert.equal(http.status, 'error')
+    assert.equal(http.reason, 'http')
+
+    const network = await fetchPublicCatalog(BASE, async () => {
+      throw new Error('network down')
+    })
+    assert.equal(network.status, 'error')
+    assert.equal(network.reason, 'network')
+
+    const invalidJson = await fetchPublicCatalog(BASE, async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        throw new SyntaxError('Unexpected token')
+      },
+    }))
+    assert.equal(invalidJson.status, 'error')
+    assert.equal(invalidJson.reason, 'malformed')
+
+    const missingEntries = await fetchPublicCatalog(BASE, async () => jsonResponse({ version: 1 }))
+    assert.equal(missingEntries.status, 'error')
+    assert.equal(missingEntries.reason, 'malformed')
+  })
+
+  it('returns error for missing, empty, or invalid PUBLIC_API_BASE_URL without fetching', async () => {
+    let called = 0
+    const fetchImpl = async () => {
+      called += 1
+      return jsonResponse({ version: 1, entries: [] })
+    }
+
+    for (const base of [undefined, '', '   ', 'http://api.example.com', 'not-a-url']) {
+      const result = await fetchPublicCatalog(base, fetchImpl)
+      assert.equal(result.status, 'error')
+      assert.equal(result.reason, 'invalid-base-url')
+    }
+
+    assert.equal(called, 0)
+  })
+
+  it('can retry after an error without a new fetch helper', async () => {
+    let attempts = 0
+    const fetchImpl = async () => {
+      attempts += 1
+      if (attempts === 1) throw new Error('network down')
+      return jsonResponse({ version: 1, entries: [episodeRaw()] })
+    }
+
+    const first = await fetchPublicCatalog(BASE, fetchImpl)
+    const second = await fetchPublicCatalog(BASE, fetchImpl)
+
+    assert.equal(first.status, 'error')
+    assert.equal(second.status, 'ok')
+    assert.equal(attempts, 2)
+  })
+})
+
+describe('normalizeEpisode', () => {
+  it('keeps list UX and host-source URL fields', () => {
+    const row = normalizeEpisode(episodeRaw({ embedAllows: false, playbackHost: 'custom' }))
+    assert.equal(row.id, '032-mitchell')
+    assert.equal(row.title, 'Mitchell')
+    assert.equal(row.experimentNumber, 32)
+    assert.equal(row.posterImageUrl, 'https://example.com/poster.jpg')
+    assert.equal(row.embedAllows, false)
+    assert.equal(row.playbackHost, 'custom')
+    assert.equal(row.youtubeWatchUrl, 'https://www.youtube.com/watch?v=NXGXtm6gcxk')
+    assert.equal(row.youtubeVideoId, 'NXGXtm6gcxk')
+  })
+})

--- a/apps/host-extension/config.js
+++ b/apps/host-extension/config.js
@@ -1,0 +1,5 @@
+/**
+ * HTTPS public HTTP API origin. Same meaning as SPA `VITE_PUBLIC_API_BASE_URL`.
+ * Must match `manifest.json` `host_permissions` for the target environment.
+ */
+export const PUBLIC_API_BASE_URL = 'https://xxxx.execute-api.us-east-1.amazonaws.com'

--- a/apps/host-extension/host-control-panel.html
+++ b/apps/host-extension/host-control-panel.html
@@ -48,6 +48,56 @@
       button:disabled {
         opacity: 0.5;
       }
+      h2 {
+        margin: 1.25rem 0 0.5rem;
+        font-size: 1rem;
+      }
+      .library-list {
+        list-style: none;
+        margin: 0 0 0.75rem;
+        padding: 0;
+        max-height: 18rem;
+        overflow: auto;
+        border: 1px solid #333;
+        border-radius: 4px;
+      }
+      .library-row {
+        display: flex;
+        gap: 0.6rem;
+        align-items: center;
+        width: 100%;
+        text-align: left;
+        padding: 0.45rem 0.6rem;
+        border: 0;
+        border-bottom: 1px solid #2a2a2a;
+        border-radius: 0;
+        background: transparent;
+      }
+      .library-list li:last-child .library-row {
+        border-bottom: 0;
+      }
+      .library-row[aria-selected='true'] {
+        background: #2a3a4a;
+      }
+      .library-poster {
+        width: 2.25rem;
+        height: 3.15rem;
+        object-fit: cover;
+        background: #222;
+        flex: 0 0 auto;
+      }
+      .library-meta {
+        min-width: 0;
+      }
+      .library-title {
+        display: block;
+        color: #f4f4f4;
+      }
+      .library-experiment {
+        display: block;
+        color: #9a9a9a;
+        font-size: 0.85rem;
+      }
       .error {
         color: #f0b4b4;
         min-height: 1.2em;
@@ -69,6 +119,12 @@
       <button id="open-media-tab" type="button" disabled>Open media tab</button>
     </p>
     <p id="error-status" class="error"></p>
+    <h2>Library</h2>
+    <p id="library-status">Loading catalog library...</p>
+    <ul id="library-list" class="library-list" hidden></ul>
+    <p>
+      <button id="library-retry" type="button" hidden>Retry</button>
+    </p>
     <script type="module" src="host-control-panel.js"></script>
   </body>
 </html>

--- a/apps/host-extension/host-control-panel.js
+++ b/apps/host-extension/host-control-panel.js
@@ -1,3 +1,5 @@
+import { fetchPublicCatalog, selectCatalogRow } from './catalogApi.js'
+import { PUBLIC_API_BASE_URL } from './config.js'
 import { resolveHostSourceTabUrl } from './hostSourceTabUrl.js'
 
 const HOST_SOURCE_FIXTURE = {
@@ -15,6 +17,12 @@ const bindEl = document.getElementById('bind-status')
 const mediaEl = document.getElementById('media-tab-status')
 const openButton = document.getElementById('open-media-tab')
 const errorEl = document.getElementById('error-status')
+const libraryStatusEl = document.getElementById('library-status')
+const libraryListEl = document.getElementById('library-list')
+const libraryRetryButton = document.getElementById('library-retry')
+
+let libraryEntries = []
+let librarySelection = { id: null, row: null }
 
 function render(state) {
   const bound = Boolean(state?.bound)
@@ -49,7 +57,97 @@ openButton.addEventListener('click', async () => {
   }
 })
 
+function setLibraryStatus(text, { listHidden = true, retryHidden = true } = {}) {
+  libraryStatusEl.textContent = text
+  libraryStatusEl.hidden = false
+  libraryListEl.hidden = listHidden
+  libraryRetryButton.hidden = retryHidden
+}
+
+function renderLibraryList() {
+  libraryListEl.replaceChildren()
+  for (const entry of libraryEntries) {
+    const item = document.createElement('li')
+    const row = document.createElement('button')
+    row.type = 'button'
+    row.className = 'library-row'
+    row.dataset.id = entry.id
+    row.setAttribute('aria-selected', entry.id === librarySelection.id ? 'true' : 'false')
+
+    if (entry.posterImageUrl) {
+      const poster = document.createElement('img')
+      poster.className = 'library-poster'
+      poster.src = entry.posterImageUrl
+      poster.alt = ''
+      row.append(poster)
+    }
+
+    const meta = document.createElement('span')
+    meta.className = 'library-meta'
+    const title = document.createElement('span')
+    title.className = 'library-title'
+    title.textContent = entry.title
+    meta.append(title)
+    if (Number.isFinite(entry.experimentNumber)) {
+      const experiment = document.createElement('span')
+      experiment.className = 'library-experiment'
+      experiment.textContent = String(entry.experimentNumber)
+      meta.append(experiment)
+    }
+    row.append(meta)
+    item.append(row)
+    libraryListEl.append(item)
+  }
+}
+
+function renderLibraryResult(result) {
+  if (result.status === 'ok') {
+    libraryEntries = result.entries
+    if (librarySelection.id) {
+      librarySelection = selectCatalogRow(libraryEntries, librarySelection.id)
+    }
+    renderLibraryList()
+    setLibraryStatus('', { listHidden: false, retryHidden: true })
+    libraryStatusEl.hidden = true
+    return
+  }
+
+  libraryEntries = []
+  libraryListEl.replaceChildren()
+  if (result.status === 'empty') {
+    setLibraryStatus('No titles in the catalog library.', {
+      listHidden: true,
+      retryHidden: true,
+    })
+    return
+  }
+
+  setLibraryStatus(result.message || 'Could not load the catalog library.', {
+    listHidden: true,
+    retryHidden: false,
+  })
+}
+
+async function loadLibrary() {
+  setLibraryStatus('Loading catalog library...', { listHidden: true, retryHidden: true })
+  const result = await fetchPublicCatalog(PUBLIC_API_BASE_URL)
+  renderLibraryResult(result)
+}
+
+libraryListEl.addEventListener('click', (event) => {
+  const row = event.target.closest('[data-id]')
+  if (!row) return
+  librarySelection = selectCatalogRow(libraryEntries, row.dataset.id)
+  renderLibraryList()
+})
+
+libraryRetryButton.addEventListener('click', () => {
+  loadLibrary()
+})
+
 chrome.runtime.sendMessage({ type: 'getState' }).then(render).catch((error) => {
   console.error(error)
   render({ bound: false, mediaTabOpen: false })
 })
+
+loadLibrary()

--- a/apps/host-extension/manifest.json
+++ b/apps/host-extension/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Host control panel for RiffSync room hosts. Does not capture media.",
   "permissions": ["sidePanel", "tabs"],
+  "host_permissions": ["https://xxxx.execute-api.us-east-1.amazonaws.com/*"],
   "action": {
     "default_title": "Open host control panel"
   },

--- a/apps/host-extension/publicApiBaseUrl.js
+++ b/apps/host-extension/publicApiBaseUrl.js
@@ -1,0 +1,20 @@
+/**
+ * Trim and strip a trailing slash. Require an HTTPS origin (host required).
+ * Mirrors SPA `getPublicApiBaseUrl` meaning, plus an HTTPS origin check.
+ */
+export function getPublicApiBaseUrl(raw) {
+  if (typeof raw !== 'string') return undefined
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+
+  let url
+  try {
+    url = new URL(trimmed)
+  } catch {
+    return undefined
+  }
+
+  if (url.protocol !== 'https:' || !url.hostname) return undefined
+
+  return trimmed.replace(/\/$/, '')
+}


### PR DESCRIPTION
## Summary

- Host control panel Library loads the full public catalog via anonymous `GET {PUBLIC_API_BASE_URL}/v1/catalog` (Decision B1; no carousel/spotlight filters, no JWT).
- Scrollable rows show `title` (keyed by `id`) plus poster/`experimentNumber` when present. Selecting a row stores that episode in panel-local state without room PATCH.
- Loading, empty, and error+retry states are distinct. `host_permissions` is scoped to the configured public API origin only (`sidePanel` + `tabs` kept; no capture).

Closes #429.

## Test plan

- [ ] `npm test --prefix apps/host-extension` (24 tests; catalog fetch mocked)
- [ ] Static greps: no `tabCapture`/`desktopCapture`; no `/v1/admin/catalog`; `host_permissions` is the configured API origin `/*`
- [ ] Set `PUBLIC_API_BASE_URL` in `config.js` and matching `host_permissions` to the same origin as SPA `VITE_PUBLIC_API_BASE_URL`
- [ ] Load unpacked `apps/host-extension`; open host control panel; confirm loading then list (or empty)
- [ ] Select a title; confirm highlight/selection without changing the room
- [ ] Simulate bad base URL or offline; confirm error + retry
- [ ] Extension details: no media-capture prompts; `sidePanel` + `tabs` present