### PR TITLE
Host control panel: change room title (PATCH + media navigate)

### DIFF
--- a/apps/host-extension/README.md
+++ b/apps/host-extension/README.md
@@ -13,16 +13,20 @@ panel**.
 
 ```text
 apps/host-extension/
-  manifest.json              # MV3; sidePanel, tabs; host_permissions for public API
-  background.js              # host control panel on action; media tab session
+  manifest.json              # MV3; sidePanel, tabs; API host_permissions; SPA content_scripts
+  background.js              # host control panel on action; media tab; title PATCH
   host-control-panel.html    # host control panel UI
-  host-control-panel.js      # bind, media-tab, catalog library browse/select
+  host-control-panel.js      # bind, media-tab, library, now playing, title change
+  host-bridge-content.js     # SPA origin-checked JWT bridge relay
   config.js                  # PUBLIC_API_BASE_URL (match SPA API origin)
   publicApiBaseUrl.js        # HTTPS origin helper (trim, strip trailing slash)
   catalogApi.js              # anonymous GET /v1/catalog + normalize
+  roomsApi.js                # anonymous GET /v1/rooms/{id}; host PATCH catalogEpisodeId
   hostSourceTabUrl.js        # pure host-source URL resolver (SPA parity)
   roomBind.js                # C1 /room/:roomId bind on allowed SPA origins
   mediaTab.js                # inactive create/update + one tracked media tabId
+  hostBridge.js              # riffsync-host-bridge v1 envelope
+  hostJwt.js                 # ephemeral SW access-token cache + JWT request
   package.json               # documented test command
   README.md
 ```
@@ -37,8 +41,24 @@ path `/*` (for example `https://{api-id}.execute-api.{region}.amazonaws.com/*`).
 Do not add SPA origins, YouTube, `https://*/*`, or capture permissions. The
 placeholder default matches the example execute-api shape; replace both values
 before using a real environment. The panel loads the public catalog with
-anonymous `GET {base}/v1/catalog` under that host permission (no JWT, no CORS
-allowlist change for `chrome-extension://`).
+anonymous `GET {base}/v1/catalog` and now playing with anonymous
+`GET {base}/v1/rooms/{roomId}` under that host permission (no CORS allowlist
+change for `chrome-extension://`).
+
+## JWT bridge
+
+Title change uses a host-authenticated `PATCH /v1/rooms/{roomId}` with body
+`{ catalogEpisodeId }`. The fan **access** JWT comes from the party SPA tab
+via a content-script bridge (`riffsync-host-bridge` v1):
+
+- The host must be signed in on the party SPA tab (`https://riffsync.tv` or
+  `http://localhost:5173`).
+- The service worker asks the content script on that tab; the SPA responds
+  with an access token only. Refresh tokens never enter the extension.
+- Tokens stay in service-worker memory for the session. They are not written
+  to `chrome.storage` or disk.
+- Content scripts match those SPA origins only. SPA origins are not added to
+  `host_permissions`.
 
 ## Test
 
@@ -57,17 +77,15 @@ npm test --prefix apps/host-extension
 That runs `node --test` on this package only. Helpers are local to
 `apps/host-extension` and do not import `apps/web`.
 
-## Host media tab
+## Host media tab and title change
 
 With the active tab on `/room/:roomId` at `https://riffsync.tv` or
-`http://localhost:5173`, **Open media tab** resolves a fixture catalog row to an
-absolute host-source URL and opens or reuses one media tab with `active: false`
-so the party tab stays focused. The panel reports **Open** vs **Not open** for
-the current hosting session.
+`http://localhost:5173`, the panel binds that room, shows now playing, and
+lets the host apply a selected library title. After PATCH 200, the extension
+opens or reuses one media tab with `active: false` so the party tab stays focused.
 
-The host control panel **Library** section loads the public catalog and stores
-a selected title in panel-local state. Title change PATCH and JWT work stay in
-#430.
+**Open media tab** still resolves a fixture catalog row for the current bind
+without mutating the room.
 
 ## Related
 

--- a/apps/host-extension/background.js
+++ b/apps/host-extension/background.js
@@ -1,10 +1,26 @@
+import { applyTitleChange } from './changeTitle.js'
+import { PUBLIC_API_BASE_URL } from './config.js'
+import { createEphemeralJwtCache, requestHostAccessToken } from './hostJwt.js'
+import { resolveHostSourceTabUrl } from './hostSourceTabUrl.js'
 import {
   createMediaTabTracker,
   openOrNavigateHostMediaTab,
   reportHostingMediaTab,
 } from './mediaTab.js'
+import { patchRoomCatalogEpisode } from './roomsApi.js'
 
 const tracker = createMediaTabTracker(chrome.tabs)
