### PR TITLE
GA4: custom product funnel events (#438)

### DIFF
--- a/apps/web/src/catalog/useResumePendingPartyRoom.test.tsx
+++ b/apps/web/src/catalog/useResumePendingPartyRoom.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CatalogEpisode } from './catalogTypes'
+import { useResumePendingPartyRoom } from './useResumePendingPartyRoom'
+import { PENDING_PARTY_EPISODE_KEY } from './pendingPartyStorage'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const trackGaEvent = vi.fn()
+const createRoom = vi.fn()
+const navigate = vi.fn()
+
+vi.mock('../config/googleAnalytics', () => ({
+  trackGaEvent: (...args: unknown[]) => trackGaEvent(...args),
+}))
+
+vi.mock('../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/roomsApi')>()
+  return {
+    ...actual,
+    createRoom: (...args: unknown[]) => createRoom(...args),
+  }
+})
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: vi.fn(() => 'fan-token'),
+}))
+
+function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
+  return {
+    id: '032-mitchell',
+    experimentNumber: 32,
+    title: 'Mitchell',
+    catalog: 'mst3k',
+    tags: [],
+    labels: [],
+    youtubeVideoId: 'NXGXtm6gcxk',
+    youtubeWatchUrl: 'https://www.youtube.com/watch?v=NXGXtm6gcxk',
+    tagline: null,
+    posterImageUrl: null,
+    backdropImageUrl: null,
+    tmdbMovieId: null,
+    tmdbArtworkSyncedAt: null,
+    carousel: false,
+    spotlight: false,
+    playbackHost: 'youtube',
+    customPlaybackUrl: null,
+    ...overrides,
+  }
+}
+
+function Harness({
+  episodes,
+  onNavigate,
+}: {
+  episodes: CatalogEpisode[]
+  onNavigate: typeof navigate
+}) {
+  useResumePendingPartyRoom(episodes, onNavigate)
+  return null
+}
+
+describe('useResumePendingPartyRoom', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    trackGaEvent.mockReset()
+    createRoom.mockReset()
+    navigate.mockReset()
+    sessionStorage.clear()
+    createRoom.mockResolvedValue({ roomId: 'room-resumed' })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    sessionStorage.clear()
+  })
+
+  it('tracks host_room_create after pending-party resume succeeds', async () => {
+    sessionStorage.setItem(PENDING_PARTY_EPISODE_KEY, '032-mitchell')
+
+    await act(async () => {
+      root.render(<Harness episodes={[episode()]} onNavigate={navigate} />)
+    })
+
+    await vi.waitFor(() => {
+      expect(createRoom).toHaveBeenCalled()
+      expect(trackGaEvent).toHaveBeenCalledWith('host_room_create', {
+        catalog_category: 'mst3k',
+        playback_host: 'youtube',
+        is_authenticated: true,
+        entry_surface: 'catalog',
+        source: 'direct',
+      })
+    })
+    const payload = trackGaEvent.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
+    expect(navigate).toHaveBeenCalledWith('/room/room-resumed', { replace: true })
+  })
+})

--- a/apps/web/src/catalog/useResumePendingPartyRoom.ts
+++ b/apps/web/src/catalog/useResumePendingPartyRoom.ts
@@ -3,6 +3,7 @@ import type { NavigateFunction } from 'react-router-dom'
 import type { CatalogEpisode } from './catalogTypes'
 import { PENDING_PARTY_EPISODE_KEY } from './pendingPartyStorage'
 import { catalogToRoomPlayback, createRoom } from '../api/roomsApi'
+import { trackGaEvent } from '../config/googleAnalytics'
 import { getFanAccessToken } from '../auth/fanTokens'
 
 async function resumePending(
@@ -20,6 +21,13 @@ async function resumePending(
       catalogEpisodeId: ep.id,
       playbackExpectation: catalogToRoomPlayback(ep),
       visibility: 'public',
+    })
+    trackGaEvent('host_room_create', {
+      catalog_category: ep.catalog,
+      playback_host: ep.playbackHost === 'custom' ? 'custom' : 'youtube',
+      is_authenticated: true,
+      entry_surface: 'catalog',
+      source: 'direct',
     })
     navigate(`/room/${encodeURIComponent(room.roomId)}`, { replace: true })
   } catch (e) {

--- a/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
+++ b/apps/web/src/components/catalog/EpisodeTileActions.test.tsx
@@ -4,15 +4,32 @@ import { createRoot, type Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CatalogEpisode } from '../../catalog/catalogTypes'
+import { getFanAccessToken } from '../../auth/fanTokens'
 import { EpisodeTileActions } from './EpisodeTileActions'
 
 vi.mock('../../auth/fanTokens', () => ({
-  getFanAccessToken: () => null,
+  getFanAccessToken: vi.fn(() => null),
 }))
 
 vi.mock('../../auth/fanHostedUiPkce', () => ({
   startFanHostedUiSignIn: vi.fn(),
 }))
+
+const trackGaEvent = vi.fn()
+
+vi.mock('../../config/googleAnalytics', () => ({
+  trackGaEvent: (...args: unknown[]) => trackGaEvent(...args),
+}))
+
+const createRoom = vi.fn()
+
+vi.mock('../../api/roomsApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/roomsApi')>()
+  return {
+    ...actual,
+    createRoom: (...args: unknown[]) => createRoom(...args),
+  }
+})
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -48,6 +65,9 @@ describe('EpisodeTileActions', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     vi.spyOn(window, 'open').mockReturnValue(null)
+    trackGaEvent.mockReset()
+    createRoom.mockReset()
+    vi.mocked(getFanAccessToken).mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -132,5 +152,30 @@ describe('EpisodeTileActions', () => {
     const startParty = container.querySelector('button.gen-button:not(.gen-button--ghost)') as HTMLButtonElement
     expect(watchSolo.disabled).toBe(true)
     expect(startParty.disabled).toBe(true)
+  })
+
+  it('tracks host_room_create after signed-in Start Party succeeds', async () => {
+    vi.mocked(getFanAccessToken).mockReturnValue('fan-token')
+    createRoom.mockResolvedValue({ roomId: 'room-new-1' })
+
+    renderActions(episode({ embedAllows: true }))
+
+    const startParty = container.querySelector('button.gen-button:not(.gen-button--ghost)') as HTMLButtonElement
+    await act(async () => {
+      startParty.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(createRoom).toHaveBeenCalled()
+      expect(trackGaEvent).toHaveBeenCalledWith('host_room_create', {
+        catalog_category: 'mst3k',
+        playback_host: 'youtube',
+        is_authenticated: true,
+        entry_surface: 'catalog',
+        source: 'catalog_episode',
+      })
+    })
+    const payload = trackGaEvent.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
   })
 })

