### PR TITLE
CloudWatch: RiffSync/Product business counters (#439)

### DIFF
--- a/infra/cdk/lambda/live-get.ts
+++ b/infra/cdk/lambda/live-get.ts
@@ -10,6 +10,7 @@ import {
 import { CATALOG_META_ID } from './catalog-meta';
 import { projectEpisode, sortEpisodes, type CatalogEpisode } from './catalog-shared';
 import { liveRoomIdForCatalogEpisodeId, LIVE_SYSTEM_HOST_SUB } from './live-channels';
+import { emitProductEmf } from './riffsync-observability';
 
 const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -186,6 +187,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     displayTitle: channel.title,
     youtubeVideoId: channel.youtubeVideoId,
   });
+
+  emitProductEmf('LiveChannelView', 'success');
 
   return {
     statusCode: 200,

--- a/infra/cdk/lambda/riffsync-observability.test.ts
+++ b/infra/cdk/lambda/riffsync-observability.test.ts
@@ -3,6 +3,7 @@ import {
   emitApiEmf,
   emitPresenceActiveFanOut,
   emitPresenceRequestRehydrated,
+  emitProductEmf,
   emitQualifyingActiveWrite,
   emitTypingRouteAccepted,
   emitTypingRouteThrottled,
@@ -18,8 +19,8 @@ import {
   wsRealtimeOutcomeFromStatus,
 } from './riffsync-observability';
 
-const FORBIDDEN_EMF_PROPERTY_KEYS = ['roomId', 'sessionId', 'sub', 'fanSub', 'connectionId'] as const;
-const FORBIDDEN_EMF_DIMENSIONS = ['roomId', 'sessionId', 'sub', 'fanSub', 'connectionId'] as const;
+const FORBIDDEN_EMF_PROPERTY_KEYS = ['roomId', 'sessionId', 'sub', 'fanSub', 'hostSub', 'connectionId', 'slug'] as const;
+const FORBIDDEN_EMF_DIMENSIONS = ['roomId', 'sessionId', 'sub', 'fanSub', 'hostSub', 'connectionId', 'slug'] as const;
 
 function parseEmfLine(line: string): Record<string, unknown> {
   return JSON.parse(line) as Record<string, unknown>;
@@ -277,6 +278,50 @@ describe('riffsync-observability', () => {
     const throttled = parseEmfLine((console.log as ReturnType<typeof vi.fn>).mock.calls[1][0] as string);
     expect(throttled.TypingRouteThrottled).toBe(1);
     expect(throttled.Route).toBe('typing_stop');
+  });
+
+  it('emits Product EMF with RiffSync/Product namespace and dimensions', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'prod';
+    emitProductEmf('RoomCreate', 'success');
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    const line = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const aws = parsed._aws as {
+      CloudWatchMetrics: Array<{
+        Namespace: string;
+        Dimensions: string[][];
+        Metrics: Array<{ Name: string; Unit: string }>;
+      }>;
+    };
+
+    expect(aws.CloudWatchMetrics[0].Namespace).toBe('RiffSync/Product');
+    expect(aws.CloudWatchMetrics[0].Dimensions).toEqual([['Environment', 'Route', 'Outcome']]);
+    expect(aws.CloudWatchMetrics[0].Metrics).toEqual([{ Name: 'Requests', Unit: 'Count' }]);
+    expect(parsed.Environment).toBe('prod');
+    expect(parsed.Route).toBe('RoomCreate');
+    expect(parsed.Outcome).toBe('success');
+    expect(parsed.Requests).toBe(1);
+  });
+
+  it('emits Product EMF for all routes without high-cardinality keys', () => {
+    process.env.RIFFSYNC_ENVIRONMENT = 'staging';
+    const routes = ['GuestRoomJoin', 'BroadcastStarted', 'RoomCreate', 'LiveChannelView'] as const;
+    for (const route of routes) {
+      emitProductEmf(route, 'success');
+    }
+
+    expect(console.log).toHaveBeenCalledTimes(4);
+    for (const call of (console.log as ReturnType<typeof vi.fn>).mock.calls) {
+      const parsed = parseEmfLine(call[0] as string);
+      assertLowCardinalityEmf(parsed);
+      const aws = parsed._aws as {
+        CloudWatchMetrics: Array<{ Namespace: string }>;
+      };
+      expect(aws.CloudWatchMetrics[0].Namespace).toBe('RiffSync/Product');
+      expect(parsed.Outcome).toBe('success');
+      expect(parsed.Requests).toBe(1);
+    }
   });
 
   it('emits presence and qualifying active EMF without high-cardinality dimensions', () => {

--- a/infra/cdk/lambda/riffsync-observability.ts
+++ b/infra/cdk/lambda/riffsync-observability.ts
@@ -64,8 +64,18 @@ export type ApiOutcome =
   | AdminCatalogPatchOutcome
   | AdminCatalogDeleteOutcome;
 
+export type ProductRoute = 'GuestRoomJoin' | 'BroadcastStarted' | 'RoomCreate' | 'LiveChannelView';
+
+export type ProductOutcome =
+  | 'success'
+  | 'validation_error'
+  | 'auth_forbidden'
+  | 'not_found'
+  | 'server_error';
+
 const REALTIME_METRIC_NAME = 'Requests';
 const API_METRIC_NAME = 'Requests';
+const PRODUCT_METRIC_NAME = 'Requests';
 
 export function wsRealtimeOutcomeFromStatus(statusCode: number): WsRealtimeOutcome {
   if (statusCode === 200) {
@@ -281,6 +291,29 @@ export function emitPresenceRequestRehydrated(): void {
 
 export function recordPresenceRequestRehydrated(): void {
   emitPresenceRequestRehydrated();
+}
+
+/** EMF counter for product funnel routes via stdout (no PutMetricData IAM required). */
+export function emitProductEmf(route: ProductRoute, outcome: ProductOutcome): void {
+  const env = riffsyncEnvironment();
+  console.log(
+    JSON.stringify({
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [
+          {
+            Namespace: 'RiffSync/Product',
+            Dimensions: [['Environment', 'Route', 'Outcome']],
+            Metrics: [{ Name: PRODUCT_METRIC_NAME, Unit: 'Count' }],
+          },
+        ],
+      },
+      Environment: env,
+      Route: route,
+      Outcome: outcome,
+      [PRODUCT_METRIC_NAME]: 1,
+    }),
+  );
 }
 
 /** EMF counter for HTTP API routes via stdout (no PutMetricData IAM required). */

--- a/infra/cdk/lambda/room-create.ts
+++ b/infra/cdk/lambda/room-create.ts
@@ -6,6 +6,7 @@ import {
   PutCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { validateCatalogRowForRoomSeed } from './catalog-room-playback-gate';
+import { emitProductEmf } from './riffsync-observability';
 import {
   initialDisplayTitleFromCatalog,
   lobbySortKey,
@@ -125,6 +126,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       ConditionExpression: 'attribute_not_exists(roomId)',
     }),
   );
+
+  emitProductEmf('RoomCreate', 'success');
 
   return {
     statusCode: 201,

--- a/infra/cdk/lambda/ws-connect.ts
+++ b/infra/cdk/lambda/ws-connect.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
 import { verifyAccessToken } from './cognito-jwt';
+import { emitProductEmf } from './riffsync-observability';
 import { maintainPublicLobbyOnHostConnect } from './room-lobby-cleanup';
 import { fanOutChatSystem, isWithinJoinReconnectCooldown } from './ws-chat-system-shared';
 import { fanSubRoomPresenceSk } from './room-presence-shared';
@@ -161,6 +162,10 @@ export const handler: APIGatewayProxyWebsocketHandlerV2 = async (event) => {
         except: connectionId,
       }).catch(() => undefined);
     }
+  }
+
+  if (!hostSub) {
+    emitProductEmf('GuestRoomJoin', 'success');
   }
 
   return { statusCode: 200, body: 'Connected' };

--- a/infra/cdk/lambda/ws-route.ts
+++ b/infra/cdk/lambda/ws-route.ts
@@ -23,7 +23,7 @@ import {
   persistReactionRemove,
   queryChatHistory,
 } from './room-chat-shared';
-import { recordTypingRouteAccepted, recordTypingRouteThrottled, recordPresenceRequestRehydrated, recordQualifyingActiveWrite, recordWsRealtimeRoute, type QualifyingActiveRoute } from './riffsync-observability';
+import { emitProductEmf, recordTypingRouteAccepted, recordTypingRouteThrottled, recordPresenceRequestRehydrated, recordQualifyingActiveWrite, recordWsRealtimeRoute, type QualifyingActiveRoute } from './riffsync-observability';
 import {
   fanOutTyping,
   recordTypingStartFanOut,
@@ -348,6 +348,9 @@ async function websocketRouteInner(event: APIGatewayProxyWebsocketEventV2): Prom
     }
     const buf = encoder.encode(JSON.stringify(out));
     await postToConnections(mgmt, doc, connTable, ids, buf, undefined, presenceTable);
+    if (state === 'started') {
+      emitProductEmf('BroadcastStarted', 'success');
+    }
     return { statusCode: 200, body: 'OK' };
   }
 


### PR DESCRIPTION
## Summary
- Add `ProductRoute`, `ProductOutcome`, and `emitProductEmf()` to `riffsync-observability.ts` following the existing stdout EMF pattern (`RiffSync/Product`, metric `Requests`, dimensions `Environment`/`Route`/`Outcome`).
- Wire success-only counters at four server trigger points: `RoomCreate` (POST /v1/rooms 201), `GuestRoomJoin` (non-publisher WS $connect 200), `BroadcastStarted` (share_state started 200 after fan-out), and `LiveChannelView` (GET /v1/live/{slug} 200).
- Extend observability unit tests with Product EMF shape assertions and low-cardinality guards (`hostSub`, `slug` added to forbidden keys).

## Test plan
- [x] `npx vitest run lambda/riffsync-observability.test.ts` passes (16 tests)
- [x] Handler tests green: `room-create.test.ts`, `ws-connect.test.ts`, `live-get.test.ts`
- [x] Grep confirms `RiffSync/Product` only in observability module, tests, and handler imports
- [x] All four trigger points emit `Outcome=success` only; no room/session/sub/slug in EMF payloads

Closes #439