+const jwtCache = createEphemeralJwtCache()
+
+function sendMessageToTab(tabId, message) {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, message, (response) => {
+      const err = chrome.runtime.lastError
+      if (err) reject(new Error(err.message))
+      else resolve(response)
+    })
+  })
+}
 
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
@@ -50,6 +66,35 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         console.error(error)
         currentState().then((state) => {
           sendResponse({ ...state, ok: false })
+          broadcastState(state)
+        })
+      })
+    return true
+  }
+
+  if (message?.type === 'changeTitle') {
+    getActiveTab()
+      .then(async (tab) => {
+        const result = await applyTitleChange({
+          activeTabUrl: tab?.url,
+          partyTabId: tab?.id,
+          catalogEpisodeId: message.catalogEpisodeId,
+          catalogRow: message.catalogRow,
+          jwtCache,
+          requestJwt: ({ tabId }) =>
+            requestHostAccessToken({ tabId, sendMessage: sendMessageToTab }),
+          patchRoom: (args) => patchRoomCatalogEpisode(PUBLIC_API_BASE_URL, args),
+          resolveUrl: resolveHostSourceTabUrl,
+          navigate: async ({ url }) => openOrNavigateHostMediaTab(tracker, tab?.url, url),
+        })
+        const state = await currentState()
+        sendResponse({ ...state, ...result })
+        broadcastState(state)
+      })
+      .catch((error) => {
+        console.error(error)
+        currentState().then((state) => {
+          sendResponse({ ...state, ok: false, reason: 'network' })
           broadcastState(state)
         })
       })

--- a/apps/host-extension/changeTitle.js
+++ b/apps/host-extension/changeTitle.js
@@ -1,0 +1,147 @@
+import { parseRoomBind } from './roomBind.js'
+
+export async function applyTitleChange({
+  activeTabUrl,
+  partyTabId,
+  catalogEpisodeId,
+  catalogRow,
+  jwtCache,
+  requestJwt,
+  patchRoom,
+  resolveUrl,
+  navigate,
+}) {
+  const bind = parseRoomBind(activeTabUrl)
+  if (!bind) {
+    return { ok: false, bound: false, reason: 'unbound' }
+  }
+
+  if (
+    typeof catalogEpisodeId !== 'string' ||
+    catalogEpisodeId.length === 0 ||
+    !catalogRow ||
+    catalogRow.id !== catalogEpisodeId
+  ) {
+    return { ok: false, bound: true, roomId: bind.roomId, reason: 'missing_selection' }
+  }
+
+  async function obtainToken({ forceRefresh }) {
+    if (forceRefresh) {
+      jwtCache.drop()
+    } else {
+      const cached = jwtCache.peek()
+      if (cached) return { ok: true, accessToken: cached }
+    }
+
+    const jwt = await requestJwt({ tabId: partyTabId })
+    if (!jwt?.ok || typeof jwt.accessToken !== 'string' || jwt.accessToken.length === 0) {
+      return { ok: false, error: jwt?.error || 'unsupported' }
+    }
+    jwtCache.store(jwt.accessToken)
+    return { ok: true, accessToken: jwt.accessToken }
+  }
+
+  let token = await obtainToken({ forceRefresh: false })
+  if (!token.ok) {
+    return { ok: false, bound: true, roomId: bind.roomId, reason: 'auth', error: token.error }
+  }
+
+  let patch = await patchRoom({
+    roomId: bind.roomId,
+    accessToken: token.accessToken,
+    catalogEpisodeId,
+  })
+
+  if (patch?.status === 401) {
+    token = await obtainToken({ forceRefresh: true })
+    if (!token.ok) {
+      return { ok: false, bound: true, roomId: bind.roomId, reason: 'auth', error: token.error }
+    }
+    patch = await patchRoom({
+      roomId: bind.roomId,
+      accessToken: token.accessToken,
+      catalogEpisodeId,
+    })
+  }
+
+  if (!patch?.ok) {
+    return {
+      ok: false,
+      bound: true,
+      roomId: bind.roomId,
+      reason: patch?.reason === 'network' ? 'network' : 'http',
+      status: patch?.status,
+      code: patch?.code,
+    }
+  }
+
+  const url = resolveUrl({
+    catalogEp: catalogRow,
+    catalogEpisodeId,
+    origin: bind.origin,
+  })
+  const nav = await navigate({ url })
+  return {
+    ok: Boolean(nav?.ok),
+    bound: true,
+    roomId: bind.roomId,
+    origin: bind.origin,
+    navigated: Boolean(nav?.ok),
+  }
+}
+
+export function titleChangeErrorMessage(result) {
+  if (!result || result.ok) return ''
+  if (result.reason === 'unbound') {
+    return 'Not on a room tab. Open a RiffSync room to change the title.'
+  }
+  if (result.reason === 'missing_selection') {
+    return 'Select a library title first.'
+  }
+  if (result.reason === 'auth') {
+    if (result.error === 'not_signed_in') {
+      return 'Sign in as the room host on the party tab.'
+    }
+    if (result.error === 'refresh_failed') {
+      return 'Could not refresh your host session. Sign in again on the party tab.'
+    }
+    if (result.error === 'forbidden_origin') {
+      return 'This page origin is not allowed for host sign-in.'
+    }
+    if (result.error === 'timeout') {
+      return 'Host sign-in timed out. Keep the party tab open and try again.'
+    }
+    if (result.error === 'content_script_missing') {
+      return 'Host bridge is not available on this tab. Reload the party page.'
+    }
+    return 'Host sign-in is not available on this page.'
+  }
+  if (result.reason === 'network') {
+    return 'Network error. Check your connection and try again.'
+  }
+  if (result.status === 401) {
+    return 'Unauthorized. Sign in as the room host and try again.'
+  }
+  if (result.status === 403) {
+    return 'You are not the host of this room.'
+  }
+  if (result.status === 404) {
+    return 'Room or episode was not found.'
+  }
+  if (result.status === 409) {
+    return 'Room was updated elsewhere. Retry the title change.'
+  }
+  if (result.code === 'catalog_episode_not_found') {
+    return 'That catalog episode was not found.'
+  }
+  if (result.code === 'catalog_episode_youtube_id_missing') {
+    return 'That catalog episode is missing a YouTube id.'
+  }
+  if (result.code === 'catalog_episode_custom_url_missing') {
+    return 'That catalog episode is missing a custom playback URL.'
+  }
+  if (result.reason === 'http' && result.status === 400) {
+    return 'The catalog episode could not be applied to this room.'
+  }
+  return 'Could not change the room title.'
+}

--- a/apps/host-extension/changeTitle.test.js
+++ b/apps/host-extension/changeTitle.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { applyTitleChange, titleChangeErrorMessage } from './changeTitle.js'
+import { createEphemeralJwtCache } from './hostJwt.js'
+import { resolveHostSourceTabUrl } from './hostSourceTabUrl.js'
+
+const ROOM_URL = 'https://riffsync.tv/room/party-1'
+const ROW = {
+  id: '032-mitchell',
+  embedAllows: true,
+  youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+  youtubeVideoId: 'NXGXtm6gcxk',
+  playbackHost: 'youtube',
+}
+
+function createDeps(overrides = {}) {
+  const jwtCache = createEphemeralJwtCache()
+  const calls = { jwt: 0, patch: [], navigate: [] }
+  return {
+    calls,
+    jwtCache,
+    args: {
+      activeTabUrl: ROOM_URL,
+      partyTabId: 3,
+      catalogEpisodeId: '032-mitchell',
+      catalogRow: ROW,
+      jwtCache,
+      requestJwt: async () => {
+        calls.jwt += 1
+        return { ok: true, accessToken: `token-${calls.jwt}` }
+      },
+      patchRoom: async (args) => {
+        calls.patch.push(args)
+        return { ok: true, status: 200 }
+      },
+      resolveUrl: resolveHostSourceTabUrl,
+      navigate: async ({ url }) => {
+        calls.navigate.push({ url, active: false })
+        return { ok: true }
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('applyTitleChange', () => {
+  it('after PATCH 200, navigates the media tab with active: false', async () => {
+    const { args, calls } = createDeps()
+    const result = await applyTitleChange(args)
+
+    assert.equal(result.ok, true)
+    assert.equal(result.navigated, true)
+    assert.equal(calls.patch.length, 1)
+    assert.equal(calls.patch[0].catalogEpisodeId, '032-mitchell')
+    assert.equal(calls.patch[0].accessToken, 'token-1')
+    assert.equal(calls.navigate.length, 1)
+    assert.equal(calls.navigate[0].active, false)
+    assert.equal(
+      calls.navigate[0].url,
+      'https://riffsync.tv/watch/032-mitchell?partyCapture=1',
+    )
+  })
+
+  it('does not navigate when PATCH fails', async () => {
+    const { args, calls } = createDeps({
+      patchRoom: async () => ({ ok: false, status: 403, reason: 'http' }),
+    })
+    const result = await applyTitleChange(args)
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 403)
+    assert.equal(calls.navigate.length, 0)
+  })
+
+  it('refuses PATCH and navigate when C1 is unbound', async () => {
+    const { args, calls } = createDeps({
+      activeTabUrl: 'https://riffsync.tv/watch/032-mitchell',
+    })
+    const result = await applyTitleChange(args)
+
+    assert.equal(result.ok, false)
+    assert.equal(result.reason, 'unbound')
+    assert.equal(calls.patch.length, 0)
+    assert.equal(calls.navigate.length, 0)
+    assert.equal(calls.jwt, 0)
+  })
+
+  it('retries JWT once after PATCH 401, then fails without navigating', async () => {
+    let patches = 0
+    const { args, calls, jwtCache } = createDeps({
+      patchRoom: async () => {
+        patches += 1
+        return { ok: false, status: 401, reason: 'http' }
+      },
+    })
+    jwtCache.store('stale')
+    const result = await applyTitleChange(args)
+
+    assert.equal(result.ok, false)
+    assert.equal(result.status, 401)
+    assert.equal(patches, 2)
+    assert.equal(calls.jwt, 1)
+    assert.equal(calls.navigate.length, 0)
+    assert.equal(jwtCache.peek(), 'token-1')
+  })
+})
+
+describe('titleChangeErrorMessage', () => {
+  it('maps unbound, auth, http, and catalog codes to distinct copy', () => {
+    assert.match(titleChangeErrorMessage({ reason: 'unbound' }), /Not on a room tab/)
+    assert.match(titleChangeErrorMessage({ reason: 'auth', error: 'not_signed_in' }), /Sign in/)
+    assert.match(titleChangeErrorMessage({ reason: 'auth', error: 'timeout' }), /timed out/)
+    assert.match(titleChangeErrorMessage({ status: 403 }), /not the host/)
+    assert.match(titleChangeErrorMessage({ status: 409 }), /Retry/)
+    assert.match(
+      titleChangeErrorMessage({ code: 'catalog_episode_youtube_id_missing' }),
+      /YouTube id/,
+    )
+  })
+})

--- a/apps/host-extension/host-bridge-content.js
+++ b/apps/host-extension/host-bridge-content.js
@@ -1,0 +1,74 @@
+(() => {
+  const CHANNEL = 'riffsync-host-bridge'
+  const VERSION = 1
+  const ALLOWED_ORIGINS = ['https://riffsync.tv', 'http://localhost:5173']
+  const PAGE_WAIT_MS = 6000
+
+  function isEnvelope(value) {
+    return (
+      Boolean(value) &&
+      typeof value === 'object' &&
+      value.channel === CHANNEL &&
+      value.v === VERSION &&
+      typeof value.requestId === 'string' &&
+      value.requestId.length > 0 &&
+      (value.type === 'HOST_JWT_REQUEST' ||
+        value.type === 'HOST_JWT_RESPONSE' ||
+        value.type === 'HOST_BRIDGE_PING' ||
+        value.type === 'HOST_BRIDGE_PONG')
+    )
+  }
+
+  function isAllowedOrigin(origin) {
+    return ALLOWED_ORIGINS.includes(origin)
+  }
+
+  function shouldForward(event, requestId) {
+    if (!event || event.source !== window) return false
+    if (!isAllowedOrigin(event.origin)) return false
+    if (!isEnvelope(event.data)) return false
+    if (event.data.requestId !== requestId) return false
+    return event.data.type === 'HOST_JWT_RESPONSE' || event.data.type === 'HOST_BRIDGE_PONG'
+  }
+
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (!isEnvelope(message)) return undefined
+    if (message.type !== 'HOST_JWT_REQUEST' && message.type !== 'HOST_BRIDGE_PING') {
+      return undefined
+    }
+
+    const pageOrigin = window.location.origin
+    if (!isAllowedOrigin(pageOrigin)) {
+      sendResponse({
+        channel: CHANNEL,
+        v: VERSION,
+        type: message.type === 'HOST_BRIDGE_PING' ? 'HOST_BRIDGE_PONG' : 'HOST_JWT_RESPONSE',
+        requestId: message.requestId,
+        ok: false,
+        error: 'forbidden_origin',
+      })
+      return false
+    }
+
+    const onPage = (event) => {
+      if (!shouldForward(event, message.requestId)) return
+      window.removeEventListener('message', onPage)
+      sendResponse(event.data)
+    }
+
+    window.addEventListener('message', onPage)
+    window.postMessage(
+      {
+        channel: CHANNEL,
+        v: VERSION,
+        type: message.type,
+        requestId: message.requestId,
+      },
+      pageOrigin,
+    )
+    setTimeout(() => {
+      window.removeEventListener('message', onPage)
+    }, PAGE_WAIT_MS)
+    return true
+  })
+})()

--- a/apps/host-extension/host-control-panel.html
+++ b/apps/host-extension/host-control-panel.html
@@ -119,6 +119,15 @@
       <button id="open-media-tab" type="button" disabled>Open media tab</button>
     </p>
     <p id="error-status" class="error"></p>
+    <h2>Now playing</h2>
+    <p id="now-playing-status">Checking room...</p>
+    <p>
+      <button id="now-playing-retry" type="button" hidden>Retry</button>
+    </p>
+    <p>
+      <button id="apply-title" type="button" disabled>Change room title</button>
+    </p>
+    <p id="title-error" class="error"></p>
     <h2>Library</h2>
     <p id="library-status">Loading catalog library...</p>
     <ul id="library-list" class="library-list" hidden></ul>

--- a/apps/host-extension/host-control-panel.js
+++ b/apps/host-extension/host-control-panel.js
@@ -1,6 +1,9 @@
 import { fetchPublicCatalog, selectCatalogRow } from './catalogApi.js'
+import { titleChangeErrorMessage } from './changeTitle.js'
 import { PUBLIC_API_BASE_URL } from './config.js'
 import { resolveHostSourceTabUrl } from './hostSourceTabUrl.js'
+import { nowPlayingLabel } from './nowPlaying.js'
+import { fetchRoomNowPlaying } from './roomsApi.js'
 
 const HOST_SOURCE_FIXTURE = {
   catalogEp: {
@@ -20,21 +23,79 @@ const errorEl = document.getElementById('error-status')
 const libraryStatusEl = document.getElementById('library-status')
 const libraryListEl = document.getElementById('library-list')
 const libraryRetryButton = document.getElementById('library-retry')
+const nowPlayingEl = document.getElementById('now-playing-status')
+const nowPlayingRetryButton = document.getElementById('now-playing-retry')
+const applyTitleButton = document.getElementById('apply-title')
+const titleErrorEl = document.getElementById('title-error')
 
 let libraryEntries = []
 let librarySelection = { id: null, row: null }
+let sessionState = { bound: false, roomId: null, origin: null, mediaTabOpen: false }
+let nowPlayingRoomId = null
+let nowPlayingRoom = null
+
+function syncActionButtons() {
+  const bound = Boolean(sessionState.bound)
+  openButton.disabled = !bound
+  applyTitleButton.disabled = !bound || !librarySelection.id
+}
 
 function render(state) {
-  const bound = Boolean(state?.bound)
-  bindEl.textContent = bound ? `Bound to room ${state.roomId}` : 'Not bound to a room'
-  mediaEl.textContent = bound && state.mediaTabOpen ? 'Open' : 'Not open'
-  openButton.disabled = !bound
+  sessionState = {
+    bound: Boolean(state?.bound),
+    roomId: state?.roomId ?? null,
+    origin: state?.origin ?? null,
+    mediaTabOpen: Boolean(state?.mediaTabOpen),
+  }
+  bindEl.textContent = sessionState.bound
+    ? `Bound to room ${sessionState.roomId}`
+    : 'Not bound to a room'
+  mediaEl.textContent = sessionState.bound && sessionState.mediaTabOpen ? 'Open' : 'Not open'
+  syncActionButtons()
   errorEl.textContent = ''
+}
+
+function setNowPlayingStatus(text, { retryHidden = true } = {}) {
+  nowPlayingEl.textContent = text
+  nowPlayingRetryButton.hidden = retryHidden
+}
+
+async function loadNowPlaying(roomId) {
+  if (!roomId) {
+    nowPlayingRoomId = null
+    nowPlayingRoom = null
+    setNowPlayingStatus('Open a RiffSync room tab to see now playing.')
+    return
+  }
+
+  nowPlayingRoomId = roomId
+  nowPlayingRoom = null
+  setNowPlayingStatus('Loading now playing...')
+  const result = await fetchRoomNowPlaying(PUBLIC_API_BASE_URL, roomId)
+  if (nowPlayingRoomId !== roomId) return
+
+  if (result.status === 'ok') {
+    nowPlayingRoom = result.room
+    setNowPlayingStatus(nowPlayingLabel(result.room, libraryEntries) || 'Now playing unavailable')
+    return
+  }
+  if (result.status === 'missing') {
+    setNowPlayingStatus('Room not found.')
+    return
+  }
+  setNowPlayingStatus('Could not load now playing.', { retryHidden: false })
+}
+
+function refreshNowPlayingForBind(state) {
+  const roomId = state?.bound ? state.roomId : null
+  if (roomId === nowPlayingRoomId && roomId) return
+  loadNowPlaying(roomId)
 }
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message?.type === 'hostSessionState') {
     render(message)
+    refreshNowPlayingForBind(message)
   }
 })
 
@@ -109,6 +170,9 @@ function renderLibraryResult(result) {
     renderLibraryList()
     setLibraryStatus('', { listHidden: false, retryHidden: true })
     libraryStatusEl.hidden = true
+    if (nowPlayingRoom) {
+      setNowPlayingStatus(nowPlayingLabel(nowPlayingRoom, libraryEntries) || 'Now playing unavailable')
+    }
     return
   }
 
@@ -139,15 +203,50 @@ libraryListEl.addEventListener('click', (event) => {
   if (!row) return
   librarySelection = selectCatalogRow(libraryEntries, row.dataset.id)
   renderLibraryList()
+  syncActionButtons()
 })
 
 libraryRetryButton.addEventListener('click', () => {
   loadLibrary()
 })
 
-chrome.runtime.sendMessage({ type: 'getState' }).then(render).catch((error) => {
+nowPlayingRetryButton.addEventListener('click', () => {
+  loadNowPlaying(sessionState.bound ? sessionState.roomId : null)
+})
+
+applyTitleButton.addEventListener('click', async () => {
+  titleErrorEl.textContent = ''
+  if (!sessionState.bound) {
+    titleErrorEl.textContent = titleChangeErrorMessage({ reason: 'unbound' })
+    return
+  }
+  if (!librarySelection.id || !librarySelection.row) {
+    titleErrorEl.textContent = titleChangeErrorMessage({ reason: 'missing_selection' })
+    return
+  }
+
+  applyTitleButton.disabled = true
+  const result = await chrome.runtime.sendMessage({
+    type: 'changeTitle',
+    catalogEpisodeId: librarySelection.id,
+    catalogRow: librarySelection.row,
+  })
+  render(result)
+  if (result?.ok) {
+    await loadNowPlaying(result.roomId || sessionState.roomId)
+  } else {
+    titleErrorEl.textContent = titleChangeErrorMessage(result)
+  }
+  syncActionButtons()
+})
+
+chrome.runtime.sendMessage({ type: 'getState' }).then((state) => {
+  render(state)
+  refreshNowPlayingForBind(state)
+}).catch((error) => {
   console.error(error)
   render({ bound: false, mediaTabOpen: false })
+  loadNowPlaying(null)
 })
 
 loadLibrary()

--- a/apps/host-extension/hostBridge.js
+++ b/apps/host-extension/hostBridge.js
@@ -1,0 +1,34 @@
+export const HOST_BRIDGE_CHANNEL = 'riffsync-host-bridge'
+export const HOST_BRIDGE_VERSION = 1
+
+export const HOST_BRIDGE_TYPES = new Set([
+  'HOST_JWT_REQUEST',
+  'HOST_JWT_RESPONSE',
+  'HOST_BRIDGE_PING',
+  'HOST_BRIDGE_PONG',
+])
+
+export const HOST_BRIDGE_ERRORS = new Set([
+  'not_signed_in',
+  'refresh_failed',
+  'forbidden_origin',
+  'unsupported',
+])
+
+export function isHostBridgeEnvelope(value) {
+  if (!value || typeof value !== 'object') return false
+  if (value.channel !== HOST_BRIDGE_CHANNEL) return false
+  if (value.v !== HOST_BRIDGE_VERSION) return false
+  if (!HOST_BRIDGE_TYPES.has(value.type)) return false
+  if (typeof value.requestId !== 'string' || value.requestId.length === 0) return false
+  return true
+}
+
+export function createHostBridgeRequest(type, requestId) {
+  return {
+    channel: HOST_BRIDGE_CHANNEL,
+    v: HOST_BRIDGE_VERSION,
+    type,
+    requestId,
+  }
+}

--- a/apps/host-extension/hostBridge.test.js
+++ b/apps/host-extension/hostBridge.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  HOST_BRIDGE_CHANNEL,
+  createHostBridgeRequest,
+  isHostBridgeEnvelope,
+} from './hostBridge.js'
+
+describe('host bridge envelope', () => {
+  it('accepts v1 envelopes with a requestId and known type', () => {
+    const request = createHostBridgeRequest('HOST_JWT_REQUEST', 'req-1')
+    assert.equal(request.channel, HOST_BRIDGE_CHANNEL)
+    assert.equal(request.v, 1)
+    assert.equal(isHostBridgeEnvelope(request), true)
+    assert.equal(
+      isHostBridgeEnvelope({
+        ...request,
+        type: 'HOST_JWT_RESPONSE',
+        ok: true,
+        accessToken: 'fan-access',
+      }),
+      true,
+    )
+  })
+
+  it('rejects wrong channel, version, type, or missing requestId', () => {
+    const request = createHostBridgeRequest('HOST_JWT_REQUEST', 'req-1')
+    assert.equal(isHostBridgeEnvelope({ ...request, channel: 'other' }), false)
+    assert.equal(isHostBridgeEnvelope({ ...request, v: 2 }), false)
+    assert.equal(isHostBridgeEnvelope({ ...request, type: 'OTHER' }), false)
+    assert.equal(isHostBridgeEnvelope({ ...request, requestId: '' }), false)
+    assert.equal(isHostBridgeEnvelope(null), false)
+  })
+})

--- a/apps/host-extension/hostBridgeRelay.js
+++ b/apps/host-extension/hostBridgeRelay.js
@@ -1,0 +1,14 @@
+import { ALLOWED_SPA_ORIGINS } from './roomBind.js'
+import { isHostBridgeEnvelope } from './hostBridge.js'
+
+export function isAllowedHostBridgeOrigin(origin) {
+  return ALLOWED_SPA_ORIGINS.includes(origin)
+}
+
+export function shouldForwardPageBridgeMessage(event, requestId, pageWindow = globalThis.window) {
+  if (!event || event.source !== pageWindow) return false
+  if (!isAllowedHostBridgeOrigin(event.origin)) return false
+  if (!isHostBridgeEnvelope(event.data)) return false
+  if (event.data.requestId !== requestId) return false
+  return event.data.type === 'HOST_JWT_RESPONSE' || event.data.type === 'HOST_BRIDGE_PONG'
+}

--- a/apps/host-extension/hostBridgeRelay.test.js
+++ b/apps/host-extension/hostBridgeRelay.test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { createHostBridgeRequest } from './hostBridge.js'
+import { isAllowedHostBridgeOrigin, shouldForwardPageBridgeMessage } from './hostBridgeRelay.js'
+
+describe('host bridge content-script relay', () => {
+  it('allows only C1 SPA origins', () => {
+    assert.equal(isAllowedHostBridgeOrigin('https://riffsync.tv'), true)
+    assert.equal(isAllowedHostBridgeOrigin('http://localhost:5173'), true)
+    assert.equal(isAllowedHostBridgeOrigin('https://example.com'), false)
+    assert.equal(isAllowedHostBridgeOrigin('http://127.0.0.1:5173'), false)
+  })
+
+  it('forwards matching requestId responses from window on an allowed origin', () => {
+    const pageWindow = {}
+    const request = createHostBridgeRequest('HOST_JWT_RESPONSE', 'req-1')
+    const event = {
+      source: pageWindow,
+      origin: 'https://riffsync.tv',
+      data: { ...request, ok: true, accessToken: 'fan-access' },
+    }
+    assert.equal(shouldForwardPageBridgeMessage(event, 'req-1', pageWindow), true)
+  })
+
+  it('drops disallowed origins, non-window sources, and other requestIds', () => {
+    const pageWindow = {}
+    const request = createHostBridgeRequest('HOST_JWT_RESPONSE', 'req-1')
+    assert.equal(
+      shouldForwardPageBridgeMessage(
+        { source: pageWindow, origin: 'https://evil.example', data: request },
+        'req-1',
+        pageWindow,
+      ),
+      false,
+    )
+    assert.equal(
+      shouldForwardPageBridgeMessage(
+        { source: {}, origin: 'https://riffsync.tv', data: request },
+        'req-1',
+        pageWindow,
+      ),
+      false,
+    )
+    assert.equal(
+      shouldForwardPageBridgeMessage(
+        { source: pageWindow, origin: 'https://riffsync.tv', data: request },
+        'other',
+        pageWindow,
+      ),
+      false,
+    )
+  })
+})

--- a/apps/host-extension/hostJwt.js
+++ b/apps/host-extension/hostJwt.js
@@ -1,0 +1,81 @@
+import { createHostBridgeRequest, isHostBridgeEnvelope } from './hostBridge.js'
+
+export const JWT_REQUEST_TIMEOUT_MS = 5000
+
+export function createEphemeralJwtCache() {
+  let accessToken = null
+
+  return {
+    peek() {
+      return accessToken
+    },
+    store(token) {
+      accessToken = typeof token === 'string' && token.length > 0 ? token : null
+    },
+    drop() {
+      accessToken = null
+    },
+  }
+}
+
+function classifySendError(error) {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  if (
+    message.includes('Receiving end does not exist') ||
+    message.includes('Could not establish connection')
+  ) {
+    return 'content_script_missing'
+  }
+  return 'unsupported'
+}
+
+function normalizeJwtResponse(response) {
+  if (!isHostBridgeEnvelope(response) || response.type !== 'HOST_JWT_RESPONSE') {
+    return { ok: false, error: 'unsupported' }
+  }
+  if (response.ok === true && typeof response.accessToken === 'string' && response.accessToken.length > 0) {
+    return { ok: true, accessToken: response.accessToken }
+  }
+  if (response.ok === false && typeof response.error === 'string' && response.error.length > 0) {
+    return { ok: false, error: response.error }
+  }
+  return { ok: false, error: 'unsupported' }
+}
+
+export async function requestHostAccessToken({
+  tabId,
+  sendMessage,
+  timeoutMs = JWT_REQUEST_TIMEOUT_MS,
+  createRequestId = () => crypto.randomUUID(),
+}) {
+  if (tabId == null) {
+    return { ok: false, error: 'content_script_missing' }
+  }
+
+  const requestId = createRequestId()
+  const request = createHostBridgeRequest('HOST_JWT_REQUEST', requestId)
+
+  let settled = false
+  return await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      resolve({ ok: false, error: 'timeout' })
+    }, timeoutMs)
+
+    Promise.resolve()
+      .then(() => sendMessage(tabId, request))
+      .then((response) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(normalizeJwtResponse(response))
+      })
+      .catch((error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve({ ok: false, error: classifySendError(error) })
+      })
+  })
+}

