### PR TITLE
Ops: product metrics CloudWatch dashboard widgets (#440)

### DIFF
--- a/.ai/operations/observability.md
+++ b/.ai/operations/observability.md
@@ -12,6 +12,9 @@
 ## Product funnels
 
 Primary product funnel instrumentation (guest join, host broadcast, catalog room create, solo watch, Live entry) is defined in **`docs/operations/product-metrics.md`**. That document is the normative contract for GA4 custom event names/parameters and CloudWatch **`RiffSync/Product`** `Route` / `Outcome` strings. Implementation tickets **#438** (GA4) and **#439** (CloudWatch) must match it verbatim. Drawer/ops namespaces below (**`RiffSync/Realtime`**, **`RiffSync/Media`**, **`RiffSync/Api`**) remain separate from product funnel counters.
+
+**CloudWatch dashboard:** Stack **`RiffSyncObservability-prod`** output **`OperationsDashboardUrl`** opens dashboard **`RiffSync-prod-operations`**. The **Product funnels** widget group plots **`RiffSync/Product`** metric **`Requests`** with **`Outcome="success"`** for routes **`RoomCreate`**, **`GuestRoomJoin`**, **`BroadcastStarted`**, and **`LiveChannelView`** (see **`infra/cdk/lib/observability-dashboard.ts`**). Series may be empty until **#439** EMF counters deploy to prod.
+
 | **Dashboards** | **`AWS::CloudWatch::Dashboard`** in IaC; ops + reconcile + optional WebSocket views. Shipped: **`RiffSync-prod-operations`** in **`infra/cdk/lib/observability-stack.ts`**. |
 | **Logs** | Structured JSON → **CloudWatch Logs**; **Logs Insights** for investigation; **metric filters** → alarms. |
 | **Alarms** | **Lightweight defaults for OSS/cost**: e.g. sustained **Lambda error rate**, **API 5xx %**, **Dynamo throttling**, **reconcile failure** custom metric — **SNS email** to maintainer **optional**; **no** mandatory commercial on-call SLA (**`.ai/interface/presentation.md`**). Tune thresholds in IaC for the **prod** footprint. |

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -226,7 +226,7 @@ One account, **one CloudFormation stack** **`RiffSyncTurn`** ([`lib/media-server
 
 ### CloudWatch operations dashboard
 
-Stack **`RiffSyncObservability-prod`** creates dashboard **`RiffSync-prod-operations`**: HTTP + WebSocket API Gateway volume/errors, critical Lambda errors/throttles/duration, DynamoDB throttles on Connections/Rooms/RoomPresence/RoomChat, **`RiffSync/Realtime`** chat EMF, **`RiffSync/Media`** **`SfuTokenDenied`**, SFU/TURN EC2 CPU and network, and **`RiffSync/Reconcile`** background metrics.
+Stack **`RiffSyncObservability-prod`** creates dashboard **`RiffSync-prod-operations`**: HTTP + WebSocket API Gateway volume/errors, critical Lambda errors/throttles/duration, DynamoDB throttles on Connections/Rooms/RoomPresence/RoomChat, **`RiffSync/Realtime`** chat EMF, **`RiffSync/Media`** **`SfuTokenDenied`**, SFU/TURN EC2 CPU and network, **`RiffSync/Reconcile`** background metrics, and a **Product funnels** widget group for **`RiffSync/Product`** success counters (**`RoomCreate`**, **`GuestRoomJoin`**, **`BroadcastStarted`**, **`LiveChannelView`**).
 
 **Deploy (after API + media stacks exist):**
 

--- a/infra/cdk/lib/observability-dashboard.test.ts
+++ b/infra/cdk/lib/observability-dashboard.test.ts
@@ -48,6 +48,11 @@ describe('observability dashboard', () => {
     expect(serialized).toContain('RiffSync/Realtime');
     expect(serialized).toContain('RiffSync/Media');
     expect(serialized).toContain('RiffSync/Reconcile');
+    expect(serialized).toContain('RiffSync/Product');
+    expect(serialized).toContain('RoomCreate');
+    expect(serialized).toContain('GuestRoomJoin');
+    expect(serialized).toContain('BroadcastStarted');
+    expect(serialized).toContain('LiveChannelView');
     expect(serialized).toContain('riffsync-sfu-high-cpu');
     expect(serialized).not.toContain('i-sfu123');
     expect(serialized).toContain('AWS/DynamoDB');

--- a/infra/cdk/lib/observability-dashboard.ts
+++ b/infra/cdk/lib/observability-dashboard.ts
@@ -376,6 +376,38 @@ export function buildRiffSyncOperationsDashboard(
         ),
       ],
     }),
+    new cloudwatch.TextWidget({
+      markdown: '**Product funnels** — success counters from **`RiffSync/Product`** EMF (room create, guest join, broadcast start, Live channel view).',
+      width: 24,
+      height: 2,
+    }),
+    new cloudwatch.GraphWidget({
+      title: 'Product funnels — RiffSync/Product requests (success)',
+      width: 24,
+      height: 6,
+      left: [
+        emfSearchMetric(
+          'RiffSync/Product,Environment,Route,Outcome',
+          `Environment="${env}" Route="RoomCreate" Outcome="success"`,
+          'RoomCreate',
+        ),
+        emfSearchMetric(
+          'RiffSync/Product,Environment,Route,Outcome',
+          `Environment="${env}" Route="GuestRoomJoin" Outcome="success"`,
+          'GuestRoomJoin',
+        ),
+        emfSearchMetric(
+          'RiffSync/Product,Environment,Route,Outcome',
+          `Environment="${env}" Route="BroadcastStarted" Outcome="success"`,
+          'BroadcastStarted',
+        ),
+        emfSearchMetric(
+          'RiffSync/Product,Environment,Route,Outcome',
+          `Environment="${env}" Route="LiveChannelView" Outcome="success"`,
+          'LiveChannelView',
+        ),
+      ],
+    }),
   );
 
   return dashboard;


### PR DESCRIPTION
## Summary
- Adds a **Product funnels** widget group to the existing **`RiffSync-prod-operations`** CloudWatch dashboard with four success-only **`RiffSync/Product`** time series: **`RoomCreate`**, **`GuestRoomJoin`**, **`BroadcastStarted`**, **`LiveChannelView`**
- Extends CDK dashboard tests to assert the **`RiffSync/Product`** namespace and route strings appear in synthesized dashboard JSON
- Documents widget location in **`.ai/operations/observability.md`** and **`infra/cdk/README.md`**

Closes #440

## Test plan
- [x] `npm run test --prefix infra/cdk -- lib/observability-dashboard.test.ts` passes (includes **`RiffSync/Product`** assertion)
- [x] `npx cdk synth RiffSyncObservability-prod --context environment=prod` succeeds; dashboard body contains four Product Route SEARCH expressions
- [x] Reviewer confirms observability doc + CDK README point maintainers to **`RiffSync-prod-operations`** → **Product funnels** widgets
- [ ] Manual: after deploy to prod, open **`OperationsDashboardUrl`** and confirm non-zero series when funnel traffic exists