--- a/apps/web/src/components/catalog/EpisodeTileActions.tsx
+++ b/apps/web/src/components/catalog/EpisodeTileActions.tsx
@@ -7,6 +7,7 @@ import {
   resolveCatalogYoutubeWatchUrl,
 } from '../../catalog/catalogYoutubePlayback'
 import { catalogToRoomPlayback, createRoom } from '../../api/roomsApi'
+import { trackGaEvent } from '../../config/googleAnalytics'
 import { getFanAccessToken } from '../../auth/fanTokens'
 import { startFanHostedUiSignIn } from '../../auth/fanHostedUiPkce'
 import { PENDING_PARTY_EPISODE_KEY } from '../../catalog/pendingPartyStorage'
@@ -39,6 +40,13 @@ export function EpisodeTileActions({
         catalogEpisodeId: episode.id,
         playbackExpectation: catalogToRoomPlayback(episode),
         visibility: 'public',
+      })
+      trackGaEvent('host_room_create', {
+        catalog_category: episode.catalog,
+        playback_host: episode.playbackHost === 'custom' ? 'custom' : 'youtube',
+        is_authenticated: true,
+        entry_surface: 'catalog',
+        source: 'catalog_episode',
       })
       navigate(`/room/${encodeURIComponent(room.roomId)}`)
     } catch (e) {

--- a/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
+++ b/apps/web/src/components/watch/SoloCustomIframePlayer.tsx
@@ -3,18 +3,28 @@ import { useEffect, useRef, useState } from 'react'
 export function SoloCustomIframePlayer({
   customPlaybackUrl,
   title,
+  onPlaybackReady,
 }: {
   customPlaybackUrl: string
   title: string
+  onPlaybackReady?: () => void
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const onPlaybackReadyRef = useRef(onPlaybackReady)
+
+  useEffect(() => {
+    onPlaybackReadyRef.current = onPlaybackReady
+  }, [onPlaybackReady])
 
   useEffect(() => {
     const iframe = iframeRef.current
     if (!iframe) return
 
-    const onLoad = () => setStatus('ready')
+    const onLoad = () => {
+      setStatus('ready')
+      onPlaybackReadyRef.current?.()
+    }
     const onError = () => setStatus('error')
     iframe.addEventListener('load', onLoad)
     iframe.addEventListener('error', onError)

--- a/apps/web/src/components/watch/SoloYouTubePlayer.tsx
+++ b/apps/web/src/components/watch/SoloYouTubePlayer.tsx
@@ -105,6 +105,8 @@ type SoloYouTubePlayerProps = {
   watchUrl?: string | null
   /** Party-capture host bridge registers play/pause while the YT player is ready. */
   onControlsChange?: (controls: SoloYouTubePlayerControls | null) => void
+  /** Fires once when the embed reports ready (solo watch funnel only when wired). */
+  onPlaybackReady?: () => void
 }
 
 export type SoloYouTubePlayerControls = {
@@ -118,17 +120,23 @@ function SoloYouTubePlayerInner({
   autoPlay = true,
   watchUrl,
   onControlsChange,
+  onPlaybackReady,
 }: SoloYouTubePlayerProps) {
   const domId = useId().replace(/:/g, '')
   const hostRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<YtPlayerInstance | null>(null)
   const onControlsChangeRef = useRef(onControlsChange)
+  const onPlaybackReadyRef = useRef(onPlaybackReady)
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
   const [errorDetail, setErrorDetail] = useState<string | null>(null)
 
   useEffect(() => {
     onControlsChangeRef.current = onControlsChange
   }, [onControlsChange])
+
+  useEffect(() => {
+    onPlaybackReadyRef.current = onPlaybackReady
+  }, [onPlaybackReady])
 
   const destroyPlayer = useCallback(() => {
     onControlsChangeRef.current?.(null)
@@ -186,6 +194,7 @@ function SoloYouTubePlayerInner({
             onReady: (e) => {
               if (cancelled) return
               setStatus('ready')
+              onPlaybackReadyRef.current?.()
               const target = e.target
               onControlsChangeRef.current?.({
                 play: () => target.playVideo(),

--- a/apps/web/src/config/googleAnalytics.test.ts
+++ b/apps/web/src/config/googleAnalytics.test.ts
@@ -6,6 +6,7 @@ import {
   initGoogleAnalytics,
   isArgumentsLikeForTests,
   resetGoogleAnalyticsInitForTests,
+  trackGaEvent,
   trackGaPageView,
 } from './googleAnalytics'
 
@@ -84,5 +85,49 @@ describe('googleAnalytics', () => {
   it('no-ops when gtag is unavailable', () => {
     vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123')
     expect(() => trackGaPageView('/')).not.toThrow()
+  })
+
+  it('no-ops trackGaEvent when measurement id is unset', () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', '')
+    const gtag = vi.fn()
+    window.gtag = gtag
+    trackGaEvent('room_join', { entry_surface: 'lobby', is_authenticated: false })
+    expect(gtag).not.toHaveBeenCalled()
+  })
+
+  it('no-ops trackGaEvent when gtag is unavailable', () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123')
+    expect(() =>
+      trackGaEvent('solo_watch_start', {
+        catalog_category: 'mst3k',
+        playback_host: 'youtube',
+        is_authenticated: true,
+      }),
+    ).not.toThrow()
+  })
+
+  it('tracks custom funnel events through gtag with allowlisted params only', () => {
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123')
+    const gtag = vi.fn()
+    window.gtag = gtag
+
+    trackGaEvent('host_room_create', {
+      catalog_category: 'mst3k',
+      playback_host: 'youtube',
+      is_authenticated: true,
+      entry_surface: 'catalog',
+      source: 'catalog_episode',
+    })
+
+    expect(gtag).toHaveBeenCalledWith('event', 'host_room_create', {
+      catalog_category: 'mst3k',
+      playback_host: 'youtube',
+      is_authenticated: true,
+      entry_surface: 'catalog',
+      source: 'catalog_episode',
+    })
+    const payload = gtag.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
+    expect(Object.keys(payload)).not.toContain('sessionId')
   })
 })

--- a/apps/web/src/config/googleAnalytics.ts
+++ b/apps/web/src/config/googleAnalytics.ts
@@ -1,3 +1,42 @@
+import type { CatalogCategory } from '../catalog/catalogTypes'
+
+/** Contract buckets from `docs/operations/product-metrics.md`. */
+export type GaEntrySurface =
+  | 'lobby'
+  | 'share_link'
+  | 'catalog'
+  | 'live'
+  | 'solo'
+  | 'home'
+  | 'unknown'
+
+/** Contract buckets from `docs/operations/product-metrics.md`. */
+export type GaSource =
+  | 'catalog_episode'
+  | 'lobby_card'
+  | 'share_url'
+  | 'live_index'
+  | 'direct'
+  | 'unknown'
+
+export type GaPlaybackHost = 'youtube' | 'custom'
+
+export type GaProductEventName =
+  | 'room_join'
+  | 'host_broadcast_start'
+  | 'host_room_create'
+  | 'solo_watch_start'
+  | 'live_channel_view'
+
+/** Allowlisted GA4 custom-event params only (low-cardinality contract enums). */
+export type GaProductEventParams = {
+  entry_surface?: GaEntrySurface
+  source?: GaSource
+  playback_host?: GaPlaybackHost
+  catalog_category?: CatalogCategory
+  is_authenticated?: boolean
+}
+
 /** Public GA4 measurement id baked at build time (`VITE_GA_MEASUREMENT_ID`). */
 export function getGaMeasurementId(): string | null {
   const id = import.meta.env.VITE_GA_MEASUREMENT_ID
@@ -94,6 +133,21 @@ export function trackGaPageView(pagePath: string): void {
   window.gtag('config', measurementId, {
     page_path: pagePath,
   })
+}
+
+/** Send a product funnel custom event; no-ops when measurement id unset or gtag missing. */
+export function trackGaEvent(name: GaProductEventName, params: GaProductEventParams = {}): void {
+  const measurementId = getGaMeasurementId()
+  if (!measurementId || typeof window.gtag !== 'function') {
+    return
+  }
+  const payload: Record<string, string | boolean> = {}
+  if (params.entry_surface !== undefined) payload.entry_surface = params.entry_surface
+  if (params.source !== undefined) payload.source = params.source
+  if (params.playback_host !== undefined) payload.playback_host = params.playback_host
+  if (params.catalog_category !== undefined) payload.catalog_category = params.catalog_category
+  if (params.is_authenticated !== undefined) payload.is_authenticated = params.is_authenticated
+  window.gtag('event', name, payload)
 }
 
 /** @internal Test helper for queued gtag commands. */

--- a/apps/web/src/pages/LiveChannelPage.test.tsx
+++ b/apps/web/src/pages/LiveChannelPage.test.tsx
@@ -14,6 +14,11 @@ const fetchFanProfile = vi.fn()
 const useLiveChannelChat = vi.fn()
 const useFanSession = vi.fn()
 const setGuestDisplayName = vi.fn<(displayName: string) => string>()
+const trackGaEvent = vi.fn()
+
+vi.mock('../config/googleAnalytics', () => ({
+  trackGaEvent: (...args: unknown[]) => trackGaEvent(...args),
+}))
 
 vi.mock('../api/liveApi', () => ({
   fetchLiveChannel: (...args: unknown[]) => fetchLiveChannel(...args),
@@ -104,6 +109,7 @@ describe('LiveChannelPage', () => {
     useFanSession.mockReturnValue({ fanToken: null })
     setGuestDisplayName.mockReset()
     setGuestDisplayName.mockImplementation((displayName: string) => displayName)
+    trackGaEvent.mockReset()
     useLiveChannelChat.mockReturnValue({
       wsStatus: 'open',
       chat: [],
@@ -158,6 +164,39 @@ describe('LiveChannelPage', () => {
     expect(container.textContent).not.toContain('Room')
     expect(container.textContent).toContain('Sign In to Chat')
     expect(container.querySelector('.riffsync-live-page__chat .riffsync-room-page__chat')).not.toBeNull()
+  })
+
+  it('tracks live_channel_view once when channel layout renders', async () => {
+    fetchLiveChannel.mockResolvedValue({
+      slug: 'mst3k-forever-a-thon',
+      path: '/live/mst3k-forever-a-thon',
+      roomId: 'live-mst3k-forever-a-thon',
+      catalogEpisodeId: 'mst3k-forever-a-thon',
+      enabled: true,
+      title: 'MST3K Forever-A-Thon',
+      tagline: '24/7',
+      posterImageUrl: null,
+      backdropImageUrl: null,
+      youtubeVideoId: 'abcdefghijk',
+      youtubeWatchUrl: 'https://www.youtube.com/watch?v=abcdefghijk',
+      embedAllows: true,
+      playbackHost: 'youtube',
+    })
+
+    await act(async () => {
+      renderLive(root, '/live/mst3k-forever-a-thon', queryClient)
+    })
+
+    await vi.waitFor(() => {
+      expect(trackGaEvent).toHaveBeenCalledWith('live_channel_view', {
+        is_authenticated: false,
+        entry_surface: 'live',
+        source: 'direct',
+      })
+    })
+    expect(trackGaEvent).toHaveBeenCalledTimes(1)
+    const payload = trackGaEvent.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
   })
 
   it('hydrates signed-in fan display name before sending live chat identity', async () => {

--- a/apps/web/src/pages/LiveChannelPage.tsx
+++ b/apps/web/src/pages/LiveChannelPage.tsx
@@ -7,6 +7,7 @@ import { SoloYouTubePlayer } from '../components/watch/SoloYouTubePlayer'
 import { getPublicWsUrl } from '../config/wsUrl'
 import { useLiveChannelQuery } from '../live/liveQueries'
 import { useLiveChannelChat } from '../live/useLiveChannelChat'
+import { trackGaEvent } from '../config/googleAnalytics'
 import { RoomPageSidebar } from '../room/RoomPageSidebar'
 import { useRoomProfileTab } from '../room/useRoomProfileTab'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
@@ -139,6 +140,7 @@ function LiveChannelReady(props: {
   const { slug, channel, sessionId, displayName, setDisplayName, myAvatarUrl, setMyAvatarUrl, fanToken } = props
   const chatInputRef = useRef<HTMLInputElement>(null)
   const castToTvButtonRef = useRef<HTMLButtonElement>(null)
+  const liveViewGaFiredRef = useRef(false)
   const [roomSidebarTab, setRoomSidebarTab] = useState<RoomSidebarTab>('chat')
   const chat = useLiveChannelChat({
     roomId: channel.roomId,
@@ -147,6 +149,16 @@ function LiveChannelReady(props: {
     fanToken,
     enabled: true,
   })
+
+  useEffect(() => {
+    if (liveViewGaFiredRef.current) return
+    liveViewGaFiredRef.current = true
+    trackGaEvent('live_channel_view', {
+      is_authenticated: Boolean(fanToken),
+      entry_surface: 'live',
+      source: 'direct',
+    })
+  }, [fanToken])
 
   const { logRef: chatLogRef, showJumpToLatest, jumpToLatestLabel, jumpToLatest } =
     useChatLogStickToBottom(chat.chat.length, true, channel.roomId)

--- a/apps/web/src/pages/RoomPage.tsx
+++ b/apps/web/src/pages/RoomPage.tsx
@@ -7,6 +7,7 @@ import { ensureGuestSession, setGuestDisplayName } from '../session/guestSession
 import { getPublicWsUrl } from '../config/wsUrl'
 import { getPublicApiBaseUrl } from '../config/apiBaseUrl'
 import { getPublicOrigin } from '../config/publicOrigin'
+import type { GaEntrySurface, GaSource } from '../config/googleAnalytics'
 import { useChatLogStickToBottom } from '../room/useChatLogStickToBottom'
 import { announceWebrtcDebugOnRoomMount } from '../room/webrtcDebug'
 import { useViewportWide } from '../room/stage/useViewportWide'
@@ -75,6 +76,13 @@ export function RoomPage() {
 
   const wsBase = getPublicWsUrl()
   const apiBaseUrl = getPublicApiBaseUrl()
+
+  const roomJoinGaContext = useMemo((): { gaEntrySurface: GaEntrySurface; gaSource: GaSource } => {
+    if (typeof document !== 'undefined' && document.referrer.includes('/lobby')) {
+      return { gaEntrySurface: 'lobby', gaSource: 'lobby_card' }
+    }
+    return { gaEntrySurface: 'share_link', gaSource: 'share_url' }
+  }, [])
 
   const {
     room,
@@ -188,6 +196,7 @@ export function RoomPage() {
     room,
     roomMode,
     isPublisher,
+    ...roomJoinGaContext,
     captureStream,
     captureStreamRef,
     youtubeVideoId,

--- a/apps/web/src/pages/SoloWatchPage.test.tsx
+++ b/apps/web/src/pages/SoloWatchPage.test.tsx
@@ -10,6 +10,16 @@ import type { CatalogEpisode } from '../catalog/catalogTypes'
 
 const useCatalogEpisodeQuery = vi.fn()
 const useCatalogListQuery = vi.fn()
+const trackGaEvent = vi.fn()
+
+vi.mock('../config/googleAnalytics', () => ({
+  trackGaEvent: (...args: unknown[]) => trackGaEvent(...args),
+}))
+
+vi.mock('../auth/fanTokens', () => ({
+  getFanAccessToken: vi.fn(() => null),
+  getFanRefreshToken: vi.fn(() => null),
+}))
 
 vi.mock('../catalog/catalogQueries', () => ({
   useCatalogEpisodeQuery: (...args: unknown[]) => useCatalogEpisodeQuery(...args),
@@ -23,12 +33,15 @@ vi.mock('../components/watch/SoloYouTubePlayer', () => ({
     videoId,
     titleHint,
     watchUrl,
+    onPlaybackReady,
   }: {
     videoId: string
     titleHint: string
     watchUrl?: string | null
-  }) =>
-    youtubePlayerFail.value ? (
+    onPlaybackReady?: () => void
+  }) => {
+    onPlaybackReady?.()
+    return youtubePlayerFail.value ? (
       <div className="riffsync-solo-player" data-testid="solo-youtube-player-error">
         <div className="riffsync-solo-player__chrome" aria-live="polite">
           <p role="alert">
@@ -51,7 +64,8 @@ vi.mock('../components/watch/SoloYouTubePlayer', () => ({
         data-title={titleHint}
         data-watch-url={watchUrl ?? ''}
       />
-    ),
+    )
+  },
 }))
 
 function episode(overrides: Partial<CatalogEpisode> = {}): CatalogEpisode {
@@ -95,6 +109,7 @@ describe('SoloWatchPage', () => {
       error: null,
       refetch: vi.fn(),
     })
+    trackGaEvent.mockReset()
   })
 
   afterEach(() => {
@@ -331,5 +346,47 @@ describe('SoloWatchPage', () => {
       container.querySelector('a[href="https://www.youtube.com/watch?v=NXGXtm6gcxk"]')?.textContent,
     ).toBe('Open on YouTube')
     expect(container.querySelector('h1.sr-only')?.textContent).toBe('Mitchell')
+  })
+
+  it('tracks solo_watch_start when solo playback becomes ready', async () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({ embedAllows: true }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage()
+
+    await vi.waitFor(() => {
+      expect(trackGaEvent).toHaveBeenCalledWith('solo_watch_start', {
+        catalog_category: 'mst3k',
+        playback_host: 'youtube',
+        is_authenticated: false,
+        entry_surface: 'solo',
+        source: 'catalog_episode',
+      })
+    })
+    const payload = trackGaEvent.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
+  })
+
+  it('does not track solo_watch_start for partyCapture host shell', async () => {
+    useCatalogEpisodeQuery.mockReturnValue({
+      data: episode({ embedAllows: true }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    renderWatchPage('/watch/032-mitchell?partyCapture=1')
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(trackGaEvent).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/pages/SoloWatchPage.tsx
+++ b/apps/web/src/pages/SoloWatchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
 import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom'
 import { SoloCustomIframePlayer } from '../components/watch/SoloCustomIframePlayer'
 import {
@@ -12,17 +12,20 @@ import {
   resolveCatalogYoutubeWatchUrl,
 } from '../catalog/catalogYoutubePlayback'
 import { SITE_DOCUMENT_TITLE, trimTabTitleSegment } from '../config/documentTitle'
+import { trackGaEvent } from '../config/googleAnalytics'
 import {
   mountHostMediaControlBridge,
   type HostMediaPlayerControls,
 } from '../hostBridge/hostMediaControlBridge'
 import { getLivePathForEpisodeId } from '../live/liveChannels'
+import { getFanAccessToken } from '../auth/fanTokens'
 
 export function SoloWatchPage() {
   const { catalogEpisodeId } = useParams<{ catalogEpisodeId: string }>()
   const [searchParams] = useSearchParams()
   const partyCapture = searchParams.get('partyCapture') === '1'
   const playerControlsRef = useRef<HostMediaPlayerControls | null>(null)
+  const soloWatchGaFiredRef = useRef(false)
 
   const { data: episode, isPending, isError, error, refetch } = useCatalogEpisodeQuery(catalogEpisodeId)
 
@@ -45,6 +48,23 @@ export function SoloWatchPage() {
   const onYouTubeControlsChange = (controls: SoloYouTubePlayerControls | null) => {
     playerControlsRef.current = controls
   }
+
+  const onSoloPlaybackReady = useCallback(() => {
+    if (partyCapture || soloWatchGaFiredRef.current || !episode) return
+    soloWatchGaFiredRef.current = true
+    const playbackHost = episode.playbackHost === 'custom' ? 'custom' : 'youtube'
+    trackGaEvent('solo_watch_start', {
+      catalog_category: episode.catalog,
+      playback_host: playbackHost,
+      is_authenticated: Boolean(getFanAccessToken()),
+      entry_surface: 'solo',
+      source: 'catalog_episode',
+    })
+  }, [episode, partyCapture])
+
+  useEffect(() => {
+    soloWatchGaFiredRef.current = false
+  }, [catalogEpisodeId])
 
   useEffect(() => {
     if (!partyCapture) {
@@ -236,6 +256,7 @@ export function SoloWatchPage() {
             key={customPlaybackUrl}
             customPlaybackUrl={customPlaybackUrl}
             title={episode.title}
+            onPlaybackReady={partyCapture ? undefined : onSoloPlaybackReady}
           />
         </div>
       ) : null}
@@ -247,6 +268,7 @@ export function SoloWatchPage() {
             autoPlay={false}
             watchUrl={episode.youtubeWatchUrl}
             onControlsChange={partyCapture ? onYouTubeControlsChange : undefined}
+            onPlaybackReady={partyCapture ? undefined : onSoloPlaybackReady}
           />
         </div>
       ) : null}

--- a/apps/web/src/room/engine/RoomMediaEngine.ts
+++ b/apps/web/src/room/engine/RoomMediaEngine.ts
@@ -2,6 +2,7 @@ import type { RoomMode, RoomSnapshot } from '../../api/roomsApi'
 import type { GiphySearchResult } from '../../api/giphySearchApi'
 import { getPublicApiBaseUrl } from '../../config/apiBaseUrl'
 import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
+import type { GaEntrySurface, GaSource } from '../../config/googleAnalytics'
 import { probeTurnReachability } from '../sfu/iceDiagnostics'
 import { createSpeakingVadRegistry, type SpeakingVadRegistry } from '../audio/speakingVadRegistry'
 import { isSpeakingVadEnabled } from '../audio/speakingVad'
@@ -86,6 +87,8 @@ export type RoomMediaEngineMountOptions = {
   fanToken: string | null
   isPublisher: boolean
   wsBase: string | undefined
+  gaEntrySurface?: GaEntrySurface
+  gaSource?: GaSource
   captureStreamRef: { current: MediaStream | null }
   announceRoomA11y: (message: string) => void
   hostPatchSuppressAnnounceUntilRef: { current: number }
@@ -320,6 +323,8 @@ export class RoomMediaEngine {
       wsUrl: options.wsBase,
       apiBaseUrl: getPublicApiBaseUrl(),
       isHost: options.isPublisher,
+      gaEntrySurface: options.gaEntrySurface,
+      gaSource: options.gaSource,
       mixEnabled: true,
       getIceServers: () => this.getIceServers(),
       getHostScreenStream: () => options.captureStreamRef.current,

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as googleAnalytics from '../../config/googleAnalytics'
 import {
   ChatSession,
   routeInboundChatMessage,
@@ -24,6 +25,10 @@ vi.mock('../realtimeDiagnostics', async (importOriginal) => {
     recordWsOpen: vi.fn(),
   }
 })
+
+vi.mock('../../config/googleAnalytics', () => ({
+  trackGaEvent: vi.fn(),
+}))
 
 const ROOM = 'room-abc'
 
@@ -506,6 +511,113 @@ describe('ChatSession lifecycle FSM', () => {
       event: 'reconnect_success',
       outcome: 'recovered',
     })
+  })
+})
+
+describe('ChatSession GA4 room_join', () => {
+  class MockWebSocket {
+    static instances: MockWebSocket[] = []
+    static OPEN = 1
+    readyState = MockWebSocket.CONNECTING
+    static CONNECTING = 0
+    private listeners = new Map<string, Array<(ev?: unknown) => void>>()
+
+    constructor(url: string) {
+      void url
+      MockWebSocket.instances.push(this)
+    }
+
+    addEventListener(type: string, fn: (ev?: unknown) => void) {
+      const list = this.listeners.get(type) ?? []
+      list.push(fn)
+      this.listeners.set(type, list)
+    }
+
+    send = vi.fn()
+
+    emit(type: string, ev?: unknown) {
+      for (const fn of this.listeners.get(type) ?? []) fn(ev)
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    vi.mocked(googleAnalytics.trackGaEvent).mockClear()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('fires room_join once for guest first connect with allowlisted params', () => {
+    const session = new ChatSession()
+    session.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-ga-guest',
+      accessToken: 'fan-token',
+      isPublisher: false,
+      trackRoomJoin: true,
+      gaEntrySurface: 'share_link',
+      gaSource: 'share_url',
+      enabled: true,
+    })
+
+    const ws = MockWebSocket.instances.at(-1)!
+    ws.readyState = MockWebSocket.OPEN
+    ws.emit('open')
+
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledTimes(1)
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledWith('room_join', {
+      entry_surface: 'share_link',
+      is_authenticated: true,
+      source: 'share_url',
+    })
+    const payload = vi.mocked(googleAnalytics.trackGaEvent).mock.calls[0]?.[1] as Record<string, unknown>
+    expect(Object.keys(payload)).not.toContain('roomId')
+    expect(Object.keys(payload)).not.toContain('sessionId')
+  })
+
+  it('skips room_join for publishers and reconnect recovery', () => {
+    const session = new ChatSession()
+    session.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-ga-host',
+      accessToken: 'host-token',
+      isPublisher: true,
+      trackRoomJoin: true,
+      gaEntrySurface: 'lobby',
+      enabled: true,
+    })
+    MockWebSocket.instances.at(-1)!.emit('open')
+    expect(googleAnalytics.trackGaEvent).not.toHaveBeenCalled()
+
+    const guest = new ChatSession()
+    guest.connect({
+      url: 'wss://ws.test',
+      roomId: ROOM,
+      sessionId: 'sess-ga-reconnect',
+      accessToken: null,
+      trackRoomJoin: true,
+      gaEntrySurface: 'lobby',
+      gaSource: 'lobby_card',
+      enabled: true,
+    })
+    const first = MockWebSocket.instances.at(-1)!
+    first.readyState = MockWebSocket.OPEN
+    first.emit('open')
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledTimes(1)
+
+    first.emit('close', { code: 1006, reason: '' })
+    vi.runOnlyPendingTimers()
+    const second = MockWebSocket.instances.at(-1)!
+    second.readyState = MockWebSocket.OPEN
+    second.emit('open')
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/web/src/room/sessions/ChatSession.test.ts
+++ b/apps/web/src/room/sessions/ChatSession.test.ts
@@ -517,9 +517,9 @@ describe('ChatSession lifecycle FSM', () => {
 describe('ChatSession GA4 room_join', () => {
   class MockWebSocket {
     static instances: MockWebSocket[] = []
+    static CONNECTING = 0
     static OPEN = 1
     readyState = MockWebSocket.CONNECTING
-    static CONNECTING = 0
     private listeners = new Map<string, Array<(ev?: unknown) => void>>()
 
     constructor(url: string) {

--- a/apps/web/src/room/sessions/ChatSession.ts
+++ b/apps/web/src/room/sessions/ChatSession.ts
@@ -1,4 +1,9 @@
 import type { RoomMode } from '../../api/roomsApi'
+import {
+  trackGaEvent,
+  type GaEntrySurface,
+  type GaSource,
+} from '../../config/googleAnalytics'
 import { emitClientDrawerLog } from '../clientDrawerLog'
 import { parseInboundChatGifMessage, type InboundChatGifLine } from '../chatGifMessage'
 import { parseInboundChatMessageId } from '../chatMessageId'
@@ -123,6 +128,12 @@ export type ChatSessionConnectOptions = {
   sessionId: string
   displayName?: string
   accessToken: string | null
+  /** When true, the tab is the room host/publisher (skip guest funnel events). */
+  isPublisher?: boolean
+  /** Enables `room_join` GA4 on first guest WS open (watch-party rooms only). */
+  trackRoomJoin?: boolean
+  gaEntrySurface?: GaEntrySurface
+  gaSource?: GaSource
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -344,6 +355,7 @@ export class ChatSession {
   private composeTypingStarted = false
   private typingStartDebounceTimer: ReturnType<typeof setTimeout> | null = null
   private typingIdleTimer: ReturnType<typeof setTimeout> | null = null
+  private gaRoomJoinTracked = false
 
   private chatTextListeners = new Set<Listener<ChatTextLine>>()
   private chatGifListeners = new Set<Listener<ChatGifLine>>()
@@ -487,9 +499,14 @@ export class ChatSession {
       sessionId: options.sessionId,
       displayName: options.displayName,
       accessToken: options.accessToken,
+      isPublisher: options.isPublisher,
+      trackRoomJoin: options.trackRoomJoin,
+      gaEntrySurface: options.gaEntrySurface,
+      gaSource: options.gaSource,
     }
     this.enabled = options.enabled !== false
     this.cancelled = false
+    this.gaRoomJoinTracked = false
     this.teardownSocket()
     if (!this.enabled || !options.url) {
       this.setStatus('idle')
@@ -776,6 +793,20 @@ export class ChatSession {
           drawer: 'chat',
           event: 'reconnect_success',
           outcome: 'recovered',
+        })
+      }
+      const joinOpts = this.connectOptions
+      if (
+        !recoveredFromReconnect &&
+        joinOpts?.trackRoomJoin === true &&
+        joinOpts.isPublisher !== true &&
+        !this.gaRoomJoinTracked
+      ) {
+        this.gaRoomJoinTracked = true
+        trackGaEvent('room_join', {
+          entry_surface: joinOpts.gaEntrySurface ?? 'unknown',
+          is_authenticated: Boolean(joinOpts.accessToken),
+          ...(joinOpts.gaSource !== undefined ? { source: joinOpts.gaSource } : {}),
         })
       }
       if (webrtcDebugEnabled()) webrtcLog('ws open')

--- a/apps/web/src/room/sessions/RoomRealtimeSdk.ts
+++ b/apps/web/src/room/sessions/RoomRealtimeSdk.ts
@@ -8,6 +8,7 @@
 
 import type { RoomMode, RoomSnapshot } from '../../api/roomsApi'
 import { fetchRtcIceServers } from '../../config/fetchRtcIceServers'
+import type { GaEntrySurface, GaSource } from '../../config/googleAnalytics'
 import type { ParticipantAvController } from '../sfu/participantAvSession'
 import type { SfuConsumerTrackEvent } from '../sfu/mediasoupSharing'
 import type { ParticipantProducerSnapshot } from '../participantProducerRegistry'
@@ -76,6 +77,8 @@ export type JoinOptions = {
   wsUrl?: string
   apiBaseUrl?: string
   isHost?: boolean
+  gaEntrySurface?: GaEntrySurface
+  gaSource?: GaSource
   /**
    * Enables the Web Audio participant mix (experimental camera/mic). When false (default for the
    * primary tab-sharing experience), host_screen audio plays directly through the <video> element
@@ -243,6 +246,10 @@ export class RoomRealtimeSdk {
         sessionId: options.sessionId,
         displayName: options.displayName,
         accessToken: options.accessToken ?? null,
+        isPublisher: this.isHost,
+        trackRoomJoin: true,
+        gaEntrySurface: options.gaEntrySurface,
+        gaSource: options.gaSource,
         enabled: true,
       })
     }

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -1168,12 +1168,14 @@ describe('SfuMediaSession GA4 host_broadcast_start', () => {
     })
 
     const publishStream = vi.fn().mockResolvedValue(undefined)
-    attachMockSessionHandle(session, {
-      detachConsumerClass: vi.fn(),
-      unpublishProducerClass: vi.fn(),
-    })
     ;(
-      session as unknown as { sessionHandle: { publishStream: typeof publishStream; ready: Promise<void> } }
+      session as unknown as {
+        sessionHandle: {
+          publishStream: typeof publishStream
+          ready: Promise<void>
+          unpublishProducerClass: ReturnType<typeof vi.fn>
+        }
+      }
     ).sessionHandle = {
       publishStream,
       ready: Promise.resolve(),

--- a/apps/web/src/room/sessions/SfuMediaSession.test.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.test.ts
@@ -15,9 +15,14 @@ import {
   startSfuRoomSession,
 } from './SfuMediaSession'
 import * as clientDrawerLog from '../clientDrawerLog'
+import * as googleAnalytics from '../../config/googleAnalytics'
 
 vi.mock('../clientDrawerLog', () => ({
   emitClientDrawerLog: vi.fn(),
+}))
+
+vi.mock('../../config/googleAnalytics', () => ({
+  trackGaEvent: vi.fn(),
 }))
 
 vi.mock('../../api/webrtcSfuApi', () => ({
@@ -1131,7 +1136,7 @@ function mockSfuUnifiedSessionHandle() {
     close: vi.fn(),
     unpublishProducerKind: vi.fn(),
     unpublishProducerClass: vi.fn(),
-    publishStream: vi.fn(),
+    publishStream: vi.fn().mockResolvedValue(undefined),
     supportsPublish: false,
     tokenRole: 'consumer' as const,
     getProducerCount: () => 0,
@@ -1144,6 +1149,69 @@ function mockSfuUnifiedSessionHandle() {
     replayConsumerTracks: vi.fn(),
   }
 }
+
+describe('SfuMediaSession GA4 host_broadcast_start', () => {
+  beforeEach(() => {
+    vi.mocked(googleAnalytics.trackGaEvent).mockClear()
+  })
+
+  it('fires host_broadcast_start once after host_screen publish succeeds', async () => {
+    const session = new SfuMediaSession()
+    session.connect({
+      apiBaseUrl: 'https://api.example.test',
+      roomId: 'room-1',
+      sessionId: 'sess-host',
+      accessToken: 'host-token',
+      getIceServers: async () => [],
+      getHostScreenStream: () => null,
+      enabled: true,
+    })
+
+    const publishStream = vi.fn().mockResolvedValue(undefined)
+    attachMockSessionHandle(session, {
+      detachConsumerClass: vi.fn(),
+      unpublishProducerClass: vi.fn(),
+    })
+    ;(
+      session as unknown as { sessionHandle: { publishStream: typeof publishStream; ready: Promise<void> } }
+    ).sessionHandle = {
+      publishStream,
+      ready: Promise.resolve(),
+      unpublishProducerClass: vi.fn(),
+    }
+
+    const videoTrack = { kind: 'video', readyState: 'live' } as MediaStreamTrack
+    const stream = {
+      getTracks: () => [videoTrack],
+    } as MediaStream
+
+    session.syncHostScreenPublish({
+      stream,
+      roomMode: 'theater',
+      isPublisher: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(publishStream).toHaveBeenCalledWith(stream, 'host_screen')
+    })
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledTimes(1)
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledWith('host_broadcast_start', {
+      is_authenticated: true,
+    })
+
+    session.syncHostScreenPublish({
+      stream,
+      roomMode: 'theater',
+      isPublisher: true,
+    })
+    await vi.waitFor(() => {
+      expect(publishStream).toHaveBeenCalledTimes(2)
+    })
+    expect(googleAnalytics.trackGaEvent).toHaveBeenCalledTimes(1)
+
+    session.disconnect()
+  })
+})
 
 describe('SfuMediaSession lifecycle FSM', () => {
   it('maps failed reconnect cycles to degraded lifecycle at threshold', () => {

--- a/apps/web/src/room/sessions/SfuMediaSession.ts
+++ b/apps/web/src/room/sessions/SfuMediaSession.ts
@@ -1,5 +1,6 @@
 import { fetchSfuJoinToken } from '../../api/webrtcSfuApi'
 import type { RoomMode } from '../../api/roomsApi'
+import { trackGaEvent } from '../../config/googleAnalytics'
 import {
   isParticipantAvTokenHardFail,
   participantAvErrorFromSfuSessionEnd,
@@ -480,6 +481,7 @@ export class SfuMediaSession {
   private participantProducerRegistryListeners = new Set<Listener<void>>()
   private participantAvStateUnsub: (() => void) | null = null
   private ownSessionId: string | null = null
+  private hostBroadcastGaTracked = false
   private readonly connectivityByTransport = new Map<string, SfuConnectivityDiagnostics>()
 
   constructor() {
@@ -660,6 +662,7 @@ export class SfuMediaSession {
   connect(options: SfuMediaSessionConnectOptions): void {
     this.connectOptions = { ...options }
     this.ownSessionId = options.sessionId
+    this.hostBroadcastGaTracked = false
     this.enabled = options.enabled !== false
     this.participantAvStateUnsub?.()
     this.participantAvStateUnsub = this.participantAv.subscribe(() => {
@@ -684,6 +687,7 @@ export class SfuMediaSession {
 
   disconnect(): void {
     this.enabled = false
+    this.hostBroadcastGaTracked = false
     this.participantAvStateUnsub?.()
     this.participantAvStateUnsub = null
     this.ownSessionId = null
@@ -802,6 +806,12 @@ export class SfuMediaSession {
         await session.ready
         if (cancelled) return
         await session.publishStream(stream, 'host_screen')
+        if (!cancelled && !this.hostBroadcastGaTracked) {
+          this.hostBroadcastGaTracked = true
+          trackGaEvent('host_broadcast_start', {
+            is_authenticated: Boolean(this.connectOptions?.accessToken),
+          })
+        }
       } catch (e) {
         emitClientDrawerLog({
           drawer: 'produce_consume',

--- a/apps/web/src/room/useRoomMediaEngine.ts
+++ b/apps/web/src/room/useRoomMediaEngine.ts
@@ -20,6 +20,7 @@ import {
   type RoomMediaEngine,
 } from './engine/RoomMediaEngine'
 import { pickRoomSnapshotMediaFields } from './engine/roomSnapshotDiff'
+import type { GaEntrySurface, GaSource } from '../config/googleAnalytics'
 
 export function useRoomMediaEngine(options: {
   wsBase: string | undefined
@@ -31,6 +32,8 @@ export function useRoomMediaEngine(options: {
   room: RoomSnapshot | null | undefined
   roomMode: RoomMode
   isPublisher: boolean
+  gaEntrySurface?: GaEntrySurface
+  gaSource?: GaSource
   captureStream: MediaStream | null
   captureStreamRef: RefObject<MediaStream | null>
   youtubeVideoId: string | null | undefined
@@ -81,6 +84,8 @@ export function useRoomMediaEngine(options: {
     room,
     roomMode,
     isPublisher,
+    gaEntrySurface,
+    gaSource,
     captureStream,
     captureStreamRef,
     youtubeVideoId,
@@ -144,6 +149,8 @@ export function useRoomMediaEngine(options: {
       displayName: displayNameRef.current,
       fanToken,
       isPublisher,
+      gaEntrySurface,
+      gaSource,
       wsBase,
       captureStreamRef,
       announceRoomA11y: (message) => announceRoomA11yRef.current(message),
@@ -175,6 +182,8 @@ export function useRoomMediaEngine(options: {
   }, [
     canonicalRoomId,
     engine,
+    gaEntrySurface,
+    gaSource,
     hostPatchSuppressAnnounceUntilRef,
     isPublisher,
     roomAvailable,


### PR DESCRIPTION
## Summary
- Add `trackGaEvent` helper and contract-aligned types in `googleAnalytics.ts` (no-op when measurement id unset or gtag missing).
- Wire five GA4 funnel events: `room_join`, `host_broadcast_start`, `host_room_create`, `solo_watch_start`, `live_channel_view` at the scoped success points with allowlisted params only.
- Add unit tests for the helper and each call site, including reconnect/party-capture dedupe guards.

## Test plan
- [x] `npm test --prefix apps/web` (1088 tests passed)
- [ ] Manual smoke on staging with `VITE_GA_MEASUREMENT_ID` set: DevTools Network shows `/g/collect` with custom event names and allowlisted params only

Closes #438