--- a/apps/host-extension/hostJwt.test.js
+++ b/apps/host-extension/hostJwt.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, it } from 'node:test'
+import { createHostBridgeRequest } from './hostBridge.js'
+import {
+  JWT_REQUEST_TIMEOUT_MS,
+  createEphemeralJwtCache,
+  requestHostAccessToken,
+} from './hostJwt.js'
+
+describe('ephemeral JWT cache', () => {
+  it('stores and drops access tokens in memory only', () => {
+    const cache = createEphemeralJwtCache()
+    cache.store('fan-access')
+    assert.equal(cache.peek(), 'fan-access')
+    cache.drop()
+    assert.equal(cache.peek(), null)
+  })
+})
+
+describe('requestHostAccessToken', () => {
+  it('returns a fan access token from a matching HOST_JWT_RESPONSE', async () => {
+    const result = await requestHostAccessToken({
+      tabId: 9,
+      createRequestId: () => 'req-1',
+      sendMessage: async (_tabId, message) => ({
+        ...createHostBridgeRequest('HOST_JWT_RESPONSE', message.requestId),
+        ok: true,
+        accessToken: 'fan-access',
+      }),
+    })
+    assert.deepEqual(result, { ok: true, accessToken: 'fan-access' })
+  })
+
+  it('maps a missing content script to content_script_missing', async () => {
+    const result = await requestHostAccessToken({
+      tabId: 9,
+      sendMessage: async () => {
+        throw new Error('Could not establish connection. Receiving end does not exist.')
+      },
+    })
+    assert.deepEqual(result, { ok: false, error: 'content_script_missing' })
+  })
+
+  it('times out as an auth error', async () => {
+    const result = await requestHostAccessToken({
+      tabId: 9,
+      timeoutMs: 10,
+      sendMessage: () => new Promise(() => {}),
+    })
+    assert.deepEqual(result, { ok: false, error: 'timeout' })
+    assert.equal(JWT_REQUEST_TIMEOUT_MS, 5000)
+  })
+
+  it('does not persist tokens to chrome.storage or handle refresh tokens', () => {
+    const src = readFileSync(new URL('./hostJwt.js', import.meta.url), 'utf8')
+    assert.equal(src.includes('chrome.storage'), false)
+    assert.equal(/refresh[_]?token/i.test(src), false)
+  })
+})

--- a/apps/host-extension/manifest.json
+++ b/apps/host-extension/manifest.json
@@ -14,5 +14,12 @@
   "background": {
     "service_worker": "background.js",
     "type": "module"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://riffsync.tv/*", "http://localhost:5173/*"],
+      "js": ["host-bridge-content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/apps/host-extension/nowPlaying.js
+++ b/apps/host-extension/nowPlaying.js
@@ -1,0 +1,16 @@
+export function nowPlayingLabel(room, libraryEntries = []) {
+  if (!room || typeof room !== 'object') return ''
+
+  const displayTitle = typeof room.displayTitle === 'string' ? room.displayTitle.trim() : ''
+  if (displayTitle) return displayTitle
+
+  const catalogEpisodeId =
+    typeof room.catalogEpisodeId === 'string' ? room.catalogEpisodeId : ''
+  const row = Array.isArray(libraryEntries)
+    ? libraryEntries.find((entry) => entry.id === catalogEpisodeId)
+    : undefined
+  const libraryTitle = typeof row?.title === 'string' ? row.title.trim() : ''
+  if (libraryTitle) return libraryTitle
+
+  return catalogEpisodeId
+}

--- a/apps/host-extension/nowPlaying.test.js
+++ b/apps/host-extension/nowPlaying.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { nowPlayingLabel } from './nowPlaying.js'
+
+const library = [{ id: '032-mitchell', title: 'Mitchell' }]
+
+describe('nowPlayingLabel', () => {
+  it('prefers displayTitle, then library title, then catalogEpisodeId', () => {
+    assert.equal(
+      nowPlayingLabel({ displayTitle: 'Host headline', catalogEpisodeId: '032-mitchell' }, library),
+      'Host headline',
+    )
+    assert.equal(
+      nowPlayingLabel({ catalogEpisodeId: '032-mitchell' }, library),
+      'Mitchell',
+    )
+    assert.equal(nowPlayingLabel({ catalogEpisodeId: 'missing-id' }, library), 'missing-id')
+  })
+})

--- a/apps/host-extension/roomsApi.js
+++ b/apps/host-extension/roomsApi.js
@@ -1,0 +1,123 @@
+import { getPublicApiBaseUrl } from './publicApiBaseUrl.js'
+
+const CATALOG_ERROR_CODES = new Set([
+  'catalog_episode_not_found',
+  'catalog_episode_youtube_id_missing',
+  'catalog_episode_custom_url_missing',
+])
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null
+}
+
+function roomUrl(base, roomId) {
+  return `${base}/v1/rooms/${encodeURIComponent(roomId)}`
+}
+
+function errorResult(reason, extra = {}) {
+  return { ok: false, status: 'error', reason, ...extra }
+}
+
+async function readJson(response) {
+  try {
+    return await response.json()
+  } catch {
+    return undefined
+  }
+}
+
+export async function fetchRoomNowPlaying(baseUrl, roomId, fetchImpl = globalThis.fetch) {
+  if (typeof roomId !== 'string' || roomId.length === 0) {
+    return { ok: false, status: 'unbound', reason: 'unbound' }
+  }
+
+  const base = getPublicApiBaseUrl(baseUrl)
+  if (!base) {
+    return errorResult('invalid-base-url')
+  }
+
+  let response
+  try {
+    response = await fetchImpl(roomUrl(base, roomId), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return errorResult('network')
+  }
+
+  if (!response || typeof response.status !== 'number') {
+    return errorResult('network')
+  }
+
+  if (response.status === 404) {
+    return { ok: false, status: 'missing', reason: 'missing' }
+  }
+
+  if (!response.ok) {
+    return errorResult('http', { httpStatus: response.status })
+  }
+
+  let body
+  try {
+    body = await response.json()
+  } catch {
+    return errorResult('malformed')
+  }
+  if (!isRecord(body) || !isRecord(body.room)) {
+    return { ok: false, status: 'missing', reason: 'missing' }
+  }
+
+  return { ok: true, status: 'ok', room: body.room }
+}
+
+function catalogCodeFromBody(body) {
+  if (!isRecord(body) || typeof body.code !== 'string') return undefined
+  return CATALOG_ERROR_CODES.has(body.code) ? body.code : undefined
+}
+
+export async function patchRoomCatalogEpisode(
+  baseUrl,
+  { roomId, accessToken, catalogEpisodeId },
+  fetchImpl = globalThis.fetch,
+) {
+  const base = getPublicApiBaseUrl(baseUrl)
+  if (!base) {
+    return { ok: false, status: 0, reason: 'invalid-base-url' }
+  }
+
+  let response
+  try {
+    response = await fetchImpl(roomUrl(base, roomId), {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ catalogEpisodeId }),
+    })
+  } catch {
+    return { ok: false, status: 0, reason: 'network' }
+  }
+
+  if (!response || typeof response.status !== 'number') {
+    return { ok: false, status: 0, reason: 'network' }
+  }
+
+  const body = await readJson(response)
+
+  if (response.status === 200) {
+    if (!isRecord(body)) {
+      return { ok: false, status: 200, reason: 'malformed' }
+    }
+    return { ok: true, status: 200, body }
+  }
+
+  return {
+    ok: false,
+    status: response.status,
+    reason: response.status === 0 ? 'network' : 'http',
+    code: catalogCodeFromBody(body),
+  }
+}

--- a/apps/host-extension/roomsApi.test.js
+++ b/apps/host-extension/roomsApi.test.js
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { fetchRoomNowPlaying, patchRoomCatalogEpisode } from './roomsApi.js'
+
+const BASE = 'https://xxxx.execute-api.us-east-1.amazonaws.com'
+const ROOM_ID = 'party-1'
+const ROOM_URL = `${BASE}/v1/rooms/${ROOM_ID}`
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+  }
+}
+
+describe('fetchRoomNowPlaying', () => {
+  it('GETs {base}/v1/rooms/{id} anonymously and returns the room', async () => {
+    const calls = []
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init })
+      return jsonResponse({
+        room: { roomId: ROOM_ID, displayTitle: 'Mitchell', catalogEpisodeId: '032-mitchell' },
+      })
+    }
+
+    const result = await fetchRoomNowPlaying(`${BASE}/`, ROOM_ID, fetchImpl)
+
+    assert.equal(result.status, 'ok')
+    assert.equal(result.room.displayTitle, 'Mitchell')
+    assert.equal(calls[0].url, ROOM_URL)
+    assert.equal(calls[0].init.method, 'GET')
+    assert.equal(calls[0].init.headers.Authorization, undefined)
+  })
+
+  it('treats HTTP 404 and a missing room body as missing', async () => {
+    const missingHttp = await fetchRoomNowPlaying(BASE, ROOM_ID, async () =>
+      jsonResponse({ error: 'not found' }, 404),
+    )
+    assert.equal(missingHttp.status, 'missing')
+
+    const missingBody = await fetchRoomNowPlaying(BASE, ROOM_ID, async () => jsonResponse({}))
+    assert.equal(missingBody.status, 'missing')
+  })
+
+  it('returns error for network and malformed JSON, and unbound without inventing a room id', async () => {
+    const network = await fetchRoomNowPlaying(BASE, ROOM_ID, async () => {
+      throw new Error('offline')
+    })
+    assert.equal(network.status, 'error')
+    assert.equal(network.reason, 'network')
+
+    const malformed = await fetchRoomNowPlaying(BASE, ROOM_ID, async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        throw new SyntaxError('bad json')
+      },
+    }))
+    assert.equal(malformed.status, 'error')
+    assert.equal(malformed.reason, 'malformed')
+
+    let called = 0
+    const unbound = await fetchRoomNowPlaying(BASE, '', async () => {
+      called += 1
+      return jsonResponse({ room: { roomId: 'invented' } })
+    })
+    assert.equal(unbound.status, 'unbound')
+    assert.equal(called, 0)
+  })
+})
+
+describe('patchRoomCatalogEpisode', () => {
+  it('PATCHes { catalogEpisodeId } only with Bearer fan access JWT', async () => {
+    const calls = []
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init })
+      return jsonResponse({ catalogEpisodeId: '032-mitchell' }, 200)
+    }
+
+    const result = await patchRoomCatalogEpisode(
+      BASE,
+      { roomId: ROOM_ID, accessToken: 'fan-access', catalogEpisodeId: '032-mitchell' },
+      fetchImpl,
+    )
+
+    assert.equal(result.ok, true)
+    assert.equal(calls[0].url, ROOM_URL)
+    assert.equal(calls[0].init.method, 'PATCH')
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer fan-access')
+    assert.equal(calls[0].init.headers['Content-Type'], 'application/json')
+    assert.equal(calls[0].init.headers.Accept, 'application/json')
+    assert.equal(calls[0].init.body, JSON.stringify({ catalogEpisodeId: '032-mitchell' }))
+    assert.equal(calls[0].init.body.includes('displayTitle'), false)
+  })
+
+  it('maps 401 / 403 / 404 / 400 codes / 409 / network to distinct results', async () => {
+    const http = async (status, body = {}) =>
+      patchRoomCatalogEpisode(
+        BASE,
+        { roomId: ROOM_ID, accessToken: 'fan-access', catalogEpisodeId: '032-mitchell' },
+        async () => jsonResponse(body, status),
+      )
+
+    assert.equal((await http(401)).status, 401)
+    assert.equal((await http(403)).status, 403)
+    assert.equal((await http(404)).status, 404)
+    assert.equal((await http(409)).status, 409)
+
+    const notFound = await http(400, { code: 'catalog_episode_not_found' })
+    assert.equal(notFound.status, 400)
+    assert.equal(notFound.code, 'catalog_episode_not_found')
+
+    const youtube = await http(400, { code: 'catalog_episode_youtube_id_missing' })
+    assert.equal(youtube.code, 'catalog_episode_youtube_id_missing')
+
+    const custom = await http(400, { code: 'catalog_episode_custom_url_missing' })
+    assert.equal(custom.code, 'catalog_episode_custom_url_missing')
+
+    const network = await patchRoomCatalogEpisode(
+      BASE,
+      { roomId: ROOM_ID, accessToken: 'fan-access', catalogEpisodeId: '032-mitchell' },
+      async () => {
+        throw new Error('offline')
+      },
+    )
+    assert.equal(network.reason, 'network')
+    assert.equal(network.ok, false)
+  })
+})

--- a/apps/web/src/hostBridge/hostJwtBridge.test.ts
+++ b/apps/web/src/hostBridge/hostJwtBridge.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  HOST_BRIDGE_CHANNEL,
+  handleHostBridgeMessage,
+  isAllowedHostBridgeOrigin,
+} from './hostJwtBridge'
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    channel: HOST_BRIDGE_CHANNEL,
+    v: 1,
+    type: 'HOST_JWT_REQUEST',
+    requestId: 'req-1',
+    ...overrides,
+  }
+}
+
+function createDeps() {
+  const posted: unknown[] = []
+  const pageWindow = {} as Window
+  return {
+    posted,
+    pageWindow,
+    refreshFanTokensIfStale: vi.fn(async () => {}),
+    getFanAccessToken: vi.fn(() => 'fan-access'),
+    getFanRefreshToken: vi.fn(() => 'refresh-should-not-be-posted'),
+    postMessage: vi.fn((message: unknown) => {
+      posted.push(message)
+    }),
+  }
+}
+
+describe('hostJwtBridge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('allows only C1 SPA origins', () => {
+    expect(isAllowedHostBridgeOrigin('https://riffsync.tv')).toBe(true)
+    expect(isAllowedHostBridgeOrigin('http://localhost:5173')).toBe(true)
+    expect(isAllowedHostBridgeOrigin('https://evil.example')).toBe(false)
+  })
+
+  it('ignores wrong channel, non-window source, and disallowed origin', async () => {
+    const deps = createDeps()
+    await handleHostBridgeMessage(
+      {
+        source: {},
+        origin: 'https://riffsync.tv',
+        data: envelope(),
+      } as MessageEvent,
+      deps,
+    )
+    await handleHostBridgeMessage(
+      {
+        source: deps.pageWindow,
+        origin: 'https://evil.example',
+        data: envelope(),
+      } as MessageEvent,
+      deps,
+    )
+    await handleHostBridgeMessage(
+      {
+        source: deps.pageWindow,
+        origin: 'https://riffsync.tv',
+        data: envelope({ channel: 'other' }),
+      } as MessageEvent,
+      deps,
+    )
+
+    expect(deps.refreshFanTokensIfStale).not.toHaveBeenCalled()
+    expect(deps.posted).toEqual([])
+  })
+
+  it('returns the fan access token after refreshFanTokensIfStale and never posts a refresh token', async () => {
+    const deps = createDeps()
+    await handleHostBridgeMessage(
+      {
+        source: deps.pageWindow,
+        origin: 'https://riffsync.tv',
+        data: envelope(),
+      } as MessageEvent,
+      deps,
+    )
+
+    expect(deps.refreshFanTokensIfStale).toHaveBeenCalledOnce()
+    expect(deps.posted).toEqual([
+      {
+        channel: HOST_BRIDGE_CHANNEL,
+        v: 1,
+        type: 'HOST_JWT_RESPONSE',
+        requestId: 'req-1',
+        ok: true,
+        accessToken: 'fan-access',
+      },
+    ])
+    expect(JSON.stringify(deps.posted)).not.toContain('refresh-should-not-be-posted')
+  })
+
+  it('returns not_signed_in when there is no session', async () => {
+    const deps = createDeps()
+    deps.getFanAccessToken.mockReturnValue(null)
+    deps.getFanRefreshToken.mockReturnValue(null)
+
+    await handleHostBridgeMessage(
+      {
+        source: deps.pageWindow,
+        origin: 'http://localhost:5173',
+        data: envelope(),
+      } as MessageEvent,
+      deps,
+    )
+
+    expect(deps.posted[0]).toMatchObject({
+      ok: false,
+      error: 'not_signed_in',
+      type: 'HOST_JWT_RESPONSE',
+    })
+  })
+
+  it('returns refresh_failed when a prior session cannot produce an access token', async () => {
+    const deps = createDeps()
+    deps.getFanAccessToken.mockReturnValue(null)
+    deps.getFanRefreshToken.mockReturnValue('stale-refresh')
+
+    await handleHostBridgeMessage(
+      {
+        source: deps.pageWindow,
+        origin: 'https://riffsync.tv',
+        data: envelope(),
+      } as MessageEvent,
+      deps,
+    )
+
+    expect(deps.posted[0]).toMatchObject({
+      ok: false,
+      error: 'refresh_failed',
+    })
+  })
+})

--- a/apps/web/src/hostBridge/hostJwtBridge.test.ts
+++ b/apps/web/src/hostBridge/hostJwtBridge.test.ts
@@ -23,8 +23,8 @@ function createDeps() {
     posted,
     pageWindow,
     refreshFanTokensIfStale: vi.fn(async () => {}),
-    getFanAccessToken: vi.fn(() => 'fan-access'),
-    getFanRefreshToken: vi.fn(() => 'refresh-should-not-be-posted'),
+    getFanAccessToken: vi.fn<() => string | null>(() => 'fan-access'),
+    getFanRefreshToken: vi.fn<() => string | null>(() => 'refresh-should-not-be-posted'),
     postMessage: vi.fn((message: unknown) => {
       posted.push(message)
     }),

--- a/apps/web/src/hostBridge/hostJwtBridge.ts
+++ b/apps/web/src/hostBridge/hostJwtBridge.ts
@@ -1,0 +1,132 @@
+import { refreshFanTokensIfStale } from '../auth/fanHostedUiPkce'
+import { getFanAccessToken, getFanRefreshToken } from '../auth/fanTokens'
+
+export const HOST_BRIDGE_CHANNEL = 'riffsync-host-bridge'
+export const HOST_BRIDGE_VERSION = 1
+
+export const ALLOWED_HOST_BRIDGE_ORIGINS = ['https://riffsync.tv', 'http://localhost:5173'] as const
+
+export type HostBridgeError = 'not_signed_in' | 'refresh_failed' | 'forbidden_origin' | 'unsupported'
+
+export type HostBridgeMessageType =
+  | 'HOST_JWT_REQUEST'
+  | 'HOST_JWT_RESPONSE'
+  | 'HOST_BRIDGE_PING'
+  | 'HOST_BRIDGE_PONG'
+
+export interface HostBridgeEnvelope {
+  channel: typeof HOST_BRIDGE_CHANNEL
+  v: typeof HOST_BRIDGE_VERSION
+  type: HostBridgeMessageType
+  requestId: string
+  ok?: boolean
+  accessToken?: string
+  error?: HostBridgeError
+}
+
+export function isAllowedHostBridgeOrigin(origin: string): boolean {
+  return (ALLOWED_HOST_BRIDGE_ORIGINS as readonly string[]).includes(origin)
+}
+
+function isHostBridgeEnvelope(value: unknown): value is HostBridgeEnvelope {
+  if (!value || typeof value !== 'object') return false
+  const msg = value as Partial<HostBridgeEnvelope>
+  return (
+    msg.channel === HOST_BRIDGE_CHANNEL &&
+    msg.v === HOST_BRIDGE_VERSION &&
+    typeof msg.requestId === 'string' &&
+    msg.requestId.length > 0 &&
+    (msg.type === 'HOST_JWT_REQUEST' ||
+      msg.type === 'HOST_JWT_RESPONSE' ||
+      msg.type === 'HOST_BRIDGE_PING' ||
+      msg.type === 'HOST_BRIDGE_PONG')
+  )
+}
+
+export interface HostJwtBridgeDeps {
+  refreshFanTokensIfStale: () => Promise<void>
+  getFanAccessToken: () => string | null
+  getFanRefreshToken: () => string | null
+  postMessage: (message: HostBridgeEnvelope, targetOrigin: string) => void
+  pageWindow?: Window
+}
+
+const defaultDeps: HostJwtBridgeDeps = {
+  refreshFanTokensIfStale,
+  getFanAccessToken,
+  getFanRefreshToken,
+  postMessage: (message, targetOrigin) => {
+    window.postMessage(message, targetOrigin)
+  },
+}
+
+function respond(
+  deps: HostJwtBridgeDeps,
+  origin: string,
+  requestId: string,
+  type: 'HOST_JWT_RESPONSE' | 'HOST_BRIDGE_PONG',
+  payload: Pick<HostBridgeEnvelope, 'ok' | 'accessToken' | 'error'>,
+): void {
+  deps.postMessage(
+    {
+      channel: HOST_BRIDGE_CHANNEL,
+      v: HOST_BRIDGE_VERSION,
+      type,
+      requestId,
+      ...payload,
+    },
+    origin,
+  )
+}
+
+export async function handleHostBridgeMessage(
+  event: MessageEvent,
+  deps: HostJwtBridgeDeps = defaultDeps,
+): Promise<void> {
+  const pageWindow = deps.pageWindow ?? (typeof window === 'undefined' ? undefined : window)
+  if (!pageWindow || event.source !== pageWindow) return
+  if (!isAllowedHostBridgeOrigin(event.origin)) return
+  if (!isHostBridgeEnvelope(event.data)) return
+
+  if (event.data.type === 'HOST_BRIDGE_PING') {
+    respond(deps, event.origin, event.data.requestId, 'HOST_BRIDGE_PONG', { ok: true })
+    return
+  }
+
+  if (event.data.type !== 'HOST_JWT_REQUEST') return
+
+  const hadRefresh = Boolean(deps.getFanRefreshToken())
+  const hadAccess = Boolean(deps.getFanAccessToken())
+
+  try {
+    await deps.refreshFanTokensIfStale()
+  } catch {
+    respond(deps, event.origin, event.data.requestId, 'HOST_JWT_RESPONSE', {
+      ok: false,
+      error: hadRefresh || hadAccess ? 'refresh_failed' : 'not_signed_in',
+    })
+    return
+  }
+
+  const accessToken = deps.getFanAccessToken()
+  if (accessToken) {
+    respond(deps, event.origin, event.data.requestId, 'HOST_JWT_RESPONSE', {
+      ok: true,
+      accessToken,
+    })
+    return
+  }
+
+  respond(deps, event.origin, event.data.requestId, 'HOST_JWT_RESPONSE', {
+    ok: false,
+    error: hadRefresh || hadAccess ? 'refresh_failed' : 'not_signed_in',
+  })
+}
+
+export function mountHostJwtBridge(): () => void {
+  const onMessage = (event: MessageEvent) => {
+    void handleHostBridgeMessage(event)
+  }
+  window.addEventListener('message', onMessage)
+  return () => window.removeEventListener('message', onMessage)
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,7 +9,10 @@ import { FanDmSessionKeepAlive } from './friends/FanDmSessionKeepAlive'
 import { GoogleAnalytics } from './components/GoogleAnalytics'
 import { ScrollToTop } from './components/ScrollToTop'
 import { AppRoutes } from './AppRoutes.tsx'
+import { mountHostJwtBridge } from './hostBridge/hostJwtBridge'
 import { PublicRouteHeadTags } from './seo/PublicRouteHeadTags'
+
+mountHostJwtBridge()
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary

- Host control panel can apply a selected catalog episode: host-authenticated `PATCH /v1/rooms/{roomId}` with `{ catalogEpisodeId }` only, then open/reuse the media tab with `active: false` so the party tab stays focused.
- Fan access JWT comes from the party SPA via `riffsync-host-bridge` v1 (content script + `window.postMessage`). Access tokens stay in service-worker memory; refresh tokens never enter the extension.
- Bound-room now playing uses anonymous `GET /v1/rooms/{roomId}` (`displayTitle`, else library title, else id) with loading / error+retry / missing states. Distinct panel errors for unbound, auth/bridge, 401/403/404/400 catalog codes, 409, and network.

Closes #430.

## Test plan

- [ ] `npm test --prefix apps/host-extension` (45 tests; room GET/PATCH and JWT/navigate mocked)
- [ ] `npm test --prefix apps/web -- src/hostBridge/hostJwtBridge.test.ts`
- [ ] Static greps: no `tabCapture`/`desktopCapture`; no SFU/signaling; no `/v1/admin/catalog`; no refresh-token handling in the extension; `host_permissions` stays the configured API origin `/*`; content scripts match SPA origins only
- [ ] Set `PUBLIC_API_BASE_URL` + matching `host_permissions`; load unpacked `apps/host-extension`
- [ ] Sign in as host on `/room/{roomId}`; open host control panel; confirm bind + now playing
- [ ] Select another library title; apply; confirm room catalog episode updates; media tab opens/reuses correct URL; party tab stays focused; now playing updates
- [ ] Repeat signed-out / non-host / unbound / offline; confirm clear errors and no success navigate
- [ ] After party-capture navigation, start page `getDisplayMedia` share from the SPA; confirm share still works
- [ ] Extension details: no media-capture prompts; API `host_permissions` only; `sidePanel` + `tabs`; content scripts for SPA origins